### PR TITLE
feat: add --no-auth flag

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -18,6 +18,7 @@ Youtarr now uses Docker Compose with separate containers:
    ./scripts/build-dev.sh
    ./scripts/start-dev.sh
    ```
+   - Optional: append `--no-auth` only when developing behind your own authentication gateway (Cloudflare Tunnel, VPN, etc.); never expose a no-auth instance directly to the internet
 
 2. View logs:
    ```bash

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
    ```bash
    ./start.sh
    ```
+   - Optional: run `./start.sh --no-auth` only when Youtarr sits behind your own authentication layer (Cloudflare Tunnel, OAuth proxy, VPN, etc.)
+   - ⚠️ Never expose Youtarr directly to the internet when using `--no-auth`; always require upstream authentication
 
 4. **Access the web interface**:
    - Navigate to `http://localhost:3087`
@@ -127,6 +129,7 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 - **File Management**: Videos must retain their `[youtubeid].mp4` filename and remain in their download location. Moving or renaming files will cause Youtarr to mark them as "missing"
 - **Filtering**: Automatically skips YouTube Shorts and subscriber-only content
 - **Authentication**: Uses local authentication (create admin account on first access)
+- **Security**: Leave authentication enabled unless you have your own auth in front of Youtarr. If you launch with `--no-auth` (or set `AUTH_ENABLED=false`), never expose that instance directly to the public internet.
 
 ### For Plex Users (Optional)
 - **Library Type**: Must be configured as "Other Videos" with "Personal Media" agent
@@ -146,7 +149,7 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 Youtarr now fully supports platform-managed deployments with automatic configuration:
 
 - **Auto-Configuration**: When `DATA_PATH` is set, config.json is auto-created on first run
-- **Platform Authentication**: Set `AUTH_ENABLED=false` to bypass internal auth (when platform handles it)
+- **Platform Authentication**: Set `AUTH_ENABLED=false` to bypass internal auth (only when platform handles it). ⚠️ Never expose a no-auth instance directly; protect it behind your platform's authentication layer.
 - **Pre-configured Plex**: Set `PLEX_URL` for automatic Plex server configuration
 - **Consolidated Storage**: All persistent data stored under single `/app/config` mount
 - **Example**: `DATA_PATH=/storage/rclone/storagebox/youtube`
@@ -169,7 +172,6 @@ Licensed under the ISC License. See [LICENSE.md](LICENSE.md) for details.
 <img width="1916" height="1482" alt="image" src="https://github.com/user-attachments/assets/18625f29-61de-475d-b509-1654420e7612" />
 <img width="1907" height="1489" alt="image" src="https://github.com/user-attachments/assets/1151811e-0a8a-4960-897b-7b1eb3ab3546" />
 <img width="1905" height="1488" alt="image" src="https://github.com/user-attachments/assets/a9e10530-a966-42fa-b71d-b2d7bbbeadff" />
-
 
 
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -484,7 +484,16 @@ function AppContent() {
                   setRequiresSetup(false);
                   window.location.href = '/configuration';
                 }} />} />
-                <Route path='/login' element={<LocalLogin setToken={setToken} />} />
+                <Route
+                  path='/login'
+                  element={
+                    isPlatformManaged ? (
+                      <Navigate to='/configuration' replace />
+                    ) : (
+                      <LocalLogin setToken={setToken} />
+                    )
+                  }
+                />
                 {token ? (
                   <>
                     <Route

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,8 @@ services:
       DB_USER: root
       DB_PASSWORD: 123qweasd
       DB_NAME: youtarr
+      # Optional: Disable authentication (for platforms with external auth like Elfhosted)
+      AUTH_ENABLED: ${AUTH_ENABLED:-}
       # Optional: Custom data path for platforms like Elfhosted (defaults to /usr/src/app/data)
       # DATA_PATH: /storage/rclone/storagebox/youtube
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       DB_USER: root
       DB_PASSWORD: 123qweasd
       DB_NAME: youtarr
+      # Optional: Disable authentication (for platforms with external auth like Elfhosted)
+      AUTH_ENABLED: ${AUTH_ENABLED:-}
       # Optional: Custom data path for platforms like Elfhosted (defaults to /usr/src/app/data)
       # DATA_PATH: /storage/rclone/storagebox/youtube
     ports:

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -16,6 +16,29 @@ get_compose_command() {
 # Get the appropriate compose command
 COMPOSE_CMD=$(get_compose_command)
 
+# Parse command line arguments
+NO_AUTH=false
+for arg in "$@"; do
+  case $arg in
+    --no-auth)
+      NO_AUTH=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      echo "Usage: $0 [--no-auth]"
+      exit 1
+      ;;
+  esac
+done
+
+# Export AUTH_ENABLED for docker-compose if --no-auth flag is present
+if [ "$NO_AUTH" = true ]; then
+  export AUTH_ENABLED=false
+  echo "⚠️  Authentication disabled via --no-auth flag"
+  echo "⚠️  Do not expose Youtarr directly to the internet when auth is disabled; protect access with your own auth proxy"
+fi
+
 # Check if config file exists
 if [ ! -f "config/config.json" ]; then
   echo ""

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -216,12 +216,16 @@ async function copyChannelPosterIfNeeded(channelId, channelFolderPath) {
       }
 
       // Add release date for Plex/mp4 embedded metadata
+      // Good lord Plex is finicky
       if (jsonData.upload_date) {
         const year = jsonData.upload_date.substring(0, 4);
         const month = jsonData.upload_date.substring(4, 6);
         const day = jsonData.upload_date.substring(6, 8);
         const releaseDate = `${year}-${month}-${day}`;
         ffmpegArgs.push('-metadata', `release_date=${releaseDate}`);
+        ffmpegArgs.push('-metadata', `date=${releaseDate}`);
+        ffmpegArgs.push('-metadata', `year=${year}`);
+        ffmpegArgs.push('-metadata', `originaldate=${releaseDate}`);
       }
 
       // Add media type hint for Plex (9 = Home Video)


### PR DESCRIPTION
- Add --no-auth flag to start.sh and start-dev.sh scripts
- Set AUTH_ENABLED=false env var when flag is used
- Redirect /login to /configuration when auth is disabled
- Document security warnings in README and README-DEV
- Improve Plex metadata with additional date fields for better compatibility