### PR TITLE
feat: live stream URL support and improved metadata

### DIFF
--- a/client/src/components/DownloadManager/DownloadProgress.tsx
+++ b/client/src/components/DownloadManager/DownloadProgress.tsx
@@ -340,7 +340,13 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
             {/* Thicker progress bar with overlay text */}
             <Box sx={{ position: 'relative', mb: 1 }}>
               <LinearProgress
-                variant="determinate"
+                variant={
+                  currentProgress.state === 'merging' ||
+                  currentProgress.state === 'metadata' ||
+                  currentProgress.state === 'processing'
+                    ? 'indeterminate'
+                    : 'determinate'
+                }
                 value={currentProgress.progress.percent}
                 sx={{
                   height: 32,

--- a/migrations/20251003160512-add-last-downloaded-at-to-videos.js
+++ b/migrations/20251003160512-add-last-downloaded-at-to-videos.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    // Add last_downloaded_at column - nullable for backwards compatibility
+    await queryInterface.addColumn('Videos', 'last_downloaded_at', {
+      type: Sequelize.DATE,
+      allowNull: true
+    });
+
+    // Add index for better query performance when sorting by download date
+    await queryInterface.addIndex('Videos', ['last_downloaded_at']);
+  },
+
+  async down (queryInterface, Sequelize) {
+    // Remove index first
+    await queryInterface.removeIndex('Videos', ['last_downloaded_at']);
+
+    // Remove column
+    await queryInterface.removeColumn('Videos', 'last_downloaded_at');
+  }
+};

--- a/server/models/video.js
+++ b/server/models/video.js
@@ -67,6 +67,11 @@ Video.init(
       allowNull: true,
       defaultValue: null,
     },
+    last_downloaded_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     sequelize,

--- a/server/modules/__tests__/videosModule.test.js
+++ b/server/modules/__tests__/videosModule.test.js
@@ -191,7 +191,7 @@ describe('VideosModule', () => {
       expect(sqlQuery).toContain('Videos.removed');
       expect(sqlQuery).toContain('Videos.youtube_removed');
       expect(sqlQuery).toContain('Videos.media_type');
-      expect(sqlQuery).toContain('COALESCE(Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, \'%Y%m%d\')) AS timeCreated');
+      expect(sqlQuery).toContain('COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, \'%Y%m%d\')) AS timeCreated');
 
       // Verify the JOINs
       expect(sqlQuery).toContain('LEFT JOIN');
@@ -200,7 +200,7 @@ describe('VideosModule', () => {
 
       // Verify the ORDER BY clause
       expect(sqlQuery).toContain('ORDER BY');
-      expect(sqlQuery).toContain('COALESCE(Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, \'%Y%m%d\')) DESC');
+      expect(sqlQuery).toContain('COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, \'%Y%m%d\')) DESC');
 
       // Verify the LIMIT and OFFSET
       expect(sqlQuery).toContain('LIMIT :limit OFFSET :offset');
@@ -307,7 +307,7 @@ describe('VideosModule', () => {
       await VideosModule.getVideosPaginated();
 
       const query2 = mockSequelize.query.mock.calls[1][0];
-      expect(query2).toContain('ORDER BY COALESCE(Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, \'%Y%m%d\')) DESC');
+      expect(query2).toContain('ORDER BY COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, \'%Y%m%d\')) DESC');
     });
 
     test('should handle date filters correctly', async () => {

--- a/server/modules/jobModule.js
+++ b/server/modules/jobModule.js
@@ -243,10 +243,13 @@ class JobModule {
             updateData.filePath = video.filePath;
             updateData.fileSize = video.fileSize;
             updateData.removed = false;
+            updateData.last_downloaded_at = new Date();
+            console.log(`[DEBUG] Setting last_downloaded_at for ${video.youtubeId} - file verified with size ${video.fileSize}`);
           } else {
             delete updateData.filePath;
             delete updateData.fileSize;
             delete updateData.removed;
+            console.log(`[DEBUG] NOT setting last_downloaded_at for ${video.youtubeId} - hasVerifiedFile is false (filePath: ${video.filePath}, fileSize: ${video.fileSize})`);
           }
 
           if (!video.media_type) {
@@ -351,11 +354,14 @@ class JobModule {
                 updateData.filePath = video.filePath;
                 updateData.fileSize = video.fileSize;
                 updateData.removed = false;
+                updateData.last_downloaded_at = new Date();
+                console.log(`[DEBUG] Setting last_downloaded_at for ${video.youtubeId} - file verified with size ${video.fileSize}`);
               } else {
                 // Otherwise leave these fields untouched so the backfill job can manage them
                 delete updateData.filePath;
                 delete updateData.fileSize;
                 delete updateData.removed;
+                console.log(`[DEBUG] NOT setting last_downloaded_at for ${video.youtubeId} - hasVerifiedFile is false (filePath: ${video.filePath}, fileSize: ${video.fileSize})`);
               }
 
               // Don't overwrite media_type if the job data doesn't have it (leave backfill value intact)

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -215,6 +215,15 @@ async function copyChannelPosterIfNeeded(channelId, channelFolderPath) {
         ffmpegArgs.push('-metadata', `keywords=${keywords}`);
       }
 
+      // Add release date for Plex/mp4 embedded metadata
+      if (jsonData.upload_date) {
+        const year = jsonData.upload_date.substring(0, 4);
+        const month = jsonData.upload_date.substring(4, 6);
+        const day = jsonData.upload_date.substring(6, 8);
+        const releaseDate = `${year}-${month}-${day}`;
+        ffmpegArgs.push('-metadata', `release_date=${releaseDate}`);
+      }
+
       // Add media type hint for Plex (9 = Home Video)
       ffmpegArgs.push('-metadata', 'media_type=9');
 

--- a/server/modules/videoValidationModule.js
+++ b/server/modules/videoValidationModule.js
@@ -53,7 +53,7 @@ class VideoValidationModule {
         if (candidate && idPattern.test(candidate)) {
           videoId = candidate;
         }
-      } else if (pathSegments[0] === 'shorts' || pathSegments[0] === 'embed') {
+      } else if (pathSegments[0] === 'shorts' || pathSegments[0] === 'embed' || pathSegments[0] === 'live') {
         const candidate = pathSegments[1];
         if (candidate && idPattern.test(candidate)) {
           videoId = candidate;

--- a/server/modules/videosModule.js
+++ b/server/modules/videosModule.js
@@ -54,7 +54,7 @@ class VideosModule {
       if (sortBy === 'published') {
         orderByColumn = 'Videos.originalDate';
       } else {
-        orderByColumn = 'COALESCE(Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, \'%Y%m%d\'))';
+        orderByColumn = 'COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, \'%Y%m%d\'))';
       }
       const orderByClause = `ORDER BY ${orderByColumn} ${sortOrder.toUpperCase()}`;
 
@@ -90,7 +90,7 @@ class VideosModule {
           Videos.removed,
           Videos.youtube_removed,
           Videos.media_type,
-          COALESCE(Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, '%Y%m%d')) AS timeCreated
+          COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, '%Y%m%d')) AS timeCreated
         FROM Videos
         LEFT JOIN JobVideos ON Videos.id = JobVideos.video_id
         LEFT JOIN Jobs ON Jobs.id = JobVideos.job_id


### PR DESCRIPTION
- Added support for /live/ URL pattern in video ID extraction to handle
  YouTube live stream links (e.g., youtube.com/live/VIDEO_ID).
- Add `last_downloaded_at` field to Videos table with index
  - Correctly shows the time a video was downloaded, even for re-downloads of videos that were removed
- Set timestamp when video file is verified during download
- Prioritize download time over job creation time in video sorting
  - Ensures that videos in the Downloaded Videos page are sorted with most recently downloaded at the top
- Use indeterminate progress bar for merging/metadata/processing states
  - Better user feedback during the download processing steps
- Embed release_date metadata in MP4 files for Plex compatibility
  - Correctly supports original release date in Plex
- Add and update tests