### PR TITLE
feat: add Deno runtime to Docker image for future yt-dlp YouTube support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,16 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     ffmpeg \
     curl \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Download the latest yt-dlp release directly from GitHub
 RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp && \
     chmod +x /usr/local/bin/yt-dlp
+
+# Install Deno
+ENV DENO_INSTALL="/usr/local"
+RUN curl -fsSL https://deno.land/install.sh | sh
 
 # Copy production node_modules
 COPY --from=dependencies /app/node_modules ./node_modules


### PR DESCRIPTION
- Install Deno alongside yt-dlp in /usr/local/bin
- Add unzip package as dependency for Deno installation
- Addresses upcoming yt-dlp requirement for JavaScript runtime (yt-dlp/yt-dlp#14404)
- No additional components needed as yt-dlp bundles JS files in binary releases