### PR TITLE
fix: remove Python dependency from setup scripts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -54,7 +54,8 @@ plex_ip_escaped=$(printf '%s\n' "$plex_ip" | sed 's:[][\/.^$*]:\\&:g')
 sed -i "s/\"plexIP\": \".*\"/\"plexIP\": \"$plex_ip_escaped\"/" ./config/config.json
 
 # Check if youtubeOutputDirectory is already set in config
-CURRENT_DIR=$(grep '"youtubeOutputDirectory"' ./config/config.json | sed 's/.*"youtubeOutputDirectory": "\(.*\)".*/\1/')
+# Extract the value between quotes after youtubeOutputDirectory
+CURRENT_DIR=$(grep '"youtubeOutputDirectory"' ./config/config.json | sed 's/.*"youtubeOutputDirectory"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
 
 # Trim whitespace from CURRENT_DIR
 CURRENT_DIR=$(echo "$CURRENT_DIR" | xargs)

--- a/start.sh
+++ b/start.sh
@@ -30,8 +30,12 @@ if [ ! -f "config/config.json" ]; then
   exit 1
 fi
 
-# Read the selected directory from the config file
-youtubeOutputDirectory=$(python -c "import json; print(json.load(open('config/config.json'))['youtubeOutputDirectory'])" 2>/dev/null)
+# Read the selected directory from the config file using shell commands
+# Extract the value between quotes after youtubeOutputDirectory
+youtubeOutputDirectory=$(grep '"youtubeOutputDirectory"' config/config.json | sed 's/.*"youtubeOutputDirectory"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+
+# Trim whitespace
+youtubeOutputDirectory=$(echo "$youtubeOutputDirectory" | xargs)
 
 # Check if the directory was successfully read and is not empty
 if [ -z "$youtubeOutputDirectory" ] || [ "$youtubeOutputDirectory" == "" ] || [ "$youtubeOutputDirectory" == "null" ]; then


### PR DESCRIPTION
Replace Python-based JSON parsing with shell-native grep/sed commands in setup.sh and start.sh. This eliminates the Python requirement, fixing the issue where setup.sh could silently fail if Python was not present.