### PR TITLE
fix: use system temp directory for channel JSON files

### DIFF
--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -5,6 +5,7 @@ const cron = require('node-cron');
 const fs = require('fs');
 const fsPromises = fs.promises;
 const path = require('path');
+const os = require('os');
 const Channel = require('../models/channel');
 const ChannelVideo = require('../models/channelvideo');
 const MessageEmitter = require('./messageEmitter.js');
@@ -85,7 +86,7 @@ class ChannelModule {
    * @returns {Promise<any>} - Result from callback
    */
   async withTempFile(prefix, callback) {
-    const tempFilePath = path.join(__dirname, `${prefix}-${uuidv4()}.json`);
+    const tempFilePath = path.join(os.tmpdir(), `${prefix}-${uuidv4()}.json`);
     try {
       const result = await callback(tempFilePath);
       try {


### PR DESCRIPTION
Fixes read-only filesystem error in platform deployments (Elfhosted/Kubernetes) by writing temporary channel JSON files to os.tmpdir() instead of application directory. These files are temporary and immediately deleted after use.