### PR TITLE
refactor: migrate to docker-compose with separate DB container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
 
       - name: Install server dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install client dependencies
         run: |
@@ -69,8 +69,12 @@ jobs:
           npm run build
           cd ..
 
+          # Build the optimized application image (without MariaDB)
           docker build -t ${{ vars.DOCKERHUB_USERNAME }}/youtarr:${{ steps.tag_version.outputs.new_tag }} .
           docker push ${{ vars.DOCKERHUB_USERNAME }}/youtarr:${{ steps.tag_version.outputs.new_tag }}
 
           docker tag ${{ vars.DOCKERHUB_USERNAME }}/youtarr:${{ steps.tag_version.outputs.new_tag }} ${{ vars.DOCKERHUB_USERNAME }}/youtarr:latest
           docker push ${{ vars.DOCKERHUB_USERNAME }}/youtarr:latest
+          
+          # Also push the MariaDB image tag for consistency (users will use official mariadb:10.3)
+          echo "Note: Users should use the official mariadb:10.3 image for the database container"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,98 +1,52 @@
 # ---- Base Node ----
-FROM node:20 AS base
-ENV PATH="/usr/local/bin:/usr/local:$PATH"
+FROM node:20-slim AS base
 WORKDIR /app
 
-# ---- MariaDB Binary Stage ----
-# This stage is separate so MariaDB download is cached independently
-FROM node:20 AS mariadb-binary
-RUN apt-get update && apt-get install -y \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Download and extract MariaDB 10.3 binary (using non-systemd version which is smaller)
-# This layer will be cached unless the MariaDB URL changes
-RUN mkdir -p /opt/mariadb && \
-    curl --retry 3 --retry-delay 5 -fsSL "https://downloads.mariadb.org/rest-api/mariadb/10.3.39/mariadb-10.3.39-linux-x86_64.tar.gz" \
-    -o /tmp/mariadb-10.3.tar.gz && \
-    tar -xzf /tmp/mariadb-10.3.tar.gz -C /opt/mariadb --strip-components=1 && \
-    rm /tmp/mariadb-10.3.tar.gz
-
-# ---- System Dependencies Stage ----
-# Install system packages that rarely change
-FROM base AS system-deps
-RUN apt-get update && apt-get install -y \
-    ffmpeg \
-    libaio1 \
-    libzstd1 \
-    liblz4-1 \
-    libncurses6 \
-    psmisc \
-    wget \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install libncurses5 dependencies for MariaDB client
-RUN wget --timeout=10 --tries=3 --retry-connrefused \
-        http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb \
-    && wget --timeout=10 --tries=3 --retry-connrefused \
-        http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libncurses5_6.3-2ubuntu0.1_amd64.deb \
-    && dpkg -i libtinfo5_6.3-2ubuntu0.1_amd64.deb \
-    && dpkg -i libncurses5_6.3-2ubuntu0.1_amd64.deb \
-    && rm libtinfo5_6.3-2ubuntu0.1_amd64.deb libncurses5_6.3-2ubuntu0.1_amd64.deb
-
-# Download the latest yt-dlp release directly from GitHub
-RUN wget --timeout=10 --tries=3 https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux -O /usr/local/bin/yt-dlp && \
-    chmod +x /usr/local/bin/yt-dlp
-
-# ---- Node Dependencies Stage ----
-FROM system-deps AS node-deps
+# ---- Dependencies ----
+FROM base AS dependencies
 COPY package*.json ./
-RUN npm ci --only=production
+# Skip prepare script (husky) for production dependencies
+RUN npm ci --only=production --ignore-scripts
 
-# ---- Build Stage ----
-FROM system-deps AS build
+# ---- Build ----
+FROM base AS build
 COPY package*.json ./
 RUN npm ci
-
-# Copy MariaDB binary from the mariadb-binary stage
-COPY --from=mariadb-binary /opt/mariadb /opt/mariadb
-
-# Create necessary directories and set up MariaDB environment
-RUN mkdir -p /run/mysqld /var/lib/mysql && \
-    useradd -r -s /bin/false mysql || true && \
-    chown -R mysql:mysql /run/mysqld /var/lib/mysql
-
-# Set MariaDB binary path
-ENV PATH="/opt/mariadb/bin:$PATH"
-
-# Copy server code and built React app into the Docker image
-# Note that this causes us to be reliant on the client being built before we run the Dockerfile build
+# Copy server code and built React app
 COPY server/ ./server/
 COPY client/build/ ./client/build/
 
-# Create MariaDB configuration file since we're using binaries
-RUN mkdir -p /etc/mysql && \
-    echo "[mysqld]" > /etc/mysql/my.cnf && \
-    echo "bind-address = 0.0.0.0" >> /etc/mysql/my.cnf && \
-    echo "port = 3321" >> /etc/mysql/my.cnf && \
-    echo "datadir = /var/lib/mysql" >> /etc/mysql/my.cnf && \
-    echo "socket = /run/mysqld/mysqld.sock" >> /etc/mysql/my.cnf && \
-    echo "pid-file = /run/mysqld/mysqld.pid" >> /etc/mysql/my.cnf && \
-    echo "user = mysql" >> /etc/mysql/my.cnf && \
-    echo "" >> /etc/mysql/my.cnf && \
-    echo "[client]" >> /etc/mysql/my.cnf && \
-    echo "port = 3321" >> /etc/mysql/my.cnf && \
-    echo "socket = /run/mysqld/mysqld.sock" >> /etc/mysql/my.cnf
+# ---- Release ----
+FROM node:20-slim AS release
+WORKDIR /app
 
-# Copy the DB initialization and entrypoint scripts into the Docker image
-COPY scripts/start_mariadb.sh /usr/local/bin/
-COPY scripts/docker-entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/start_mariadb.sh /usr/local/bin/docker-entrypoint.sh
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download the latest yt-dlp release directly from GitHub
+RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp && \
+    chmod +x /usr/local/bin/yt-dlp
+
+# Copy production node_modules
+COPY --from=dependencies /app/node_modules ./node_modules
+
+# Copy application files
+COPY --from=build /app/server ./server
+COPY --from=build /app/client/build ./client/build
+
+# Copy the new simplified entrypoint script
+COPY scripts/docker-entrypoint-simple.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Expose port for the application
 EXPOSE 3011
-EXPOSE 3321
 
-# Use the entrypoint script that handles graceful shutdown
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:3011/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})" || exit 1
+
+# Use the entrypoint script
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -3,22 +3,121 @@
 These instructions are meant to explain how to do local development.
 They will show you how to run a local server with hot reload for both the Node.js server and the React client, as well as how to run database migrations.
 
+## Architecture Changes
+
+Youtarr now uses Docker Compose with separate containers:
+- **youtarr**: Node.js application container (~600MB, down from 1.5GB)
+- **youtarr-db**: MariaDB 10.3 database container
+
 ## Running the DB, server and client with hot reload for development
 
+### Option 1: Using Docker Compose (Recommended)
+
+1. Build and start the development environment:
+   ```bash
+   ./scripts/build-dev.sh
+   ./scripts/start-dev.sh
+   ```
+
+2. View logs:
+   ```bash
+   docker compose -f docker-compose.dev.yml logs -f
+   ```
+
+3. Stop the development environment:
+   ```bash
+   ./scripts/stop-dev.sh
+   ```
+
+### Option 2: Local development with hot reload
+
 1. First run the database in Docker:
-   `npm run start:db`
+   ```bash
+   npm run start:db
+   ```
 
-2. Then run the client/server:
-   `npm run dev`
+2. Then run the client/server with hot reload:
+   ```bash
+   npm run dev
+   ```
 
-3. Running migrations with this setup: `./scripts/db-migrate.sh`
+3. Running migrations with this setup:
+   ```bash
+   ./scripts/db-migrate.sh
+   ```
 
-4. Create a new migration file (to be filled in): `./scripts/db-create-migration.sh`
+4. Create a new migration file (to be filled in):
+   ```bash
+   ./scripts/db-create-migration.sh
+   ```
 
-## Creating and running a test docker image for local validation
+## Building and Testing
 
-1. `./script/build-dev.sh` then `./scripts/start-dev.sh`
+### Creating a test docker image for local validation
+
+1. Build the development image:
+   ```bash
+   ./scripts/build-dev.sh
+   ```
+   - Add `--install-deps` flag if this is your first build
+   - Add `--no-cache` flag to force download of latest yt-dlp
+
+2. Start the development containers:
+   ```bash
+   ./scripts/start-dev.sh
+   ```
+
+3. Stop the development containers:
+   ```bash
+   ./scripts/stop-dev.sh
+   ```
 
 ## Creating a release build
 
-`./scripts/create-release.sh`
+The release process is now automated via GitHub Actions:
+
+1. Merge your changes to the `main` branch
+2. Go to Actions → "Create Release V2" → Run workflow
+3. The workflow will:
+   - Bump the version
+   - Build the optimized Docker image (~600MB)
+   - Push to Docker Hub with version and latest tags
+
+## Docker Compose Details
+
+### Files
+- `docker-compose.yml` - Production configuration
+- `docker-compose.dev.yml` - Development configuration
+- `Dockerfile` - Multi-stage build for optimized image size
+
+### Key Changes from Single Container
+- MariaDB runs separately (port 3321)
+- Application connects via `DB_HOST` environment variable
+- Database data persists in `./database` directory
+- All scripts support both `docker compose` (v2) and `docker-compose` (v1)
+
+### Useful Commands
+```bash
+# View running containers
+docker compose ps
+
+# View logs for specific service
+docker compose logs -f youtarr
+docker compose logs -f youtarr-db
+
+# Restart a specific service
+docker compose restart youtarr
+
+# Execute commands in running container
+docker compose exec youtarr bash
+docker compose exec youtarr-db mysql -p123qweasd
+```
+
+## Environment Variables
+
+The application now uses these environment variables for database connection:
+- `DB_HOST` - Database host (default: localhost, docker-compose sets to youtarr-db)
+- `DB_PORT` - Database port (default: 3321)
+- `DB_USER` - Database user (default: root)
+- `DB_PASSWORD` - Database password (default: 123qweasd)
+- `DB_NAME` - Database name (default: youtarr)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Your engagement and feedback play a crucial role in shaping the future of this a
 
 To use Youtarr, you need to have the following software installed on your system:
 
-1. **Docker:** Youtarr uses Docker to create an isolated environment where it can run without interfering with your system or requiring you to install a bunch of software. You can download Docker from the official website.
+1. **Docker & Docker Compose:** Youtarr uses Docker Compose to run the application and database in separate containers. Docker Compose is included with Docker Desktop. You can download Docker from the official website.
 
 2. **Bash Shell:** Bash is a Unix shell and command language. The setup and start scripts are written in bash. For Windows users, you can use Git Bash, which is included when you install Git for Windows.
 
@@ -59,12 +59,14 @@ In order for Plex to properly pull in the poster images and metadata for the you
 
 **Before running this in either dev or production mode**: First run `./setup.sh`. This will let you select the root directory where Youtube videos that are downloaded will be placed.
 
-### To run in production mode in a Docker container (for most users)
+### To run in production mode with Docker Compose (for most users)
 
 #### NOTES:
 
 **This has been tested in git bash on Windows with Docker Desktop. This is designed to be run from the same system as your Plex server.**
 **When running in production mode with the above config, your Plex Server IP Address should be set to host.docker.internal**
+
+**NEW: Youtarr now uses Docker Compose with separate containers for the application and database. This reduces the image size by ~60% and follows Docker best practices.**
 
 This app uses Plex for auth. To login it will use Plex and then will verify that the Plex server on the local system is accessible to the Plex account you logged in to.
 
@@ -72,13 +74,24 @@ This app uses Plex for auth. To login it will use Plex and then will verify that
 
 If not you will be unable to login.
 
-1. Run `./start.sh`. The frontend UI will be exposed at `localhost:3087`
+1. Run `./start.sh`. This will start both the Youtarr application and MariaDB database containers. The frontend UI will be exposed at `localhost:3087`
 2. Once you are logged in, set your options in the Configuration screen and save them. You will want to select the Plex library that videos are supposed to be downloaded to, as well as the directory where they will be downloaded.
 3. If you want to be able to browse videos from your subscribed channels from within the app, and initiate downloads of new videos that way, you will need to enter a Youtube API Key in your Configuration page as well.
    You can get an API key at https://console.developers.google.com/apis/credentials This is not required to run the app.
-4. Once you set your download directory, you will need to restart the app. From the command line just to `./stop.sh` and then `./start.sh`
+4. Once you set your download directory, you will need to restart the app. From the command line just run `./stop.sh` and then `./start.sh`
+5. To view logs: The start/stop scripts will automatically detect whether you have `docker compose` (v2) or `docker-compose` (v1) installed and use the appropriate command. You can check logs with `docker compose logs -f` or `docker-compose logs -f`
 
    Each video will be placed in a directory named for the Youtube channel it came from.
+
+### Upgrading from Previous Versions
+
+If you're upgrading from an older version:
+
+1. Pull the latest code: `git pull`
+2. Stop the current setup: `./stop.sh` (this automatically handles both old single-container and new compose setups)
+3. Start with the new setup: `./start.sh`
+
+Your existing database in the `./database` directory will be automatically preserved and used.
 
 ## Login Troubleshooting
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,50 @@
+version: '3.8'
+
+services:
+  youtarr-db:
+    image: mariadb:10.3
+    container_name: youtarr-db-dev
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: 123qweasd
+      MYSQL_DATABASE: youtarr
+      MYSQL_TCP_PORT: 3321
+    ports:
+      - "3321:3321"
+    volumes:
+      - ./database:/var/lib/mysql
+      - ./migrations:/docker-entrypoint-initdb.d
+    command: --port=3321
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-P", "3321", "-p123qweasd"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  youtarr:
+    image: youtarr-dev:latest
+    container_name: youtarr-dev
+    restart: unless-stopped
+    depends_on:
+      youtarr-db:
+        condition: service_healthy
+    environment:
+      IN_DOCKER_CONTAINER: 1
+      DB_HOST: youtarr-db-dev
+      DB_PORT: 3321
+      DB_USER: root
+      DB_PASSWORD: 123qweasd
+      DB_NAME: youtarr
+    ports:
+      - "3087:3011"
+    volumes:
+      - ${YOUTUBE_OUTPUT_DIR}:/usr/src/app/data
+      - ./server/images:/app/server/images
+      - ./config:/app/config
+      - ./jobs:/app/jobs
+      - ./migrations:/app/migrations
+
+networks:
+  default:
+    name: youtarr-dev-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.8'
+
+services:
+  youtarr-db:
+    image: mariadb:10.3
+    container_name: youtarr-db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: 123qweasd
+      MYSQL_DATABASE: youtarr
+      MYSQL_TCP_PORT: 3321
+    ports:
+      - "3321:3321"
+    volumes:
+      - ./database:/var/lib/mysql
+      - ./migrations:/docker-entrypoint-initdb.d
+    command: --port=3321
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-P", "3321", "-p123qweasd"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  youtarr:
+    image: dialmaster/youtarr:latest
+    container_name: youtarr
+    restart: unless-stopped
+    depends_on:
+      youtarr-db:
+        condition: service_healthy
+    environment:
+      IN_DOCKER_CONTAINER: 1
+      DB_HOST: youtarr-db
+      DB_PORT: 3321
+      DB_USER: root
+      DB_PASSWORD: 123qweasd
+      DB_NAME: youtarr
+    ports:
+      - "3087:3011"
+    volumes:
+      - ${YOUTUBE_OUTPUT_DIR}:/usr/src/app/data
+      - ./server/images:/app/server/images
+      - ./config:/app/config
+      - ./jobs:/app/jobs
+      - ./migrations:/app/migrations
+
+networks:
+  default:
+    name: youtarr-network

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -24,7 +24,11 @@ cd ..
 # Build the Docker container -- do we need --no-cache?
 if [ "$1" = "--no-cache" ]
 then
-  docker build --no-cache -t youtarr-dev .
+  docker build --no-cache -t youtarr-dev:latest .
 else
-  docker build -t youtarr-dev .
+  docker build -t youtarr-dev:latest .
 fi
+
+echo ""
+echo "Development image built successfully!"
+echo "To start the development environment, run: ./scripts/start-dev.sh"

--- a/scripts/docker-entrypoint-simple.sh
+++ b/scripts/docker-entrypoint-simple.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Simple entrypoint script for Youtarr application container
+# This version doesn't need to manage MariaDB since it's in a separate container
+
+# Trap signals for graceful shutdown
+trap 'handle_shutdown' SIGTERM SIGINT
+
+# Function to handle shutdown gracefully
+handle_shutdown() {
+    echo "Received shutdown signal, stopping Node.js server gracefully..."
+    
+    # Stop Node.js server if it's running
+    if [ ! -z "$NODE_PID" ]; then
+        echo "Stopping Node.js server (PID: $NODE_PID)..."
+        kill -TERM "$NODE_PID" 2>/dev/null
+        wait "$NODE_PID" 2>/dev/null
+    fi
+    
+    echo "Shutdown complete."
+    exit 0
+}
+
+# Wait for database to be ready
+echo "Waiting for database to be ready..."
+MAX_TRIES=30
+TRIES=0
+while [ $TRIES -lt $MAX_TRIES ]; do
+    if node -e "
+        const mysql = require('mysql2/promise');
+        mysql.createConnection({
+            host: process.env.DB_HOST || 'localhost',
+            port: process.env.DB_PORT || 3321,
+            user: process.env.DB_USER || 'root',
+            password: process.env.DB_PASSWORD || '123qweasd',
+            database: process.env.DB_NAME || 'youtarr'
+        }).then(() => {
+            console.log('Database connection successful');
+            process.exit(0);
+        }).catch((err) => {
+            process.exit(1);
+        });
+    " 2>/dev/null; then
+        echo "Database is ready!"
+        break
+    fi
+    
+    TRIES=$((TRIES + 1))
+    if [ $TRIES -eq $MAX_TRIES ]; then
+        echo "Failed to connect to database after $MAX_TRIES attempts"
+        exit 1
+    fi
+    
+    echo "Waiting for database... (attempt $TRIES/$MAX_TRIES)"
+    sleep 2
+done
+
+# Start Node.js server
+echo "Starting Node.js server..."
+node /app/server/server.js &
+NODE_PID=$!
+echo "Node.js server started with PID: $NODE_PID"
+
+# Wait for Node.js process
+# This keeps the script running and allows trap to work
+wait "$NODE_PID"
+
+# If we get here, Node crashed without signal
+echo "Node.js server exited unexpectedly"
+exit 1

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,12 +1,24 @@
 #!/bin/bash
 
-# Read the selected directory from the config file
+# Function to check if docker compose (v2) or docker-compose (v1) is available
+get_compose_command() {
+    if docker compose version &>/dev/null; then
+        echo "docker compose"
+    elif docker-compose version &>/dev/null; then
+        echo "docker-compose"
+    else
+        echo "Error: Neither 'docker compose' nor 'docker-compose' command found." >&2
+        echo "Please install Docker Compose." >&2
+        exit 1
+    fi
+}
+
+# Get the appropriate compose command
+COMPOSE_CMD=$(get_compose_command)
+echo "Using compose command: $COMPOSE_CMD"
+
 # Read the selected directory from the config file
 youtubeOutputDirectory=$(python -c "import json; print(json.load(open('config/config.json'))['youtubeOutputDirectory'])")
-
-# Do not display errors from the following command
-# If the container does not exist, it will return an error, but it is not a problem
-docker rm -f youtarr 2> /dev/null
 
 # Convert the windows path to Unix path and remove trailing whitespaces
 ## ONLY NEEDED IF RUNNING IN GIT BASH!!!
@@ -17,5 +29,19 @@ if [[ "$OSTYPE" == "msys" ]]; then
   youtubeOutputDirectory="/$youtubeOutputDirectory"
 fi
 
-# Start the Docker container with the selected directory mounted
-docker run --name youtarr-dev -d -v $youtubeOutputDirectory:/usr/src/app/data -v /$(pwd)/config:/app/config -v /$(pwd)/server/images:/app/server/images -v /$(pwd)/jobs:/app/jobs -v /$(pwd)/migrations:/app/migrations -v /$(pwd)/database:/var/lib/mysql -p 3087:3011 -p 3321:3321 -e IN_DOCKER_CONTAINER=1 youtarr-dev
+# Export the YouTube output directory for docker-compose
+export YOUTUBE_OUTPUT_DIR="$youtubeOutputDirectory"
+
+# Stop and remove existing containers (if any)
+echo "Stopping existing containers..."
+$COMPOSE_CMD -f docker-compose.dev.yml down
+
+# Start the containers using docker-compose for development
+echo "Starting Youtarr development environment..."
+$COMPOSE_CMD -f docker-compose.dev.yml up -d
+
+# Show the status
+echo ""
+echo "Youtarr development environment is starting up..."
+echo "You can check the logs with: $COMPOSE_CMD -f docker-compose.dev.yml logs -f"
+echo "To stop the development environment, run: $COMPOSE_CMD -f docker-compose.dev.yml down"

--- a/scripts/stop-dev.sh
+++ b/scripts/stop-dev.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
-docker stop youtarr-dev
-docker rm youtarr-dev
 
+# Function to check if docker compose (v2) or docker-compose (v1) is available
+get_compose_command() {
+    if docker compose version &>/dev/null; then
+        echo "docker compose"
+    elif docker-compose version &>/dev/null; then
+        echo "docker-compose"
+    else
+        echo "Error: Neither 'docker compose' nor 'docker-compose' command found." >&2
+        echo "Please install Docker Compose." >&2
+        exit 1
+    fi
+}
+
+# Get the appropriate compose command
+COMPOSE_CMD=$(get_compose_command)
+echo "Using compose command: $COMPOSE_CMD"
+
+# Set a dummy value for YOUTUBE_OUTPUT_DIR since it's not needed for stopping
+export YOUTUBE_OUTPUT_DIR="/tmp"
+
+# Stop the development containers using docker-compose
+echo "Stopping Youtarr development environment..."
+$COMPOSE_CMD -f docker-compose.dev.yml down
+
+echo "Youtarr development environment has been stopped."

--- a/server/db.js
+++ b/server/db.js
@@ -1,11 +1,16 @@
 const { Sequelize } = require('sequelize');
 
-const sequelize = new Sequelize('youtarr', 'root', '123qweasd', {
-  host: 'localhost',
-  dialect: 'mysql',
-  port: 3321,
-  logging: false,
-});
+const sequelize = new Sequelize(
+  process.env.DB_NAME || 'youtarr',
+  process.env.DB_USER || 'root',
+  process.env.DB_PASSWORD || '123qweasd',
+  {
+    host: process.env.DB_HOST || 'localhost',
+    dialect: 'mysql',
+    port: process.env.DB_PORT || 3321,
+    logging: false,
+  }
+);
 
 const initializeDatabase = async () => {
   try {

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -39,10 +39,11 @@ if (fs.existsSync(jsonPath)) {
     ); // define the new path for image thumbnail
     fs.copySync(imagePath, newImageFullPath, { overwrite: true }); // copy the image thumbnail
 
-    // Resize the image using ffmpeg
+    // Resize the image using ffmpeg with proper settings to avoid deprecated format warnings
+    // Using -loglevel error to suppress the deprecated pixel format warnings but still show actual errors
     try {
       execSync(
-        `${configModule.ffmpegPath} -y -i ${newImageFullPath} -vf "scale=iw*0.5:ih*0.5" ${newImageFullPathSmall}`,
+        `${configModule.ffmpegPath} -loglevel error -y -i "${newImageFullPath}" -vf "scale=iw*0.5:ih*0.5" -q:v 2 "${newImageFullPathSmall}"`,
         { stdio: 'inherit' }
       );
       fs.rename(newImageFullPathSmall, newImageFullPath);

--- a/server/server.js
+++ b/server/server.js
@@ -45,6 +45,11 @@ const initialize = async () => {
 
     /**** ONLY ROUTES BELOW THIS LINE *********/
 
+    // Health check endpoint
+    app.get('/health', (req, res) => {
+      res.status(200).json({ status: 'healthy' });
+    });
+
     // Serve image files
     app.use('/images', express.static(path.join(__dirname, 'images')));
 

--- a/stop.sh
+++ b/stop.sh
@@ -1,4 +1,50 @@
 #!/bin/bash
-docker stop youtarr
-docker rm youtarr
 
+# Function to check if docker compose (v2) or docker-compose (v1) is available
+get_compose_command() {
+    if docker compose version &>/dev/null; then
+        echo "docker compose"
+    elif docker-compose version &>/dev/null; then
+        echo "docker-compose"
+    else
+        echo ""  # Return empty string if neither is available
+    fi
+}
+
+echo "Stopping Youtarr..."
+
+# First, try to stop and remove the old single-container version if it exists
+if docker ps -a --format '{{.Names}}' | grep -q '^youtarr$'; then
+    echo "Found old single-container Youtarr, stopping and removing it..."
+    docker stop youtarr 2>/dev/null
+    docker rm youtarr 2>/dev/null
+    echo "Old single-container Youtarr has been removed."
+fi
+
+# Now handle the docker-compose version
+COMPOSE_CMD=$(get_compose_command)
+
+if [ -n "$COMPOSE_CMD" ]; then
+    # Docker Compose is available
+    echo "Using compose command: $COMPOSE_CMD"
+    
+    # Set a dummy value for YOUTUBE_OUTPUT_DIR since it's not needed for stopping
+    export YOUTUBE_OUTPUT_DIR="/tmp"
+    
+    # Check if docker-compose containers are running
+    if $COMPOSE_CMD ps --services 2>/dev/null | grep -q 'youtarr'; then
+        echo "Stopping Youtarr docker-compose containers..."
+        $COMPOSE_CMD down
+        echo "Youtarr has been stopped."
+    else
+        # Even if no services are listed, try to bring down any orphaned containers
+        $COMPOSE_CMD down 2>/dev/null
+    fi
+else
+    # Docker Compose is not available, but we already handled the single container above
+    if ! docker ps -a --format '{{.Names}}' | grep -q '^youtarr$'; then
+        echo "Docker Compose not found and no Youtarr containers are running."
+    fi
+fi
+
+echo "Done."


### PR DESCRIPTION
- Split monolithic container into separate app and MariaDB containers
- Reduce Docker image size significantly by removing embedded MariaDB
- Add docker-compose.yml for production and docker-compose.dev.yml for development
- Update all scripts to support both docker-compose v1 and v2
- Make database connection configurable via environment variables
- Add automatic migration handling in stop.sh for seamless upgrades
- Fix ffmpeg deprecated pixel format warnings in video processing
- Add health check endpoint for container monitoring
- Update documentation for new architecture