### PR TITLE
Feature: Add series configuration for TV show organization (optional)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test:*)",
+      "Bash(npm run test:backend:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,19 @@ RUN npm ci --only=production --ignore-scripts
 FROM base AS build
 COPY package*.json ./
 RUN npm ci
-# Copy server code and built React app
+
+# Copy and build the React frontend
+COPY client/package*.json ./client/
+RUN cd client && npm ci --unsafe-perm=true --allow-root
+COPY client/ ./client/
+# Set permissions and build
+RUN chmod -R 755 ./client/node_modules/.bin || true
+RUN cd client && npm run build --unsafe-perm=true --allow-root
+
+# Copy server code, scripts, and migrations
 COPY server/ ./server/
-COPY client/build/ ./client/build/
+COPY scripts/ ./scripts/
+COPY migrations/ ./migrations/
 
 # ---- Release ----
 FROM node:20-slim AS release
@@ -36,10 +46,13 @@ COPY --from=dependencies /app/node_modules ./node_modules
 # Copy application files
 COPY --from=build /app/server ./server
 COPY --from=build /app/client/build ./client/build
+COPY --from=build /app/scripts ./scripts
+COPY --from=build /app/migrations ./migrations
 
-# Copy the new simplified entrypoint script
-COPY scripts/docker-entrypoint-simple.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+# Copy the entrypoint script
+COPY --from=build /app/scripts/docker-entrypoint-simple.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && \
+    sed -i 's/\r$//' /usr/local/bin/docker-entrypoint.sh
 
 # Expose port for the application
 EXPOSE 3011

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5310,9 +5310,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001488",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
-      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
       "funding": [
         {
           "type": "opencollective",
@@ -5326,7 +5326,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",

--- a/client/src/components/ChannelPage.tsx
+++ b/client/src/components/ChannelPage.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { Card, CardContent, Grid, Typography, Button } from '@mui/material';
+import { Card, CardContent, Grid, Typography, Button, Tabs, Tab, Box } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { Channel } from '../types/Channel';
 import ChannelVideos from './ChannelPage/ChannelVideos';
+import ChannelProfileManager from './ChannelProfiles/ChannelProfileManager';
 import KeyboardDoubleArrowLeft from '@mui/icons-material/KeyboardDoubleArrowLeft';
+import { VideoLibrary, Settings } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 
 interface ChannelPageProps {
@@ -17,6 +19,7 @@ function ChannelPage({ token }: ChannelPageProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [channel, setChannel] = useState<Channel | null>(null);
+  const [tabValue, setTabValue] = useState(0);
   const { channel_id } = useParams();
   const navigate = useNavigate();
 
@@ -42,6 +45,10 @@ function ChannelPage({ token }: ChannelPageProps) {
       .replace(/(https?:\/\/[^\s]+)/g, '<a href="$1">$1</a>')
       .replace(/(?:\r\n|\r|\n)/g, '<br />'); // replace newlines with <br />
   }
+
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setTabValue(newValue);
+  };
 
   return (
     <>
@@ -91,7 +98,30 @@ function ChannelPage({ token }: ChannelPageProps) {
         </CardContent>
       </Card>
 
-      <ChannelVideos token={token} />
+      {/* Tabs for channel content */}
+      <Card elevation={8}>
+        <Tabs value={tabValue} onChange={handleTabChange} variant="fullWidth">
+          <Tab icon={<VideoLibrary />} label="Videos" />
+          <Tab icon={<Settings />} label="Series Configuration" />
+        </Tabs>
+
+        <Box sx={{ p: 2 }}>
+          {tabValue === 0 && (
+            <ChannelVideos token={token} />
+          )}
+          {tabValue === 1 && channel?.db_id && (
+            <ChannelProfileManager
+              channelId={channel.db_id}
+              token={token || ''}
+            />
+          )}
+          {tabValue === 1 && !channel?.db_id && (
+            <Typography color="textSecondary" align="center">
+              Channel information is loading...
+            </Typography>
+          )}
+        </Box>
+      </Card>
     </>
   );
 }

--- a/client/src/components/ChannelProfiles/ChannelProfileManager.tsx
+++ b/client/src/components/ChannelProfiles/ChannelProfileManager.tsx
@@ -1,0 +1,394 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+  ListItemSecondaryAction,
+  IconButton,
+  Switch,
+  FormControlLabel,
+  Typography,
+  Chip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Alert,
+  Snackbar,
+  Tooltip,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  Edit as EditIcon,
+  Delete as DeleteIcon,
+  DragIndicator as DragIcon,
+  PlayArrow as TestIcon,
+} from '@mui/icons-material';
+import axios from 'axios';
+import ProfileEditor from './ProfileEditor';
+import FilterTester from './FilterTester';
+import { ChannelProfile, ProfileFilter } from '../../types/ChannelProfile';
+
+interface ChannelProfileManagerProps {
+  channelId: number;
+  token: string;
+}
+
+const ChannelProfileManager: React.FC<ChannelProfileManagerProps> = ({
+  channelId,
+  token,
+}) => {
+  const [profiles, setProfiles] = useState<ChannelProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingProfile, setEditingProfile] = useState<ChannelProfile | null>(null);
+  const [showEditor, setShowEditor] = useState(false);
+  const [showTester, setShowTester] = useState(false);
+  const [testingProfile, setTestingProfile] = useState<ChannelProfile | null>(null);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [profileToDelete, setProfileToDelete] = useState<ChannelProfile | null>(null);
+  const [snackbar, setSnackbar] = useState<{
+    open: boolean;
+    message: string;
+    severity: 'success' | 'error' | 'info';
+  }>({ open: false, message: '', severity: 'info' });
+
+  const showSnackbar = useCallback((message: string, severity: 'success' | 'error' | 'info') => {
+    setSnackbar({ open: true, message, severity });
+  }, []);
+
+  const loadProfiles = useCallback(async () => {
+    try {
+      setLoading(true);
+      const response = await axios.get(`/api/channels/${channelId}/profiles`, {
+        headers: { 'x-access-token': token },
+      });
+      setProfiles(response.data);
+    } catch (error) {
+      console.error('Error loading profiles:', error);
+      showSnackbar('Error loading profiles', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [channelId, token, showSnackbar]);
+
+  useEffect(() => {
+    loadProfiles();
+  }, [loadProfiles]);
+
+  const handleCloseSnackbar = () => {
+    setSnackbar({ ...snackbar, open: false });
+  };
+
+  const handleCreateProfile = () => {
+    setEditingProfile(null);
+    setShowEditor(true);
+  };
+
+  const handleEditProfile = (profile: ChannelProfile) => {
+    setEditingProfile(profile);
+    setShowEditor(true);
+  };
+
+  const handleSaveProfile = async (profileData: Partial<ChannelProfile>) => {
+    try {
+      if (editingProfile) {
+        // Update existing profile
+        await axios.put(`/api/profiles/${editingProfile.id}`, profileData, {
+          headers: { 'x-access-token': token },
+        });
+        showSnackbar('Profile updated successfully', 'success');
+      } else {
+        // Create new profile
+        await axios.post(`/api/channels/${channelId}/profiles`, profileData, {
+          headers: { 'x-access-token': token },
+        });
+        showSnackbar('Profile created successfully', 'success');
+      }
+
+      setShowEditor(false);
+      setEditingProfile(null);
+      await loadProfiles();
+    } catch (error) {
+      console.error('Error saving profile:', error);
+      showSnackbar('Error saving profile', 'error');
+    }
+  };
+
+  const handleDeleteProfile = (profile: ChannelProfile) => {
+    setProfileToDelete(profile);
+    setDeleteConfirmOpen(true);
+  };
+
+  const confirmDeleteProfile = async () => {
+    if (!profileToDelete) return;
+
+    try {
+      await axios.delete(`/api/profiles/${profileToDelete.id}`, {
+        headers: { 'x-access-token': token },
+      });
+      showSnackbar('Profile deleted successfully', 'success');
+      setDeleteConfirmOpen(false);
+      setProfileToDelete(null);
+      await loadProfiles();
+    } catch (error) {
+      console.error('Error deleting profile:', error);
+      showSnackbar('Error deleting profile', 'error');
+    }
+  };
+
+  const handleToggleEnabled = async (profile: ChannelProfile) => {
+    try {
+      await axios.put(
+        `/api/profiles/${profile.id}`,
+        { enabled: !profile.enabled },
+        { headers: { 'x-access-token': token } }
+      );
+      await loadProfiles();
+      showSnackbar(
+        `Profile ${profile.enabled ? 'disabled' : 'enabled'}`,
+        'success'
+      );
+    } catch (error) {
+      console.error('Error toggling profile:', error);
+      showSnackbar('Error updating profile', 'error');
+    }
+  };
+
+  const handleTestProfile = (profile: ChannelProfile) => {
+    setTestingProfile(profile);
+    setShowTester(true);
+  };
+
+  const getFilterSummary = (filters: ProfileFilter[]) => {
+    if (!filters || filters.length === 0) {
+      return 'No filters';
+    }
+
+    const filterTypes = filters.map(f => {
+      switch (f.filter_type) {
+        case 'title_regex':
+          return 'Regex';
+        case 'title_contains':
+          return 'Contains';
+        case 'duration_range':
+          return 'Duration';
+        default:
+          return 'Unknown';
+      }
+    });
+
+    return filterTypes.join(', ');
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader title="Series Configuration" />
+        <CardContent>
+          <Typography>Loading profiles...</Typography>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader
+          title="Series Configuration"
+          subheader="Configure automatic series organization for this channel"
+          action={
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={handleCreateProfile}
+              color="primary"
+            >
+              Add Profile
+            </Button>
+          }
+        />
+        <CardContent>
+          {profiles.length === 0 ? (
+            <Alert severity="info">
+              No series profiles configured. Videos will be downloaded using the standard naming convention.
+              Create a profile to enable automatic series organization.
+            </Alert>
+          ) : (
+            <List>
+              {profiles.map((profile, index) => (
+                <ListItem
+                  key={profile.id}
+                  divider={index < profiles.length - 1}
+                  sx={{
+                    opacity: profile.enabled ? 1 : 0.6,
+                    backgroundColor: profile.is_default ? 'action.hover' : 'transparent',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', mr: 2 }}>
+                    <DragIcon color="disabled" />
+                  </Box>
+
+                  <ListItemText
+                    primary={
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography variant="subtitle1" component="span">
+                          {profile.profile_name}
+                        </Typography>
+                        {profile.is_default && (
+                          <Chip
+                            label="Default"
+                            size="small"
+                            color="secondary"
+                            variant="outlined"
+                          />
+                        )}
+                        {profile.generate_nfo && (
+                          <Chip
+                            label="NFO"
+                            size="small"
+                            color="info"
+                            variant="outlined"
+                          />
+                        )}
+                      </Box>
+                    }
+                    secondary={
+                      <Box>
+                        <Typography variant="body2" color="textSecondary">
+                          Season {profile.season_number} • Episode {profile.episode_counter} • {getFilterSummary(profile.filters)}
+                        </Typography>
+                        <Typography variant="body2" color="textSecondary" noWrap>
+                          Template: {profile.naming_template}
+                        </Typography>
+                        {profile.destination_path && (
+                          <Typography variant="body2" color="textSecondary" noWrap>
+                            Path: {profile.destination_path}
+                          </Typography>
+                        )}
+                      </Box>
+                    }
+                  />
+
+                  <ListItemSecondaryAction>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <FormControlLabel
+                        control={
+                          <Switch
+                            checked={profile.enabled}
+                            onChange={() => handleToggleEnabled(profile)}
+                            size="small"
+                          />
+                        }
+                        label=""
+                        sx={{ m: 0 }}
+                      />
+
+                      <Tooltip title="Test Filters">
+                        <IconButton
+                          onClick={() => handleTestProfile(profile)}
+                          size="small"
+                          color="info"
+                        >
+                          <TestIcon />
+                        </IconButton>
+                      </Tooltip>
+
+                      <Tooltip title="Edit Profile">
+                        <IconButton
+                          onClick={() => handleEditProfile(profile)}
+                          size="small"
+                          color="primary"
+                        >
+                          <EditIcon />
+                        </IconButton>
+                      </Tooltip>
+
+                      <Tooltip title="Delete Profile">
+                        <IconButton
+                          onClick={() => handleDeleteProfile(profile)}
+                          size="small"
+                          color="error"
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </Tooltip>
+                    </Box>
+                  </ListItemSecondaryAction>
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Profile Editor Dialog */}
+      <ProfileEditor
+        open={showEditor}
+        profile={editingProfile}
+        onClose={() => {
+          setShowEditor(false);
+          setEditingProfile(null);
+        }}
+        onSave={handleSaveProfile}
+        token={token}
+      />
+
+      {/* Filter Tester Dialog */}
+      {testingProfile && (
+        <FilterTester
+          open={showTester}
+          profile={testingProfile}
+          token={token}
+          onClose={() => {
+            setShowTester(false);
+            setTestingProfile(null);
+          }}
+        />
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={deleteConfirmOpen}
+        onClose={() => setDeleteConfirmOpen(false)}
+      >
+        <DialogTitle>Delete Profile</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete the profile "{profileToDelete?.profile_name}"?
+            This action cannot be undone.
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteConfirmOpen(false)}>Cancel</Button>
+          <Button onClick={confirmDeleteProfile} color="error" autoFocus>
+            Delete
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Snackbar for notifications */}
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity={snackbar.severity}
+          variant="filled"
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+export default ChannelProfileManager;

--- a/client/src/components/ChannelProfiles/FilterBuilder.tsx
+++ b/client/src/components/ChannelProfiles/FilterBuilder.tsx
@@ -1,0 +1,299 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  TextField,
+  IconButton,
+  Typography,
+  Alert,
+  Chip,
+  Paper,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  DragIndicator as DragIcon,
+  Help as HelpIcon,
+} from '@mui/icons-material';
+import { ProfileFilter } from '../../types/ChannelProfile';
+
+interface FilterBuilderProps {
+  filters: ProfileFilter[];
+  onChange: (filters: ProfileFilter[]) => void;
+  error?: string;
+}
+
+const FilterBuilder: React.FC<FilterBuilderProps> = ({
+  filters,
+  onChange,
+  error,
+}) => {
+  const [newFilter, setNewFilter] = useState<Partial<ProfileFilter>>({
+    filter_type: 'title_contains',
+    filter_value: '',
+    priority: filters.length,
+  });
+
+  const [regexValidation, setRegexValidation] = useState<Record<number, string>>({});
+
+  const handleAddFilter = () => {
+    if (!newFilter.filter_value?.trim()) return;
+
+    const filter: ProfileFilter = {
+      filter_type: newFilter.filter_type as ProfileFilter['filter_type'],
+      filter_value: newFilter.filter_value.trim(),
+      priority: filters.length,
+    };
+
+    onChange([...filters, filter]);
+    setNewFilter({
+      filter_type: 'title_contains',
+      filter_value: '',
+      priority: filters.length + 1,
+    });
+  };
+
+  const handleRemoveFilter = (index: number) => {
+    const updatedFilters = filters.filter((_, i) => i !== index);
+    // Reorder priorities
+    const reorderedFilters = updatedFilters.map((filter, i) => ({
+      ...filter,
+      priority: i,
+    }));
+    onChange(reorderedFilters);
+  };
+
+  const handleFilterChange = (index: number, field: keyof ProfileFilter, value: any) => {
+    const updatedFilters = [...filters];
+    updatedFilters[index] = {
+      ...updatedFilters[index],
+      [field]: value,
+    };
+
+    // Validate regex if it's a regex filter
+    if (field === 'filter_value' && updatedFilters[index].filter_type === 'title_regex') {
+      validateRegex(index, value);
+    }
+
+    onChange(updatedFilters);
+  };
+
+  const validateRegex = (index: number, pattern: string) => {
+    try {
+      new RegExp(pattern, 'i');
+      setRegexValidation(prev => {
+        const newValidation = { ...prev };
+        delete newValidation[index];
+        return newValidation;
+      });
+    } catch (error) {
+      setRegexValidation(prev => ({
+        ...prev,
+        [index]: 'Invalid regex pattern',
+      }));
+    }
+  };
+
+  const moveFilter = (fromIndex: number, toIndex: number) => {
+    if (toIndex < 0 || toIndex >= filters.length) return;
+
+    const updatedFilters = [...filters];
+    const [movedFilter] = updatedFilters.splice(fromIndex, 1);
+    updatedFilters.splice(toIndex, 0, movedFilter);
+
+    // Reorder priorities
+    const reorderedFilters = updatedFilters.map((filter, i) => ({
+      ...filter,
+      priority: i,
+    }));
+
+    onChange(reorderedFilters);
+  };
+
+  const getFilterTypeLabel = (type: ProfileFilter['filter_type']) => {
+    switch (type) {
+      case 'title_regex':
+        return 'Title Regex';
+      case 'title_contains':
+        return 'Title Contains';
+      case 'duration_range':
+        return 'Duration Range';
+      default:
+        return type;
+    }
+  };
+
+  const getFilterHelperText = (type: ProfileFilter['filter_type']) => {
+    switch (type) {
+      case 'title_regex':
+        return 'Regular expression pattern (e.g., "Episode \\d+:")';
+      case 'title_contains':
+        return 'Text that must be in the title (e.g., "Tutorial")';
+      case 'duration_range':
+        return 'Duration range in seconds (e.g., "300-1800" for 5-30 minutes)';
+      default:
+        return '';
+    }
+  };
+
+  const validateDurationRange = (value: string): boolean => {
+    if (!value.includes('-')) return false;
+    const [min, max] = value.split('-').map(Number);
+    return !isNaN(min) && !isNaN(max) && min >= 0 && max > min;
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {/* Existing Filters */}
+      {filters.map((filter, index) => (
+        <Card key={index} variant="outlined">
+          <CardContent sx={{ py: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <IconButton
+                  size="small"
+                  onClick={() => moveFilter(index, index - 1)}
+                  disabled={index === 0}
+                >
+                  ↑
+                </IconButton>
+                <DragIcon color="disabled" />
+                <IconButton
+                  size="small"
+                  onClick={() => moveFilter(index, index + 1)}
+                  disabled={index === filters.length - 1}
+                >
+                  ↓
+                </IconButton>
+              </Box>
+
+              <Chip
+                label={`Priority ${index + 1}`}
+                size="small"
+                variant="outlined"
+              />
+
+              <FormControl sx={{ minWidth: 150 }}>
+                <Select
+                  value={filter.filter_type}
+                  onChange={(e) => handleFilterChange(index, 'filter_type', e.target.value)}
+                  size="small"
+                >
+                  <MenuItem value="title_contains">Title Contains</MenuItem>
+                  <MenuItem value="title_regex">Title Regex</MenuItem>
+                  <MenuItem value="duration_range">Duration Range</MenuItem>
+                </Select>
+              </FormControl>
+
+              <TextField
+                value={filter.filter_value}
+                onChange={(e) => handleFilterChange(index, 'filter_value', e.target.value)}
+                placeholder={getFilterHelperText(filter.filter_type)}
+                error={Boolean(regexValidation[index]) || Boolean(
+                  filter.filter_type === 'duration_range' &&
+                  filter.filter_value &&
+                  !validateDurationRange(filter.filter_value)
+                )}
+                helperText={regexValidation[index] ||
+                           (filter.filter_type === 'duration_range' &&
+                            filter.filter_value && !validateDurationRange(filter.filter_value) ?
+                            'Invalid format. Use "min-max" (e.g., "300-1800")' : '')}
+                sx={{ flex: 1 }}
+                size="small"
+              />
+
+              <IconButton
+                onClick={() => handleRemoveFilter(index)}
+                color="error"
+                size="small"
+              >
+                <DeleteIcon />
+              </IconButton>
+            </Box>
+
+            <Typography variant="caption" color="textSecondary" sx={{ mt: 1, display: 'block' }}>
+              {getFilterTypeLabel(filter.filter_type)}: {getFilterHelperText(filter.filter_type)}
+            </Typography>
+          </CardContent>
+        </Card>
+      ))}
+
+      {/* Add New Filter */}
+      <Paper sx={{ p: 2, bgcolor: 'grey.50' }}>
+        <Typography variant="subtitle2" gutterBottom>
+          Add New Filter
+        </Typography>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <FormControl sx={{ minWidth: 150 }}>
+            <InputLabel>Filter Type</InputLabel>
+            <Select
+              value={newFilter.filter_type || 'title_contains'}
+              onChange={(e) => setNewFilter({ ...newFilter, filter_type: e.target.value as ProfileFilter['filter_type'] })}
+              label="Filter Type"
+              size="small"
+            >
+              <MenuItem value="title_contains">Title Contains</MenuItem>
+              <MenuItem value="title_regex">Title Regex</MenuItem>
+              <MenuItem value="duration_range">Duration Range</MenuItem>
+            </Select>
+          </FormControl>
+
+          <TextField
+            label="Filter Value"
+            value={newFilter.filter_value || ''}
+            onChange={(e) => setNewFilter({ ...newFilter, filter_value: e.target.value })}
+            placeholder={getFilterHelperText(newFilter.filter_type as ProfileFilter['filter_type'])}
+            sx={{ flex: 1 }}
+            size="small"
+          />
+
+          <Button
+            onClick={handleAddFilter}
+            variant="contained"
+            startIcon={<AddIcon />}
+            disabled={!newFilter.filter_value?.trim()}
+          >
+            Add
+          </Button>
+        </Box>
+
+        <Typography variant="caption" color="textSecondary" sx={{ mt: 1, display: 'block' }}>
+          {getFilterHelperText(newFilter.filter_type as ProfileFilter['filter_type'])}
+        </Typography>
+      </Paper>
+
+      {/* Help Section */}
+      <Alert severity="info" icon={<HelpIcon />}>
+        <Typography variant="body2">
+          <strong>Filter Evaluation:</strong> All filters must match for a video to be assigned to this profile.
+          Filters are evaluated in priority order (top to bottom).
+        </Typography>
+        <Box sx={{ mt: 1 }}>
+          <Typography variant="caption" component="div">
+            <strong>Examples:</strong>
+          </Typography>
+          <Typography variant="caption" component="div">
+            • <strong>Title Contains:</strong> "Python Tutorial" → matches "Python Tutorial: Variables"
+          </Typography>
+          <Typography variant="caption" component="div">
+            • <strong>Title Regex:</strong> "Episode \d+:" → matches "Episode 5: Advanced Topics"
+          </Typography>
+          <Typography variant="caption" component="div">
+            • <strong>Duration Range:</strong> "300-1800" → matches videos between 5-30 minutes
+          </Typography>
+        </Box>
+      </Alert>
+    </Box>
+  );
+};
+
+export default FilterBuilder;

--- a/client/src/components/ChannelProfiles/FilterTester.tsx
+++ b/client/src/components/ChannelProfiles/FilterTester.tsx
@@ -1,0 +1,272 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+  CircularProgress,
+  Alert,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Chip,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  TextField,
+  InputAdornment,
+} from '@mui/material';
+import {
+  ExpandMore as ExpandMoreIcon,
+  Search as SearchIcon,
+  CheckCircle as CheckIcon,
+  Cancel as CancelIcon,
+} from '@mui/icons-material';
+import axios from 'axios';
+import { ChannelProfile } from '../../types/ChannelProfile';
+
+interface VideoMatch {
+  video_id: number;
+  youtube_id: string;
+  original_title: string;
+  clean_title: string;
+  new_filename: string;
+  season: number;
+  episode: number;
+  matched_by_filter: boolean;
+}
+
+interface FilterTesterProps {
+  open: boolean;
+  profile: ChannelProfile;
+  token: string;
+  onClose: () => void;
+}
+
+const FilterTester: React.FC<FilterTesterProps> = ({
+  open,
+  profile,
+  token,
+  onClose,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [matches, setMatches] = useState<VideoMatch[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  useEffect(() => {
+    if (open && profile) {
+      testFilters();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, profile]);
+
+  const testFilters = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await axios.post(
+        `/api/profiles/${profile.id}/test`,
+        {},
+        { headers: { 'x-access-token': token } }
+      );
+      setMatches(response.data.matches || []);
+    } catch (err) {
+      console.error('Error testing filters:', err);
+      setError('Failed to test filters');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const filteredMatches = matches.filter(match =>
+    match.original_title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    match.new_filename.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const matchedCount = matches.filter(m => m.matched_by_filter).length;
+  const totalCount = matches.length;
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>
+        Test Filters: {profile.profile_name}
+        {profile.is_default && (
+          <Chip label="Default Profile" size="small" color="secondary" sx={{ ml: 2 }} />
+        )}
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {/* Profile Info */}
+          <Accordion>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="h6">Profile Configuration</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Typography variant="body2">
+                  <strong>Naming Template:</strong> {profile.naming_template}
+                </Typography>
+                <Typography variant="body2">
+                  <strong>Season:</strong> {profile.season_number}
+                </Typography>
+                <Typography variant="body2">
+                  <strong>Filters:</strong>
+                </Typography>
+                {profile.filters && profile.filters.length > 0 ? (
+                  <Box sx={{ pl: 2 }}>
+                    {profile.filters.map((filter, index) => (
+                      <Typography key={index} variant="body2" sx={{ mb: 1 }}>
+                        {index + 1}. <strong>{filter.filter_type}:</strong> {filter.filter_value}
+                      </Typography>
+                    ))}
+                  </Box>
+                ) : (
+                  <Typography variant="body2" color="textSecondary" sx={{ pl: 2 }}>
+                    No filters (default profile catches all videos)
+                  </Typography>
+                )}
+              </Box>
+            </AccordionDetails>
+          </Accordion>
+
+          {/* Results Summary */}
+          {!loading && !error && (
+            <Alert
+              severity={matchedCount > 0 ? 'success' : 'info'}
+              icon={matchedCount > 0 ? <CheckIcon /> : <CancelIcon />}
+            >
+              <Typography variant="body2">
+                {profile.is_default ? (
+                  `Found ${totalCount} videos that would be processed as specials (Season 00)`
+                ) : (
+                  `Found ${matchedCount} matching videos out of ${totalCount} total videos in channel`
+                )}
+              </Typography>
+            </Alert>
+          )}
+
+          {/* Search */}
+          {matches.length > 0 && (
+            <TextField
+              placeholder="Search videos..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon />
+                  </InputAdornment>
+                ),
+              }}
+              size="small"
+            />
+          )}
+
+          {/* Loading */}
+          {loading && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress />
+              <Typography sx={{ ml: 2 }}>Testing filters...</Typography>
+            </Box>
+          )}
+
+          {/* Error */}
+          {error && (
+            <Alert severity="error">
+              {error}
+              <Button onClick={testFilters} sx={{ ml: 2 }}>
+                Retry
+              </Button>
+            </Alert>
+          )}
+
+          {/* Results Table */}
+          {!loading && !error && filteredMatches.length > 0 && (
+            <TableContainer component={Paper} sx={{ maxHeight: 400 }}>
+              <Table stickyHeader size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Match</TableCell>
+                    <TableCell>Episode</TableCell>
+                    <TableCell>Original Title</TableCell>
+                    <TableCell>New Filename</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {filteredMatches.map((match, index) => (
+                    <TableRow key={match.video_id}>
+                      <TableCell>
+                        {match.matched_by_filter ? (
+                          <CheckIcon color="success" fontSize="small" />
+                        ) : (
+                          <Chip label="Default" size="small" color="secondary" />
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2">
+                          S{String(match.season).padStart(2, '0')}E{String(match.episode).padStart(3, '0')}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2" noWrap>
+                          {match.original_title}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography
+                          variant="body2"
+                          noWrap
+                          sx={{
+                            fontFamily: 'monospace',
+                            fontSize: '0.8rem',
+                            maxWidth: 300,
+                          }}
+                        >
+                          {match.new_filename}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+
+          {/* No Results */}
+          {!loading && !error && matches.length === 0 && (
+            <Alert severity="info">
+              No videos found in this channel to test against.
+            </Alert>
+          )}
+
+          {/* Filtered No Results */}
+          {!loading && !error && matches.length > 0 && filteredMatches.length === 0 && searchTerm && (
+            <Alert severity="info">
+              No videos match your search term "{searchTerm}".
+            </Alert>
+          )}
+        </Box>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={testFilters} disabled={loading}>
+          Refresh
+        </Button>
+        <Button onClick={onClose} variant="contained">
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default FilterTester;

--- a/client/src/components/ChannelProfiles/FolderBrowser.tsx
+++ b/client/src/components/ChannelProfiles/FolderBrowser.tsx
@@ -1,0 +1,258 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Box,
+  Typography,
+  Breadcrumbs,
+  Link,
+  CircularProgress,
+  Alert,
+  IconButton,
+  Tooltip,
+} from '@mui/material';
+import {
+  Folder as FolderIcon,
+  FolderOpen as FolderOpenIcon,
+  ArrowUpward as ArrowUpIcon,
+  Home as HomeIcon,
+  CheckCircle as CheckIcon,
+} from '@mui/icons-material';
+import axios from 'axios';
+
+interface FolderBrowserProps {
+  open: boolean;
+  currentPath?: string;
+  onClose: () => void;
+  onSelect: (path: string) => void;
+  token: string;
+}
+
+interface DirectoryItem {
+  name: string;
+  path: string;
+  isWritable: boolean;
+}
+
+interface BrowseResponse {
+  currentPath: string;
+  parentPath: string | null;
+  directories: DirectoryItem[];
+  defaultPath: string;
+}
+
+const FolderBrowser: React.FC<FolderBrowserProps> = ({
+  open,
+  currentPath,
+  onClose,
+  onSelect,
+  token,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [browseData, setBrowseData] = useState<BrowseResponse | null>(null);
+  const [selectedPath, setSelectedPath] = useState(currentPath || '');
+
+  const fetchDirectories = async (path?: string) => {
+    setLoading(true);
+    setError('');
+
+    try {
+      const response = await axios.get('/api/browse-directories', {
+        params: { path },
+        headers: { 'x-access-token': token },
+      });
+      setBrowseData(response.data);
+      setSelectedPath(response.data.currentPath);
+    } catch (err) {
+      console.error('Error browsing directories:', err);
+      setError('Failed to browse directories');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      fetchDirectories(currentPath);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, currentPath]);
+
+  const handleNavigate = (path: string) => {
+    fetchDirectories(path);
+  };
+
+  const handleGoToParent = () => {
+    if (browseData?.parentPath) {
+      fetchDirectories(browseData.parentPath);
+    }
+  };
+
+  const handleGoToDefault = () => {
+    if (browseData?.defaultPath) {
+      fetchDirectories(browseData.defaultPath);
+    }
+  };
+
+  const handleSelect = () => {
+    onSelect(selectedPath);
+    onClose();
+  };
+
+  const getPathBreadcrumbs = () => {
+    if (!browseData) return [];
+
+    const parts = browseData.currentPath.split(/[/\\]/).filter(Boolean);
+    const breadcrumbs: { name: string; path: string }[] = [];
+
+    // Add root
+    breadcrumbs.push({ name: 'Root', path: '/' });
+
+    // Build path incrementally
+    let currentPath = '';
+    parts.forEach(part => {
+      currentPath += '/' + part;
+      breadcrumbs.push({ name: part, path: currentPath });
+    });
+
+    return breadcrumbs;
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: { height: '80vh' }
+      }}
+    >
+      <DialogTitle>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Typography variant="h6">Select Destination Folder</Typography>
+          <Box>
+            <Tooltip title="Go to default download directory">
+              <IconButton onClick={handleGoToDefault} size="small">
+                <HomeIcon />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
+      </DialogTitle>
+
+      <DialogContent>
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            {error}
+          </Alert>
+        )}
+
+        {browseData && (
+          <Box sx={{ mb: 2 }}>
+            <Breadcrumbs sx={{ mb: 2 }}>
+              {getPathBreadcrumbs().map((crumb, index) => {
+                const isLast = index === getPathBreadcrumbs().length - 1;
+                return isLast ? (
+                  <Typography key={crumb.path} color="text.primary">
+                    {crumb.name}
+                  </Typography>
+                ) : (
+                  <Link
+                    key={crumb.path}
+                    component="button"
+                    variant="body2"
+                    onClick={() => handleNavigate(crumb.path)}
+                    underline="hover"
+                  >
+                    {crumb.name}
+                  </Link>
+                );
+              })}
+            </Breadcrumbs>
+
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              Current: {browseData.currentPath}
+            </Typography>
+          </Box>
+        )}
+
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <List>
+            {browseData?.parentPath && (
+              <ListItem disablePadding>
+                <ListItemButton onClick={handleGoToParent}>
+                  <ListItemIcon>
+                    <ArrowUpIcon />
+                  </ListItemIcon>
+                  <ListItemText primary=".." secondary="Parent directory" />
+                </ListItemButton>
+              </ListItem>
+            )}
+
+            {browseData?.directories.map((dir) => (
+              <ListItem
+                key={dir.path}
+                disablePadding
+                secondaryAction={
+                  selectedPath === dir.path && (
+                    <CheckIcon color="primary" />
+                  )
+                }
+              >
+                <ListItemButton
+                  onClick={() => handleNavigate(dir.path)}
+                  selected={selectedPath === dir.path}
+                >
+                  <ListItemIcon>
+                    {selectedPath === dir.path ? <FolderOpenIcon /> : <FolderIcon />}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={dir.name}
+                    secondary={!dir.isWritable ? 'Read-only' : undefined}
+                  />
+                </ListItemButton>
+              </ListItem>
+            ))}
+
+            {browseData?.directories.length === 0 && (
+              <ListItem>
+                <ListItemText
+                  primary="No subdirectories"
+                  secondary="You can select this folder or go back"
+                />
+              </ListItem>
+            )}
+          </List>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={handleSelect}
+          variant="contained"
+          disabled={!selectedPath || loading}
+          startIcon={<CheckIcon />}
+        >
+          Select This Folder
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default FolderBrowser;

--- a/client/src/components/ChannelProfiles/NamingTemplateEditor.tsx
+++ b/client/src/components/ChannelProfiles/NamingTemplateEditor.tsx
@@ -1,0 +1,342 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  TextField,
+  Button,
+  Typography,
+  Chip,
+  Paper,
+  Alert,
+  Divider,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  ContentCopy as CopyIcon,
+} from '@mui/icons-material';
+
+interface TemplateVariable {
+  var: string;
+  desc: string;
+}
+
+interface NamingTemplateEditorProps {
+  template: string;
+  onChange: (template: string) => void;
+  error?: string;
+  variables: TemplateVariable[];
+}
+
+const NamingTemplateEditor: React.FC<NamingTemplateEditorProps> = ({
+  template,
+  onChange,
+  error,
+  variables,
+}) => {
+  const [previewData, setPreviewData] = useState({
+    series: 'My Series',
+    season: 1,
+    episode: 5,
+    title: 'Sample Video Title with Extra Info',
+    clean_title: 'Sample Video Title',
+    year: '2024',
+    month: '01',
+    day: '15',
+    channel: 'Channel Name',
+    id: 'abc123def456',
+  });
+
+  const presetTemplates = [
+    {
+      name: 'Standard TV Show',
+      template: '{series} - s{season:02d}e{episode:03d} - {clean_title}',
+      description: 'Standard format: Series - s01e001 - Title',
+    },
+    {
+      name: 'Simple Format',
+      template: 'S{season:02d}E{episode:03d} - {title}',
+      description: 'Simple format: S01E001 - Title',
+    },
+    {
+      name: 'Date-Based',
+      template: '{series} - {year}x{month:02d}{day:02d} - {title}',
+      description: 'Date format: Series - 2024x0115 - Title',
+    },
+    {
+      name: 'Channel Prefix',
+      template: '{channel} - {series} - s{season:02d}e{episode:03d} - {clean_title}',
+      description: 'With channel: Channel - Series - s01e001 - Title',
+    },
+    {
+      name: 'Minimal',
+      template: '{episode:03d} - {clean_title}',
+      description: 'Just episode: 001 - Title',
+    },
+  ];
+
+  const generatePreview = (templateStr: string): string => {
+    let result = templateStr;
+
+    // Helper function to pad numbers
+    const pad = (num: number, size: number) => {
+      let s = num.toString();
+      while (s.length < size) s = '0' + s;
+      return s;
+    };
+
+    // Replace template variables
+    const replacements: Record<string, string> = {
+      '{series}': previewData.series,
+      '{season}': previewData.season.toString(),
+      '{season:02d}': pad(previewData.season, 2),
+      '{season:03d}': pad(previewData.season, 3),
+      '{episode}': previewData.episode.toString(),
+      '{episode:02d}': pad(previewData.episode, 2),
+      '{episode:03d}': pad(previewData.episode, 3),
+      '{title}': previewData.title,
+      '{clean_title}': previewData.clean_title,
+      '{year}': previewData.year,
+      '{month}': previewData.month,
+      '{month:02d}': pad(parseInt(previewData.month), 2),
+      '{day}': previewData.day,
+      '{day:02d}': pad(parseInt(previewData.day), 2),
+      '{channel}': previewData.channel,
+      '{id}': previewData.id,
+    };
+
+    for (const [key, value] of Object.entries(replacements)) {
+      result = result.replace(new RegExp(key.replace(/[{}]/g, '\\$&'), 'g'), value);
+    }
+
+    // Clean up invalid filename characters for preview
+    result = result.replace(/[<>:"/\\|?*]/g, '');
+    result = result.replace(/\s+/g, ' ').trim();
+
+    return result;
+  };
+
+  const insertVariable = (variable: string) => {
+    const textarea = document.getElementById('template-input') as HTMLTextAreaElement;
+    if (textarea) {
+      const start = textarea.selectionStart;
+      const end = textarea.selectionEnd;
+      const newTemplate = template.substring(0, start) + variable + template.substring(end);
+      onChange(newTemplate);
+
+      // Restore cursor position
+      setTimeout(() => {
+        textarea.selectionStart = textarea.selectionEnd = start + variable.length;
+        textarea.focus();
+      }, 0);
+    } else {
+      onChange(template + variable);
+    }
+  };
+
+  const applyPreset = (presetTemplate: string) => {
+    onChange(presetTemplate);
+  };
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+  };
+
+  const validateTemplate = (templateStr: string): string | null => {
+    if (!templateStr.trim()) {
+      return 'Template cannot be empty';
+    }
+
+    // Check for required variables (at least one should be present)
+    const hasEpisodeInfo = templateStr.includes('{episode') || templateStr.includes('{season');
+    const hasTitleInfo = templateStr.includes('{title') || templateStr.includes('{clean_title');
+
+    if (!hasEpisodeInfo && !hasTitleInfo) {
+      return 'Template should include at least episode or title information';
+    }
+
+    // Check for invalid filename characters in static parts
+    const invalidChars = /[<>:"/\\|?*]/;
+    const staticParts = templateStr.replace(/\{[^}]+\}/g, '');
+    if (invalidChars.test(staticParts)) {
+      return 'Template contains invalid filename characters outside of variables';
+    }
+
+    return null;
+  };
+
+  const templateError = error || validateTemplate(template);
+  const preview = templateError ? 'Invalid template' : generatePreview(template);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {/* Template Input */}
+      <TextField
+        id="template-input"
+        label="Naming Template"
+        value={template}
+        onChange={(e) => onChange(e.target.value)}
+        error={!!templateError}
+        helperText={templateError || 'Use variables to create dynamic filenames'}
+        multiline
+        rows={2}
+        fullWidth
+      />
+
+      {/* Preview */}
+      <Paper sx={{ p: 2, bgcolor: 'grey.50' }}>
+        <Typography variant="subtitle2" gutterBottom>
+          Preview
+        </Typography>
+        <Typography
+          variant="body2"
+          sx={{
+            fontFamily: 'monospace',
+            p: 1,
+            bgcolor: 'white',
+            border: 1,
+            borderColor: 'grey.300',
+            borderRadius: 1,
+            color: templateError ? 'error.main' : 'text.primary',
+          }}
+        >
+          {preview}
+        </Typography>
+      </Paper>
+
+      {/* Variable Buttons */}
+      <Box>
+        <Typography variant="subtitle2" gutterBottom>
+          Insert Variables
+        </Typography>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+          {variables.map((variable) => (
+            <Chip
+              key={variable.var}
+              label={variable.var}
+              onClick={() => insertVariable(variable.var)}
+              clickable
+              size="small"
+              variant="outlined"
+              icon={<AddIcon />}
+            />
+          ))}
+        </Box>
+      </Box>
+
+      <Divider />
+
+      {/* Preset Templates */}
+      <Box>
+        <Typography variant="subtitle2" gutterBottom>
+          Preset Templates
+        </Typography>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          {presetTemplates.map((preset, index) => (
+            <Paper key={index} sx={{ p: 2, border: 1, borderColor: 'grey.200' }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                <Typography variant="subtitle2">
+                  {preset.name}
+                </Typography>
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <Button
+                    size="small"
+                    onClick={() => copyToClipboard(preset.template)}
+                    startIcon={<CopyIcon />}
+                  >
+                    Copy
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="outlined"
+                    onClick={() => applyPreset(preset.template)}
+                  >
+                    Use
+                  </Button>
+                </Box>
+              </Box>
+              <Typography variant="body2" color="textSecondary" gutterBottom>
+                {preset.description}
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontFamily: 'monospace',
+                  display: 'block',
+                  p: 1,
+                  bgcolor: 'grey.100',
+                  borderRadius: 1,
+                }}
+              >
+                {preset.template}
+              </Typography>
+              <Typography variant="caption" color="textSecondary" sx={{ mt: 0.5, display: 'block' }}>
+                Preview: {generatePreview(preset.template)}
+              </Typography>
+            </Paper>
+          ))}
+        </Box>
+      </Box>
+
+      {/* Sample Data Editor */}
+      <Paper sx={{ p: 2, bgcolor: 'grey.50' }}>
+        <Typography variant="subtitle2" gutterBottom>
+          Preview Data (Edit to test different scenarios)
+        </Typography>
+        <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 2 }}>
+          <TextField
+            label="Series"
+            value={previewData.series}
+            onChange={(e) => setPreviewData({ ...previewData, series: e.target.value })}
+            size="small"
+          />
+          <TextField
+            label="Season"
+            type="number"
+            value={previewData.season}
+            onChange={(e) => setPreviewData({ ...previewData, season: parseInt(e.target.value) || 1 })}
+            size="small"
+          />
+          <TextField
+            label="Episode"
+            type="number"
+            value={previewData.episode}
+            onChange={(e) => setPreviewData({ ...previewData, episode: parseInt(e.target.value) || 1 })}
+            size="small"
+          />
+          <TextField
+            label="Title"
+            value={previewData.title}
+            onChange={(e) => setPreviewData({ ...previewData, title: e.target.value })}
+            size="small"
+          />
+          <TextField
+            label="Clean Title"
+            value={previewData.clean_title}
+            onChange={(e) => setPreviewData({ ...previewData, clean_title: e.target.value })}
+            size="small"
+          />
+          <TextField
+            label="Channel"
+            value={previewData.channel}
+            onChange={(e) => setPreviewData({ ...previewData, channel: e.target.value })}
+            size="small"
+          />
+        </Box>
+      </Paper>
+
+      {/* Help */}
+      <Alert severity="info">
+        <Typography variant="body2">
+          <strong>Tips:</strong>
+        </Typography>
+        <ul style={{ marginTop: 4, marginBottom: 0, paddingLeft: 16 }}>
+          <li>Use <code>{'{clean_title}'}</code> instead of <code>{'{title}'}</code> to remove filter-matched text</li>
+          <li>Add padding to numbers: <code>{'{episode:03d}'}</code> becomes "001", "002", etc.</li>
+          <li>The preview updates in real-time as you type</li>
+          <li>Invalid filename characters will be automatically removed</li>
+        </ul>
+      </Alert>
+    </Box>
+  );
+};
+
+export default NamingTemplateEditor;

--- a/client/src/components/ChannelProfiles/ProfileEditor.tsx
+++ b/client/src/components/ChannelProfiles/ProfileEditor.tsx
@@ -1,0 +1,378 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  FormControlLabel,
+  Switch,
+  Box,
+  Typography,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Chip,
+  Paper,
+  Divider,
+} from '@mui/material';
+import {
+  ExpandMore as ExpandMoreIcon,
+  Help as HelpIcon,
+  FolderOpen as FolderOpenIcon,
+} from '@mui/icons-material';
+import FilterBuilder from './FilterBuilder';
+import NamingTemplateEditor from './NamingTemplateEditor';
+import FolderBrowser from './FolderBrowser';
+import { ChannelProfile, ProfileFilter } from '../../types/ChannelProfile';
+
+interface ProfileEditorProps {
+  open: boolean;
+  profile: ChannelProfile | null;
+  onClose: () => void;
+  onSave: (profile: Partial<ChannelProfile>) => void;
+  token: string;
+}
+
+const ProfileEditor: React.FC<ProfileEditorProps> = ({
+  open,
+  profile,
+  onClose,
+  onSave,
+  token,
+}) => {
+  const [showFolderBrowser, setShowFolderBrowser] = useState(false);
+  const [formData, setFormData] = useState<Partial<ChannelProfile>>({
+    profile_name: '',
+    series_name: '',
+    is_default: false,
+    destination_path: '',
+    naming_template: '{series} - s{season:02d}e{episode:03d} - {title}',
+    season_number: 1,
+    episode_counter: 1,
+    generate_nfo: false,
+    enabled: true,
+    filters: [],
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (profile) {
+      setFormData({
+        ...profile,
+        filters: profile.filters || [],
+      });
+    } else {
+      setFormData({
+        profile_name: '',
+        series_name: '',
+        is_default: false,
+        destination_path: '',
+        naming_template: '{series} - s{season:02d}e{episode:03d} - {title}',
+        season_number: 1,
+        episode_counter: 1,
+        generate_nfo: false,
+        enabled: true,
+        filters: [],
+      });
+    }
+    setErrors({});
+  }, [profile, open]);
+
+  const handleInputChange = (field: keyof ChannelProfile, value: any) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value,
+    }));
+
+    // Clear error when user starts typing
+    if (errors[field]) {
+      setErrors(prev => ({
+        ...prev,
+        [field]: '',
+      }));
+    }
+  };
+
+  const handleFiltersChange = (filters: ProfileFilter[]) => {
+    handleInputChange('filters', filters);
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.profile_name?.trim()) {
+      newErrors.profile_name = 'Profile name is required';
+    }
+
+    if (!formData.naming_template?.trim()) {
+      newErrors.naming_template = 'Naming template is required';
+    }
+
+    if (!formData.is_default && (!formData.filters || formData.filters.length === 0)) {
+      newErrors.filters = 'Non-default profiles must have at least one filter';
+    }
+
+    if (formData.season_number !== undefined && formData.season_number < 0) {
+      newErrors.season_number = 'Season number must be 0 or greater';
+    }
+
+    if (formData.episode_counter !== undefined && formData.episode_counter < 1) {
+      newErrors.episode_counter = 'Episode counter must be 1 or greater';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSave = () => {
+    if (!validateForm()) {
+      return;
+    }
+
+    onSave(formData);
+  };
+
+  const templateVariables = [
+    { var: '{series}', desc: 'Series name (uses series_name or falls back to profile_name)' },
+    { var: '{season}', desc: 'Season number' },
+    { var: '{season:02d}', desc: 'Season number (padded to 2 digits)' },
+    { var: '{episode}', desc: 'Episode number' },
+    { var: '{episode:03d}', desc: 'Episode number (padded to 3 digits)' },
+    { var: '{title}', desc: 'Original video title' },
+    { var: '{clean_title}', desc: 'Title with filter match removed' },
+    { var: '{year}', desc: 'Upload year' },
+    { var: '{month}', desc: 'Upload month' },
+    { var: '{day}', desc: 'Upload day' },
+    { var: '{channel}', desc: 'Channel name' },
+    { var: '{id}', desc: 'YouTube video ID' },
+  ];
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle>
+        {profile ? 'Edit Profile' : 'Create Profile'}
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          {/* Basic Settings */}
+          <Paper sx={{ p: 2 }}>
+            <Typography variant="h6" gutterBottom>
+              Basic Settings
+            </Typography>
+
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <TextField
+                label="Profile Name"
+                value={formData.profile_name || ''}
+                onChange={(e) => handleInputChange('profile_name', e.target.value)}
+                error={!!errors.profile_name}
+                helperText={errors.profile_name || 'Name for this series profile (for internal organization)'}
+                fullWidth
+                required
+              />
+
+              <TextField
+                label="Series Name"
+                value={formData.series_name || ''}
+                onChange={(e) => handleInputChange('series_name', e.target.value)}
+                helperText="Name that will appear in your media server (leave empty to use profile name)"
+                fullWidth
+              />
+
+              <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+                <TextField
+                  label="Destination Path"
+                  value={formData.destination_path || ''}
+                  onChange={(e) => handleInputChange('destination_path', e.target.value)}
+                  helperText="Custom path for this series (leave empty to use default download directory)"
+                  fullWidth
+                />
+                <Button
+                  variant="outlined"
+                  startIcon={<FolderOpenIcon />}
+                  onClick={() => setShowFolderBrowser(true)}
+                  sx={{ mt: 1, minWidth: 100 }}
+                >
+                  Browse
+                </Button>
+              </Box>
+
+              <Box sx={{ display: 'flex', gap: 2 }}>
+                <TextField
+                  label="Season Number"
+                  type="number"
+                  value={formData.season_number ?? 1}
+                  onChange={(e) => {
+                    const value = e.target.value === '' ? 1 : parseInt(e.target.value);
+                    handleInputChange('season_number', isNaN(value) ? 1 : value);
+                  }}
+                  error={!!errors.season_number}
+                  helperText={errors.season_number || 'Season number (0 for specials, 1+ for regular seasons)'}
+                  sx={{ flex: 1 }}
+                  inputProps={{ min: 0 }}
+                />
+
+                <TextField
+                  label="Episode Counter"
+                  type="number"
+                  value={formData.episode_counter || 1}
+                  onChange={(e) => handleInputChange('episode_counter', parseInt(e.target.value) || 1)}
+                  error={!!errors.episode_counter}
+                  helperText={errors.episode_counter || 'Next episode number to assign'}
+                  sx={{ flex: 1 }}
+                />
+              </Box>
+
+              <Box sx={{ display: 'flex', gap: 2 }}>
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={formData.is_default || false}
+                      onChange={(e) => handleInputChange('is_default', e.target.checked)}
+                    />
+                  }
+                  label="Default Profile"
+                />
+
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={formData.generate_nfo || false}
+                      onChange={(e) => handleInputChange('generate_nfo', e.target.checked)}
+                    />
+                  }
+                  label="Generate NFO Files"
+                />
+
+                <FormControlLabel
+                  control={
+                    <Switch
+                      checked={formData.enabled !== false}
+                      onChange={(e) => handleInputChange('enabled', e.target.checked)}
+                    />
+                  }
+                  label="Enabled"
+                />
+              </Box>
+
+              {formData.is_default && (
+                <Typography variant="body2" color="textSecondary">
+                  <strong>Default Profile:</strong> Will catch all videos that don't match other profiles.
+                  Videos will be placed in Season 00 (Specials).
+                </Typography>
+              )}
+            </Box>
+          </Paper>
+
+          {/* Naming Template */}
+          <Paper sx={{ p: 2 }}>
+            <Typography variant="h6" gutterBottom>
+              Naming Template
+            </Typography>
+
+            <NamingTemplateEditor
+              template={formData.naming_template || ''}
+              onChange={(template) => handleInputChange('naming_template', template)}
+              error={errors.naming_template}
+              variables={templateVariables}
+            />
+          </Paper>
+
+          {/* Filters */}
+          {!formData.is_default && (
+            <Paper sx={{ p: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Filters
+              </Typography>
+
+              <FilterBuilder
+                filters={formData.filters || []}
+                onChange={handleFiltersChange}
+                error={errors.filters}
+              />
+            </Paper>
+          )}
+
+          {/* Help Section */}
+          <Accordion>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="h6">
+                <HelpIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
+                Help & Examples
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Typography variant="subtitle2">Template Variables:</Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                  {templateVariables.map((item) => (
+                    <Chip
+                      key={item.var}
+                      label={`${item.var} - ${item.desc}`}
+                      variant="outlined"
+                      size="small"
+                    />
+                  ))}
+                </Box>
+
+                <Divider />
+
+                <Typography variant="subtitle2">Example Templates:</Typography>
+                <Box sx={{ pl: 2 }}>
+                  <Typography variant="body2">
+                    <strong>Standard:</strong> <code>{'{series} - s{season:02d}e{episode:03d} - {clean_title}'}</code>
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Date-based:</strong> <code>{'{series} - {year}x{month:02d}{day:02d} - {title}'}</code>
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Minimal:</strong> <code>{'S{season:02d}E{episode:03d} - {title}'}</code>
+                  </Typography>
+                </Box>
+
+                <Divider />
+
+                <Typography variant="subtitle2">Filter Examples:</Typography>
+                <Box sx={{ pl: 2 }}>
+                  <Typography variant="body2">
+                    <strong>Regex:</strong> <code>{'Tutorial #(\\d+):'}</code> - Matches "Tutorial #1: Introduction"
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Contains:</strong> <code>Daily Show</code> - Matches any title containing "Daily Show"
+                  </Typography>
+                  <Typography variant="body2">
+                    <strong>Duration:</strong> <code>300-1800</code> - Matches videos between 5-30 minutes
+                  </Typography>
+                </Box>
+              </Box>
+            </AccordionDetails>
+          </Accordion>
+        </Box>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained" color="primary">
+          {profile ? 'Update' : 'Create'}
+        </Button>
+      </DialogActions>
+
+      <FolderBrowser
+        open={showFolderBrowser}
+        currentPath={formData.destination_path}
+        onClose={() => setShowFolderBrowser(false)}
+        onSelect={(path) => {
+          handleInputChange('destination_path', path);
+          setShowFolderBrowser(false);
+        }}
+        token={token}
+      />
+    </Dialog>
+  );
+};
+
+export default ProfileEditor;

--- a/client/src/types/Channel.ts
+++ b/client/src/types/Channel.ts
@@ -4,4 +4,6 @@ export interface Channel {
   channel_id?: string;
   description?: string;
   title?: string;
+  id?: string; // YouTube channel ID
+  db_id?: number; // Database ID for series profiles
 }

--- a/client/src/types/ChannelProfile.ts
+++ b/client/src/types/ChannelProfile.ts
@@ -1,0 +1,20 @@
+export interface ChannelProfile {
+  id: number;
+  profile_name: string;
+  series_name?: string;
+  is_default: boolean;
+  destination_path?: string;
+  naming_template: string;
+  season_number: number;
+  episode_counter: number;
+  generate_nfo: boolean;
+  enabled: boolean;
+  filters: ProfileFilter[];
+}
+
+export interface ProfileFilter {
+  id?: number;
+  filter_type: 'title_regex' | 'title_contains' | 'duration_range';
+  filter_value: string;
+  priority: number;
+}

--- a/docs/SERIES_CONFIGURATION.md
+++ b/docs/SERIES_CONFIGURATION.md
@@ -1,0 +1,317 @@
+# Series Configuration Feature
+
+## Overview
+
+This feature adds channel-specific configuration to Youtarr, allowing users to automatically organize downloaded videos into TV show/series format with proper Season/Episode naming for compatibility with media servers like Plex, Jellyfin, and Emby.
+
+## Goals
+
+### Primary Objectives
+1. **Automatic Series Organization**: Allow channels to have multiple "series profiles" that filter and organize videos into proper TV show structure
+2. **Flexible Naming Templates**: Support custom naming schemes with Season/Episode numbering
+3. **Media Server Compatibility**: Generate Plex/Jellyfin-compatible file names and thumbnails
+4. **Unmatched Content Handling**: Automatically place non-series videos in "Specials" (Season 00)
+5. **Optional NFO Support**: Generate metadata files for Jellyfin/Emby/Kodi (Plex doesn't support NFO)
+
+### Key Features
+- Multiple series profiles per channel
+- Regex-based video filtering to match videos to series
+- Customizable file naming templates
+- Automatic episode numbering with counters
+- Proper thumbnail naming for media server detection
+- Optional NFO metadata file generation
+- Backward compatibility with existing functionality
+
+## Technical Design
+
+### Database Schema
+
+#### Table: `channel_profiles`
+Stores series configuration profiles for each channel.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INT | Primary key |
+| channel_id | INT | Foreign key to channels table |
+| profile_name | VARCHAR(255) | Name of the series/profile |
+| is_default | BOOLEAN | If true, catches unmatched videos |
+| destination_path | TEXT | Custom output directory path |
+| naming_template | VARCHAR(500) | File naming template string |
+| season_number | INT | Fixed season number for this profile |
+| episode_counter | INT | Auto-incrementing episode counter |
+| generate_nfo | BOOLEAN | Whether to generate NFO files |
+| enabled | BOOLEAN | Profile active status |
+
+#### Table: `profile_filters`
+Defines filters to match videos to profiles.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INT | Primary key |
+| profile_id | INT | Foreign key to channel_profiles |
+| filter_type | ENUM | 'title_regex', 'title_contains', 'duration_range' |
+| filter_value | TEXT | Regex pattern or filter criteria |
+| priority | INT | Filter evaluation order |
+
+#### Table: `video_profile_mappings`
+Tracks which videos have been processed by which profile.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INT | Primary key |
+| video_id | INT | Foreign key to Videos table |
+| profile_id | INT | Foreign key to channel_profiles |
+| season | INT | Assigned season number |
+| episode | INT | Assigned episode number |
+| processed_at | TIMESTAMP | When the video was processed |
+
+### File Organization
+
+#### Current Structure
+```
+/YouTube Downloads/
+  /ChannelName/
+    /ChannelName - Video Title - abc123/
+      ChannelName - Video Title [abc123].mp4
+      poster.jpg
+```
+
+#### New Structure (with Series Profile)
+```
+/TV Shows/
+  /Series Name/
+    tvshow.nfo (optional - for Jellyfin/Emby)
+    /Season 01/
+      Series Name - s01e01 - Episode Title.mp4
+      Series Name - s01e01 - Episode Title.jpg
+      Series Name - s01e01 - Episode Title.nfo (optional)
+    /Season 00/ (Specials/Unmatched)
+      Series Name - s00e001 - Special Title.mp4
+      Series Name - s00e001 - Special Title.jpg
+      Series Name - s00e001 - Special Title.nfo (optional)
+```
+
+### Naming Template System
+
+#### Supported Variables
+- `{series}` - Series/profile name
+- `{season}` or `{season:02d}` - Season number with optional padding
+- `{episode}` or `{episode:03d}` - Episode number with optional padding
+- `{title}` - Original video title
+- `{clean_title}` - Title with filter match removed
+- `{year}`, `{month}`, `{day}` - From video upload date
+- `{channel}` - YouTube channel name
+- `{id}` - YouTube video ID
+
+#### Example Templates
+1. **Standard Format**: `{series} - s{season:02d}e{episode:03d} - {clean_title}`
+   - Output: `Tech Tutorials - s01e001 - Introduction to Python.mp4`
+
+2. **Date-Based**: `{series} - {year}x{month:02d}{day:02d} - {title}`
+   - Output: `Daily Show - 2024x0115 - Monday News Update.mp4`
+
+3. **Minimal**: `S{season:02d}E{episode:03d} - {title}`
+   - Output: `S01E001 - Building Your First App.mp4`
+
+### Post-Processing Workflow
+
+1. **Video Downloaded**: Standard yt-dlp download completes
+2. **Channel Profile Check**: System checks if channel has profiles configured
+3. **Filter Evaluation**: Video title tested against profile filters in priority order
+4. **Match Found**:
+   - Apply naming template to generate new filename
+   - Move video to profile's destination path with series structure
+   - Rename thumbnail to match episode name (for Plex compatibility)
+   - Generate NFO file if enabled
+   - Update episode counter in database
+5. **No Match (Default Profile)**:
+   - Place in Season 00 as "Special"
+   - Auto-increment special episode counter
+6. **No Profiles**: Use existing Youtarr behavior
+
+### NFO File Format
+
+#### Episode NFO (`Series Name - s01e01.nfo`)
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<episodedetails>
+    <title>Episode Title</title>
+    <season>1</season>
+    <episode>1</episode>
+    <plot>Video description from YouTube</plot>
+    <aired>2024-01-15</aired>
+    <premiered>2024-01-15</premiered>
+    <studio>Channel Name</studio>
+    <uniqueid type="youtube" default="true">abc123def456</uniqueid>
+</episodedetails>
+```
+
+#### Series NFO (`tvshow.nfo`)
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<tvshow>
+    <title>Series Name</title>
+    <plot>YouTube series from Channel Name</plot>
+    <studio>Channel Name</studio>
+    <premiered>2024-01-01</premiered>
+    <status>Continuing</status>
+    <uniqueid type="youtube_channel">UCxxxxxxxxxxxxx</uniqueid>
+</tvshow>
+```
+
+## API Endpoints
+
+### Profile Management
+- `GET /api/channels/:id/profiles` - List all profiles for a channel
+- `POST /api/channels/:id/profiles` - Create new profile
+- `PUT /api/profiles/:id` - Update profile configuration
+- `DELETE /api/profiles/:id` - Delete profile
+- `POST /api/profiles/:id/test` - Test filters against existing videos
+- `GET /api/profiles/:id/preview` - Preview naming for matched videos
+
+### Request/Response Examples
+
+#### Create Profile
+```json
+POST /api/channels/1/profiles
+{
+  "profile_name": "Python Tutorials",
+  "destination_path": "/TV Shows/Python Tutorials",
+  "naming_template": "{series} - s{season:02d}e{episode:03d} - {clean_title}",
+  "season_number": 1,
+  "generate_nfo": true,
+  "filters": [
+    {
+      "filter_type": "title_regex",
+      "filter_value": "Python Tutorial #(\\d+)",
+      "priority": 1
+    }
+  ]
+}
+```
+
+## User Interface
+
+### Channel Configuration Page
+New "Series Configuration" tab in channel details with:
+- List of existing profiles
+- Add/Edit/Delete profile buttons
+- Drag-and-drop profile reordering
+- Enable/Disable toggles
+- Test filters functionality
+
+### Profile Editor
+- Profile name and destination path
+- Season number selection
+- Naming template builder with variable buttons
+- NFO generation toggle
+- Filter builder with regex helpers
+- Live preview of matched videos
+
+## Implementation Roadmap
+
+### Phase 1: Foundation
+- [ ] Create database migration files
+- [ ] Implement channel_profiles table
+- [ ] Implement profile_filters table
+- [ ] Implement video_profile_mappings table
+
+### Phase 2: Backend Core
+- [ ] Create channelProfileModule.js
+- [ ] Implement CRUD operations for profiles
+- [ ] Build filter evaluation engine
+- [ ] Add episode counter management
+
+### Phase 3: Post-Processing
+- [ ] Enhance videoDownloadPostProcessFiles.js
+- [ ] Implement file moving/renaming logic
+- [ ] Add thumbnail renaming for media servers
+- [ ] Implement optional NFO generation
+
+### Phase 4: API Layer
+- [ ] Add profile management endpoints
+- [ ] Implement filter testing endpoint
+- [ ] Add preview functionality
+
+### Phase 5: Frontend Basic
+- [ ] Create ChannelProfileManager component
+- [ ] Build ProfileEditor form
+- [ ] Add profile list UI
+- [ ] Implement enable/disable toggles
+
+### Phase 6: Frontend Advanced
+- [ ] Create FilterBuilder component
+- [ ] Build NamingTemplateEditor
+- [ ] Add VideoMatcher preview
+- [ ] Implement drag-and-drop reordering
+
+### Phase 7: Testing & Polish
+- [ ] Test series matching logic
+- [ ] Verify file organization
+- [ ] Test NFO generation
+- [ ] Add error handling
+- [ ] Write user documentation
+
+## Configuration Examples
+
+### Example 1: Tutorial Series with Numbered Episodes
+**Channel**: TechEducation
+**Profile**: "Python Course"
+- **Filter**: Regex `Python Tutorial #(\d+):`
+- **Template**: `Python Course - s01e{episode:03d} - {clean_title}`
+- **Result**: `Python Course - s01e001 - Variables and Data Types.mp4`
+
+### Example 2: Daily Show with Date-Based Episodes
+**Channel**: NewsChannel
+**Profile**: "Daily Updates"
+- **Filter**: Contains `Daily News`
+- **Template**: `Daily News - {year}x{month:02d}{day:02d} - {title}`
+- **Result**: `Daily News - 2024x0115 - Market Analysis.mp4`
+
+### Example 3: Mixed Content with Specials
+**Channel**: GamingChannel
+**Profile 1**: "Let's Play Series"
+- **Filter**: Regex `Let's Play .+ Part (\d+)`
+- **Season**: 1
+- **Template**: `Gaming - s{season:02d}e{episode:03d} - {clean_title}`
+
+**Default Profile**: "Gaming Extras"
+- **No filters** (catches all unmatched)
+- **Season**: 0 (Specials)
+- **Template**: `Gaming - s00e{episode:03d} - {title}`
+
+## Backward Compatibility
+
+- System continues to function normally without profiles configured
+- Existing downloaded videos remain in their current locations
+- Profile system is opt-in per channel
+- Can be disabled globally in configuration
+- Future enhancement: Bulk migration tool for existing videos
+
+## Media Server Compatibility
+
+### Plex
+- ✅ Proper file naming (Series - s##e## - Title.mp4)
+- ✅ Episode thumbnails (same name as video file)
+- ❌ NFO files not supported (Plex ignores them)
+
+### Jellyfin/Emby
+- ✅ Proper file naming
+- ✅ Episode thumbnails
+- ✅ NFO files for metadata
+- ✅ tvshow.nfo for series metadata
+
+### Kodi
+- ✅ All features supported
+- ✅ NFO format compatible
+
+## Future Enhancements
+
+1. **Smart Series Detection**: AI-powered suggestions for series patterns
+2. **Bulk Reprocessing**: Re-organize existing videos with new profiles
+3. **Profile Templates**: Import/export profile configurations
+4. **Multi-Language Support**: Localized season folder names
+5. **Advanced Filters**: Duration ranges, upload date filters, view count thresholds
+6. **Series Artwork**: Auto-fetch or generate series posters/banners
+7. **Episode Ordering**: Custom episode order based on upload date or title
+8. **Series Completion**: Mark series as complete to stop downloading

--- a/migrations/20250119204401-add-channel-profiles.js
+++ b/migrations/20250119204401-add-channel-profiles.js
@@ -1,0 +1,87 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('channel_profiles', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      channel_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'channels',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+      },
+      profile_name: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+      },
+      is_default: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      },
+      destination_path: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+      },
+      naming_template: {
+        type: Sequelize.STRING(500),
+        allowNull: true,
+        defaultValue: '{series} - s{season:02d}e{episode:03d} - {title}',
+      },
+      season_number: {
+        type: Sequelize.INTEGER,
+        defaultValue: 1,
+        allowNull: false,
+      },
+      episode_counter: {
+        type: Sequelize.INTEGER,
+        defaultValue: 1,
+        allowNull: false,
+      },
+      generate_nfo: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+        allowNull: false,
+      },
+      enabled: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: true,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        allowNull: false,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        allowNull: false,
+      },
+    });
+
+    // Add indexes for performance
+    await queryInterface.addIndex('channel_profiles', ['channel_id', 'enabled'], {
+      name: 'idx_channel_enabled',
+    });
+
+    // Note: MySQL doesn't support partial indexes with WHERE clause
+    // We enforce "only one default per channel" in application code through transactions
+    // Just add a regular index for query performance
+    await queryInterface.addIndex('channel_profiles', ['channel_id', 'is_default'], {
+      name: 'idx_channel_default',
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('channel_profiles');
+  },
+};

--- a/migrations/20250119204402-add-profile-filters.js
+++ b/migrations/20250119204402-add-profile-filters.js
@@ -1,0 +1,55 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('profile_filters', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      profile_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'channel_profiles',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+      },
+      filter_type: {
+        type: Sequelize.ENUM('title_regex', 'title_contains', 'duration_range'),
+        allowNull: false,
+      },
+      filter_value: {
+        type: Sequelize.TEXT,
+        allowNull: false,
+      },
+      priority: {
+        type: Sequelize.INTEGER,
+        defaultValue: 0,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        allowNull: false,
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        allowNull: false,
+      },
+    });
+
+    // Add index for efficient filter lookup
+    await queryInterface.addIndex('profile_filters', ['profile_id', 'priority'], {
+      name: 'idx_profile_priority',
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('profile_filters');
+  },
+};

--- a/migrations/20250119204403-add-video-profile-mappings.js
+++ b/migrations/20250119204403-add-video-profile-mappings.js
@@ -1,0 +1,60 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('video_profile_mappings', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false,
+      },
+      video_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Videos',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+      },
+      profile_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'channel_profiles',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+      },
+      season: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      episode: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      processed_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+        allowNull: false,
+      },
+    });
+
+    // Ensure each video is only mapped to one profile
+    await queryInterface.addIndex('video_profile_mappings', ['video_id', 'profile_id'], {
+      name: 'unique_video_profile',
+      unique: true,
+    });
+
+    // Index for efficient lookups
+    await queryInterface.addIndex('video_profile_mappings', ['profile_id'], {
+      name: 'idx_profile_mapping',
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('video_profile_mappings');
+  },
+};

--- a/migrations/20250920000000-add-series-name-to-channel-profiles.js
+++ b/migrations/20250920000000-add-series-name-to-channel-profiles.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('channel_profiles', 'series_name', {
+      type: Sequelize.STRING(255),
+      allowNull: true,
+      after: 'profile_name',
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('channel_profiles', 'series_name');
+  },
+};

--- a/server/models/channelprofile.js
+++ b/server/models/channelprofile.js
@@ -1,0 +1,71 @@
+const { Model, DataTypes } = require('sequelize');
+const { sequelize } = require('../db');
+
+class ChannelProfile extends Model {}
+
+ChannelProfile.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false,
+    },
+    channel_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    profile_name: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    series_name: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+    },
+    is_default: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    },
+    destination_path: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    naming_template: {
+      type: DataTypes.STRING(500),
+      allowNull: true,
+      defaultValue: '{series} - s{season:02d}e{episode:03d} - {title}',
+    },
+    season_number: {
+      type: DataTypes.INTEGER,
+      defaultValue: 1,
+      allowNull: false,
+    },
+    episode_counter: {
+      type: DataTypes.INTEGER,
+      defaultValue: 1,
+      allowNull: false,
+    },
+    generate_nfo: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    },
+    enabled: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: true,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'ChannelProfile',
+    tableName: 'channel_profiles',
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+  }
+);
+
+module.exports = ChannelProfile;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -4,6 +4,9 @@ const JobVideo = require('./jobvideo');
 const Video = require('./video');
 const Channel = require('./channel');
 const Session = require('./session');
+const ChannelProfile = require('./channelprofile');
+const ProfileFilter = require('./profilefilter');
+const VideoProfileMapping = require('./videoprofilemapping');
 
 Job.hasMany(JobVideo, { foreignKey: 'job_id', as: 'jobVideos' });
 
@@ -11,6 +14,18 @@ JobVideo.belongsTo(Job, { foreignKey: 'job_id', as: 'job' });
 JobVideo.belongsTo(Video, { foreignKey: 'video_id', as: 'video' });
 
 Video.hasMany(JobVideo, { foreignKey: 'video_id', as: 'jobVideos' });
+Video.hasMany(VideoProfileMapping, { foreignKey: 'video_id', as: 'profileMappings' });
+
+Channel.hasMany(ChannelProfile, { foreignKey: 'channel_id', as: 'profiles' });
+
+ChannelProfile.belongsTo(Channel, { foreignKey: 'channel_id', as: 'channel' });
+ChannelProfile.hasMany(ProfileFilter, { foreignKey: 'profile_id', as: 'filters' });
+ChannelProfile.hasMany(VideoProfileMapping, { foreignKey: 'profile_id', as: 'videoMappings' });
+
+ProfileFilter.belongsTo(ChannelProfile, { foreignKey: 'profile_id', as: 'profile' });
+
+VideoProfileMapping.belongsTo(Video, { foreignKey: 'video_id', as: 'video' });
+VideoProfileMapping.belongsTo(ChannelProfile, { foreignKey: 'profile_id', as: 'profile' });
 
 module.exports = {
   Job,
@@ -18,4 +33,7 @@ module.exports = {
   Video,
   Channel,
   Session,
+  ChannelProfile,
+  ProfileFilter,
+  VideoProfileMapping,
 };

--- a/server/models/profilefilter.js
+++ b/server/models/profilefilter.js
@@ -1,0 +1,42 @@
+const { Model, DataTypes } = require('sequelize');
+const { sequelize } = require('../db');
+
+class ProfileFilter extends Model {}
+
+ProfileFilter.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false,
+    },
+    profile_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    filter_type: {
+      type: DataTypes.ENUM('title_regex', 'title_contains', 'duration_range'),
+      allowNull: false,
+    },
+    filter_value: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    priority: {
+      type: DataTypes.INTEGER,
+      defaultValue: 0,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'ProfileFilter',
+    tableName: 'profile_filters',
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+  }
+);
+
+module.exports = ProfileFilter;

--- a/server/models/videoprofilemapping.js
+++ b/server/models/videoprofilemapping.js
@@ -1,0 +1,44 @@
+const { Model, DataTypes } = require('sequelize');
+const { sequelize } = require('../db');
+
+class VideoProfileMapping extends Model {}
+
+VideoProfileMapping.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false,
+    },
+    video_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    profile_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    season: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    episode: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    processed_at: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'VideoProfileMapping',
+    tableName: 'video_profile_mappings',
+    timestamps: false,
+  }
+);
+
+module.exports = VideoProfileMapping;

--- a/server/modules/__tests__/channelProfileModule.test.js
+++ b/server/modules/__tests__/channelProfileModule.test.js
@@ -1,0 +1,376 @@
+/* eslint-env jest */
+
+jest.mock('../../models');
+jest.mock('../configModule', () => ({
+  directoryPath: '/test/downloads'
+}));
+
+describe('ChannelProfileModule', () => {
+  let channelProfileModule;
+  let ChannelProfile;
+  let ProfileFilter;
+  let Video;
+  let VideoProfileMapping;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Reset modules to get fresh instances
+    jest.resetModules();
+
+    // Import models after mocking
+    const models = require('../../models');
+    ChannelProfile = models.ChannelProfile;
+    ProfileFilter = models.ProfileFilter;
+    Video = models.Video;
+    VideoProfileMapping = models.VideoProfileMapping;
+
+    // Set up mock implementations
+    ChannelProfile.sequelize = {
+      transaction: jest.fn().mockResolvedValue({
+        commit: jest.fn(),
+        rollback: jest.fn()
+      })
+    };
+
+    ChannelProfile.findAll = jest.fn();
+    ChannelProfile.findByPk = jest.fn();
+    ChannelProfile.create = jest.fn();
+    ChannelProfile.update = jest.fn();
+    ChannelProfile.destroy = jest.fn();
+
+    ProfileFilter.bulkCreate = jest.fn();
+    ProfileFilter.destroy = jest.fn();
+
+    Video.findAll = jest.fn();
+    Video.findOne = jest.fn();
+
+    VideoProfileMapping.create = jest.fn();
+
+    // Import the module after setting up mocks
+    channelProfileModule = require('../channelProfileModule');
+  });
+
+  describe('getProfilesForChannel', () => {
+    it('should return all profiles for a channel', async () => {
+      const mockProfiles = [
+        { id: 1, channel_id: 1, profile_name: 'Test Profile', filters: [] }
+      ];
+
+      ChannelProfile.findAll.mockResolvedValue(mockProfiles);
+
+      const result = await channelProfileModule.getProfilesForChannel(1);
+
+      expect(ChannelProfile.findAll).toHaveBeenCalledWith({
+        where: { channel_id: 1 },
+        include: expect.any(Array),
+        order: [['is_default', 'DESC'], ['profile_name', 'ASC']]
+      });
+      expect(result).toEqual(mockProfiles);
+    });
+  });
+
+  describe('checkFilters', () => {
+    const videoData = {
+      title: 'VFX Artists React to Bad CGI',
+      duration: 1200
+    };
+
+    it('should return true when title_contains filter matches (OR logic)', async () => {
+      const filters = [
+        { filter_type: 'title_contains', filter_value: 'React', priority: 0 },
+        { filter_type: 'title_contains', filter_value: 'Review', priority: 1 }
+      ];
+
+      const result = await channelProfileModule.checkFilters(videoData, filters);
+      expect(result).toBe(true);
+    });
+
+    it('should return false when no filters match', async () => {
+      const filters = [
+        { filter_type: 'title_contains', filter_value: 'Review', priority: 0 },
+        { filter_type: 'title_contains', filter_value: 'Tutorial', priority: 1 }
+      ];
+
+      const result = await channelProfileModule.checkFilters(videoData, filters);
+      expect(result).toBe(false);
+    });
+
+    it('should handle title_regex filter', async () => {
+      const filters = [
+        { filter_type: 'title_regex', filter_value: 'VFX.*React', priority: 0 }
+      ];
+
+      const result = await channelProfileModule.checkFilters(videoData, filters);
+      expect(result).toBe(true);
+    });
+
+    it('should handle duration_range filter', async () => {
+      const filters = [
+        { filter_type: 'duration_range', filter_value: '600-1800', priority: 0 }
+      ];
+
+      const result = await channelProfileModule.checkFilters(videoData, filters);
+      expect(result).toBe(true);
+    });
+
+    it('should return false for empty filters', async () => {
+      const result = await channelProfileModule.checkFilters(videoData, []);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('applyNamingTemplate', () => {
+    it('should correctly apply template with season 0', () => {
+      const template = '{series} - s{season:02d}e{episode:03d} - {title}';
+      const data = {
+        series: 'Test Series',
+        season: 0,
+        episode: 1,
+        title: 'Test Episode'
+      };
+
+      const result = channelProfileModule.applyNamingTemplate(template, data);
+      expect(result).toBe('Test Series - s00e001 - Test Episode');
+    });
+
+    it('should correctly apply template with season 1', () => {
+      const template = '{series} - s{season:02d}e{episode:03d} - {title}';
+      const data = {
+        series: 'Test Series',
+        season: 1,
+        episode: 5,
+        title: 'Test Episode'
+      };
+
+      const result = channelProfileModule.applyNamingTemplate(template, data);
+      expect(result).toBe('Test Series - s01e005 - Test Episode');
+    });
+
+    it('should handle clean_title template variable', () => {
+      const template = '{series} - {clean_title}';
+      const data = {
+        series: 'Test Series',
+        clean_title: 'Clean Title',
+        title: 'Original Title with Pattern'
+      };
+
+      const result = channelProfileModule.applyNamingTemplate(template, data);
+      expect(result).toBe('Test Series - Clean Title');
+    });
+
+    it('should handle date variables', () => {
+      const template = '{year}-{month:02d}-{day:02d} - {title}';
+      const data = {
+        year: '2025',
+        month: '9',
+        day: '5',
+        title: 'Test'
+      };
+
+      const result = channelProfileModule.applyNamingTemplate(template, data);
+      expect(result).toBe('2025-09-05 - Test');
+    });
+
+    it('should remove invalid filename characters', () => {
+      const template = '{title}';
+      const data = {
+        title: 'Test: Episode <1> | Part "A"'
+      };
+
+      const result = channelProfileModule.applyNamingTemplate(template, data);
+      expect(result).toBe('Test Episode 1 Part A');
+    });
+  });
+
+  describe('evaluateVideoAgainstProfiles', () => {
+    const videoData = {
+      title: 'Pass It On Challenge',
+      duration: 1500
+    };
+
+    it('should return matching non-default profile', async () => {
+      const mockProfiles = [
+        {
+          id: 1,
+          profile_name: 'Pass It On',
+          is_default: false,
+          enabled: true,
+          filters: [
+            { filter_type: 'title_contains', filter_value: 'Pass It On' }
+          ]
+        },
+        {
+          id: 2,
+          profile_name: 'Default',
+          is_default: true,
+          enabled: true,
+          filters: []
+        }
+      ];
+
+      ChannelProfile.findAll.mockResolvedValue(mockProfiles);
+
+      const result = await channelProfileModule.evaluateVideoAgainstProfiles(videoData, 1);
+
+      expect(result).toEqual(mockProfiles[0]);
+    });
+
+    it('should return default profile when no match', async () => {
+      const mockProfiles = [
+        {
+          id: 1,
+          profile_name: 'Other Series',
+          is_default: false,
+          enabled: true,
+          filters: [
+            { filter_type: 'title_contains', filter_value: 'Different' }
+          ]
+        },
+        {
+          id: 2,
+          profile_name: 'Default',
+          is_default: true,
+          enabled: true,
+          filters: []
+        }
+      ];
+
+      ChannelProfile.findAll.mockResolvedValue(mockProfiles);
+
+      const result = await channelProfileModule.evaluateVideoAgainstProfiles(videoData, 1);
+
+      expect(result).toEqual(mockProfiles[1]);
+    });
+
+    it('should skip disabled profiles', async () => {
+      const mockProfiles = [
+        {
+          id: 1,
+          profile_name: 'Pass It On',
+          is_default: false,
+          enabled: false, // Disabled
+          filters: [
+            { filter_type: 'title_contains', filter_value: 'Pass It On' }
+          ]
+        },
+        {
+          id: 2,
+          profile_name: 'Default',
+          is_default: true,
+          enabled: true,
+          filters: []
+        }
+      ];
+
+      ChannelProfile.findAll.mockResolvedValue(mockProfiles);
+
+      const result = await channelProfileModule.evaluateVideoAgainstProfiles(videoData, 1);
+
+      expect(result).toEqual(mockProfiles[1]); // Should get default instead
+    });
+  });
+
+  describe('createProfile', () => {
+    it('should create profile with filters', async () => {
+      const profileData = {
+        profile_name: 'Test Profile',
+        season_number: 1,
+        episode_counter: 1,
+        is_default: false
+      };
+
+      const filters = [
+        { filter_type: 'title_contains', filter_value: 'Test' }
+      ];
+
+      const mockProfile = { id: 1, ...profileData };
+      ChannelProfile.create.mockResolvedValue(mockProfile);
+      ChannelProfile.findByPk.mockResolvedValue({ ...mockProfile, filters });
+      ProfileFilter.bulkCreate.mockResolvedValue([]);
+
+      const result = await channelProfileModule.createProfile(1, profileData, filters);
+
+      expect(ChannelProfile.create).toHaveBeenCalled();
+      expect(ProfileFilter.bulkCreate).toHaveBeenCalled();
+      expect(result).toHaveProperty('filters');
+    });
+
+    it('should unset existing default when creating new default', async () => {
+      const profileData = {
+        profile_name: 'New Default',
+        is_default: true
+      };
+
+      const mockProfile = { id: 2, ...profileData };
+      ChannelProfile.create.mockResolvedValue(mockProfile);
+      ChannelProfile.findByPk.mockResolvedValue(mockProfile);
+      ChannelProfile.update.mockResolvedValue([1]);
+
+      await channelProfileModule.createProfile(1, profileData, []);
+
+      expect(ChannelProfile.update).toHaveBeenCalledWith(
+        { is_default: false },
+        expect.objectContaining({
+          where: {
+            channel_id: 1,
+            is_default: true
+          }
+        })
+      );
+    });
+  });
+
+  describe('getCleanTitle', () => {
+    it('should remove matched regex pattern from title', () => {
+      const title = 'Tutorial #5: Advanced Techniques';
+      const filters = [
+        { filter_type: 'title_regex', filter_value: 'Tutorial #\\d+:\\s*' }
+      ];
+
+      const result = channelProfileModule.getCleanTitle(title, filters);
+      expect(result).toBe('Advanced Techniques');
+    });
+
+    it('should return original title when no filters match', () => {
+      const title = 'Regular Video Title';
+      const filters = [
+        { filter_type: 'title_regex', filter_value: 'Tutorial' }
+      ];
+
+      const result = channelProfileModule.getCleanTitle(title, filters);
+      expect(result).toBe('Regular Video Title');
+    });
+
+    it('should handle empty filters', () => {
+      const title = 'Test Title';
+      const result = channelProfileModule.getCleanTitle(title, []);
+      expect(result).toBe('Test Title');
+    });
+  });
+
+  describe('incrementEpisodeCounter', () => {
+    it('should increment episode counter by 1', async () => {
+      const mockProfile = {
+        id: 1,
+        episode_counter: 5,
+        save: jest.fn()
+      };
+
+      ChannelProfile.findByPk.mockResolvedValue(mockProfile);
+
+      const result = await channelProfileModule.incrementEpisodeCounter(1);
+
+      expect(mockProfile.episode_counter).toBe(6);
+      expect(mockProfile.save).toHaveBeenCalled();
+      expect(result).toBe(6);
+    });
+
+    it('should throw error if profile not found', async () => {
+      ChannelProfile.findByPk.mockResolvedValue(null);
+
+      await expect(channelProfileModule.incrementEpisodeCounter(999))
+        .rejects.toThrow('Profile not found');
+    });
+  });
+});

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -133,6 +133,7 @@ class ChannelModule {
   mapChannelToResponse(channel) {
     return {
       id: channel.channel_id,
+      db_id: channel.id, // Database ID for series profiles
       uploader: channel.uploader,
       uploader_id: channel.uploader_id || channel.channel_id,
       title: channel.title,

--- a/server/modules/channelProfileModule.js
+++ b/server/modules/channelProfileModule.js
@@ -1,0 +1,497 @@
+const { ChannelProfile, ProfileFilter, Channel, Video } = require('../models');
+const { Op } = require('sequelize');
+
+class ChannelProfileModule {
+  /**
+   * Get all profiles for a channel
+   * @param {number} channelId - Channel ID
+   * @returns {Promise<Array>} Array of profiles with filters
+   */
+  async getProfilesForChannel(channelId) {
+    try {
+      const profiles = await ChannelProfile.findAll({
+        where: { channel_id: channelId },
+        include: [
+          {
+            model: ProfileFilter,
+            as: 'filters',
+            order: [['priority', 'ASC']],
+          },
+        ],
+        order: [['is_default', 'DESC'], ['profile_name', 'ASC']],
+      });
+      return profiles;
+    } catch (error) {
+      console.error('Error fetching channel profiles:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Create a new profile for a channel
+   * @param {number} channelId - Channel ID
+   * @param {Object} profileData - Profile configuration
+   * @param {Array} filters - Array of filter configurations
+   * @returns {Promise<Object>} Created profile
+   */
+  async createProfile(channelId, profileData, filters = []) {
+    const transaction = await ChannelProfile.sequelize.transaction();
+
+    try {
+      // If this is set as default, unset any existing default
+      if (profileData.is_default) {
+        await ChannelProfile.update(
+          { is_default: false },
+          {
+            where: {
+              channel_id: channelId,
+              is_default: true
+            },
+            transaction,
+          }
+        );
+      }
+
+      // Create the profile
+      const profile = await ChannelProfile.create(
+        {
+          channel_id: channelId,
+          ...profileData,
+        },
+        { transaction }
+      );
+
+      // Create filters if provided
+      if (filters && filters.length > 0) {
+        const filterData = filters.map((filter, index) => ({
+          profile_id: profile.id,
+          filter_type: filter.filter_type,
+          filter_value: filter.filter_value,
+          priority: filter.priority !== undefined ? filter.priority : index,
+        }));
+
+        await ProfileFilter.bulkCreate(filterData, { transaction });
+      }
+
+      await transaction.commit();
+
+      // Return profile with filters
+      return await ChannelProfile.findByPk(profile.id, {
+        include: [
+          {
+            model: ProfileFilter,
+            as: 'filters',
+            order: [['priority', 'ASC']],
+          },
+        ],
+      });
+    } catch (error) {
+      await transaction.rollback();
+      console.error('Error creating channel profile:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Update an existing profile
+   * @param {number} profileId - Profile ID
+   * @param {Object} profileData - Updated profile data
+   * @param {Array} filters - Updated filters (will replace existing)
+   * @returns {Promise<Object>} Updated profile
+   */
+  async updateProfile(profileId, profileData, filters = null) {
+    const transaction = await ChannelProfile.sequelize.transaction();
+
+    try {
+      const profile = await ChannelProfile.findByPk(profileId);
+      if (!profile) {
+        throw new Error('Profile not found');
+      }
+
+      // If setting as default, unset any other default for this channel
+      if (profileData.is_default && !profile.is_default) {
+        await ChannelProfile.update(
+          { is_default: false },
+          {
+            where: {
+              channel_id: profile.channel_id,
+              is_default: true,
+              id: { [Op.ne]: profileId }
+            },
+            transaction,
+          }
+        );
+      }
+
+      // Update profile
+      await profile.update(profileData, { transaction });
+
+      // Update filters if provided
+      if (filters !== null) {
+        // Delete existing filters
+        await ProfileFilter.destroy({
+          where: { profile_id: profileId },
+          transaction,
+        });
+
+        // Create new filters
+        if (filters.length > 0) {
+          const filterData = filters.map((filter, index) => ({
+            profile_id: profileId,
+            filter_type: filter.filter_type,
+            filter_value: filter.filter_value,
+            priority: filter.priority !== undefined ? filter.priority : index,
+          }));
+
+          await ProfileFilter.bulkCreate(filterData, { transaction });
+        }
+      }
+
+      await transaction.commit();
+
+      // Return updated profile with filters
+      return await ChannelProfile.findByPk(profileId, {
+        include: [
+          {
+            model: ProfileFilter,
+            as: 'filters',
+            order: [['priority', 'ASC']],
+          },
+        ],
+      });
+    } catch (error) {
+      await transaction.rollback();
+      console.error('Error updating channel profile:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Delete a profile
+   * @param {number} profileId - Profile ID
+   * @returns {Promise<boolean>} Success status
+   */
+  async deleteProfile(profileId) {
+    try {
+      const result = await ChannelProfile.destroy({
+        where: { id: profileId },
+      });
+      return result > 0;
+    } catch (error) {
+      console.error('Error deleting channel profile:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Evaluate a video against channel profiles to find a match
+   * @param {Object} videoData - Video information (title, duration, etc.)
+   * @param {number} channelId - Channel ID
+   * @returns {Promise<Object|null>} Matched profile or null
+   */
+  async evaluateVideoAgainstProfiles(videoData, channelId) {
+    try {
+      const profiles = await this.getProfilesForChannel(channelId);
+
+      // Filter to only enabled profiles
+      const enabledProfiles = profiles.filter(p => p.enabled);
+
+      // Sort profiles: non-default first, then default
+      const sortedProfiles = enabledProfiles.sort((a, b) => {
+        if (a.is_default && !b.is_default) return 1;
+        if (!a.is_default && b.is_default) return -1;
+        return 0;
+      });
+
+      for (const profile of sortedProfiles) {
+        // Skip default profile in first pass
+        if (profile.is_default) continue;
+
+        // Check if video matches any filter
+        const matches = await this.checkFilters(videoData, profile.filters);
+        if (matches) {
+          return profile;
+        }
+      }
+
+      // Return default profile if no specific match
+      const defaultProfile = sortedProfiles.find(p => p.is_default);
+      return defaultProfile || null;
+    } catch (error) {
+      console.error('Error evaluating video against profiles:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Check if video matches profile filters
+   * @param {Object} videoData - Video information
+   * @param {Array} filters - Profile filters
+   * @returns {Promise<boolean>} Match status
+   */
+  async checkFilters(videoData, filters) {
+    if (!filters || filters.length === 0) {
+      return false;
+    }
+
+    // Sort filters by priority
+    const sortedFilters = [...filters].sort((a, b) => a.priority - b.priority);
+
+    for (const filter of sortedFilters) {
+      let matches = false;
+
+      switch (filter.filter_type) {
+      case 'title_regex': {
+        try {
+          const regex = new RegExp(filter.filter_value, 'i');
+          matches = regex.test(videoData.title || '');
+        } catch (error) {
+          console.error(`Invalid regex pattern: ${filter.filter_value}`, error);
+        }
+        break;
+      }
+
+      case 'title_contains': {
+        const title = (videoData.title || '').toLowerCase();
+        const searchTerm = filter.filter_value.toLowerCase();
+        matches = title.includes(searchTerm);
+        break;
+      }
+
+      case 'duration_range': {
+        // Parse duration range (e.g., "300-600" for 5-10 minutes)
+        const [min, max] = filter.filter_value.split('-').map(Number);
+        const duration = videoData.duration || 0;
+        matches = duration >= min && duration <= max;
+        break;
+      }
+      }
+
+      // Any filter can match (OR logic)
+      if (matches) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Get the next episode number for a profile
+   * @param {number} profileId - Profile ID
+   * @returns {Promise<number>} Next episode number
+   */
+  async getNextEpisodeNumber(profileId) {
+    try {
+      const profile = await ChannelProfile.findByPk(profileId);
+      if (!profile) {
+        throw new Error('Profile not found');
+      }
+      return profile.episode_counter;
+    } catch (error) {
+      console.error('Error getting next episode number:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Increment the episode counter for a profile
+   * @param {number} profileId - Profile ID
+   * @returns {Promise<number>} New episode number
+   */
+  async incrementEpisodeCounter(profileId) {
+    try {
+      const profile = await ChannelProfile.findByPk(profileId);
+      if (!profile) {
+        throw new Error('Profile not found');
+      }
+
+      profile.episode_counter += 1;
+      await profile.save();
+
+      return profile.episode_counter;
+    } catch (error) {
+      console.error('Error incrementing episode counter:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Apply naming template to generate filename
+   * @param {string} template - Naming template
+   * @param {Object} data - Template data
+   * @returns {string} Generated filename
+   */
+  applyNamingTemplate(template, data) {
+    let result = template;
+
+    // Helper function to pad numbers
+    const pad = (num, size) => {
+      let s = num.toString();
+      while (s.length < size) s = '0' + s;
+      return s;
+    };
+
+    // Parse and replace template variables
+    const replacements = {
+      '{series}': data.series || '',
+      '{season}': data.season ?? 1,
+      '{season:02d}': pad(data.season ?? 1, 2),
+      '{season:03d}': pad(data.season ?? 1, 3),
+      '{episode}': data.episode ?? 1,
+      '{episode:02d}': pad(data.episode ?? 1, 2),
+      '{episode:03d}': pad(data.episode ?? 1, 3),
+      '{title}': data.title || '',
+      '{clean_title}': data.clean_title || data.title || '',
+      '{year}': data.year || '',
+      '{month}': data.month || '',
+      '{month:02d}': pad(data.month || 1, 2),
+      '{day}': data.day || '',
+      '{day:02d}': pad(data.day || 1, 2),
+      '{channel}': data.channel || '',
+      '{id}': data.id || '',
+    };
+
+    for (const [key, value] of Object.entries(replacements)) {
+      result = result.replace(new RegExp(key.replace(/[{}]/g, '\\$&'), 'g'), value);
+    }
+
+    // Clean up the filename
+    result = result.replace(/[<>:"/\\|?*]/g, ''); // Remove invalid filename characters
+    result = result.replace(/\s+/g, ' ').trim(); // Clean up whitespace
+
+    return result;
+  }
+
+  /**
+   * Get clean title by removing matched filter pattern
+   * @param {string} title - Original title
+   * @param {Array} filters - Profile filters
+   * @returns {string} Clean title
+   */
+  getCleanTitle(title, filters) {
+    if (!filters || filters.length === 0) {
+      return title;
+    }
+
+    let cleanTitle = title;
+
+    for (const filter of filters) {
+      if (filter.filter_type === 'title_regex') {
+        try {
+          const regex = new RegExp(filter.filter_value, 'i');
+          const match = title.match(regex);
+          if (match) {
+            // Remove the matched part and clean up
+            cleanTitle = title.replace(match[0], '').trim();
+            // Remove any leading/trailing separators
+            cleanTitle = cleanTitle.replace(/^[-–—:]\s*/, '').replace(/\s*[-–—:]$/, '');
+            break;
+          }
+        } catch (error) {
+          console.error(`Invalid regex pattern: ${filter.filter_value}`, error);
+        }
+      }
+    }
+
+    return cleanTitle;
+  }
+
+  /**
+   * Test profile filters against existing channel videos
+   * @param {number} profileId - Profile ID
+   * @returns {Promise<Array>} Array of matched videos with preview names
+   */
+  async testProfileFilters(profileId) {
+    try {
+      const profile = await ChannelProfile.findByPk(profileId, {
+        include: [
+          {
+            model: ProfileFilter,
+            as: 'filters',
+          },
+          {
+            model: Channel,
+            as: 'channel',
+          },
+        ],
+      });
+
+      if (!profile) {
+        throw new Error('Profile not found');
+      }
+
+      // Get all videos for the channel
+      const videos = await Video.findAll({
+        where: { channel_id: profile.channel.channel_id },
+        order: [['originalDate', 'ASC']],
+      });
+
+      const matches = [];
+      let episodeCounter = 1;
+
+      for (const video of videos) {
+        const videoData = {
+          title: video.youTubeVideoName,
+          duration: video.duration,
+        };
+
+        const isMatch = await this.checkFilters(videoData, profile.filters);
+
+        if (isMatch || profile.is_default) {
+          let cleanTitle = this.getCleanTitle(video.youTubeVideoName, profile.filters);
+
+          // Remove channel name from title if present
+          const channelName = profile.channel.title || profile.channel.uploader;
+          if (cleanTitle.toLowerCase().startsWith(channelName.toLowerCase())) {
+            cleanTitle = cleanTitle.substring(channelName.length).replace(/^[-–—:\s]+/, '').trim();
+          }
+
+          // Parse date if available
+          let year = '', month = '', day = '';
+          if (video.originalDate) {
+            const dateStr = video.originalDate.toString();
+            year = dateStr.substring(0, 4);
+            month = dateStr.substring(4, 6);
+            day = dateStr.substring(6, 8);
+          }
+
+          const templateData = {
+            series: profile.series_name || profile.profile_name,
+            season: profile.is_default ? 0 : profile.season_number,
+            episode: episodeCounter,
+            title: video.youTubeVideoName,
+            clean_title: cleanTitle,
+            year,
+            month,
+            day,
+            channel: profile.channel.title || profile.channel.uploader,
+            id: video.youtubeId,
+          };
+
+          const newFilename = this.applyNamingTemplate(profile.naming_template, templateData);
+
+          matches.push({
+            video_id: video.id,
+            youtube_id: video.youtubeId,
+            original_title: video.youTubeVideoName,
+            clean_title: cleanTitle,
+            new_filename: newFilename,
+            season: templateData.season,
+            episode: episodeCounter,
+            matched_by_filter: !profile.is_default,
+          });
+
+          episodeCounter++;
+        }
+      }
+
+      return matches;
+    } catch (error) {
+      console.error('Error testing profile filters:', error);
+      throw error;
+    }
+  }
+}
+
+module.exports = new ChannelProfileModule();

--- a/server/modules/nfoGeneratorModule.js
+++ b/server/modules/nfoGeneratorModule.js
@@ -1,0 +1,210 @@
+const fs = require('fs-extra');
+const path = require('path');
+
+class NFOGeneratorModule {
+  /**
+   * Generate an episode NFO file
+   * @param {Object} data - Episode data
+   * @param {string} data.title - Episode title
+   * @param {number} data.season - Season number
+   * @param {number} data.episode - Episode number
+   * @param {string} data.plot - Episode description/plot
+   * @param {string} data.aired - Aired date (YYYY-MM-DD format)
+   * @param {string} data.studio - Studio/channel name
+   * @param {string} data.uniqueId - Unique identifier (YouTube ID)
+   * @param {string} data.thumb - Thumbnail filename (optional)
+   * @returns {string} NFO XML content
+   */
+  generateEpisodeNFO(data) {
+    const xmlContent = `<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<episodedetails>
+    <title>${this.escapeXML(data.title || '')}</title>
+    <season>${data.season || 1}</season>
+    <episode>${data.episode || 1}</episode>
+    <plot>${this.escapeXML(data.plot || '')}</plot>
+    <aired>${data.aired || ''}</aired>
+    <premiered>${data.aired || ''}</premiered>
+    <studio>${this.escapeXML(data.studio || '')}</studio>
+    <uniqueid type="youtube" default="true">${data.uniqueId || ''}</uniqueid>${data.thumb ? `
+    <thumb>${this.escapeXML(data.thumb)}</thumb>` : ''}
+</episodedetails>`;
+
+    return xmlContent;
+  }
+
+  /**
+   * Generate a TV show NFO file
+   * @param {Object} data - TV show data
+   * @param {string} data.title - Series title
+   * @param {string} data.plot - Series description
+   * @param {string} data.studio - Studio/channel name
+   * @param {string} data.premiered - First episode date
+   * @param {string} data.status - Show status (Continuing/Ended)
+   * @param {string} data.uniqueId - Channel ID
+   * @returns {string} NFO XML content
+   */
+  generateTVShowNFO(data) {
+    const xmlContent = `<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<tvshow>
+    <title>${this.escapeXML(data.title || '')}</title>
+    <plot>${this.escapeXML(data.plot || '')}</plot>
+    <studio>${this.escapeXML(data.studio || '')}</studio>
+    <premiered>${data.premiered || ''}</premiered>
+    <status>${data.status || 'Continuing'}</status>
+    <uniqueid type="youtube_channel">${data.uniqueId || ''}</uniqueid>
+</tvshow>`;
+
+    return xmlContent;
+  }
+
+  /**
+   * Write an episode NFO file to disk
+   * @param {string} filePath - Path to save the NFO file (without extension)
+   * @param {Object} episodeData - Episode data
+   * @returns {Promise<string>} Path to created NFO file
+   */
+  async writeEpisodeNFO(filePath, episodeData) {
+    try {
+      const nfoPath = `${filePath}.nfo`;
+      const nfoContent = this.generateEpisodeNFO(episodeData);
+
+      await fs.writeFile(nfoPath, nfoContent, 'utf8');
+      return nfoPath;
+    } catch (error) {
+      console.error('Error writing episode NFO:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Write a TV show NFO file to disk
+   * @param {string} seriesPath - Path to series directory
+   * @param {Object} showData - TV show data
+   * @returns {Promise<string>} Path to created NFO file
+   */
+  async writeTVShowNFO(seriesPath, showData) {
+    try {
+      const nfoPath = path.join(seriesPath, 'tvshow.nfo');
+      const nfoContent = this.generateTVShowNFO(showData);
+
+      await fs.writeFile(nfoPath, nfoContent, 'utf8');
+      return nfoPath;
+    } catch (error) {
+      console.error('Error writing TV show NFO:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Check if a TV show NFO already exists
+   * @param {string} seriesPath - Path to series directory
+   * @returns {Promise<boolean>} True if tvshow.nfo exists
+   */
+  async tvShowNFOExists(seriesPath) {
+    try {
+      const nfoPath = path.join(seriesPath, 'tvshow.nfo');
+      return await fs.pathExists(nfoPath);
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
+   * Create NFO files for a processed video
+   * @param {Object} options - NFO creation options
+   * @param {string} options.videoPath - Full path to video file (without extension)
+   * @param {string} options.seriesPath - Path to series directory
+   * @param {Object} options.videoData - Video metadata
+   * @param {Object} options.profileData - Profile configuration
+   * @param {number} options.season - Season number
+   * @param {number} options.episode - Episode number
+   * @returns {Promise<Object>} Paths to created NFO files
+   */
+  async createNFOFiles(options) {
+    const results = {
+      episodeNFO: null,
+      tvshowNFO: null
+    };
+
+    try {
+      // Format the aired date
+      let airedDate = '';
+      if (options.videoData.originalDate) {
+        const dateStr = options.videoData.originalDate.toString();
+        const year = dateStr.substring(0, 4);
+        const month = dateStr.substring(4, 6);
+        const day = dateStr.substring(6, 8);
+        airedDate = `${year}-${month}-${day}`;
+      }
+
+      // Create episode NFO
+      const episodeData = {
+        title: options.videoData.title || options.videoData.youTubeVideoName,
+        season: options.season,
+        episode: options.episode,
+        plot: options.videoData.description || '',
+        aired: airedDate,
+        studio: options.videoData.youTubeChannelName || '',
+        uniqueId: options.videoData.youtubeId || '',
+        thumb: path.basename(options.videoPath) + '.jpg'
+      };
+
+      results.episodeNFO = await this.writeEpisodeNFO(options.videoPath, episodeData);
+
+      // Create TV show NFO if it doesn't exist
+      const tvshowExists = await this.tvShowNFOExists(options.seriesPath);
+      if (!tvshowExists) {
+        const showData = {
+          title: options.profileData.profile_name,
+          plot: `YouTube series from ${options.videoData.youTubeChannelName}`,
+          studio: options.videoData.youTubeChannelName || '',
+          premiered: airedDate,
+          status: 'Continuing',
+          uniqueId: options.videoData.channel_id || ''
+        };
+
+        results.tvshowNFO = await this.writeTVShowNFO(options.seriesPath, showData);
+      }
+
+      return results;
+    } catch (error) {
+      console.error('Error creating NFO files:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Escape special XML characters
+   * @param {string} text - Text to escape
+   * @returns {string} Escaped text
+   */
+  escapeXML(text) {
+    if (!text) return '';
+
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  /**
+   * Parse upload date to YYYY-MM-DD format
+   * @param {string} uploadDate - Upload date in YYYYMMDD format
+   * @returns {string} Formatted date YYYY-MM-DD
+   */
+  formatUploadDate(uploadDate) {
+    if (!uploadDate || uploadDate.length !== 8) {
+      return '';
+    }
+
+    const year = uploadDate.substring(0, 4);
+    const month = uploadDate.substring(4, 6);
+    const day = uploadDate.substring(6, 8);
+
+    return `${year}-${month}-${day}`;
+  }
+}
+
+module.exports = new NFOGeneratorModule();


### PR DESCRIPTION
This is my first time making a PR to a public project like this. Forgive me if I'm going about this the wrong way. But I humbly present a feature I thought this app was missing to help organize your downloads for displaying in media apps.

I use plex so I wanted to see if I could get Youtarr to organize some of the channels I watch that put out various series on their channel into different seasons in plex to create what looks like series selection. 
  - Add channel profiles for organizing videos into TV series format
  - Channel profiles are optional and the original workflow of the app will work as the default behavior for unconfigured channels
  - Support multiple profiles per channel with filter matching (OR logic)
  - Add Season/Episode numbering with Season 0 support for specials
  - Implement customizable naming templates with variable substitution
  - Add folder browser for destination path selection
  - Generate NFO metadata files for Jellyfin/Emby/Kodi compatibility
  - Names thumbnail image to match video name for plex to auto set the episode image
  - Include comprehensive test coverage (21 new tests)
  - Add database migrations for new profile tables
  - Fix Docker build permissions for react-scripts