### PR TITLE
feat: add full platform deployment support for Elfhosted/Kubernetes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ config/channels.list
 config/complete.list
 config/jobs.json
 config/config.json
+config/config.json.*
 database
 server/images
 
@@ -22,6 +23,8 @@ yt-dlp.exe
 client/build
 client/node_modules
 jobs/*
+config/jobs/*
+config/images/*
 
 # misc
 .DS_Store
@@ -33,3 +36,6 @@ jobs/*
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Platform deployment testing
+docker-compose.override.*

--- a/README.md
+++ b/README.md
@@ -113,10 +113,15 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 - **Network Access**: Run on same machine as Plex server (the app must be able to write to the Plex library directory)
 - **Docker on Windows**: Use `host.docker.internal` as your Plex server address
 
-### For Platform Deployments (Elfhosted, etc.)
-- **Custom Data Path**: Set `DATA_PATH` environment variable for platforms requiring consistent paths across pods
+### For Platform Deployments (Elfhosted, Kubernetes, etc.)
+Youtarr now fully supports platform-managed deployments with automatic configuration:
+
+- **Auto-Configuration**: When `DATA_PATH` is set, config.json is auto-created on first run
+- **Platform Authentication**: Set `AUTH_ENABLED=false` to bypass internal auth (when platform handles it)
+- **Pre-configured Plex**: Set `PLEX_URL` for automatic Plex server configuration
+- **Consolidated Storage**: All persistent data stored under single `/app/config` mount
 - **Example**: `DATA_PATH=/storage/rclone/storagebox/youtube`
-- **Details**: See [Docker Guide](docs/DOCKER.md#data_path-configuration-advanced) for configuration
+- **Details**: See [Docker Guide](docs/DOCKER.md#platform-deployment-configuration) for full configuration
 
 ## ⚖️ Legal Disclaimer
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -44,6 +44,7 @@ function App() {
   const [serverVersion, setServerVersion] = useState('');
   const [requiresSetup, setRequiresSetup] = useState<boolean | null>(null);
   const [checkingSetup, setCheckingSetup] = useState(true);
+  const [isPlatformManaged, setIsPlatformManaged] = useState(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const drawerWidth = isMobile ? '50%' : 240; // specify your drawer width
@@ -66,7 +67,14 @@ function App() {
       .then(data => {
         setRequiresSetup(data.requiresSetup);
         setCheckingSetup(false);
-        
+
+        if (data.platformManaged) {
+          setIsPlatformManaged(true);
+          setToken('platform-managed-auth');
+          localStorage.setItem('authToken', 'platform-managed-auth');
+          return;
+        }
+
         // If setup is required, clear ALL existing tokens to force fresh authentication
         if (data.requiresSetup) {
           localStorage.removeItem('authToken');
@@ -270,7 +278,7 @@ function App() {
                   primary='Downloaded Videos'
                 />
               </ListItem>
-              {!token && (
+              {!token && !isPlatformManaged && (
                 <ListItem
                   button
                   component={Link}
@@ -283,7 +291,7 @@ function App() {
                   />
                 </ListItem>
               )}
-              {token && (
+              {token && !isPlatformManaged && (
                 <ListItem
                   button
                   onClick={() => {
@@ -296,6 +304,15 @@ function App() {
                   <ListItemText
                     primaryTypographyProps={{ fontSize: 'large' }}
                     primary='Logout'
+                  />
+                </ListItem>
+              )}
+              {isPlatformManaged && (
+                <ListItem>
+                  <ListItemText
+                    primary="Platform Authentication"
+                    secondary="Managed by platform"
+                    secondaryTypographyProps={{ fontSize: 'small' }}
                   />
                 </ListItem>
               )}

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -203,13 +203,14 @@ class ChannelModule {
    * @returns {Promise<void>}
    */
   async resizeChannelThumbnail(channelId) {
-    const realImagePath = path.resolve(
-      __dirname,
-      `../images/channelthumb-${channelId}.jpg`
+    const imagePath = configModule.getImagePath();
+    const realImagePath = path.join(
+      imagePath,
+      `channelthumb-${channelId}.jpg`
     );
-    const smallImagePath = path.resolve(
-      __dirname,
-      `../images/channelthumb-${channelId}-small.jpg`
+    const smallImagePath = path.join(
+      imagePath,
+      `channelthumb-${channelId}-small.jpg`
     );
 
     try {
@@ -326,9 +327,10 @@ class ChannelModule {
    * @returns {Promise<void>}
    */
   async downloadChannelThumbnail(channelUrl) {
-    const imagePath = path.resolve(
-      __dirname,
-      '../images/channelthumb-%(channel_id)s.jpg'
+    const imageDir = configModule.getImagePath();
+    const imagePath = path.join(
+      imageDir,
+      'channelthumb-%(channel_id)s.jpg'
     );
 
     await this.executeYtDlpCommand([

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -68,8 +68,8 @@ class DownloadModule {
           .map((url) => {
             let id = url.split('youtu.be/')[1].trim();
             let dataPath = path.join(
-              __dirname,
-              `../../jobs/info/${id}.info.json`
+              configModule.getJobsPath(),
+              `info/${id}.info.json`
             );
             console.log('Looking for info.json file at', dataPath);
 

--- a/server/modules/jobModule.js
+++ b/server/modules/jobModule.js
@@ -8,11 +8,12 @@ const JobVideo = require('../models/jobvideo');
 const ChannelVideo = require('../models/channelvideo');
 const cron = require('node-cron');
 const MessageEmitter = require('./messageEmitter.js'); // import the helper function
+const configModule = require('./configModule');
 
 class JobModule {
   constructor() {
-    this.jobsDir = path.join(__dirname, '../../jobs');
-    this.jobsFilePath = path.join(__dirname, '../../jobs', 'jobs.json');
+    this.jobsDir = configModule.getJobsPath();
+    this.jobsFilePath = path.join(this.jobsDir, 'jobs.json');
     this.jobsFilePathOld = path.join(this.jobsDir, 'jobs.json.old');
     this.isSaving = false; // Locking mechanism to prevent multiple saves at the same time
     this.jobs = {}; // Initialize this.jobs as an empty object

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -46,8 +46,8 @@ if (fs.existsSync(jsonPath)) {
   const id = matches
     ? matches[matches.length - 1].replace(/[[\]]/g, '')
     : 'default'; // take the last match and remove brackets or use 'default'
-  const directoryPath = path.resolve(__dirname, '../../jobs/info');
-  const newImagePath = path.resolve(__dirname, '../images');
+  const directoryPath = path.join(configModule.getJobsPath(), 'info');
+  const newImagePath = configModule.getImagePath();
 
   fs.ensureDirSync(directoryPath); // ensures that the directory exists, if it doesn't it will create it
   const newJsonPath = path.join(directoryPath, `${id}.info.json`); // define the new path


### PR DESCRIPTION
- Auto-create config.json when DATA_PATH environment variable is set
- Support AUTH_ENABLED=false to bypass internal authentication
- Pre-configure Plex URL via PLEX_URL environment variable
- Consolidate persistent data under /app/config for platform deployments
- Add platform-aware paths for images and jobs storage
- Show "Platform Managed" indicators in UI for protected fields
- Fix channel thumbnails and video recording in platform mode
- Update documentation with platform deployment configuration