### PR TITLE
feat: add video codec preference configuration

### DIFF
--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -58,6 +58,7 @@ function Configuration({ token }: ConfigurationProps) {
     channelDownloadFrequency: '',
     channelFilesToDownload: 3,
     preferredResolution: '1080',
+    videoCodec: 'default',
     initialSetup: true,
     plexApiKey: '',
     youtubeOutputDirectory: '',
@@ -777,6 +778,7 @@ function Configuration({ token }: ConfigurationProps) {
       'channelDownloadFrequency',
       'channelFilesToDownload',
       'preferredResolution',
+      'videoCodec',
       'plexApiKey',
       'youtubeOutputDirectory',
       'plexYoutubeLibraryId',
@@ -1102,6 +1104,31 @@ function Configuration({ token }: ConfigurationProps) {
                   </Select>
                 </FormControl>
                 {getInfoIcon('The resolution we will try to download from YouTube. Note that this is not guaranteed as YouTube may not have your preferred resolution available.')}
+              </Box>
+            </Grid>
+
+            <Grid item xs={12} md={6}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  <FormControl fullWidth>
+                    <InputLabel>Preferred Video Codec</InputLabel>
+                    <Select
+                      value={config.videoCodec}
+                      onChange={(e: SelectChangeEvent<string>) =>
+                        setConfig({ ...config, videoCodec: e.target.value })
+                      }
+                      label="Preferred Video Codec"
+                    >
+                      <MenuItem value="default">Default (No Preference)</MenuItem>
+                      <MenuItem value="h264">H.264/AVC (Best Compatibility)</MenuItem>
+                      <MenuItem value="h265">H.265/HEVC (Balanced)</MenuItem>
+                    </Select>
+                  </FormControl>
+                  {getInfoIcon('Select your preferred video codec. Youtarr will download this codec when available, but will automatically fall back to other codecs if your preference is not available for a video. H.264 is recommended for Apple TV and maximum device compatibility.')}
+                </Box>
+                <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
+                  Note: H.264 produces larger file sizes but offers maximum compatibility. This is a preference and will fall back to available codecs.
+                </Typography>
               </Box>
             </Grid>
 

--- a/client/src/components/__tests__/Configuration.test.tsx
+++ b/client/src/components/__tests__/Configuration.test.tsx
@@ -116,6 +116,7 @@ const mockConfig = {
   channelDownloadFrequency: '0 */4 * * *',
   channelFilesToDownload: 3,
   preferredResolution: '1080',
+  videoCodec: 'default',
   initialSetup: false,
   plexApiKey: 'test-plex-key',
   youtubeOutputDirectory: '/videos',
@@ -298,6 +299,34 @@ const renderConfiguration = async ({
       await user.click(option);
 
       await screen.findByRole('button', { name: /4K \(2160p\)/i });
+    });
+
+    test('changes preferred video codec', async () => {
+      await setupComponent();
+      const user = createUser();
+
+      // MUI Select renders as a div with role="button" showing current value
+      const selectButton = screen.getByRole('button', { name: /Default \(No Preference\)/i });
+      await user.click(selectButton);
+
+      const option = await screen.findByRole('option', { name: 'H.264/AVC (Best Compatibility)' });
+      await user.click(option);
+
+      await screen.findByRole('button', { name: /H\.264\/AVC \(Best Compatibility\)/i });
+    });
+
+    test('changes preferred video codec to H.265', async () => {
+      await setupComponent();
+      const user = createUser();
+
+      // MUI Select renders as a div with role="button" showing current value
+      const selectButton = screen.getByRole('button', { name: /Default \(No Preference\)/i });
+      await user.click(selectButton);
+
+      const option = await screen.findByRole('option', { name: 'H.265/HEVC (Balanced)' });
+      await user.click(option);
+
+      await screen.findByRole('button', { name: /H\.265\/HEVC \(Balanced\)/i });
     });
   });
 

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -4,6 +4,7 @@
   "channelAutoDownload": false,
   "channelDownloadFrequency": "0 * * * *",
   "preferredResolution": "1080",
+  "videoCodec": "default",
   "plexIP": "",
   "plexPort": "32400",
   "plexApiKey": "",

--- a/server/modules/__tests__/configModule.test.js
+++ b/server/modules/__tests__/configModule.test.js
@@ -428,6 +428,7 @@ describe('ConfigModule', () => {
 
       expect(ConfigModule.config.channelFilesToDownload).toBe(3);
       expect(ConfigModule.config.preferredResolution).toBe('1080');
+      expect(ConfigModule.config.videoCodec).toBe('default');
       expect(ConfigModule.ffmpegPath).toBeUndefined();
       expect(ConfigModule.directoryPath).toBeUndefined();
     });
@@ -828,6 +829,86 @@ describe('ConfigModule', () => {
       expect(migrated.notificationsEnabled).toBe(true);
       expect(migrated.notificationService).toBe('discord');
       expect(migrated.discordWebhookUrl).toBe('https://discord.com/api/webhooks/existing');
+    });
+  });
+
+  describe('video codec configuration', () => {
+    beforeEach(() => {
+      ConfigModule = require('../configModule');
+    });
+
+    test('should initialize videoCodec to default when missing', () => {
+      const configWithoutCodec = { ...mockConfig };
+      delete configWithoutCodec.videoCodec;
+      fs.readFileSync.mockReturnValue(JSON.stringify(configWithoutCodec));
+
+      jest.resetModules();
+      jest.doMock('fs', () => ({
+        readFileSync: jest.fn().mockReturnValue(JSON.stringify(configWithoutCodec)),
+        writeFileSync: jest.fn(),
+        watch: jest.fn().mockReturnValue({ close: jest.fn() }),
+        existsSync: jest.fn().mockReturnValue(true),
+        mkdirSync: jest.fn()
+      }));
+      jest.doMock('uuid', () => ({
+        v4: jest.fn(() => 'test-uuid-1234')
+      }));
+
+      const FreshConfigModule = require('../configModule');
+
+      expect(FreshConfigModule.config.videoCodec).toBe('default');
+    });
+
+    test('should preserve existing videoCodec setting', () => {
+      const configWithCodec = {
+        ...mockConfig,
+        videoCodec: 'h264'
+      };
+
+      fs.readFileSync.mockReturnValue(JSON.stringify(configWithCodec));
+
+      jest.resetModules();
+      jest.doMock('fs', () => ({
+        readFileSync: jest.fn().mockReturnValue(JSON.stringify(configWithCodec)),
+        writeFileSync: jest.fn(),
+        watch: jest.fn().mockReturnValue({ close: jest.fn() }),
+        existsSync: jest.fn().mockReturnValue(true),
+        mkdirSync: jest.fn()
+      }));
+      jest.doMock('uuid', () => ({
+        v4: jest.fn(() => 'test-uuid-1234')
+      }));
+
+      const FreshConfigModule = require('../configModule');
+
+      expect(FreshConfigModule.config.videoCodec).toBe('h264');
+    });
+
+    test('migration 1.38.0 should add videoCodec setting', () => {
+      ConfigModule = require('../configModule');
+
+      const configWithoutCodec = {
+        plexApiKey: 'test',
+        youtubeOutputDirectory: '/test'
+      };
+
+      const migrated = ConfigModule.migrateConfig(configWithoutCodec);
+
+      expect(migrated.videoCodec).toBe('default');
+    });
+
+    test('migration 1.38.0 should preserve existing videoCodec setting', () => {
+      ConfigModule = require('../configModule');
+
+      const configWithCodec = {
+        plexApiKey: 'test',
+        youtubeOutputDirectory: '/test',
+        videoCodec: 'h265'
+      };
+
+      const migrated = ConfigModule.migrateConfig(configWithCodec);
+
+      expect(migrated.videoCodec).toBe('h265');
     });
   });
 

--- a/server/modules/configModule.js
+++ b/server/modules/configModule.js
@@ -45,6 +45,11 @@ class ConfigModule extends EventEmitter {
       this.config.preferredResolution = '1080';
     }
 
+    if (!this.config.videoCodec) {
+      this.config.videoCodec = 'default';
+      configModified = true;
+    }
+
     if (this.config.plexPort === undefined || this.config.plexPort === null || this.config.plexPort === '') {
       this.config.plexPort = '32400';
       configModified = true;
@@ -218,6 +223,7 @@ class ConfigModule extends EventEmitter {
       defaultConfig = {
         channelFilesToDownload: 3,
         preferredResolution: '1080',
+        videoCodec: 'default',
         channelAutoDownload: false,
         channelDownloadFrequency: '0 */6 * * *',
         plexApiKey: '',
@@ -347,6 +353,7 @@ class ConfigModule extends EventEmitter {
       youtubeOutputDirectory: process.env.DATA_PATH,
       channelFilesToDownload: 3,
       preferredResolution: '1080',
+      videoCodec: 'default',
 
       // Channel auto-download settings
       channelAutoDownload: false,
@@ -534,6 +541,16 @@ class ConfigModule extends EventEmitter {
         }
         if (migrated.discordWebhookUrl === undefined) {
           migrated.discordWebhookUrl = '';
+        }
+
+        return migrated;
+      },
+      '1.38.0': (cfg) => {
+        const migrated = { ...cfg };
+
+        // Add video codec preference setting
+        if (!migrated.videoCodec) {
+          migrated.videoCodec = 'default';
         }
 
         return migrated;

--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -127,6 +127,65 @@ describe('YtdlpCommandBuilder', () => {
     });
   });
 
+  describe('buildFormatString', () => {
+    it('should build default format string with no codec preference', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('1080', 'default');
+      expect(result).toBe('bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should build default format string when codec is undefined', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('1080');
+      expect(result).toBe('bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should build H.264 format string with avc codec preference', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('1080', 'h264');
+      expect(result).toBe('bestvideo[height<=1080][ext=mp4][vcodec^=avc]+bestaudio[ext=m4a]/bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should build H.265 format string with hevc codec preference', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('1080', 'h265');
+      expect(result).toBe('bestvideo[height<=1080][ext=mp4][vcodec^=hev]+bestaudio[ext=m4a]/bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should handle 720p resolution with h264', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('720', 'h264');
+      expect(result).toBe('bestvideo[height<=720][ext=mp4][vcodec^=avc]+bestaudio[ext=m4a]/bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should handle 720p resolution with h265', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('720', 'h265');
+      expect(result).toBe('bestvideo[height<=720][ext=mp4][vcodec^=hev]+bestaudio[ext=m4a]/bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should handle 4K resolution with default codec', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('2160', 'default');
+      expect(result).toBe('bestvideo[height<=2160][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should use default resolution (1080) when resolution is null', () => {
+      const result = YtdlpCommandBuilder.buildFormatString(null, 'h264');
+      expect(result).toBe('bestvideo[height<=1080][ext=mp4][vcodec^=avc]+bestaudio[ext=m4a]/bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should use default resolution (1080) when resolution is undefined', () => {
+      const result = YtdlpCommandBuilder.buildFormatString(undefined, 'h265');
+      expect(result).toBe('bestvideo[height<=1080][ext=mp4][vcodec^=hev]+bestaudio[ext=m4a]/bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should handle unknown codec as default', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('1080', 'unknown-codec');
+      expect(result).toBe('bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should include fallback to best mp4 and ultimate fallback', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('1080', 'h264');
+      // Should have multiple fallback options separated by /
+      expect(result).toContain('best[ext=mp4]');
+      expect(result).toMatch(/\/best$/); // Should end with ultimate fallback
+    });
+  });
+
   describe('buildCookiesArgs', () => {
     it('should return empty array when no cookies path exists', () => {
       configModule.getCookiesPath.mockReturnValue(null);
@@ -275,6 +334,48 @@ describe('YtdlpCommandBuilder', () => {
       expect(result).toContain('--fragment-retries');
       expect(result).toContain('5');
     });
+
+    it('should use default videoCodec when not configured', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgs();
+      const formatIndex = result.indexOf('-f');
+      const formatString = result[formatIndex + 1];
+      // Default codec should not include vcodec filters
+      expect(formatString).toBe('bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should use h264 videoCodec when configured', () => {
+      mockConfig.videoCodec = 'h264';
+      const result = YtdlpCommandBuilder.getBaseCommandArgs();
+      const formatIndex = result.indexOf('-f');
+      const formatString = result[formatIndex + 1];
+      expect(formatString).toContain('[vcodec^=avc]');
+      expect(formatString).toBe('bestvideo[height<=1080][ext=mp4][vcodec^=avc]+bestaudio[ext=m4a]/bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should use h265 videoCodec when configured', () => {
+      mockConfig.videoCodec = 'h265';
+      const result = YtdlpCommandBuilder.getBaseCommandArgs();
+      const formatIndex = result.indexOf('-f');
+      const formatString = result[formatIndex + 1];
+      expect(formatString).toContain('[vcodec^=hev]');
+      expect(formatString).toBe('bestvideo[height<=1080][ext=mp4][vcodec^=hev]+bestaudio[ext=m4a]/bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should combine custom resolution with h264 codec', () => {
+      mockConfig.videoCodec = 'h264';
+      const result = YtdlpCommandBuilder.getBaseCommandArgs('720');
+      const formatIndex = result.indexOf('-f');
+      const formatString = result[formatIndex + 1];
+      expect(formatString).toBe('bestvideo[height<=720][ext=mp4][vcodec^=avc]+bestaudio[ext=m4a]/bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should combine custom resolution with h265 codec', () => {
+      mockConfig.videoCodec = 'h265';
+      const result = YtdlpCommandBuilder.getBaseCommandArgs('2160');
+      const formatIndex = result.indexOf('-f');
+      const formatString = result[formatIndex + 1];
+      expect(formatString).toBe('bestvideo[height<=2160][ext=mp4][vcodec^=hev]+bestaudio[ext=m4a]/bestvideo[height<=2160][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
   });
 
   describe('getBaseCommandArgsForManualDownload', () => {
@@ -349,6 +450,47 @@ describe('YtdlpCommandBuilder', () => {
 
       const formatIndex = result.indexOf('-f');
       expect(result[formatIndex + 1]).toMatch(/bestvideo\[height<=360\]/);
+    });
+
+    it('should use default videoCodec when not configured', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload();
+      const formatIndex = result.indexOf('-f');
+      const formatString = result[formatIndex + 1];
+      expect(formatString).toBe('bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should use h264 videoCodec when configured', () => {
+      mockConfig.videoCodec = 'h264';
+      const result = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload();
+      const formatIndex = result.indexOf('-f');
+      const formatString = result[formatIndex + 1];
+      expect(formatString).toContain('[vcodec^=avc]');
+      expect(formatString).toBe('bestvideo[height<=1080][ext=mp4][vcodec^=avc]+bestaudio[ext=m4a]/bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should use h265 videoCodec when configured', () => {
+      mockConfig.videoCodec = 'h265';
+      const result = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload();
+      const formatIndex = result.indexOf('-f');
+      const formatString = result[formatIndex + 1];
+      expect(formatString).toContain('[vcodec^=hev]');
+      expect(formatString).toBe('bestvideo[height<=1080][ext=mp4][vcodec^=hev]+bestaudio[ext=m4a]/bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should combine custom resolution with h264 codec', () => {
+      mockConfig.videoCodec = 'h264';
+      const result = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload('480');
+      const formatIndex = result.indexOf('-f');
+      const formatString = result[formatIndex + 1];
+      expect(formatString).toBe('bestvideo[height<=480][ext=mp4][vcodec^=avc]+bestaudio[ext=m4a]/bestvideo[height<=480][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should combine custom resolution with h265 codec', () => {
+      mockConfig.videoCodec = 'h265';
+      const result = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload('1440');
+      const formatIndex = result.indexOf('-f');
+      const formatString = result[formatIndex + 1];
+      expect(formatString).toBe('bestvideo[height<=1440][ext=mp4][vcodec^=hev]+bestaudio[ext=m4a]/bestvideo[height<=1440][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
     });
   });
 


### PR DESCRIPTION
- Add H.264/H.265 codec preference in settings UI
- Include automatic fallback to available codecs
- Update yt-dlp format string builder with codec filters
- Add migration for videoCodec config field
- Add tests