### PR TITLE
feat: add configurable storage path for Kubernetes/Elfhosted platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 - **🔍 Browse Channels**: View all videos from subscribed channels before downloading
 - **📊 Download History**: Track what you've downloaded with smart duplicate prevention
 - **🔐 Secure Access**: Local authentication system with admin controls
+- **☁️ Platform Flexible**: Configurable storage paths for Kubernetes/Elfhosted deployments
 
 ### Optional Plex Integration
 - **🔄 Auto Library Refresh**: Automatically update Plex after downloads
@@ -111,6 +112,11 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 - **API Key**: Get it automatically via Configuration page or [manually](https://www.plexopedia.com/plex-media-server/general/plex-token/)
 - **Network Access**: Run on same machine as Plex server (the app must be able to write to the Plex library directory)
 - **Docker on Windows**: Use `host.docker.internal` as your Plex server address
+
+### For Platform Deployments (Elfhosted, etc.)
+- **Custom Data Path**: Set `DATA_PATH` environment variable for platforms requiring consistent paths across pods
+- **Example**: `DATA_PATH=/storage/rclone/storagebox/youtube`
+- **Details**: See [Docker Guide](docs/DOCKER.md#data_path-configuration-advanced) for configuration
 
 ## ⚖️ Legal Disclaimer
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,8 @@ services:
       DB_USER: root
       DB_PASSWORD: 123qweasd
       DB_NAME: youtarr
+      # Optional: Custom data path for platforms like Elfhosted (defaults to /usr/src/app/data)
+      # DATA_PATH: /storage/rclone/storagebox/youtube
     ports:
       - "3087:3011"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       DB_USER: root
       DB_PASSWORD: 123qweasd
       DB_NAME: youtarr
+      # Optional: Custom data path for platforms like Elfhosted (defaults to /usr/src/app/data)
+      # DATA_PATH: /storage/rclone/storagebox/youtube
     ports:
       - "3087:3011"
     volumes:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -97,7 +97,19 @@ environment:
   - DB_PASSWORD=123qweasd
   - DB_NAME=youtarr
   - YOUTUBE_OUTPUT_DIR=${YOUTUBE_OUTPUT_DIR}
+  # Optional: Custom data path (for Elfhosted or similar platforms)
+  # - DATA_PATH=/storage/rclone/storagebox/youtube
 ```
+
+### DATA_PATH Configuration (Advanced)
+
+The `DATA_PATH` environment variable allows customization of the video storage path **inside** the container. This is primarily for platforms like Elfhosted where paths must be consistent across all pods.
+
+- **Default**: `/usr/src/app/data` (standard Docker setup)
+- **Use case**: Platforms that mount storage at a lower level and need consistent paths across services
+- **Example**: `DATA_PATH=/storage/rclone/storagebox/youtube`
+
+**Note**: For standard Docker deployments, you don't need this. Use volume mounts instead (`${YOUTUBE_OUTPUT_DIR}:/usr/src/app/data`).
 
 ## Volume Management
 

--- a/server/modules/__tests__/configModule.test.js
+++ b/server/modules/__tests__/configModule.test.js
@@ -23,12 +23,12 @@ describe('ConfigModule', () => {
   beforeEach(() => {
     // Clear module cache
     jest.resetModules();
-    
+
     // Reset UUID mock
     jest.doMock('uuid', () => ({
       v4: jest.fn(() => 'test-uuid-1234')
     }));
-    
+
     // Mock fs module
     jest.doMock('fs', () => ({
       readFileSync: jest.fn().mockReturnValue(JSON.stringify(mockConfig)),
@@ -37,10 +37,10 @@ describe('ConfigModule', () => {
         close: jest.fn()
       })
     }));
-    
+
     // Get the mocked fs for assertions
     fs = require('fs');
-    
+
     // Clear environment
     delete process.env.IN_DOCKER_CONTAINER;
   });
@@ -56,7 +56,7 @@ describe('ConfigModule', () => {
   describe('constructor and initialization', () => {
     test('should load config from file and set defaults', () => {
       ConfigModule = require('../configModule');
-      
+
       expect(fs.readFileSync).toHaveBeenCalledWith(mockConfigPath);
       expect(ConfigModule.config).toMatchObject(mockConfig);
       expect(ConfigModule.config.channelFilesToDownload).toBe(3);
@@ -66,7 +66,7 @@ describe('ConfigModule', () => {
     test('should generate and save UUID if not present', () => {
       const uuid = require('uuid');
       ConfigModule = require('../configModule');
-      
+
       expect(uuid.v4).toHaveBeenCalled();
       expect(ConfigModule.config.uuid).toBe('test-uuid-1234');
       expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -78,10 +78,10 @@ describe('ConfigModule', () => {
     test('should not generate UUID if already present', () => {
       const configWithUuid = { ...mockConfig, uuid: 'existing-uuid' };
       fs.readFileSync.mockReturnValue(JSON.stringify(configWithUuid));
-      
+
       const uuid = require('uuid');
       ConfigModule = require('../configModule');
-      
+
       expect(uuid.v4).not.toHaveBeenCalled();
       expect(ConfigModule.config.uuid).toBe('existing-uuid');
       // Should still save for other defaults
@@ -91,21 +91,32 @@ describe('ConfigModule', () => {
     test('should use Docker paths when IN_DOCKER_CONTAINER is set', () => {
       process.env.IN_DOCKER_CONTAINER = '1';
       ConfigModule = require('../configModule');
-      
+
       expect(ConfigModule.directoryPath).toBe('/usr/src/app/data');
       expect(ConfigModule.ffmpegPath).toBe('/usr/bin/ffmpeg');
     });
 
+    test('should use custom DATA_PATH when set in Docker environment', () => {
+      process.env.IN_DOCKER_CONTAINER = '1';
+      process.env.DATA_PATH = '/storage/rclone/storagebox/youtube';
+      ConfigModule = require('../configModule');
+
+      expect(ConfigModule.directoryPath).toBe('/storage/rclone/storagebox/youtube');
+      expect(ConfigModule.ffmpegPath).toBe('/usr/bin/ffmpeg');
+
+      delete process.env.DATA_PATH;
+    });
+
     test('should use dev paths when not in Docker', () => {
       ConfigModule = require('../configModule');
-      
+
       expect(ConfigModule.directoryPath).toBe('/dev/output');
       expect(ConfigModule.ffmpegPath).toBe('/usr/local/bin/ffmpeg');
     });
 
     test('should start watching config file', () => {
       ConfigModule = require('../configModule');
-      
+
       expect(fs.watch).toHaveBeenCalledWith(mockConfigPath, expect.any(Function));
     });
   });
@@ -117,7 +128,7 @@ describe('ConfigModule', () => {
 
     test('getConfig should return current config', () => {
       const config = ConfigModule.getConfig();
-      
+
       expect(config).toMatchObject(mockConfig);
       expect(config.uuid).toBe('test-uuid-1234');
       expect(config.channelFilesToDownload).toBe(3);
@@ -127,10 +138,10 @@ describe('ConfigModule', () => {
     test('updateConfig should save and emit change event', () => {
       const changeListener = jest.fn();
       const newConfig = { ...mockConfig, plexApiKey: 'new-key' };
-      
+
       ConfigModule.on('change', changeListener);
       ConfigModule.updateConfig(newConfig);
-      
+
       expect(ConfigModule.config.plexApiKey).toBe('new-key');
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         mockConfigPath,
@@ -142,7 +153,7 @@ describe('ConfigModule', () => {
     test('saveConfig should write formatted JSON', () => {
       ConfigModule.config.testField = 'test-value';
       ConfigModule.saveConfig();
-      
+
       expect(fs.writeFileSync).toHaveBeenCalled();
       const savedData = fs.writeFileSync.mock.calls[fs.writeFileSync.mock.calls.length - 1][1];
       const parsed = JSON.parse(savedData);
@@ -158,16 +169,16 @@ describe('ConfigModule', () => {
     test('should reload config on file change', () => {
       const changeListener = jest.fn();
       ConfigModule.on('change', changeListener);
-      
+
       // Get the watch callback
       const watchCallback = fs.watch.mock.calls[0][1];
-      
+
       // Simulate file change
       const updatedConfig = { ...mockConfig, plexApiKey: 'updated-key' };
       fs.readFileSync.mockReturnValue(JSON.stringify(updatedConfig));
-      
+
       watchCallback('change');
-      
+
       expect(ConfigModule.config.plexApiKey).toBe('updated-key');
       expect(changeListener).toHaveBeenCalled();
     });
@@ -175,17 +186,17 @@ describe('ConfigModule', () => {
     test('should ignore non-change events', () => {
       const changeListener = jest.fn();
       ConfigModule.on('change', changeListener);
-      
+
       const watchCallback = fs.watch.mock.calls[0][1];
       watchCallback('rename');
-      
+
       expect(changeListener).not.toHaveBeenCalled();
     });
 
     test('stopWatchingConfig should close watcher', () => {
       const mockWatcher = { close: jest.fn() };
       fs.watch.mockReturnValue(mockWatcher);
-      
+
       // Re-require to get new watcher
       jest.resetModules();
       jest.doMock('fs', () => ({
@@ -196,10 +207,10 @@ describe('ConfigModule', () => {
       jest.doMock('uuid', () => ({
         v4: jest.fn(() => 'test-uuid-1234')
       }));
-      
+
       const FreshConfigModule = require('../configModule');
       FreshConfigModule.stopWatchingConfig();
-      
+
       expect(mockWatcher.close).toHaveBeenCalled();
     });
   });
@@ -211,10 +222,10 @@ describe('ConfigModule', () => {
 
     test('onConfigChange should register listener', () => {
       const callback = jest.fn();
-      
+
       ConfigModule.onConfigChange(callback);
       ConfigModule.emit('change');
-      
+
       expect(callback).toHaveBeenCalled();
     });
 
@@ -241,9 +252,9 @@ describe('ConfigModule', () => {
 /dev/sda1      1099511627776 549755813888 549755813888  50% /usr/src/app/data`;
 
       execFilePromise.mockResolvedValue({ stdout: mockDfOutput });
-      
+
       const status = await ConfigModule.getStorageStatus();
-      
+
       expect(execFilePromise).toHaveBeenCalledWith('df', ['-B', '1', '/usr/src/app/data']);
       expect(status).toMatchObject({
         total: 1099511627776,
@@ -260,28 +271,43 @@ describe('ConfigModule', () => {
     test('should handle df command errors', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       execFilePromise.mockRejectedValue(new Error('df command failed'));
-      
+
       const status = await ConfigModule.getStorageStatus();
-      
+
       expect(status).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Error getting storage status:',
         expect.any(Error)
       );
-      
+
       consoleErrorSpy.mockRestore();
     });
 
     test('should handle unexpected df output', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       execFilePromise.mockResolvedValue({ stdout: 'invalid output' });
-      
+
       const status = await ConfigModule.getStorageStatus();
-      
+
       expect(status).toBeNull();
       expect(consoleErrorSpy).toHaveBeenCalled();
-      
+
       consoleErrorSpy.mockRestore();
+    });
+
+    test('should use custom DATA_PATH when set', async () => {
+      process.env.DATA_PATH = '/custom/storage/path';
+      const mockDfOutput = `Filesystem     1K-blocks    Used Available Use% Mounted on
+/dev/sda1      1099511627776 549755813888 549755813888  50% /custom/storage/path`;
+
+      execFilePromise.mockResolvedValue({ stdout: mockDfOutput });
+
+      const status = await ConfigModule.getStorageStatus();
+
+      expect(execFilePromise).toHaveBeenCalledWith('df', ['-B', '1', '/custom/storage/path']);
+      expect(status).toBeTruthy();
+
+      delete process.env.DATA_PATH;
     });
   });
 
@@ -291,10 +317,10 @@ describe('ConfigModule', () => {
         plexApiKey: 'key',
         youtubeOutputDirectory: '/output'
       };
-      
+
       fs.readFileSync.mockReturnValue(JSON.stringify(minimalConfig));
       ConfigModule = require('../configModule');
-      
+
       expect(ConfigModule.config.channelFilesToDownload).toBe(3);
       expect(ConfigModule.config.preferredResolution).toBe('1080');
       expect(ConfigModule.ffmpegPath).toBeUndefined(); // No devffmpegPath in config
@@ -307,10 +333,10 @@ describe('ConfigModule', () => {
         channelFilesToDownload: 5,
         preferredResolution: '720'
       };
-      
+
       fs.readFileSync.mockReturnValue(JSON.stringify(configWithDefaults));
       ConfigModule = require('../configModule');
-      
+
       expect(ConfigModule.config.channelFilesToDownload).toBe(5);
       expect(ConfigModule.config.preferredResolution).toBe('720');
     });

--- a/server/modules/configModule.js
+++ b/server/modules/configModule.js
@@ -13,7 +13,9 @@ class ConfigModule extends EventEmitter {
 
     this.directoryPath = '';
     if (process.env.IN_DOCKER_CONTAINER) {
-      this.directoryPath = '/usr/src/app/data';
+      // Allow custom data path via environment variable (for Elfhosted compatibility)
+      // Falls back to default /usr/src/app/data for backward compatibility
+      this.directoryPath = process.env.DATA_PATH || '/usr/src/app/data';
       this.ffmpegPath = '/usr/bin/ffmpeg';
     } else {
       this.ffmpegPath = this.config.devffmpegPath;
@@ -111,8 +113,8 @@ class ConfigModule extends EventEmitter {
     const execFilePromise = util.promisify(execFile);
     
     try {
-      // Always use the fixed Docker mount path for safety
-      const dataPath = '/usr/src/app/data';
+      // Use configurable data path (falls back to /usr/src/app/data for backward compatibility)
+      const dataPath = process.env.DATA_PATH || '/usr/src/app/data';
       
       // Use execFile with array arguments to prevent shell injection
       // -B 1 forces output in bytes for accurate calculations


### PR DESCRIPTION
Add DATA_PATH environment variable to allow custom video storage paths inside containers. Enables deployment on platforms like Elfhosted where paths must be consistent across all pods. Maintains full backward compatibility with existing Docker deployments.

- Add DATA_PATH env var support with fallback to /usr/src/app/data
- Update Docker Compose files with configuration examples
- Add comprehensive test coverage for new functionality
- Document feature in README and Docker guide