### PR TITLE
feat: fetch channel videos by channel id

### DIFF
--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -121,10 +121,6 @@ function ChannelVideos({ token }: ChannelVideosProps) {
 
   const videosPerPage = isMobile ? 8 : 16;
   let videosToDisplay = videos.filter((video) => {
-    // Filter out shorts (videos 70 seconds or less)
-    if (video.duration <= 70) {
-      return false;
-    }
     // Filter out downloaded videos if hideDownloaded is enabled
     return hideDownloaded ? !video.added : true;
   });
@@ -327,6 +323,13 @@ function ChannelVideos({ token }: ChannelVideosProps) {
               <TableBody>
                 {videos.length === 0 && !videoFailed && (
                   <>
+                    <TableRow>
+                      <TableCell colSpan={isMobile ? 2 : 4} align="center" sx={{ py: 2 }}>
+                        <Typography variant="body2" color="text.secondary">
+                          Refreshing channel videos — please wait
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
                     {[...Array(videosPerPage)].map((_, index) => (
                       <TableRow key={`skeleton-${index}`}>
                         {isMobile ? (

--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -559,18 +559,6 @@ describe('ChannelModule', () => {
         });
       });
 
-      test('should skip shorts (videos under 70 seconds)', () => {
-        const entry = {
-          id: 'short123',
-          title: 'Short Video',
-          duration: 60
-        };
-
-        const result = ChannelModule.parseVideoMetadata(entry);
-
-        expect(result).toBeNull();
-      });
-
       test('should handle missing fields with defaults', () => {
         const entry = {
           id: 'video123'
@@ -644,7 +632,7 @@ describe('ChannelModule', () => {
             enabled: true
           }
         ];
-        
+
         Channel.findAll = jest.fn().mockResolvedValue(mockChannels);
 
         const result = await ChannelModule.readChannels();
@@ -652,7 +640,7 @@ describe('ChannelModule', () => {
         expect(Channel.findAll).toHaveBeenCalledWith({
           where: { enabled: true }
         });
-        
+
         expect(result).toEqual([
           {
             url: 'https://youtube.com/@channel1',
@@ -731,29 +719,29 @@ describe('ChannelModule', () => {
           { url: 'https://youtube.com/@channel1' },
           { url: 'https://youtube.com/@channel2' }
         ];
-        
+
         Channel.findAll = jest.fn().mockResolvedValue(mockChannels);
         fsPromises.writeFile.mockResolvedValue();
-        
+
         const tempPath = await ChannelModule.generateChannelsFile();
-        
+
         expect(Channel.findAll).toHaveBeenCalledWith({
           where: { enabled: true },
-          attributes: ['url']
+          attributes: ['channel_id', 'url']
         });
-        
+
         expect(fsPromises.writeFile).toHaveBeenCalledWith(
           expect.stringContaining('channels-temp-'),
           'https://youtube.com/@channel1\nhttps://youtube.com/@channel2'
         );
-        
+
         expect(tempPath).toContain('channels-temp-');
       });
-      
+
       test('should handle error and cleanup temp file', async () => {
         Channel.findAll = jest.fn().mockRejectedValue(new Error('DB Error'));
         fsPromises.unlink.mockResolvedValue();
-        
+
         await expect(ChannelModule.generateChannelsFile()).rejects.toThrow('DB Error');
       });
     });


### PR DESCRIPTION
- Fetch channel videos via canonical URL built from channel ID
  - Resilient to handle/name changes
- Detect the Videos tab and exclude Shorts by URL
  - Remove duration-based shorts filtering (<=70s) during population
- Implement automatic channel URL updates when handles change
- Optimize yt-dlp fetch count based on data recency
- Improve playlist extraction for nested YouTube responses
- Add user feedback during channel video refresh

NOTE: Automatic channel downloads still use match-filter duration > 70s (and exclude subscriber_only).