### PR TITLE
feat: set downloaded video timestamps to original YouTube upload date

### DIFF
--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -79,8 +79,6 @@ if (fs.existsSync(jsonPath)) {
 
   // Set the file timestamps to match the upload date
   if (uploadDate) {
-    const timestamp = uploadDate.getTime() / 1000; // Convert to Unix timestamp
-
     // Set timestamp for the video file
     if (fs.existsSync(videoPath)) {
       try {


### PR DESCRIPTION
Sets file modification times for video, thumbnail, and directory to match the YouTube video's upload date instead of current download time.