### PR TITLE
feat: add configurable video download resolution

### DIFF
--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -32,6 +32,7 @@ function Configuration({ token }: ConfigurationProps) {
     channelAutoDownload: false,
     channelDownloadFrequency: '',
     channelFilesToDownload: 3,
+    preferredResolution: '1080',
     initialSetup: true,
     plexApiKey: '',
     youtubeOutputDirectory: '',
@@ -253,6 +254,43 @@ function Configuration({ token }: ConfigurationProps) {
                       {i + 1}
                     </MenuItem>
                   ))}
+                </Select>
+              </FormControl>
+            </Tooltip>
+          </Grid>
+          <Grid item xs={12}>
+            <Tooltip
+              placement='top-start'
+              title='The resolution we will try to download from YouTube. Note that this is not guaranteed as YouTube may not have your preferred resolution available.'
+            >
+              <FormControl fullWidth>
+                <InputLabel>Preferred download resolution</InputLabel>
+                <Select
+                  label='Preferred download resolution'
+                  value={config.preferredResolution}
+                  onChange={(event: SelectChangeEvent<string>) => {
+                    setConfig({
+                      ...config,
+                      preferredResolution: event.target.value,
+                    });
+                  }}
+                  name='preferredResolution'
+                  inputProps={{
+                    style: { fontSize: isMobile ? 'small' : 'medium' },
+                  }}
+                >
+                  <MenuItem value='2160' style={{ fontSize: isMobile ? 'small' : 'medium' }}>
+                    4k
+                  </MenuItem>
+                  <MenuItem value='1080' style={{ fontSize: isMobile ? 'small' : 'medium' }}>
+                    1080p
+                  </MenuItem>
+                  <MenuItem value='720' style={{ fontSize: isMobile ? 'small' : 'medium' }}>
+                    720p
+                  </MenuItem>
+                  <MenuItem value='480' style={{ fontSize: isMobile ? 'small' : 'medium' }}>
+                    480p
+                  </MenuItem>
                 </Select>
               </FormControl>
             </Tooltip>

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -3,6 +3,7 @@
   "channelFilesToDownload": 5,
   "channelAutoDownload": false,
   "channelDownloadFrequency": "0 * * * *",
+  "preferredResolution": "1080",
   "plexIP": "host.docker.internal",
   "plexApiKey": "",
   "plexYoutubeLibraryId": "",

--- a/server/modules/configModule.js
+++ b/server/modules/configModule.js
@@ -24,6 +24,10 @@ class ConfigModule extends EventEmitter {
       this.config.channelFilesToDownload = 3;
     }
 
+    if (!this.config.preferredResolution) {
+      this.config.preferredResolution = '1080';
+    }
+
     // Check if a UUID exists in the config
     if (!this.config.uuid) {
       // Generate a new UUID

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -209,13 +209,14 @@ class DownloadModule {
     }
   }
 
-  // Download 1080p mp4 because it contains embedded metadata
+  // Download mp4 at the user's preferred resolution because it contains embedded metadata
   // We write the info.json file to the same directory because Youtarr parses those for video information display
   getBaseCommand() {
+    const resolution = configModule.config.preferredResolution || '1080';
     return (
       'yt-dlp -4 --ffmpeg-location ' +
       configModule.ffmpegPath +
-      ' -f "bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best" --write-thumbnail --convert-thumbnails jpg ' +
+      ` -f "bestvideo[height<=${resolution}][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best" --write-thumbnail --convert-thumbnails jpg ` +
       '--download-archive ./config/complete.list --ignore-errors --embed-metadata --write-info-json ' +
       '-o "' +
       configModule.directoryPath +


### PR DESCRIPTION
- Add preferredResolution config option with 4k/1080p/720p/480p choices
- Update downloadModule to use configured resolution in yt-dlp command
- Add resolution dropdown to Configuration UI with tooltip
- Default to 1080p for backwards compatibility with existing users