### PR TITLE
feat: implement full UTF-8 (utf8mb4) support for database and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ This is a known issue with Docker Desktop on Windows where mount points can beco
 
 **Note:** This is a Docker Desktop on Windows issue, not specific to Youtarr. If this problem persists, consider running Docker natively in WSL2 without Docker Desktop for more stability.
 
+
+## UTF-8 Character Support
+
+Youtarr now supports full UTF-8 characters including emojis in channel names and video titles. 
+
+### For New Installations
+New installations automatically use `utf8mb4` encoding and will handle all Unicode characters correctly.
+
+### For Existing Installations
+If you encounter errors like `Incorrect string value: '\\xF0\\x9F\\xA7\\xA1'`, your database needs to be upgraded to support 4-byte UTF-8 characters.
+
+**Check your current setup:**
+```bash
+./scripts/check-database-charset.sh
+```
+
 ## Accessing Youtarr from Outside Your Network
 
 If you wish to access Youtarr from outside your network, or from other computers aside from the one you are running it on, you will need to forward port 3087 on your local computer firewall (Eg: Windows Defender Firewall) and on your router.

--- a/config/dbconfig.json
+++ b/config/dbconfig.json
@@ -5,7 +5,17 @@
     "database": "youtarr",
     "host": "127.0.0.1",
     "dialect": "mysql",
-    "port": 3321
+    "port": 3321,
+    "dialectOptions": {
+      "charset": "utf8mb4",
+      "collate": "utf8mb4_unicode_ci",
+      "supportBigNumbers": true,
+      "bigNumberStrings": true
+    },
+    "define": {
+      "charset": "utf8mb4",
+      "collate": "utf8mb4_unicode_ci"
+    }
   },
   "test": {
     "username": "root",
@@ -13,7 +23,17 @@
     "database": "youtarr",
     "host": "127.0.0.1",
     "dialect": "mysql",
-    "port": 3321
+    "port": 3321,
+    "dialectOptions": {
+      "charset": "utf8mb4",
+      "collate": "utf8mb4_unicode_ci",
+      "supportBigNumbers": true,
+      "bigNumberStrings": true
+    },
+    "define": {
+      "charset": "utf8mb4",
+      "collate": "utf8mb4_unicode_ci"
+    }
   },
   "production": {
     "username": "root",
@@ -21,6 +41,16 @@
     "database": "youtarr",
     "host": "127.0.0.1",
     "dialect": "mysql",
-    "port": 3321
+    "port": 3321,
+    "dialectOptions": {
+      "charset": "utf8mb4",
+      "collate": "utf8mb4_unicode_ci",
+      "supportBigNumbers": true,
+      "bigNumberStrings": true
+    },
+    "define": {
+      "charset": "utf8mb4",
+      "collate": "utf8mb4_unicode_ci"
+    }
   }
 }

--- a/config/dbconfig.json
+++ b/config/dbconfig.json
@@ -8,7 +8,6 @@
     "port": 3321,
     "dialectOptions": {
       "charset": "utf8mb4",
-      "collate": "utf8mb4_unicode_ci",
       "supportBigNumbers": true,
       "bigNumberStrings": true
     },
@@ -26,7 +25,6 @@
     "port": 3321,
     "dialectOptions": {
       "charset": "utf8mb4",
-      "collate": "utf8mb4_unicode_ci",
       "supportBigNumbers": true,
       "bigNumberStrings": true
     },
@@ -44,7 +42,6 @@
     "port": 3321,
     "dialectOptions": {
       "charset": "utf8mb4",
-      "collate": "utf8mb4_unicode_ci",
       "supportBigNumbers": true,
       "bigNumberStrings": true
     },

--- a/config/mariadb.cnf
+++ b/config/mariadb.cnf
@@ -1,0 +1,16 @@
+[mysqld]
+# Ensure utf8mb4 is the default for new databases/tables
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+init-connect = 'SET NAMES utf8mb4'
+
+# Enable full Unicode support
+innodb_large_prefix = 1
+innodb_file_format = barracuda
+innodb_file_per_table = 1
+
+[mysql]
+default-character-set = utf8mb4
+
+[client]
+default-character-set = utf8mb4

--- a/config/mariadb.cnf
+++ b/config/mariadb.cnf
@@ -6,7 +6,6 @@ init-connect = 'SET NAMES utf8mb4'
 
 # Enable full Unicode support
 innodb_large_prefix = 1
-innodb_file_format = barracuda
 innodb_file_per_table = 1
 
 [mysql]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,12 +9,16 @@ services:
       MYSQL_ROOT_PASSWORD: 123qweasd
       MYSQL_DATABASE: youtarr
       MYSQL_TCP_PORT: 3321
+      # Set utf8mb4 as default for new installations
+      MYSQL_CHARSET: utf8mb4
+      MYSQL_COLLATION: utf8mb4_unicode_ci
     ports:
       - "3321:3321"
     volumes:
       - ./database:/var/lib/mysql
       - ./migrations:/docker-entrypoint-initdb.d
-    command: --port=3321
+      - ./config/mariadb.cnf:/etc/mysql/conf.d/charset.cnf:ro
+    command: --port=3321 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-P", "3321", "-p123qweasd"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,16 @@ services:
       MYSQL_ROOT_PASSWORD: 123qweasd
       MYSQL_DATABASE: youtarr
       MYSQL_TCP_PORT: 3321
+      # Set utf8mb4 as default for new installations
+      MYSQL_CHARSET: utf8mb4
+      MYSQL_COLLATION: utf8mb4_unicode_ci
     ports:
       - "3321:3321"
     volumes:
       - ./database:/var/lib/mysql
       - ./migrations:/docker-entrypoint-initdb.d
-    command: --port=3321
+      - ./config/mariadb.cnf:/etc/mysql/conf.d/charset.cnf:ro
+    command: --port=3321 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-P", "3321", "-p123qweasd"]
       interval: 10s

--- a/migrations/20250907000000-upgrade-to-utf8mb4-if-needed.js
+++ b/migrations/20250907000000-upgrade-to-utf8mb4-if-needed.js
@@ -1,0 +1,131 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      // Check current database charset
+      const [dbInfo] = await queryInterface.sequelize.query(
+        `SELECT DEFAULT_CHARACTER_SET_NAME as charset, DEFAULT_COLLATION_NAME as collation 
+         FROM information_schema.SCHEMATA 
+         WHERE SCHEMA_NAME = DATABASE()`,
+        { transaction, type: Sequelize.QueryTypes.SELECT }
+      );
+
+      console.log(`Current database charset: ${dbInfo.charset}, collation: ${dbInfo.collation}`);
+
+      // Only migrate if not already utf8mb4
+      if (dbInfo.charset !== 'utf8mb4') {
+        console.log('Upgrading database to utf8mb4...');
+
+        // Log current state for reference
+        await queryInterface.sequelize.query(
+          `CREATE TABLE IF NOT EXISTS _charset_migration_log (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            migration_date DATETIME DEFAULT CURRENT_TIMESTAMP,
+            original_db_charset VARCHAR(50),
+            original_db_collation VARCHAR(50),
+            table_name VARCHAR(64),
+            original_table_collation VARCHAR(50),
+            new_table_collation VARCHAR(50)
+          )`,
+          { transaction }
+        );
+
+        // Log database upgrade
+        await queryInterface.sequelize.query(
+          `INSERT INTO _charset_migration_log (original_db_charset, original_db_collation, table_name) 
+           VALUES ('${dbInfo.charset}', '${dbInfo.collation}', 'DATABASE')`,
+          { transaction }
+        );
+
+        // Get all table information before migration
+        const tables = await queryInterface.sequelize.query(
+          `SELECT TABLE_NAME, TABLE_COLLATION 
+           FROM information_schema.tables 
+           WHERE TABLE_SCHEMA = DATABASE() 
+           AND TABLE_TYPE = 'BASE TABLE'
+           AND TABLE_NAME NOT LIKE '_charset_migration_log'`,
+          { transaction, type: Sequelize.QueryTypes.SELECT }
+        );
+
+        // Log each table's current state
+        for (const table of tables) {
+          await queryInterface.sequelize.query(
+            `INSERT INTO _charset_migration_log (table_name, original_table_collation) 
+             VALUES ('${table.TABLE_NAME}', '${table.TABLE_COLLATION}')`,
+            { transaction }
+          );
+        }
+
+        // Upgrade database
+        await queryInterface.sequelize.query(
+          'ALTER DATABASE youtarr CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci',
+          { transaction }
+        );
+
+        // Upgrade tables that need it
+        for (const table of tables) {
+          if (!table.TABLE_COLLATION.includes('utf8mb4')) {
+            console.log(`Converting table ${table.TABLE_NAME} from ${table.TABLE_COLLATION} to utf8mb4_unicode_ci`);
+
+            await queryInterface.sequelize.query(
+              `ALTER TABLE \`${table.TABLE_NAME}\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`,
+              { transaction }
+            );
+
+            // Update log with new collation
+            await queryInterface.sequelize.query(
+              `UPDATE _charset_migration_log 
+               SET new_table_collation = 'utf8mb4_unicode_ci' 
+               WHERE table_name = '${table.TABLE_NAME}' 
+               AND migration_date = (SELECT MAX(migration_date) FROM _charset_migration_log AS l2 WHERE l2.table_name = '${table.TABLE_NAME}')`,
+              { transaction }
+            );
+          } else {
+            console.log(`Table ${table.TABLE_NAME} already uses utf8mb4, skipping`);
+          }
+        }
+
+        console.log('UTF8mb4 migration completed successfully');
+      } else {
+        console.log('Database already uses utf8mb4, skipping migration');
+      }
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      console.error('UTF8mb4 migration failed:', error);
+      throw error;
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    // Charset migrations are irreversible to prevent data loss
+    console.log('Warning: Charset migrations cannot be safely reversed.');
+    console.log('Downgrading from utf8mb4 to utf8 may cause data loss if 4-byte characters exist.');
+    console.log('If you need to rollback, please restore from a backup taken before the migration.');
+
+    // Show migration log for reference
+    try {
+      const logs = await queryInterface.sequelize.query(
+        'SELECT * FROM _charset_migration_log ORDER BY migration_date DESC LIMIT 10',
+        { type: Sequelize.QueryTypes.SELECT }
+      );
+
+      if (logs.length > 0) {
+        console.log('Migration history:');
+        console.table(logs);
+      }
+    } catch (error) {
+      console.log('Could not retrieve migration history');
+    }
+
+    throw new Error(
+      'Charset migration rollback disabled to prevent data loss. ' +
+      'Restore from backup if rollback is absolutely necessary.'
+    );
+  },
+};

--- a/scripts/check-database-charset.sh
+++ b/scripts/check-database-charset.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+echo "Checking database charset configuration..."
+
+# Function to check if docker compose (v2) or docker-compose (v1) is available
+get_compose_command() {
+    if docker compose version &>/dev/null; then
+        echo "docker compose"
+    elif docker-compose version &>/dev/null; then
+        echo "docker-compose"
+    else
+        echo "docker"
+    fi
+}
+
+COMPOSE_CMD=$(get_compose_command)
+
+# Check if database container is running
+if [ "$COMPOSE_CMD" = "docker" ]; then
+    if ! docker ps | grep -q "youtarr-db"; then
+        echo "Error: youtarr-db container is not running"
+        exit 1
+    fi
+    DB_CONTAINER="youtarr-db"
+else
+    if ! $COMPOSE_CMD ps | grep -q "youtarr-db"; then
+        echo "Error: youtarr-db container is not running"
+        exit 1
+    fi
+    DB_CONTAINER="youtarr-db"
+fi
+
+echo "Checking database and table character sets..."
+
+docker exec -i $DB_CONTAINER mysql -u root -p123qweasd youtarr <<EOF
+SELECT 'DATABASE CHARSET:' as info, DEFAULT_CHARACTER_SET_NAME as charset, DEFAULT_COLLATION_NAME as collation
+FROM information_schema.SCHEMATA
+WHERE SCHEMA_NAME = 'youtarr';
+
+SELECT 'TABLE CHARSETS:' as info, '' as charset, '' as collation
+UNION ALL
+SELECT TABLE_NAME, TABLE_COLLATION, ''
+FROM information_schema.tables
+WHERE TABLE_SCHEMA = 'youtarr'
+AND TABLE_TYPE = 'BASE TABLE'
+ORDER BY TABLE_NAME;
+EOF
+
+echo ""
+echo "✅ If all entries show 'utf8mb4_unicode_ci', your database is properly configured"
+echo "⚠️  If you see 'utf8_' entries, run the migration to upgrade: ./scripts/db-migrate.sh"

--- a/server/db.js
+++ b/server/db.js
@@ -12,7 +12,6 @@ const sequelize = new Sequelize(
     // Ensure utf8mb4 for new connections
     dialectOptions: {
       charset: 'utf8mb4',
-      collate: 'utf8mb4_unicode_ci',
       // Additional connection options for better utf8mb4 support
       supportBigNumbers: true,
       bigNumberStrings: true
@@ -23,7 +22,6 @@ const sequelize = new Sequelize(
       // Ensure all new tables use utf8mb4 by default
       dialectOptions: {
         charset: 'utf8mb4',
-        collate: 'utf8mb4_unicode_ci'
       }
     }
   }

--- a/server/db.js
+++ b/server/db.js
@@ -9,6 +9,23 @@ const sequelize = new Sequelize(
     dialect: 'mysql',
     port: process.env.DB_PORT || 3321,
     logging: false,
+    // Ensure utf8mb4 for new connections
+    dialectOptions: {
+      charset: 'utf8mb4',
+      collate: 'utf8mb4_unicode_ci',
+      // Additional connection options for better utf8mb4 support
+      supportBigNumbers: true,
+      bigNumberStrings: true
+    },
+    define: {
+      charset: 'utf8mb4',
+      collate: 'utf8mb4_unicode_ci',
+      // Ensure all new tables use utf8mb4 by default
+      dialectOptions: {
+        charset: 'utf8mb4',
+        collate: 'utf8mb4_unicode_ci'
+      }
+    }
   }
 );
 
@@ -16,6 +33,9 @@ const initializeDatabase = async () => {
   try {
     await sequelize.authenticate();
     console.log('Connection has been established successfully.');
+
+    // Ensure connection uses utf8mb4
+    await sequelize.query("SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci");
 
     // Run migrations
     const Umzug = require('umzug');


### PR DESCRIPTION
The current database setup doesn't properly handle 4-byte UTF-8 characters (emojis, special symbols) causing errors like:

```
sqlMessage: "Incorrect string value: '\\xF0\\x9F\\xA7\\xA1 W"
```

This happens because the database is using the default `utf8` character set which only supports 3-byte UTF-8 characters, while modern Unicode characters (emojis) require 4-byte UTF-8 encoding.

This PR should address the issue and allow users to migrate if needed, and all future installs will use utf8mb4 by default.

I manually fixed the database issue yesterday when I integrated this into a Plex docker compose setup but have been unable to test this locally, so i've marked it as draft, if you could test it out, or I can try to test it fully later this week hopefully.