### PR TITLE
feat: bootstrap admin credentials from AUTH_PRESET env vars

### DIFF
--- a/config/external-db.env.example
+++ b/config/external-db.env.example
@@ -13,3 +13,7 @@ DB_PASSWORD=super-secret-password
 
 # Optional: override the schema name (defaults to youtarr)
 DB_NAME=youtarr
+
+# Optional: seed initial admin credentials for headless deployments
+# Export AUTH_PRESET_USERNAME and AUTH_PRESET_PASSWORD alongside this file
+# when running ./start.sh --external-db or start-with-external-db.sh

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,6 +42,9 @@ services:
       DB_NAME: youtarr
       # Optional: Disable authentication (for platforms with external auth like Elfhosted)
       AUTH_ENABLED: ${AUTH_ENABLED:-}
+      # Optional: Seed initial admin credentials for headless or scripted dev runs
+      AUTH_PRESET_USERNAME: ${AUTH_PRESET_USERNAME:-}
+      AUTH_PRESET_PASSWORD: ${AUTH_PRESET_PASSWORD:-}
       # Optional: Custom data path for platforms like Elfhosted (defaults to /usr/src/app/data)
       # DATA_PATH: /storage/rclone/storagebox/youtube
     ports:

--- a/docker-compose.external-db.yml
+++ b/docker-compose.external-db.yml
@@ -11,6 +11,8 @@ services:
       DB_PASSWORD: ${DB_PASSWORD:?Set DB_PASSWORD in config/external-db.env}
       DB_NAME: ${DB_NAME:-youtarr}
       AUTH_ENABLED: ${AUTH_ENABLED:-}
+      AUTH_PRESET_USERNAME: ${AUTH_PRESET_USERNAME:-}
+      AUTH_PRESET_PASSWORD: ${AUTH_PRESET_PASSWORD:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,9 @@ services:
       DB_NAME: youtarr
       # Optional: Disable authentication (for platforms with external auth like Elfhosted)
       AUTH_ENABLED: ${AUTH_ENABLED:-}
+      # Optional: Seed initial admin credentials for headless deployments
+      AUTH_PRESET_USERNAME: ${AUTH_PRESET_USERNAME:-}
+      AUTH_PRESET_PASSWORD: ${AUTH_PRESET_PASSWORD:-}
       # Optional: Custom data path for platforms like Elfhosted (defaults to /usr/src/app/data)
       # DATA_PATH: /storage/rclone/storagebox/youtube
     ports:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -38,6 +38,7 @@ Starting with version 1.23.0, Youtarr now **automatically creates** a `config/co
    - Run `./setup.sh` to configure your YouTube video directory
    - Script creates `config.json` with your chosen host path
    - Use `./start.sh` to start containers (reads path from config and sets volume mount)
+   - If no admin credentials exist, `./start.sh` prompts for an initial username/password and exports them as `AUTH_PRESET_USERNAME` / `AUTH_PRESET_PASSWORD` for the upcoming container boot
    - Use `./stop.sh` to stop containers
    - **UI Behavior**: YouTube Output Directory field is **editable** - changes require restart via `./start.sh`
 
@@ -193,6 +194,17 @@ Youtarr supports platform-managed deployments (Elfhosted, Kubernetes, etc.) with
 | `DATA_PATH` | Video storage path inside container | `/storage/rclone/storagebox/youtube` |
 | `AUTH_ENABLED` | Set to `false` to bypass internal authentication | `false` |
 | `PLEX_URL` | Pre-configured Plex server URL | `http://plex:32400` |
+
+### Preset Credentials for Headless Deployments
+
+For platforms where you cannot access `http://localhost:3087` (Unraid, Kubernetes, etc.), you can seed the initial login without touching the UI by setting both environment variables below. They are only applied when the config file does not already contain credentials.
+
+| Variable | Description |
+|----------|-------------|
+| `AUTH_PRESET_USERNAME` | Initial admin username. Trimmed and must be ≤ 32 characters. |
+| `AUTH_PRESET_PASSWORD` | Initial admin password (8–64 characters). Stored as a hash on first boot. |
+
+If only one variable is present, or the values fall outside the validation rules, the preset is ignored and the localhost-only setup wizard remains active. Once the credentials are saved to `config/config.json`, subsequent restarts ignore the preset variables so they can safely remain in your container template.
 
 #### What Happens in Platform Mode
 

--- a/docs/EXTERNAL_DB.md
+++ b/docs/EXTERNAL_DB.md
@@ -49,6 +49,7 @@ If your platform limits wildcard access, replace `'%'` with the container's IP o
    - `./start-with-external-db.sh` wraps `docker run` for platforms where Docker Compose is unavailable
    - Both scripts use the same `config/external-db.env` file
    - Add `--no-auth` if you are fronting Youtarr with your own authentication layer
+   - Provide `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` (either exported before running the script or via your platform's UI) when you need to bypass the localhost-only setup wizard
    - Use `--image` with `start-with-external-db.sh` to pin a specific container tag when testing
 
 To revert to the bundled database, simply run `./start.sh` without the flag.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -7,9 +7,11 @@
 **Problem**: Unable to access the initial setup page or getting "Initial setup can only be performed from localhost" error.
 
 **Solution**:
-- Initial setup must be done from the same machine running Youtarr
-- Access the setup using `http://localhost:3087` not the machine's IP address
-- If running in Docker, ensure you're accessing from the host machine
+- Initial setup must be done from the same machine running Youtarr unless you seed credentials via environment variables
+- Run `./start.sh` (or `./start.sh --external-db`) – if no credentials exist you will be prompted for an initial admin username/password and the script will export the required `AUTH_PRESET_USERNAME` / `AUTH_PRESET_PASSWORD` values automatically
+- Alternatively, pass both preset variables yourself when launching the container (e.g. through Docker Compose, Unraid template's environment, or other orchestration tools)
+- If you prefer to use the UI wizard, access the setup using `http://localhost:3087` (not the machine's IP address)
+- When running in Docker, make sure you browse from the host machine or forward the port securely as described below
 
 #### Accessing from a Headless/Remote Server
 
@@ -30,6 +32,8 @@ ssh -L 3087:localhost:3087 username@<server-ip-address>
 ```
 
 This creates a secure tunnel between your local machine's port 3087 and the server's port 3087, allowing you to complete the initial setup as if you were on localhost. After completing the setup, you can access Youtarr normally using the server's IP address.
+
+> Tip: If you cannot use SSH port forwarding, provide `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` in your container environment (or via `./start.sh`) before the first boot. Youtarr will hash the password and skip the localhost-only wizard.
 
 ### Forgotten Admin Password {#reset-admin-password}
 

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -39,6 +39,12 @@ if [ "$NO_AUTH" = true ]; then
   echo "⚠️  Do not expose Youtarr directly to the internet when auth is disabled; protect access with your own auth proxy"
 fi
 
+# Track whether preset credentials were provided before running this script
+PRESET_SUPPLIED_ALREADY=false
+if [ -n "${AUTH_PRESET_USERNAME:-}" ] && [ -n "${AUTH_PRESET_PASSWORD:-}" ]; then
+  PRESET_SUPPLIED_ALREADY=true
+fi
+
 # Check if config file exists
 if [ ! -f "config/config.json" ]; then
   echo ""
@@ -113,6 +119,80 @@ echo "YouTube output directory verified: $CHECK_DIR"
 # Export the YouTube output directory for docker-compose
 export YOUTUBE_OUTPUT_DIR="$youtubeOutputDirectory"
 
+# Determine if authentication is already configured in config.json
+passwordHash=$(grep -o '"passwordHash"[[:space:]]*:[[:space:]]*"[^"]*"' config/config.json 2>/dev/null | \
+  sed 's/.*"passwordHash"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' | head -n 1)
+passwordHash=$(echo "$passwordHash" | xargs)
+HAS_PASSWORD_HASH=""
+if [ -n "$passwordHash" ]; then
+  HAS_PASSWORD_HASH="yes"
+fi
+
+AUTH_PRESET_FROM_PROMPT=false
+
+if [ "$NO_AUTH" != true ] && [ -z "$HAS_PASSWORD_HASH" ]; then
+  if [ -n "${AUTH_PRESET_USERNAME:-}" ] && [ -n "${AUTH_PRESET_PASSWORD:-}" ]; then
+    echo "Using preset credentials from environment variables."
+  elif [ -n "${AUTH_PRESET_USERNAME:-}" ] || [ -n "${AUTH_PRESET_PASSWORD:-}" ]; then
+    echo "⚠️  Ignoring partial preset credentials. Both AUTH_PRESET_USERNAME and AUTH_PRESET_PASSWORD must be set." >&2
+    unset AUTH_PRESET_USERNAME
+    unset AUTH_PRESET_PASSWORD
+  else
+    echo ""
+    echo "================================================================"
+    echo "No admin credentials detected. Let's seed them for the dev stack."
+    echo "These values will be written to config/config.json on startup"
+    echo "and can be changed later from the UI."
+    echo "================================================================"
+
+    while true; do
+      read -r -p "Initial admin username [admin]: " INITIAL_USERNAME
+      INITIAL_USERNAME=${INITIAL_USERNAME:-admin}
+      INITIAL_USERNAME=$(echo "$INITIAL_USERNAME" | xargs)
+      if [ -z "$INITIAL_USERNAME" ]; then
+        echo "Username cannot be blank."
+        continue
+      fi
+      if [ ${#INITIAL_USERNAME} -gt 32 ]; then
+        echo "Username must be 32 characters or fewer."
+        continue
+      fi
+      break
+    done
+
+    while true; do
+      read -r -s -p "Initial admin password (min 8 chars): " INITIAL_PASSWORD
+      echo ""
+      read -r -s -p "Confirm password: " INITIAL_PASSWORD_CONFIRM
+      echo ""
+
+      if [ "$INITIAL_PASSWORD" != "$INITIAL_PASSWORD_CONFIRM" ]; then
+        echo "Passwords do not match. Please try again."
+        continue
+      fi
+
+      PASS_LENGTH=${#INITIAL_PASSWORD}
+      if [ $PASS_LENGTH -lt 8 ]; then
+        echo "Password must be at least 8 characters."
+        continue
+      fi
+      if [ $PASS_LENGTH -gt 64 ]; then
+        echo "Password must be 64 characters or fewer."
+        continue
+      fi
+
+      break
+    done
+
+    export AUTH_PRESET_USERNAME="$INITIAL_USERNAME"
+    export AUTH_PRESET_PASSWORD="$INITIAL_PASSWORD"
+    AUTH_PRESET_FROM_PROMPT=true
+
+    echo "Preset credentials captured. They will be applied on container startup."
+    echo "Initial admin username: $INITIAL_USERNAME"
+  fi
+fi
+
 # Stop and remove existing containers (if any)
 echo "Stopping existing containers..."
 $COMPOSE_CMD -f docker-compose.dev.yml down
@@ -126,3 +206,11 @@ echo ""
 echo "Youtarr development environment is starting up..."
 echo "You can check the logs with: $COMPOSE_CMD -f docker-compose.dev.yml logs -f"
 echo "To stop the development environment, run: $COMPOSE_CMD -f docker-compose.dev.yml down"
+
+if [ "$AUTH_PRESET_FROM_PROMPT" = true ]; then
+  unset AUTH_PRESET_USERNAME
+  unset AUTH_PRESET_PASSWORD
+  unset INITIAL_USERNAME
+  unset INITIAL_PASSWORD
+  unset INITIAL_PASSWORD_CONFIRM
+fi

--- a/start-with-external-db.sh
+++ b/start-with-external-db.sh
@@ -161,6 +161,15 @@ if [[ -n "$AUTH_ENABLED_VALUE" ]]; then
   RUN_ARGS+=( -e "AUTH_ENABLED=${AUTH_ENABLED_VALUE}" )
 fi
 
+if [[ -n "${AUTH_PRESET_USERNAME:-}" && -n "${AUTH_PRESET_PASSWORD:-}" ]]; then
+  RUN_ARGS+=(
+    -e "AUTH_PRESET_USERNAME=${AUTH_PRESET_USERNAME}"
+    -e "AUTH_PRESET_PASSWORD=${AUTH_PRESET_PASSWORD}"
+  )
+elif [[ -n "${AUTH_PRESET_USERNAME:-}" || -n "${AUTH_PRESET_PASSWORD:-}" ]]; then
+  echo "⚠️  Ignoring partial preset credentials. Both AUTH_PRESET_USERNAME and AUTH_PRESET_PASSWORD must be set." >&2
+fi
+
 RUN_ARGS+=(
   -v "${DOCKER_MOUNT_SOURCE}:/usr/src/app/data"
   -v "${ROOT_DIR}/config:/app/config"

--- a/start.sh
+++ b/start.sh
@@ -83,6 +83,12 @@ if [ "$NO_AUTH" = true ]; then
   echo "⚠️  Do not expose Youtarr directly to the internet when auth is disabled; protect access with your own auth proxy"
 fi
 
+# Track whether preset credentials were provided before running this script
+PRESET_SUPPLIED_ALREADY=false
+if [ -n "${AUTH_PRESET_USERNAME:-}" ] && [ -n "${AUTH_PRESET_PASSWORD:-}" ]; then
+  PRESET_SUPPLIED_ALREADY=true
+fi
+
 # Pull latest changes
 git pull
 
@@ -164,6 +170,83 @@ echo "YouTube output directory verified: $CHECK_DIR"
 # Export the YouTube output directory for docker-compose
 export YOUTUBE_OUTPUT_DIR="$youtubeOutputDirectory"
 
+# Determine if authentication is already configured in config.json
+passwordHash=$(grep -o '"passwordHash"[[:space:]]*:[[:space:]]*"[^"]*"' config/config.json 2>/dev/null | \
+  sed 's/.*"passwordHash"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' | head -n 1)
+passwordHash=$(echo "$passwordHash" | xargs)
+HAS_PASSWORD_HASH=""
+if [ -n "$passwordHash" ]; then
+  HAS_PASSWORD_HASH="yes"
+fi
+
+AUTH_PRESET_FROM_PROMPT=false
+
+if [ "$NO_AUTH" != true ] && [ -z "$HAS_PASSWORD_HASH" ]; then
+  if [ -n "${AUTH_PRESET_USERNAME:-}" ] && [ -n "${AUTH_PRESET_PASSWORD:-}" ]; then
+    echo "Using preset credentials from environment variables."
+  elif [ -n "${AUTH_PRESET_USERNAME:-}" ] || [ -n "${AUTH_PRESET_PASSWORD:-}" ]; then
+    echo "⚠️  Ignoring partial preset credentials. Both AUTH_PRESET_USERNAME and AUTH_PRESET_PASSWORD must be set." >&2
+    unset AUTH_PRESET_USERNAME
+    unset AUTH_PRESET_PASSWORD
+  else
+    echo ""
+    echo "================================================================"
+    echo "No admin credentials detected. Let's set them up now."
+    echo "These values will be written to config/config.json as soon as"
+    echo "the container starts. You can change them later from the UI."
+    echo "================================================================"
+
+    # Prompt for username (default to admin) and validate length
+    while true; do
+      read -r -p "Initial admin username [admin]: " INITIAL_USERNAME
+      INITIAL_USERNAME=${INITIAL_USERNAME:-admin}
+      # Trim leading/trailing whitespace
+      INITIAL_USERNAME=$(echo "$INITIAL_USERNAME" | xargs)
+      if [ -z "$INITIAL_USERNAME" ]; then
+        echo "Username cannot be blank."
+        continue
+      fi
+      if [ ${#INITIAL_USERNAME} -gt 32 ]; then
+        echo "Username must be 32 characters or fewer."
+        continue
+      fi
+      break
+    done
+
+    # Prompt for password and confirmation with validation
+    while true; do
+      read -r -s -p "Initial admin password (min 8 chars): " INITIAL_PASSWORD
+      echo ""
+      read -r -s -p "Confirm password: " INITIAL_PASSWORD_CONFIRM
+      echo ""
+
+      if [ "$INITIAL_PASSWORD" != "$INITIAL_PASSWORD_CONFIRM" ]; then
+        echo "Passwords do not match. Please try again."
+        continue
+      fi
+
+      PASS_LENGTH=${#INITIAL_PASSWORD}
+      if [ $PASS_LENGTH -lt 8 ]; then
+        echo "Password must be at least 8 characters."
+        continue
+      fi
+      if [ $PASS_LENGTH -gt 64 ]; then
+        echo "Password must be 64 characters or fewer."
+        continue
+      fi
+
+      break
+    done
+
+    export AUTH_PRESET_USERNAME="$INITIAL_USERNAME"
+    export AUTH_PRESET_PASSWORD="$INITIAL_PASSWORD"
+    AUTH_PRESET_FROM_PROMPT=true
+
+    echo "Preset credentials captured. They will be applied on container startup."
+    echo "Initial admin username: $INITIAL_USERNAME"
+  fi
+fi
+
 # Pull the latest images
 echo "Pulling latest images..."
 if [ "$USE_EXTERNAL_DB" = true ]; then
@@ -188,8 +271,8 @@ else
   $COMPOSE_CMD up -d
 fi
 
-# Check for auth setup after starting containers (skip if --no-auth was used)
-if [ "$NO_AUTH" != true ] && ! grep -q "passwordHash" config/config.json 2>/dev/null; then
+# Check for auth setup after starting containers (skip if presets were supplied)
+if [ "$NO_AUTH" != true ] && [ -z "$HAS_PASSWORD_HASH" ] && [ "$AUTH_PRESET_FROM_PROMPT" != true ] && [ "$PRESET_SUPPLIED_ALREADY" != true ] && { [ -z "${AUTH_PRESET_USERNAME:-}" ] || [ -z "${AUTH_PRESET_PASSWORD:-}" ]; }; then
   echo ""
   echo "================================================================"
   echo "⚠️  IMPORTANT: FIRST-TIME SETUP REQUIRED"
@@ -221,3 +304,11 @@ echo ""
 echo "Youtarr is starting up..."
 echo "You can check the logs with: $COMPOSE_CMD logs -f"
 echo "To stop Youtarr, run: ./stop.sh"
+
+if [ "$AUTH_PRESET_FROM_PROMPT" = true ]; then
+  unset AUTH_PRESET_USERNAME
+  unset AUTH_PRESET_PASSWORD
+  unset INITIAL_USERNAME
+  unset INITIAL_PASSWORD
+  unset INITIAL_PASSWORD_CONFIRM
+fi


### PR DESCRIPTION
- prompt for initial creds in start scripts when config lacks auth
- pass preset env vars through docker compose + external DB helpers
- validate/persist presets on server init and expand auth tests
- document headless setup flow and troubleshooting guidance