### PR TITLE
feat: standardize health checks with curl and update endpoint path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 EXPOSE 3011
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3011/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})" || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+  CMD curl --fail --silent --show-error --output /dev/null http://localhost:3011/api/health || exit 1
 
 # Use the entrypoint script
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -55,6 +55,12 @@ services:
       - ./config:/app/config
       - ./jobs:/app/jobs
       - ./migrations:/app/migrations
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--output", "/dev/null", "http://localhost:3011/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
 networks:
   default:

--- a/docker-compose.external-db.yml
+++ b/docker-compose.external-db.yml
@@ -23,6 +23,12 @@ services:
       - ./config:/app/config
       - ./jobs:/app/jobs
       - ./migrations:/app/migrations
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--output", "/dev/null", "http://localhost:3011/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,12 @@ services:
       - ./config:/app/config
       - ./jobs:/app/jobs
       - ./migrations:/app/migrations
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--output", "/dev/null", "http://localhost:3011/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
 networks:
   default:

--- a/server/__tests__/server.core.test.js
+++ b/server/__tests__/server.core.test.js
@@ -246,8 +246,8 @@ describe('server initialization', () => {
     expect(dbMock.initializeDatabase).toHaveBeenCalledTimes(1);
     expect(channelModuleMock.subscribe).toHaveBeenCalledTimes(1);
 
-    const [healthHandler] = findRouteHandlers(app, 'get', '/health');
-    const req = createMockRequest({ path: '/health' });
+    const [healthHandler] = findRouteHandlers(app, 'get', '/api/health');
+    const req = createMockRequest({ path: '/api/health' });
     const res = createMockResponse();
 
     await healthHandler(req, res);

--- a/server/server.js
+++ b/server/server.js
@@ -219,8 +219,8 @@ const initialize = async () => {
 
     /**** ONLY ROUTES BELOW THIS LINE *********/
 
-    // Health check endpoint
-    app.get('/health', (req, res) => {
+    // Health check endpoint - unauthenticated for Docker health checks
+    app.get('/api/health', (req, res) => {
       res.status(200).json({ status: 'healthy' });
     });
 


### PR DESCRIPTION
- Move health endpoint from /health to /api/health for API consistency
- Replace node-based HEALTHCHECK with curl for simplicity
- Add healthcheck configuration to all Docker Compose files
- Increase timeout to 10s and start_period to 40s to account for migrations
- Update server tests to match new health endpoint path