### PR TITLE
fix: allow platform auth to bypass plex setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,6 @@ module.exports = {
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
   testTimeout: 10000,
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js']
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  maxWorkers: 1
 };

--- a/server/__tests__/server.plex-routes.test.js
+++ b/server/__tests__/server.plex-routes.test.js
@@ -1,0 +1,211 @@
+/* eslint-env jest */
+
+const findRouteHandler = (app, method, routePath) => {
+  const stack = app?._router?.stack || [];
+  for (const layer of stack) {
+    if (layer.route && layer.route.path === routePath && layer.route.methods[method]) {
+      return layer.route.stack[0].handle;
+    }
+  }
+  throw new Error(`Route ${method.toUpperCase()} ${routePath} not found`);
+};
+
+const createMockRequest = (overrides = {}) => ({
+  params: {},
+  query: {},
+  headers: {},
+  body: {},
+  path: '',
+  ip: '127.0.0.1',
+  connection: { remoteAddress: '127.0.0.1' },
+  socket: { remoteAddress: '127.0.0.1' },
+  ...overrides
+});
+
+const createMockResponse = () => {
+  const res = {
+    statusCode: 200,
+    headers: {}
+  };
+
+  res.status = jest.fn((code) => {
+    res.statusCode = code;
+    return res;
+  });
+
+  res.json = jest.fn((payload) => {
+    res.body = payload;
+    return res;
+  });
+
+  res.send = jest.fn((payload) => {
+    res.body = payload;
+    return res;
+  });
+
+  return res;
+};
+
+const setupServer = async ({ authEnabled = 'false', passwordHash = null } = {}) => {
+  jest.resetModules();
+  jest.clearAllMocks();
+
+  process.env.NODE_ENV = 'test';
+
+  if (authEnabled === undefined) {
+    delete process.env.AUTH_ENABLED;
+  } else {
+    process.env.AUTH_ENABLED = authEnabled;
+  }
+
+  const https = require('https');
+  jest.spyOn(https, 'get').mockImplementation(() => {});
+
+  const fakeConfig = {
+    passwordHash,
+    username: passwordHash ? 'tester' : null,
+    dockerAutoCreated: false,
+    plexUrl: 'http://plex:32400'
+  };
+
+  const configModuleMock = {
+    directoryPath: '/downloads',
+    getConfig: jest.fn(() => fakeConfig),
+    updateConfig: jest.fn((nextConfig) => Object.assign(fakeConfig, nextConfig)),
+    getImagePath: jest.fn(() => '/images'),
+    getCookiesStatus: jest.fn(() => ({ cookiesEnabled: false })),
+    writeCustomCookiesFile: jest.fn(),
+    deleteCustomCookiesFile: jest.fn(),
+    getStorageStatus: jest.fn().mockResolvedValue({ total: 1, free: 1 }),
+    config: fakeConfig,
+    stopWatchingConfig: jest.fn()
+  };
+
+  const plexModuleMock = {
+    getLibrariesWithParams: jest.fn().mockResolvedValue([]),
+    getLibraries: jest.fn().mockResolvedValue([]),
+    refreshLibrary: jest.fn().mockResolvedValue(),
+    getAuthUrl: jest.fn().mockResolvedValue({ url: 'https://plex.example/auth' }),
+    checkPin: jest.fn().mockResolvedValue({ authenticated: true })
+  };
+
+  jest.doMock('../db', () => ({
+    initializeDatabase: jest.fn().mockResolvedValue(),
+    Session: {
+      findOne: jest.fn().mockResolvedValue(null),
+      destroy: jest.fn().mockResolvedValue(0)
+    },
+    Sequelize: { Op: { gt: Symbol('gt'), lt: Symbol('lt'), or: Symbol('or') } }
+  }));
+
+  jest.doMock('../modules/configModule', () => configModuleMock);
+  jest.doMock('../modules/plexModule', () => plexModuleMock);
+  jest.doMock('../modules/channelModule', () => ({
+    subscribe: jest.fn(),
+    readChannels: jest.fn().mockResolvedValue([]),
+    writeChannels: jest.fn().mockResolvedValue(),
+    getChannelInfo: jest.fn().mockResolvedValue({}),
+    getChannelVideos: jest.fn().mockResolvedValue([])
+  }));
+  jest.doMock('../modules/downloadModule', () => ({
+    doSpecificDownloads: jest.fn(),
+    doChannelDownloads: jest.fn()
+  }));
+  jest.doMock('../modules/jobModule', () => ({
+    getJob: jest.fn(),
+    getRunningJobs: jest.fn(() => [])
+  }));
+  jest.doMock('../modules/videosModule', () => ({
+    getVideos: jest.fn().mockResolvedValue([])
+  }));
+  jest.doMock('../modules/webSocketServer.js', () => jest.fn());
+
+  jest.doMock('node-cron', () => ({ schedule: jest.fn() }));
+  jest.doMock('express-rate-limit', () => jest.fn(() => (req, res, next) => next()));
+
+  const serverModule = require('../server');
+  await serverModule.initialize();
+
+  return {
+    app: serverModule.app,
+    configModuleMock,
+    plexModuleMock
+  };
+};
+
+describe('Plex authentication routes', () => {
+  afterEach(() => {
+    delete process.env.AUTH_ENABLED;
+    jest.restoreAllMocks();
+  });
+
+  test('bypasses password requirement when platform manages auth', async () => {
+    const { app, plexModuleMock } = await setupServer({ authEnabled: 'false', passwordHash: null });
+
+    const handler = findRouteHandler(app, 'get', '/plex/auth-url');
+    const req = createMockRequest({ path: '/plex/auth-url' });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ url: 'https://plex.example/auth' });
+    expect(plexModuleMock.getAuthUrl).toHaveBeenCalledTimes(1);
+  });
+
+  test('blocks Plex auth when local auth not configured', async () => {
+    const { app, plexModuleMock } = await setupServer({ authEnabled: 'true', passwordHash: null });
+
+    const handler = findRouteHandler(app, 'get', '/plex/auth-url');
+    const req = createMockRequest({ path: '/plex/auth-url' });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({
+      error: 'Authentication not configured',
+      requiresSetup: true,
+      message: 'Please complete initial setup first'
+    });
+    expect(plexModuleMock.getAuthUrl).not.toHaveBeenCalled();
+  });
+
+  test('allows Plex PIN checks when platform manages auth', async () => {
+    const { app, plexModuleMock } = await setupServer({ authEnabled: 'false', passwordHash: null });
+
+    const handler = findRouteHandler(app, 'get', '/plex/check-pin/:pinId');
+    const req = createMockRequest({
+      path: '/plex/check-pin/sample',
+      params: { pinId: 'sample' }
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ authenticated: true });
+    expect(plexModuleMock.checkPin).toHaveBeenCalledWith('sample');
+  });
+
+  test('blocks Plex PIN checks when local auth required but missing', async () => {
+    const { app, plexModuleMock } = await setupServer({ authEnabled: 'true', passwordHash: null });
+
+    const handler = findRouteHandler(app, 'get', '/plex/check-pin/:pinId');
+    const req = createMockRequest({
+      path: '/plex/check-pin/sample',
+      params: { pinId: 'sample' }
+    });
+    const res = createMockResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({
+      error: 'Authentication not configured',
+      requiresSetup: true,
+      message: 'Please complete initial setup first'
+    });
+    expect(plexModuleMock.checkPin).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- guard plex auth and pin routes when AUTH_ENABLED=false
- export app/initialize and skip server boot in NODE_ENV=test
- serialize Jest workers and add regression tests for Plex routes