### PR TITLE
feat: add external database support with helper scripts and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,11 @@ config/jobs.json
 config/config.json
 config/config.json.*
 config/cookies.user.txt
+config/*.env
 database
 server/images
+
+.env
 
 # Local dev exclusion
 ffmpeg.exe

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
        allow you to add and browse YouTube channels
    - If containers don’t start or the app isn’t reachable, see [Troubleshooting](docs/TROUBLESHOOTING.md)
 
+### Using an External Database
+- Already running MariaDB/MySQL elsewhere? Copy `config/external-db.env.example` to `config/external-db.env`, fill in your connection details, then either:
+  - Run `./start.sh --external-db` (Docker Compose helper) or
+  - Run `./start-with-external-db.sh` (single-container helper for platforms like UNRAID)
+- Full walkthrough (including local testing steps) lives in [docs/EXTERNAL_DB.md](docs/EXTERNAL_DB.md)
+
 ## 📋 Usage Examples
 
 ### Download Individual Videos
@@ -179,5 +185,3 @@ Licensed under the ISC License. See [LICENSE.md](LICENSE.md) for details.
 <img width="1916" height="1482" alt="image" src="https://github.com/user-attachments/assets/18625f29-61de-475d-b509-1654420e7612" />
 <img width="1907" height="1489" alt="image" src="https://github.com/user-attachments/assets/1151811e-0a8a-4960-897b-7b1eb3ab3546" />
 <img width="1905" height="1488" alt="image" src="https://github.com/user-attachments/assets/a9e10530-a966-42fa-b71d-b2d7bbbeadff" />
-
-

--- a/config/external-db.env.example
+++ b/config/external-db.env.example
@@ -1,0 +1,15 @@
+# Copy this file to config/external-db.env and update the values
+# These values are used when running ./start.sh --external-db
+
+# Hostname or IP of the MariaDB/MySQL server
+DB_HOST=your-database-host
+
+# Optional: change if your database listens on a custom port (defaults to 3306)
+DB_PORT=3306
+
+# Database credentials with access to the Youtarr schema
+DB_USER=youtarr
+DB_PASSWORD=super-secret-password
+
+# Optional: override the schema name (defaults to youtarr)
+DB_NAME=youtarr

--- a/docker-compose.external-db.yml
+++ b/docker-compose.external-db.yml
@@ -1,0 +1,27 @@
+services:
+  youtarr:
+    image: dialmaster/youtarr:latest
+    container_name: youtarr
+    restart: unless-stopped
+    environment:
+      IN_DOCKER_CONTAINER: 1
+      DB_HOST: ${DB_HOST:?Set DB_HOST in config/external-db.env}
+      DB_PORT: ${DB_PORT:-3306}
+      DB_USER: ${DB_USER:?Set DB_USER in config/external-db.env}
+      DB_PASSWORD: ${DB_PASSWORD:?Set DB_PASSWORD in config/external-db.env}
+      DB_NAME: ${DB_NAME:-youtarr}
+      AUTH_ENABLED: ${AUTH_ENABLED:-}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "3087:3011"
+    volumes:
+      - ${YOUTUBE_OUTPUT_DIR}:/usr/src/app/data
+      - ./server/images:/app/server/images
+      - ./config:/app/config
+      - ./jobs:/app/jobs
+      - ./migrations:/app/migrations
+
+networks:
+  default:
+    name: youtarr-network

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -96,6 +96,17 @@ If you need to change the directory later:
 # Update "youtubeOutputDirectory" value
 ```
 
+## Using an External Database
+
+Some users prefer to supply their own MariaDB/MySQL instance instead of the bundled `youtarr-db` container. You now have two helper scripts:
+
+- Copy `config/external-db.env.example` to `config/external-db.env` and enter your credentials
+- Run `./start.sh --external-db` to launch only the application container via Docker Compose (uses `docker-compose.external-db.yml`)
+- Run `./start-with-external-db.sh` to launch a single container (should work for UNRAID or plain `docker run` workflows)
+- Follow the full walkthrough (including a local test harness) in [docs/EXTERNAL_DB.md](EXTERNAL_DB.md)
+
+Both helpers automatically run migrations against the external database on boot, so no manual schema management is required once connectivity is in place.
+
 ## Docker Commands
 
 ### Starting and Stopping

--- a/docs/EXTERNAL_DB.md
+++ b/docs/EXTERNAL_DB.md
@@ -1,0 +1,120 @@
+# Using Youtarr With an External Database
+
+Youtarr now supports running against an existing MariaDB or MySQL instance. This guide walks you through preparing the database, configuring the container, and testing the setup locally so you can ship a confident experience to users who already manage their own database (including UNRAID deployments).
+
+## Requirements
+
+- MariaDB 10.3+ or MySQL 8.0+ reachable from the Youtarr container
+- A database/schema dedicated to Youtarr (default name `youtarr`)
+- A user with full privileges on that schema
+- UTF-8 support (`utf8mb4` / `utf8mb4_unicode_ci`)
+
+> **Tip:** Keep the database and Youtarr container on the same Docker network or ensure routing/firewall rules allow traffic from Youtarr to the DB host/port.
+
+## 1. Prepare the External Database
+
+Run the following SQL on your target database host (adjust usernames/passwords as needed):
+
+```sql
+CREATE DATABASE youtarr CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER 'youtarr'@'%' IDENTIFIED BY 'change-me';
+GRANT ALL PRIVILEGES ON youtarr.* TO 'youtarr'@'%';
+FLUSH PRIVILEGES;
+```
+
+If your platform limits wildcard access, replace `'%'` with the container's IP or network CIDR.
+
+## 2. Configure Youtarr for the External DB
+
+1. Copy the new example file and fill in your connection details:
+   ```bash
+   cp config/external-db.env.example config/external-db.env
+   ${EDITOR:-nano} config/external-db.env
+   ```
+2. Verify the following keys are set:
+   - `DB_HOST` – hostname/IP of your database server
+     - On Docker Desktop/WSL, `host.docker.internal` is the most reliable host name for reaching Windows services from the container
+   - `DB_PORT` – defaults to 3306 if omitted
+   - `DB_USER` / `DB_PASSWORD` – credentials created above
+   - `DB_NAME` – defaults to `youtarr`
+3. Start Youtarr with whichever helper fits your setup:
+   ```bash
+   # Docker Compose helper (launches only the app container)
+   ./start.sh --external-db
+
+   # Single-container helper (wraps docker run, should be easier to use for UNRAID)
+   ./start-with-external-db.sh
+   ```
+   - `./start.sh --external-db` uses a dedicated compose stack (`docker-compose.external-db.yml`) that starts only the application container
+   - `./start-with-external-db.sh` wraps `docker run` for platforms where Docker Compose is unavailable
+   - Both scripts use the same `config/external-db.env` file
+   - Add `--no-auth` if you are fronting Youtarr with your own authentication layer
+   - Use `--image` with `start-with-external-db.sh` to pin a specific container tag when testing
+
+To revert to the bundled database, simply run `./start.sh` without the flag.
+
+## 3. Running `docker compose` Manually
+
+If you prefer manual Docker Compose commands:
+
+```bash
+# Export DB settings for this shell
+set -a
+. config/external-db.env
+set +a
+
+# Launch the single-service stack that targets your external database
+docker compose -f docker-compose.external-db.yml up -d
+```
+
+## 4. Testing Locally With a Throwaway DB
+
+Use this flow to verify the external-DB path without touching production:
+
+```bash
+# Create an isolated network so both containers can reach each other
+docker network create youtarr-ext-test
+
+# Launch a standalone MariaDB container that acts as the "external" DB
+docker run -d --name youtarr-ext-db \
+  --network youtarr-ext-test \
+  -e MYSQL_ROOT_PASSWORD=supersecret \
+  -e MYSQL_DATABASE=youtarr \
+  -e MYSQL_TCP_PORT=3306 \
+  mariadb:10.6 \
+  --character-set-server=utf8mb4 \
+  --collation-server=utf8mb4_unicode_ci
+
+# Update config/external-db.env
+cat <<'ENV' > config/external-db.env
+DB_HOST=youtarr-ext-db
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=supersecret
+DB_NAME=youtarr
+ENV
+
+# Start Youtarr against that database
+./start.sh --external-db
+```
+
+When you are finished testing:
+```bash
+./stop.sh
+docker rm -f youtarr-ext-db
+docker network rm youtarr-ext-test
+```
+
+## 5. Notes for UNRAID & Other Platforms
+
+- Create a MariaDB/MySQL container (or point to an existing server) and make sure it lives on the same Docker network as Youtarr.
+- Mount `config/`, `jobs/`, and your download directory into the Youtarr container just as you would with the standard stack.
+- Populate `config/external-db.env` inside the appdata share and run the container with `./start.sh --external-db` (or the equivalent command in the GUI).
+- Because migrations run automatically on boot, no manual schema management is required beyond the initial database/user creation.
+
+## 6. Troubleshooting Checklist
+
+- **Authentication errors**: confirm the credentials in `config/external-db.env` match the DB user and that the user has access from the container's IP.
+- **Connection timeout**: ensure the DB port is open and routable from the Docker network; check firewall or security group rules.
+- **Schema mismatch**: rerun `./start.sh --external-db` after clearing out a misconfigured database—the app will apply migrations automatically on startup.
+- **Character-set warnings**: verify the database is created with `utf8mb4` so emoji and YouTube metadata are stored correctly.

--- a/start-with-external-db.sh
+++ b/start-with-external-db.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [--no-auth] [--image IMAGE]" >&2
+  exit 1
+}
+
+NO_AUTH=false
+IMAGE="dialmaster/youtarr:latest"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-auth)
+      NO_AUTH=true
+      shift
+      ;;
+    --image)
+      if [[ $# -lt 2 ]]; then
+        usage
+      fi
+      IMAGE="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Error: docker command not found. Install Docker and try again." >&2
+  exit 1
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR="$SCRIPT_DIR"
+CONFIG_FILE="$ROOT_DIR/config/config.json"
+DB_ENV_FILE="$ROOT_DIR/config/external-db.env"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "===============================================" >&2
+  echo "ERROR: Configuration file not found!" >&2
+  echo "===============================================" >&2
+  echo "Please run ./setup.sh first to configure Youtarr." >&2
+  echo "===============================================" >&2
+  exit 1
+fi
+
+if [[ ! -f "$DB_ENV_FILE" ]]; then
+  echo "===============================================" >&2
+  echo "ERROR: External DB configuration missing!" >&2
+  echo "===============================================" >&2
+  echo "Expected environment file: $DB_ENV_FILE" >&2
+  echo "Create it from config/external-db.env.example and set" >&2
+  echo "DB_HOST, DB_USER, DB_PASSWORD (and optionally DB_PORT, DB_NAME)." >&2
+  echo "===============================================" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$DB_ENV_FILE"
+set +a
+
+REQUIRED_VARS=(DB_HOST DB_USER DB_PASSWORD)
+for var in "${REQUIRED_VARS[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "===============================================" >&2
+    echo "ERROR: Missing required variable $var in $DB_ENV_FILE" >&2
+    echo "===============================================" >&2
+    exit 1
+  fi
+done
+
+DB_PORT=${DB_PORT:-3306}
+DB_NAME=${DB_NAME:-youtarr}
+
+if [[ "$NO_AUTH" = true ]]; then
+  AUTH_ENABLED_VALUE="false"
+  echo "⚠️  Authentication disabled via --no-auth flag"
+  echo "⚠️  Do not expose Youtarr directly to the internet when auth is disabled; protect access with your own auth proxy"
+elif [[ -n "${AUTH_ENABLED:-}" ]]; then
+  AUTH_ENABLED_VALUE="$AUTH_ENABLED"
+else
+  AUTH_ENABLED_VALUE=""
+fi
+
+youtubeOutputDirectory=$(grep '"youtubeOutputDirectory"' "$CONFIG_FILE" | sed 's/.*"youtubeOutputDirectory"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+youtubeOutputDirectory=$(echo "$youtubeOutputDirectory" | xargs)
+
+if [[ -z "$youtubeOutputDirectory" || "$youtubeOutputDirectory" == "null" ]]; then
+  echo "===============================================" >&2
+  echo "ERROR: YouTube output directory not configured!" >&2
+  echo "===============================================" >&2
+  echo "Please run ./setup.sh to configure the download directory." >&2
+  echo "===============================================" >&2
+  exit 1
+fi
+
+DOCKER_MOUNT_SOURCE="$youtubeOutputDirectory"
+CHECK_DIR="$youtubeOutputDirectory"
+
+if [[ "$OSTYPE" == "msys" ]]; then
+  DOCKER_MOUNT_SOURCE="/$DOCKER_MOUNT_SOURCE"
+  CHECK_DIR="${DOCKER_MOUNT_SOURCE:1}"
+fi
+
+if [[ ! -d "$CHECK_DIR" ]]; then
+  echo "===============================================" >&2
+  echo "ERROR: YouTube output directory does not exist!" >&2
+  echo "===============================================" >&2
+  echo "Directory: $CHECK_DIR" >&2
+  echo "===============================================" >&2
+  exit 1
+fi
+
+if [[ ! -r "$CHECK_DIR" ]]; then
+  echo "===============================================" >&2
+  echo "ERROR: YouTube output directory is not readable!" >&2
+  echo "===============================================" >&2
+  echo "Directory: $CHECK_DIR" >&2
+  echo "===============================================" >&2
+  exit 1
+fi
+
+echo "YouTube output directory verified: $CHECK_DIR"
+
+echo "Preparing host directories..."
+mkdir -p "$ROOT_DIR/jobs" "$ROOT_DIR/server/images"
+
+CONTAINER_NAME="youtarr"
+
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+  echo "Stopping existing container $CONTAINER_NAME..."
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+fi
+
+echo "Pulling image $IMAGE..."
+docker pull "$IMAGE" >/dev/null
+
+RUN_ARGS=(
+  docker run -d
+  --name "$CONTAINER_NAME"
+  --restart unless-stopped
+  -p 3087:3011
+  --add-host host.docker.internal:host-gateway
+  -e IN_DOCKER_CONTAINER=1
+  -e DB_HOST="${DB_HOST}"
+  -e DB_PORT="${DB_PORT}"
+  -e DB_USER="${DB_USER}"
+  -e DB_PASSWORD="${DB_PASSWORD}"
+  -e DB_NAME="${DB_NAME}"
+)
+
+if [[ -n "$AUTH_ENABLED_VALUE" ]]; then
+  RUN_ARGS+=( -e "AUTH_ENABLED=${AUTH_ENABLED_VALUE}" )
+fi
+
+RUN_ARGS+=(
+  -v "${DOCKER_MOUNT_SOURCE}:/usr/src/app/data"
+  -v "${ROOT_DIR}/config:/app/config"
+  -v "${ROOT_DIR}/jobs:/app/jobs"
+  -v "${ROOT_DIR}/server/images:/app/server/images"
+  -v "${ROOT_DIR}/migrations:/app/migrations"
+  "$IMAGE"
+)
+
+echo "External database target: ${DB_HOST}:${DB_PORT} (schema: ${DB_NAME})"
+
+"${RUN_ARGS[@]}"
+
+echo "Youtarr is starting up..."
+echo "You can check the logs with: docker logs -f $CONTAINER_NAME"
+echo "To stop Youtarr, run: ./stop.sh"


### PR DESCRIPTION
- Add docker-compose.external-db.yml for external DB deployments
- Add start-with-external-db.sh script for single-container setups
- Add config/external-db.env.example template for DB credentials
- Update start.sh with --external-db flag to use external database
- Add docs/EXTERNAL_DB.md with setup guide and local testing workflow
- Update README.md and DOCKER.md with external DB usage instructions
- Update .gitignore to exclude *.env files