### PR TITLE
feat: add SponsorBlock integration for automatic segment handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 - **📥 Smart Downloads**: Pre-validate YouTube URLs with metadata preview before downloading (powered by [yt-dlp](https://github.com/yt-dlp/yt-dlp))
 - **🎯 Custom Quality Settings**: Per-download resolution control with support from 360p to 4K
 - **📺 Channel Subscriptions**: Subscribe to channels and auto-download new videos
+- **🚫 SponsorBlock Integration**: Automatically remove or mark sponsored segments, intros, outros, and more using the crowdsourced SponsorBlock database
 - **🗂️ Smart Organization**: Videos organized by channel with metadata and thumbnails
 - **⏰ Scheduled Downloads**: Configure automatic downloads on your schedule (cron-based)
 - **📱 Web Interface**: Manage everything through a responsive web UI
@@ -81,6 +82,13 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 2. Set download schedule (e.g., every 6 hours)
 3. Choose video resolution and download limits
 4. (Optional) Connect Plex for auto-refresh
+
+### Configure SponsorBlock
+1. Go to Configuration page → SponsorBlock Integration section
+2. Enable SponsorBlock to automatically handle sponsored content
+3. Choose action: Remove segments entirely or mark them as chapters
+4. Select which types of segments to handle (sponsors, intros, outros, etc.)
+5. All new downloads will automatically process selected segments
 
 ## 📖 Documentation
 

--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -51,6 +51,19 @@ function Configuration({ token }: ConfigurationProps) {
     plexYoutubeLibraryId: '',
     plexIP: '',
     uuid: '',
+    sponsorblockEnabled: false,
+    sponsorblockAction: 'remove' as 'remove' | 'mark',
+    sponsorblockCategories: {
+      sponsor: true,
+      intro: false,
+      outro: false,
+      selfpromo: true,
+      preview: false,
+      filler: false,
+      interaction: false,
+      music_offtopic: false,
+    },
+    sponsorblockApiUrl: '',
   });
   const [openPlexLibrarySelector, setOpenPlexLibrarySelector] = useState(false);
   const [openPlexAuthDialog, setOpenPlexAuthDialog] = useState(false);
@@ -412,6 +425,10 @@ function Configuration({ token }: ConfigurationProps) {
       'youtubeOutputDirectory',
       'plexYoutubeLibraryId',
       'plexIP',
+      'sponsorblockEnabled',
+      'sponsorblockAction',
+      'sponsorblockCategories',
+      'sponsorblockApiUrl',
     ];
     const changed = keysToCompare.some((k) => {
       return (config as any)[k] !== (initialConfig as any)[k];
@@ -714,6 +731,126 @@ function Configuration({ token }: ConfigurationProps) {
                 </Typography>
               )}
             </Grid>
+          </Grid>
+        </AccordionDetails>
+      </Accordion>
+
+      <Accordion defaultExpanded={false} sx={{ mb: 2 }}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Optional: SponsorBlock Integration
+          </Typography>
+          <Chip
+            label={config.sponsorblockEnabled ? "Enabled" : "Disabled"}
+            color={config.sponsorblockEnabled ? "success" : "default"}
+            size="small"
+            sx={{ mr: 1 }}
+          />
+        </AccordionSummary>
+        <AccordionDetails>
+          <Alert severity="info" sx={{ mb: 2 }}>
+            <AlertTitle>What is SponsorBlock?</AlertTitle>
+            <Typography variant="body2">
+              SponsorBlock is a crowdsourced database that identifies segments in YouTube videos like sponsors, intros, outros, and self-promotions.
+              When enabled, Youtarr can automatically remove or mark these segments during download.
+            </Typography>
+          </Alert>
+
+          <Grid container spacing={2}>
+            <Grid item xs={12}>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    name="sponsorblockEnabled"
+                    checked={config.sponsorblockEnabled}
+                    onChange={(e) => setConfig({ ...config, sponsorblockEnabled: e.target.checked })}
+                  />
+                }
+                label={
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    Enable SponsorBlock
+                    {getInfoIcon('Automatically handle sponsored segments and other marked content in downloaded videos.')}
+                  </Box>
+                }
+              />
+            </Grid>
+
+            {config.sponsorblockEnabled && (
+              <>
+                <Grid item xs={12} md={6}>
+                  <FormControl fullWidth>
+                    <InputLabel>Action for Segments</InputLabel>
+                    <Select
+                      value={config.sponsorblockAction}
+                      onChange={(e) => setConfig({ ...config, sponsorblockAction: e.target.value as 'remove' | 'mark' })}
+                      label="Action for Segments"
+                    >
+                      <MenuItem value="remove">Remove segments from video</MenuItem>
+                      <MenuItem value="mark">Mark segments as chapters</MenuItem>
+                    </Select>
+                  </FormControl>
+                  <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+                    Remove: Cuts out segments entirely. Mark: Creates chapter markers for easy skipping.
+                  </Typography>
+                </Grid>
+
+                <Grid item xs={12} md={6}>
+                  <TextField
+                    fullWidth
+                    label="Custom API URL (Optional)"
+                    name="sponsorblockApiUrl"
+                    value={config.sponsorblockApiUrl}
+                    onChange={(e) => setConfig({ ...config, sponsorblockApiUrl: e.target.value })}
+                    placeholder="https://sponsor.ajay.app"
+                    helperText="Leave empty to use the default SponsorBlock API"
+                  />
+                </Grid>
+
+                <Grid item xs={12}>
+                  <Typography variant="subtitle1" gutterBottom sx={{ mt: 1, mb: 1 }}>
+                    Segment Categories to {config.sponsorblockAction === 'remove' ? 'Remove' : 'Mark'}:
+                  </Typography>
+
+                  <Grid container spacing={1}>
+                    {[
+                      { key: 'sponsor', label: 'Sponsor', description: 'Paid promotions, product placements' },
+                      { key: 'intro', label: 'Intro', description: 'Opening sequences, title cards' },
+                      { key: 'outro', label: 'Outro', description: 'End cards, credits' },
+                      { key: 'selfpromo', label: 'Self-Promotion', description: 'Channel merch, Patreon, other videos' },
+                      { key: 'preview', label: 'Preview/Recap', description: '"Coming up" or "Previously on" segments' },
+                      { key: 'filler', label: 'Filler', description: 'Tangential content, dead space' },
+                      { key: 'interaction', label: 'Interaction', description: '"Like and subscribe" reminders' },
+                      { key: 'music_offtopic', label: 'Music Off-Topic', description: 'Non-music content in music videos' },
+                    ].map(({ key, label, description }) => (
+                      <Grid item xs={12} sm={6} key={key}>
+                        <FormControlLabel
+                          control={
+                            <Checkbox
+                              checked={config.sponsorblockCategories[key as keyof typeof config.sponsorblockCategories]}
+                              onChange={(e) => setConfig({
+                                ...config,
+                                sponsorblockCategories: {
+                                  ...config.sponsorblockCategories,
+                                  [key]: e.target.checked
+                                }
+                              })}
+                            />
+                          }
+                          label={
+                            <Box>
+                              <Typography variant="body2">{label}</Typography>
+                              <Typography variant="caption" color="text.secondary">
+                                {description}
+                              </Typography>
+                            </Box>
+                          }
+                        />
+                      </Grid>
+                    ))}
+                  </Grid>
+                </Grid>
+              </>
+            )}
           </Grid>
         </AccordionDetails>
       </Accordion>

--- a/server/modules/configModule.js
+++ b/server/modules/configModule.js
@@ -28,6 +28,33 @@ class ConfigModule extends EventEmitter {
       this.config.preferredResolution = '1080';
     }
 
+    // Initialize Sponsorblock settings if not present
+    if (this.config.sponsorblockEnabled === undefined) {
+      this.config.sponsorblockEnabled = false;
+    }
+
+    if (!this.config.sponsorblockAction) {
+      this.config.sponsorblockAction = 'remove'; // 'remove' or 'mark'
+    }
+
+    if (!this.config.sponsorblockCategories) {
+      this.config.sponsorblockCategories = {
+        sponsor: true,
+        intro: false,
+        outro: false,
+        selfpromo: true,
+        preview: false,
+        filler: false,
+        interaction: false,
+        music_offtopic: false
+      };
+    }
+
+    // sponsorblockApiUrl is optional, defaults to empty string (uses default API)
+    if (this.config.sponsorblockApiUrl === undefined) {
+      this.config.sponsorblockApiUrl = '';
+    }
+
     // Check if a UUID exists in the config
     if (!this.config.uuid) {
       // Generate a new UUID

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -254,6 +254,35 @@ class DownloadModule {
     }
   }
 
+  // Build Sponsorblock args based on configuration
+  buildSponsorblockArgs(config) {
+    const args = [];
+
+    if (!config.sponsorblockEnabled) return args;
+
+    // Build categories list from enabled categories
+    const enabledCategories = Object.entries(config.sponsorblockCategories || {})
+      .filter(([, enabled]) => enabled)
+      .map(([category]) => category);
+
+    if (enabledCategories.length > 0) {
+      const categoriesStr = enabledCategories.join(',');
+
+      if (config.sponsorblockAction === 'remove') {
+        args.push('--sponsorblock-remove', categoriesStr);
+      } else if (config.sponsorblockAction === 'mark') {
+        args.push('--sponsorblock-mark', categoriesStr);
+      }
+    }
+
+    // Add custom API URL if specified
+    if (config.sponsorblockApiUrl && config.sponsorblockApiUrl.trim()) {
+      args.push('--sponsorblock-api', config.sponsorblockApiUrl.trim());
+    }
+
+    return args;
+  }
+
   // Build yt-dlp command args array for channel downloads
   getBaseCommandArgs(resolution) {
     const res = resolution || configModule.config.preferredResolution || '1080';
@@ -276,6 +305,11 @@ class DownloadModule {
       '-o', 'pl_thumbnail:',
       '--exec', `node ${path.resolve(__dirname, './videoDownloadPostProcessFiles.js')} {}`
     ];
+
+    // Add Sponsorblock args if configured
+    const sponsorblockArgs = this.buildSponsorblockArgs(configModule.config);
+    args.push(...sponsorblockArgs);
+
     return args;
   }
 
@@ -301,6 +335,11 @@ class DownloadModule {
       '-o', 'pl_thumbnail:',
       '--exec', `node ${path.resolve(__dirname, './videoDownloadPostProcessFiles.js')} {}`
     ];
+
+    // Add Sponsorblock args if configured
+    const sponsorblockArgs = this.buildSponsorblockArgs(configModule.config);
+    args.push(...sponsorblockArgs);
+
     return args;
   }
 }


### PR DESCRIPTION
Add optional SponsorBlock support to automatically remove or mark sponsored segments, intros, outros, and other content during video downloads. Users can configure which segment categories to handle and choose between removing segments entirely or marking them as chapters. Feature is disabled by default and fully configurable through the web UI.