### PR TITLE
feat(#100): add support for downloading shorts and live streams from YouTube channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 ### Core Features (No Plex Required)
 - **📥 Smart Downloads**: Pre-validate YouTube URLs with metadata preview before downloading (powered by [yt-dlp](https://github.com/yt-dlp/yt-dlp))
 - **🎯 Custom Quality Settings**: Per-download resolution control with support from 360p to 4K
-- **📺 Channel Subscriptions**: Subscribe to channels and auto-download new videos
+- **📺 Channel Subscriptions**: Subscribe to channels and auto-download new videos, shorts, and streams with per-tab controls
 - **🚫 SponsorBlock Integration**: Automatically remove or mark sponsored segments, intros, outros, and more using the crowdsourced SponsorBlock database
 - **🗂️ Smart Organization**: Videos organized by channel with metadata and thumbnails
 - **📝 Multi-Server Support**: Compatible with Plex, Kodi, Jellyfin, and Emby through NFO metadata files and embedded MP4 metadata
@@ -28,7 +28,8 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 - **⏰ Scheduled Downloads**: Configure automatic downloads on your schedule (cron-based)
 - **🧹 Automatic Cleanup**: Nightly auto-removal with configurable age and free-space thresholds plus dry-run previews
 - **📱 Web Interface**: Manage everything through a responsive web UI
-- **🔍 Browse Channels**: View and search all videos from subscribed channels with advanced filtering
+- **🔍 Browse Channels**: View and search all videos from subscribed channels with advanced filtering, tabbed views for Videos/Shorts/Streams, and contextual publish date accuracy tips
+- **🔴 Live-Aware Downloads**: Track live status to avoid grabbing still-airing streams and see LIVE indicators in the UI
 - **📊 Download History**: Track what you've downloaded with smart duplicate prevention
 - **🔔 Discord Alerts**: Send optional webhook notifications when new videos finish downloading
 - **♻️ Re-download Missing**: Easily identify and re-download videos that were removed from disk
@@ -154,7 +155,7 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 - **Storage Growth**: Downloads can consume significant disk space over time. The UI includes a storage status chip that shows total and free space for your selected directory/drive, making it easy to monitor and adjust limits/schedule as needed. Automatic Video Removal can purge old videos nightly at 2:00 AM once you configure age or free-space thresholds; space-based cleanup relies on the storage status chip reporting accurate disk usage.
 - **Format**: Downloads as MP4 with comprehensive embedded metadata (title, genre, studio, keywords) and NFO files for maximum media server compatibility
 - **File Management**: Videos must retain their `[youtubeid].mp4` filename and remain in their download location. Moving or renaming files will cause Youtarr to mark them as "missing"
-- **Filtering**: Automatically skips YouTube Shorts and subscriber-only content
+- **Filtering**: Automatically skips subscriber-only content; configure auto-downloads separately for long-form videos, Shorts, and Streams
 - **Authentication**: Uses local authentication (create admin account on first access)
 - **Security**: Leave authentication enabled unless you have your own auth in front of Youtarr. If you launch with `--no-auth` (or set `AUTH_ENABLED=false`), never expose that instance directly to the public internet.
 

--- a/client/src/components/ChannelManager.tsx
+++ b/client/src/components/ChannelManager.tsx
@@ -19,10 +19,12 @@ import {
   Snackbar,
   Alert,
   CircularProgress,
+  Chip,
 } from '@mui/material';
 import Delete from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
 import InfoIcon from '@mui/icons-material/Info';
+import AlarmOnIcon from '@mui/icons-material/AlarmOn';
 import axios from 'axios';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
@@ -336,6 +338,60 @@ function ChannelManager({ token }: ChannelManagerProps) {
     setIsDialogOpen(false);
   };
 
+  const renderAutoDownloadBadges = (autoDownloadTabs: string | undefined) => {
+    const tabMap: Record<string, { full: string; short: string }> = {
+      'video': { full: 'Videos', short: 'Videos' },
+      'short': { full: 'Shorts', short: 'Shorts' },
+      'livestream': { full: 'Live', short: 'Live' },
+    };
+
+    const tabs = autoDownloadTabs
+      ? autoDownloadTabs
+          .split(',')
+          .map(tab => tab.trim())
+          .filter(tab => tab.length > 0)
+      : [];
+
+    if (tabs.length === 0) {
+      return (
+        <Box sx={{ mt: 0.5 }}>
+          <span style={{ fontSize: isMobile ? '0.65rem' : '0.75rem', color: '#888' }}>
+            Automatic downloads disabled
+          </span>
+        </Box>
+      );
+    }
+
+    return (
+      <Box sx={{ display: 'flex', gap: 0.5, mt: 0.5, flexWrap: 'wrap' }}>
+        {tabs.map((tab) => {
+          const tabInfo = tabMap[tab];
+          if (!tabInfo) return null;
+
+          return (
+            <Chip
+              key={tab}
+              label={isMobile ? tabInfo.short : tabInfo.full}
+              size="small"
+              variant="outlined"
+              icon={<AlarmOnIcon sx={{ fontSize: isMobile ? '0.75rem' : '0.85rem', color: 'error.main' }} />}
+              sx={{
+                height: isMobile ? '18px' : '20px',
+                fontSize: isMobile ? '0.65rem' : '0.7rem',
+                '& .MuiChip-label': {
+                  px: isMobile ? 0.5 : 0.75,
+                },
+                '& .MuiChip-icon': {
+                  ml: isMobile ? 0.25 : 0.5,
+                },
+              }}
+            />
+          );
+        })}
+      </Box>
+    );
+  };
+
   return (
     <Card elevation={8} style={{
       padding: '8px',
@@ -436,6 +492,8 @@ function ChannelManager({ token }: ChannelManagerProps) {
                               {channel.uploader || channel.url}
                             </div>
                           }
+                          secondary={renderAutoDownloadBadges(channel.auto_download_enabled_tabs)}
+                          secondaryTypographyProps={{ component: 'div' }}
                         />
                       </div>{' '}
                     </Grid>

--- a/client/src/components/ChannelPage.tsx
+++ b/client/src/components/ChannelPage.tsx
@@ -96,7 +96,7 @@ function ChannelPage({ token }: ChannelPageProps) {
         </CardContent>
       </Card>
 
-      <ChannelVideos token={token} />
+      <ChannelVideos token={token} channelAutoDownloadTabs={channel?.auto_download_enabled_tabs} />
     </>
   );
 }

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -1,25 +1,12 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   Card,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Checkbox,
-  Button,
   Box,
-  FormControlLabel,
   Typography,
   Alert,
-  IconButton,
-  Tooltip,
-  Snackbar,
   Skeleton,
   Grid,
-  Fade,
   Zoom,
   Fab,
   Badge,
@@ -29,53 +16,32 @@ import {
   ListItemIcon,
   ListItemText,
   Divider,
-  TextField,
-  InputAdornment,
-  ToggleButton,
-  ToggleButtonGroup,
-  Switch,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
-  CardContent,
+  IconButton,
+  Pagination,
 } from '@mui/material';
 
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import CloudOffIcon from '@mui/icons-material/CloudOff';
-import SearchIcon from '@mui/icons-material/Search';
-import ViewModuleIcon from '@mui/icons-material/ViewModule';
-import TableChartIcon from '@mui/icons-material/TableChart';
-import ViewListIcon from '@mui/icons-material/ViewList';
 import DownloadIcon from '@mui/icons-material/Download';
 import SelectAllIcon from '@mui/icons-material/SelectAll';
 import ClearIcon from '@mui/icons-material/Clear';
-import RefreshIcon from '@mui/icons-material/Refresh';
-import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
-import StorageIcon from '@mui/icons-material/Storage';
-import LockIcon from '@mui/icons-material/Lock';
-import NewReleasesIcon from '@mui/icons-material/NewReleases';
-import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
-import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import CloseIcon from '@mui/icons-material/Close';
-import ScheduleIcon from '@mui/icons-material/Schedule';
-import VideoLibraryIcon from '@mui/icons-material/VideoLibrary';
 import DeleteIcon from '@mui/icons-material/Delete';
 
-import Pagination from '@mui/material/Pagination';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import Chip from '@mui/material/Chip';
-import LinearProgress from '@mui/material/LinearProgress';
 import { useTheme } from '@mui/material/styles';
-import { formatDuration } from '../../utils';
-import { ChannelVideo } from '../../types/ChannelVideo';
 import { useNavigate } from 'react-router-dom';
 import { useSwipeable } from 'react-swipeable';
-import DownloadSettingsDialog from '../DownloadManager/ManualDownload/DownloadSettingsDialog';
 import { DownloadSettings } from '../DownloadManager/ManualDownload/types';
-import DeleteVideosDialog from '../shared/DeleteVideosDialog';
 import { useVideoDeletion } from '../shared/useVideoDeletion';
+import { getVideoStatus } from '../../utils/videoStatus';
+import VideoCard from './VideoCard';
+import VideoListItem from './VideoListItem';
+import VideoTableView from './VideoTableView';
+import ChannelVideosHeader from './ChannelVideosHeader';
+import ChannelVideosDialogs from './ChannelVideosDialogs';
+import { useChannelVideos } from './hooks/useChannelVideos';
+import { useRefreshChannelVideos } from './hooks/useRefreshChannelVideos';
+import { useConfig } from '../../hooks/useConfig';
+import { useTriggerDownloads } from '../../hooks/useTriggerDownloads';
 
 interface ChannelVideosProps {
   token: string | null;
@@ -99,17 +65,10 @@ function ChannelVideos({ token }: ChannelVideosProps) {
   // Data states
   const pageSize = isMobile ? 8 : 16;
   const [page, setPage] = useState(1);
-  const [videos, setVideos] = useState<ChannelVideo[]>([]);
-  const [videoFailed, setVideoFailed] = useState<Boolean>(false);
   const [checkedBoxes, setCheckedBoxes] = useState<string[]>([]);
   const [hideDownloaded, setHideDownloaded] = useState(false);
   const [mobileTooltip, setMobileTooltip] = useState<string | null>(null);
   const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
-  const [defaultResolution, setDefaultResolution] = useState<string>('1080');
-  const [totalCount, setTotalCount] = useState<number>(0);
-  const [oldestVideoDate, setOldestVideoDate] = useState<string | null>(null);
-  const [fetchingAllVideos, setFetchingAllVideos] = useState(false);
-  const [fetchAllError, setFetchAllError] = useState<string | null>(null);
   const [hoveredVideo, setHoveredVideo] = useState<string | null>(null);
   const [refreshConfirmOpen, setRefreshConfirmOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -120,94 +79,37 @@ function ChannelVideos({ token }: ChannelVideosProps) {
   const { deleteVideosByYoutubeIds, loading: deleteLoading } = useVideoDeletion();
 
   const { channel_id } = useParams();
+
+  // Use custom hooks for data fetching
+  const {
+    videos,
+    totalCount,
+    oldestVideoDate,
+    videoFailed,
+    refetch: refetchVideos,
+  } = useChannelVideos({
+    channelId: channel_id,
+    page,
+    pageSize,
+    hideDownloaded,
+    searchQuery,
+    sortBy,
+    sortOrder,
+    token,
+  });
+
+  const { config } = useConfig(token);
+  const defaultResolution = config.preferredResolution || '1080';
+
+  const { triggerDownloads } = useTriggerDownloads(token);
+
+  const {
+    refreshVideos,
+    loading: fetchingAllVideos,
+    error: fetchAllError,
+    clearError: clearFetchAllError,
+  } = useRefreshChannelVideos(channel_id, page, pageSize, hideDownloaded, token);
   const navigate = useNavigate();
-
-  const formatFileSize = (bytes: number | null | undefined): string => {
-    if (!bytes) return '';
-    const gb = bytes / (1024 * 1024 * 1024);
-    if (gb >= 1) {
-      return `${gb.toFixed(1)}GB`;
-    }
-    const mb = bytes / (1024 * 1024);
-    return `${mb.toFixed(0)}MB`;
-  };
-
-  const decodeHtml = (html: string) => {
-    const txt = document.createElement('textarea');
-    txt.innerHTML = html;
-    return txt.value;
-  };
-
-  const getVideoStatus = (video: ChannelVideo): 'never_downloaded' | 'downloaded' | 'missing' | 'members_only' => {
-    if (video.availability === 'subscriber_only') {
-      return 'members_only';
-    }
-    if (!video.added) {
-      return 'never_downloaded';
-    }
-    if (video.removed) {
-      return 'missing';
-    }
-    return 'downloaded';
-  };
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'downloaded':
-        return 'success';
-      case 'missing':
-        return 'warning';
-      case 'members_only':
-        return 'default';
-      default:
-        return 'info';
-    }
-  };
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'downloaded':
-        return <CheckCircleIcon fontSize="small" />;
-      case 'missing':
-        return <CloudOffIcon fontSize="small" />;
-      case 'members_only':
-        return <LockIcon fontSize="small" />;
-      default:
-        return <NewReleasesIcon fontSize="small" />;
-    }
-  };
-
-  const getStatusLabel = (status: string) => {
-    switch (status) {
-      case 'downloaded':
-        return 'Downloaded';
-      case 'missing':
-        return 'Missing';
-      case 'members_only':
-        return 'Members Only';
-      default:
-        return 'Not Downloaded';
-    }
-  };
-
-  const getMediaTypeInfo = (mediaType?: string | null) => {
-    switch (mediaType) {
-      case 'short':
-        return {
-          label: 'Short',
-          color: 'secondary' as const,
-          icon: <ScheduleIcon fontSize="small" />,
-        };
-      case 'livestream':
-        return {
-          label: 'Live',
-          color: 'error' as const,
-          icon: <VideoLibraryIcon fontSize="small" />,
-        };
-      default:
-        return null;
-    }
-  };
 
   // Videos are already filtered, sorted, and paginated by the server
   const paginatedVideos = videos;
@@ -249,25 +151,15 @@ function ChannelVideos({ token }: ChannelVideosProps) {
   const handleDownloadConfirm = async (settings: DownloadSettings | null) => {
     setDownloadDialogOpen(false);
 
-    const requestBody: any = {
-      urls: checkedBoxes.map(id => `https://www.youtube.com/watch?v=${id}`)
-    };
+    const urls = checkedBoxes.map(id => `https://www.youtube.com/watch?v=${id}`);
+    const overrideSettings = settings
+      ? {
+          resolution: settings.resolution,
+          allowRedownload: settings.allowRedownload,
+        }
+      : undefined;
 
-    if (settings) {
-      requestBody.overrideSettings = {
-        resolution: settings.resolution,
-        allowRedownload: settings.allowRedownload
-      };
-    }
-
-    await fetch('/triggerspecificdownloads', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-access-token': token || '',
-      },
-      body: JSON.stringify(requestBody),
-    });
+    await triggerDownloads({ urls, overrideSettings });
 
     setCheckedBoxes([]);
     navigate('/downloads');
@@ -279,35 +171,10 @@ function ChannelVideos({ token }: ChannelVideosProps) {
 
   const handleRefreshConfirm = async () => {
     setRefreshConfirmOpen(false);
-    setFetchingAllVideos(true);
-    setFetchAllError(null);
-
-    try {
-      const response = await fetch(`/fetchallchannelvideos/${channel_id}?page=${page}&pageSize=${pageSize}&hideDownloaded=${hideDownloaded}`, {
-        method: 'POST',
-        headers: {
-          'x-access-token': token || '',
-        },
-      });
-
-      const data = await response.json();
-
-      if (!response.ok || !data.success) {
-        if (response.status === 409 || data.error === 'FETCH_IN_PROGRESS') {
-          throw new Error('A fetch operation is already in progress for this channel. Please wait for it to complete.');
-        }
-        throw new Error(data.message || 'Failed to fetch all videos');
-      }
-
-      setVideos(data.videos || []);
-      setTotalCount(data.totalCount || 0);
-      setOldestVideoDate(data.oldestVideoDate || null);
-    } catch (error: any) {
-      console.error('Error fetching all videos:', error);
-      setFetchAllError(error.message || 'Failed to fetch all videos for channel');
-    } finally {
-      setFetchingAllVideos(false);
-    }
+    await refreshVideos();
+    // The hook handles loading and error states
+    // After refresh completes, refetch the videos to update the list
+    await refetchVideos();
   };
 
   const handleRefreshCancel = () => {
@@ -342,29 +209,7 @@ function ChannelVideos({ token }: ChannelVideosProps) {
       setSuccessMessage(`Successfully deleted ${result.deleted.length} video${result.deleted.length !== 1 ? 's' : ''}`);
       setSelectedForDeletion([]);
       // Refresh the videos list
-      const queryParams = new URLSearchParams({
-        page: page.toString(),
-        pageSize: pageSize.toString(),
-        hideDownloaded: hideDownloaded.toString(),
-        searchQuery: searchQuery,
-        sortBy: sortBy,
-        sortOrder: sortOrder
-      });
-
-      fetch(`/getchannelvideos/${channel_id}?${queryParams}`, {
-        headers: {
-          'x-access-token': token || '',
-        },
-      })
-        .then((response) => response.json())
-        .then((data) => {
-          if (data.videos !== undefined) {
-            setVideos(data.videos || []);
-          }
-          setTotalCount(data.totalCount || 0);
-          setOldestVideoDate(data.oldestVideoDate || null);
-        })
-        .catch((error) => console.error(error));
+      await refetchVideos();
     } else {
       const deletedCount = result.deleted.length;
       const failedCount = result.failed.length;
@@ -373,29 +218,7 @@ function ChannelVideos({ token }: ChannelVideosProps) {
         setSuccessMessage(`Deleted ${deletedCount} video${deletedCount !== 1 ? 's' : ''}, but ${failedCount} failed`);
         setSelectedForDeletion(prev => prev.filter(id => !result.deleted.includes(id)));
         // Refresh list
-        const queryParams = new URLSearchParams({
-          page: page.toString(),
-          pageSize: pageSize.toString(),
-          hideDownloaded: hideDownloaded.toString(),
-          searchQuery: searchQuery,
-          sortBy: sortBy,
-          sortOrder: sortOrder
-        });
-
-        fetch(`/getchannelvideos/${channel_id}?${queryParams}`, {
-          headers: {
-            'x-access-token': token || '',
-          },
-        })
-          .then((response) => response.json())
-          .then((data) => {
-            if (data.videos !== undefined) {
-              setVideos(data.videos || []);
-            }
-            setTotalCount(data.totalCount || 0);
-            setOldestVideoDate(data.oldestVideoDate || null);
-          })
-          .catch((error) => console.error(error));
+        await refetchVideos();
       } else {
         setErrorMessage(`Failed to delete videos: ${result.failed[0]?.error || 'Unknown error'}`);
       }
@@ -437,56 +260,6 @@ function ChannelVideos({ token }: ChannelVideosProps) {
     }, 0);
   };
 
-  // Data fetching - use proper server-side pagination with search and sort
-  useEffect(() => {
-    const queryParams = new URLSearchParams({
-      page: page.toString(),
-      pageSize: pageSize.toString(),
-      hideDownloaded: hideDownloaded.toString(),
-      searchQuery: searchQuery,
-      sortBy: sortBy,
-      sortOrder: sortOrder
-    });
-
-    fetch(`/getchannelvideos/${channel_id}?${queryParams}`, {
-      headers: {
-        'x-access-token': token || '',
-      },
-    })
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(response.statusText);
-        }
-        return response.json();
-      })
-      .then((data) => {
-        if (data.videos !== undefined) {
-          setVideos(data.videos || []);
-        }
-        setVideoFailed(data.videoFail || false);
-        setTotalCount(data.totalCount || 0);
-        setOldestVideoDate(data.oldestVideoDate || null);
-      })
-      .catch((error) => console.error(error));
-  }, [token, channel_id, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder]);
-
-  useEffect(() => {
-    if (!token) return;
-
-    fetch('/getconfig', {
-      headers: {
-        'x-access-token': token,
-      },
-    })
-      .then((response) => response.json())
-      .then((data) => {
-        if (data.preferredResolution) {
-          setDefaultResolution(data.preferredResolution);
-        }
-      })
-      .catch((error) => console.error('Failed to fetch config:', error));
-  }, [token]);
-
   // Swipe handlers for mobile
   const handlers = useSwipeable({
     onSwipedLeft: () => {
@@ -502,427 +275,7 @@ function ChannelVideos({ token }: ChannelVideosProps) {
     trackMouse: false,
   });
 
-  // Render video card for grid view
-  const renderVideoCard = (video: ChannelVideo) => {
-    const status = getVideoStatus(video);
-    const isSelectable = status === 'never_downloaded' || status === 'missing';
-    const isChecked = checkedBoxes.includes(video.youtube_id);
-    const mediaTypeInfo = getMediaTypeInfo(video.media_type);
-
-    return (
-      <Fade in timeout={300} key={video.youtube_id}>
-        <Grid item xs={12} sm={6} md={4} lg={3}>
-          <Card
-            sx={{
-              height: '100%',
-              display: 'flex',
-              flexDirection: 'column',
-              position: 'relative',
-              transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-              cursor: isSelectable ? 'pointer' : 'default',
-              opacity: status === 'members_only' ? 0.7 : 1,
-              transform: hoveredVideo === video.youtube_id ? 'translateY(-4px)' : 'translateY(0)',
-              boxShadow: hoveredVideo === video.youtube_id ? theme.shadows[8] : theme.shadows[1],
-              '&:hover': {
-                boxShadow: theme.shadows[4],
-              },
-            }}
-            onMouseEnter={() => setHoveredVideo(video.youtube_id)}
-            onMouseLeave={() => setHoveredVideo(null)}
-            onClick={() => isSelectable && handleCheckChange(video.youtube_id, !isChecked)}
-          >
-            {/* Thumbnail with overlay */}
-            <Box sx={{ position: 'relative', paddingTop: isMobile ? '52%' : '56.25%', bgcolor: 'grey.900' }}>
-              <img
-                src={video.thumbnail}
-                alt={decodeHtml(video.title)}
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  height: '100%',
-                  objectFit: 'cover',
-                }}
-                loading="lazy"
-              />
-
-              {/* YouTube Removed Banner */}
-              {video.youtube_removed ? (
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    right: 0,
-                    backgroundColor: 'rgba(211, 47, 47, 0.95)',
-                    color: 'white',
-                    padding: '4px 8px',
-                    fontSize: '0.75rem',
-                    fontWeight: 'bold',
-                    textAlign: 'center',
-                    zIndex: 2,
-                  }}
-                >
-                  Removed From YouTube
-                </Box>
-              ) : null}
-
-              {/* Duration overlay */}
-              <Chip
-                label={formatDuration(video.duration)}
-                size="small"
-                sx={{
-                  position: 'absolute',
-                  bottom: 8,
-                  right: 8,
-                  bgcolor: 'rgba(0,0,0,0.8)',
-                  color: 'white',
-                  fontSize: '0.75rem',
-                  height: 22,
-                }}
-              />
-
-              {/* Selection overlay for download */}
-              {isSelectable && (
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    right: 0,
-                    bottom: 0,
-                    bgcolor: isChecked ? 'rgba(25, 118, 210, 0.3)' : 'transparent',
-                    display: 'flex',
-                    alignItems: 'flex-start',
-                    justifyContent: 'flex-start',
-                    p: 1,
-                    transition: 'background-color 0.2s',
-                  }}
-                >
-                  <Checkbox
-                    checked={isChecked}
-                    onClick={(e) => e.stopPropagation()}
-                    onChange={(e) => {
-                      e.stopPropagation();
-                      handleCheckChange(video.youtube_id, e.target.checked);
-                    }}
-                    sx={{
-                      color: 'white',
-                      bgcolor: 'rgba(0,0,0,0.5)',
-                      '&.Mui-checked': {
-                        color: 'primary.main',
-                      },
-                      '&:hover': {
-                        bgcolor: 'rgba(0,0,0,0.7)',
-                      },
-                    }}
-                  />
-                </Box>
-              )}
-
-              {/* Delete icon for downloaded videos */}
-              {status === 'downloaded' && (
-                <IconButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    toggleDeletionSelection(video.youtube_id);
-                  }}
-                  sx={{
-                    position: 'absolute',
-                    top: 8,
-                    right: 8,
-                    bgcolor: selectedForDeletion.includes(video.youtube_id) ? 'error.main' : 'rgba(0,0,0,0.6)',
-                    color: 'white',
-                    '&:hover': {
-                      bgcolor: selectedForDeletion.includes(video.youtube_id) ? 'error.dark' : 'rgba(0,0,0,0.8)',
-                    },
-                    transition: 'all 0.2s',
-                    zIndex: 3,
-                  }}
-                  size="small"
-                >
-                  <DeleteIcon fontSize="small" />
-                </IconButton>
-              )}
-            </Box>
-
-            {/* Card content */}
-            <Box sx={{ p: isMobile ? 1.5 : 2, flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
-              <Typography
-                variant="body2"
-                sx={{
-                  mb: 1,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  display: '-webkit-box',
-                  WebkitLineClamp: 2,
-                  WebkitBoxOrient: 'vertical',
-                  lineHeight: 1.3,
-                  minHeight: '2.6em',
-                }}
-                title={decodeHtml(video.title)}
-              >
-                {decodeHtml(video.title)}
-              </Typography>
-
-              <Box sx={{ mt: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
-                {/* Date, size, and status - same line on mobile, separate on desktop */}
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-                  <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                    <CalendarTodayIcon sx={{ fontSize: 12 }} />
-                    {isMobile
-                      ? new Date(video.publishedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-                      : new Date(video.publishedAt).toLocaleDateString()
-                    }
-                  </Typography>
-                  {video.fileSize && (
-                    <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                      <StorageIcon sx={{ fontSize: 12 }} />
-                      {formatFileSize(video.fileSize)}
-                    </Typography>
-                  )}
-                  {mediaTypeInfo && (
-                    <Chip
-                      size="small"
-                      icon={mediaTypeInfo.icon}
-                      label={mediaTypeInfo.label}
-                      color={mediaTypeInfo.color}
-                      variant="outlined"
-                      sx={{ height: 20, fontSize: '0.7rem' }}
-                    />
-                  )}
-                  {isMobile && (
-                    <Chip
-                      icon={getStatusIcon(status)}
-                      label={getStatusLabel(status)}
-                      size="small"
-                      color={getStatusColor(status)}
-                      variant={status === 'downloaded' ? 'filled' : 'outlined'}
-                      sx={{ height: 20, fontSize: '0.7rem' }}
-                    />
-                  )}
-                </Box>
-
-                {/* Status chip for desktop only */}
-                {!isMobile && (
-                  <Chip
-                    icon={getStatusIcon(status)}
-                    label={getStatusLabel(status)}
-                    size="small"
-                    color={getStatusColor(status)}
-                    variant={status === 'downloaded' ? 'filled' : 'outlined'}
-                    sx={{ width: 'fit-content' }}
-                  />
-                )}
-              </Box>
-            </Box>
-          </Card>
-        </Grid>
-      </Fade>
-    );
-  };
-
-  // Render video list item (compact view for mobile)
-  const renderVideoListItem = (video: ChannelVideo) => {
-    const status = getVideoStatus(video);
-    const isSelectable = status === 'never_downloaded' || status === 'missing';
-    const isChecked = checkedBoxes.includes(video.youtube_id);
-    const mediaTypeInfo = getMediaTypeInfo(video.media_type);
-
-    return (
-      <Fade in timeout={300} key={video.youtube_id}>
-        <Card
-          sx={{
-            mb: 1.5,
-            display: 'flex',
-            position: 'relative',
-            transition: 'all 0.2s ease',
-            cursor: isSelectable ? 'pointer' : 'default',
-            opacity: status === 'members_only' ? 0.7 : 1,
-            '&:hover': {
-              boxShadow: theme.shadows[3],
-            },
-          }}
-          onClick={() => isSelectable && handleCheckChange(video.youtube_id, !isChecked)}
-        >
-          {/* Thumbnail */}
-          <Box
-            sx={{
-              position: 'relative',
-              width: 120,
-              minWidth: 120,
-              height: 90,
-              bgcolor: 'grey.900',
-            }}
-          >
-            <img
-              src={video.thumbnail}
-              alt={decodeHtml(video.title)}
-              style={{
-                width: '100%',
-                height: '100%',
-                objectFit: 'cover',
-              }}
-              loading="lazy"
-            />
-
-            {/* YouTube Removed Banner */}
-            {video.youtube_removed ? (
-              <Box
-                sx={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  backgroundColor: 'rgba(211, 47, 47, 0.95)',
-                  color: 'white',
-                  padding: '2px 4px',
-                  fontSize: '0.65rem',
-                  fontWeight: 'bold',
-                  textAlign: 'center',
-                  zIndex: 2,
-                }}
-              >
-                Removed From YouTube
-              </Box>
-            ) : null}
-
-            {/* Duration overlay */}
-            <Chip
-              label={formatDuration(video.duration)}
-              size="small"
-              sx={{
-                position: 'absolute',
-                bottom: 4,
-                right: 4,
-                bgcolor: 'rgba(0,0,0,0.8)',
-                color: 'white',
-                fontSize: '0.7rem',
-                height: 18,
-                '& .MuiChip-label': { px: 0.5 },
-              }}
-            />
-
-            {/* Checkbox for selectable videos */}
-            {isSelectable && (
-              <Checkbox
-                checked={isChecked}
-                onClick={(e) => e.stopPropagation()}
-                onChange={(e) => {
-                  e.stopPropagation();
-                  handleCheckChange(video.youtube_id, e.target.checked);
-                }}
-                sx={{
-                  position: 'absolute',
-                  top: 2,
-                  left: 2,
-                  color: 'white',
-                  bgcolor: 'rgba(0,0,0,0.5)',
-                  padding: 0.5,
-                  '&.Mui-checked': {
-                    color: 'primary.main',
-                    bgcolor: 'rgba(0,0,0,0.7)',
-                  },
-                  '& .MuiSvgIcon-root': { fontSize: 20 },
-                }}
-              />
-            )}
-
-            {/* Delete icon for downloaded videos */}
-            {status === 'downloaded' && (
-              <IconButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggleDeletionSelection(video.youtube_id);
-                }}
-                sx={{
-                  position: 'absolute',
-                  top: 2,
-                  left: 2,
-                  bgcolor: selectedForDeletion.includes(video.youtube_id) ? 'error.main' : 'rgba(0,0,0,0.6)',
-                  color: 'white',
-                  padding: 0.5,
-                  '&:hover': {
-                    bgcolor: selectedForDeletion.includes(video.youtube_id) ? 'error.dark' : 'rgba(0,0,0,0.8)',
-                  },
-                  transition: 'all 0.2s',
-                }}
-                size="small"
-              >
-                <DeleteIcon sx={{ fontSize: 18 }} />
-              </IconButton>
-            )}
-          </Box>
-
-          {/* Content */}
-          <CardContent sx={{ flex: 1, py: 1, px: 1.5, '&:last-child': { pb: 1 } }}>
-            {/* Title */}
-            <Typography
-              variant="body2"
-              sx={{
-                mb: 0.5,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                display: '-webkit-box',
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: 'vertical',
-                lineHeight: 1.3,
-                fontSize: '0.875rem',
-              }}
-              title={decodeHtml(video.title)}
-            >
-              {decodeHtml(video.title)}
-            </Typography>
-
-            {/* Date, Size, and Status on same line */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mt: 'auto' }}>
-              <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.3, fontSize: '0.7rem' }}>
-                <CalendarTodayIcon sx={{ fontSize: 11 }} />
-                {new Date(video.publishedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: '2-digit' })}
-              </Typography>
-              {video.fileSize && (
-                <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.3, fontSize: '0.7rem' }}>
-                  <StorageIcon sx={{ fontSize: 11 }} />
-                  {formatFileSize(video.fileSize)}
-                </Typography>
-              )}
-              {mediaTypeInfo && (
-                <Chip
-                  size="small"
-                  icon={mediaTypeInfo.icon}
-                  label={mediaTypeInfo.label}
-                  color={mediaTypeInfo.color}
-                  variant="outlined"
-                  sx={{
-                    height: 18,
-                    fontSize: '0.7rem',
-                    '& .MuiChip-icon': { fontSize: 14, ml: 0.5 },
-                    '& .MuiChip-label': { px: 0.6 },
-                  }}
-                />
-              )}
-              <Chip
-                icon={getStatusIcon(status)}
-                label={getStatusLabel(status)}
-                size="small"
-                color={getStatusColor(status)}
-                variant={status === 'downloaded' ? 'filled' : 'outlined'}
-                sx={{
-                  height: 20,
-                  fontSize: '0.7rem',
-                  '& .MuiChip-icon': { fontSize: 14, ml: 0.5 },
-                  '& .MuiChip-label': { px: 0.75 },
-                }}
-              />
-            </Box>
-          </CardContent>
-        </Card>
-      </Fade>
-    );
-  };
-
-  // Mobile action drawer
+  // Mobile drawer render
   const renderMobileDrawer = () => (
     <Drawer
       anchor="bottom"
@@ -1034,169 +387,36 @@ function ChannelVideos({ token }: ChannelVideosProps) {
   return (
     <>
       <Card elevation={3} sx={{ mb: 2 }}>
-        {/* Header */}
-        <Box
-          sx={{
-            position: 'sticky',
-            top: 0,
-            zIndex: 10,
-            bgcolor: 'background.paper',
-            borderBottom: '1px solid',
-            borderColor: 'divider',
+        <ChannelVideosHeader
+          isMobile={isMobile}
+          viewMode={viewMode}
+          searchQuery={searchQuery}
+          hideDownloaded={hideDownloaded}
+          totalCount={totalCount}
+          oldestVideoDate={oldestVideoDate}
+          fetchingAllVideos={fetchingAllVideos}
+          checkedBoxes={checkedBoxes}
+          selectedForDeletion={selectedForDeletion}
+          deleteLoading={deleteLoading}
+          paginatedVideos={paginatedVideos}
+          page={page}
+          totalPages={totalPages}
+          onViewModeChange={handleViewModeChange}
+          onSearchChange={(query) => {
+            setSearchQuery(query);
+            setPage(1);
           }}
-        >
-          <Box sx={{ p: 2 }}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-                <Typography variant="h6">Channel Videos</Typography>
-                {totalCount > 0 && (
-                  <Chip label={totalCount} size="small" color="primary" />
-                )}
-                {oldestVideoDate && !isMobile && (
-                  <Typography variant="caption" color="text.secondary">
-                    Oldest: {new Date(oldestVideoDate).toLocaleDateString()}
-                  </Typography>
-                )}
-              </Box>
-
-              <Button
-                onClick={handleRefreshClick}
-                variant="outlined"
-                size="small"
-                disabled={fetchingAllVideos}
-                startIcon={<RefreshIcon />}
-              >
-                {fetchingAllVideos ? 'Refreshing...' : 'Refresh'}
-              </Button>
-            </Box>
-
-            {/* Search and filters */}
-            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center' }}>
-              <TextField
-                placeholder="Search videos..."
-                size="small"
-                value={searchQuery}
-                onChange={(e) => {
-                  setSearchQuery(e.target.value);
-                  setPage(1);
-                }}
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <SearchIcon fontSize="small" />
-                    </InputAdornment>
-                  ),
-                }}
-                sx={{ flexGrow: 1, minWidth: 200 }}
-              />
-
-              {/* View mode toggle - mobile shows list/grid, desktop shows table/grid */}
-              <ToggleButtonGroup
-                value={viewMode}
-                exclusive
-                onChange={handleViewModeChange}
-                size="small"
-              >
-                {!isMobile && (
-                  <ToggleButton value="table">
-                    <Tooltip title="Table View">
-                      <TableChartIcon fontSize="small" />
-                    </Tooltip>
-                  </ToggleButton>
-                )}
-                <ToggleButton value="grid">
-                  <Tooltip title="Grid View">
-                    <ViewModuleIcon fontSize="small" />
-                  </Tooltip>
-                </ToggleButton>
-                {isMobile && (
-                  <ToggleButton value="list">
-                    <Tooltip title="List View">
-                      <ViewListIcon fontSize="small" />
-                    </Tooltip>
-                  </ToggleButton>
-                )}
-              </ToggleButtonGroup>
-
-              {!isMobile && (
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={hideDownloaded}
-                      onChange={(e) => {
-                        setHideDownloaded(e.target.checked);
-                        setPage(1);
-                      }}
-                      size="small"
-                    />
-                  }
-                  label="Hide Downloaded"
-                />
-              )}
-            </Box>
-
-            {/* Action buttons for desktop */}
-            {!isMobile && (
-              <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
-                <Button
-                  variant="contained"
-                  size="small"
-                  startIcon={<DownloadIcon />}
-                  onClick={handleDownloadClick}
-                  disabled={checkedBoxes.length === 0}
-                >
-                  Download {checkedBoxes.length > 0 ? `${checkedBoxes.length} ${checkedBoxes.length === 1 ? 'Video' : 'Videos'}` : 'Selected'}
-                </Button>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  onClick={handleSelectAll}
-                  disabled={checkedBoxes.length === 0 && paginatedVideos.filter(v => {
-                    const status = getVideoStatus(v);
-                    return status === 'never_downloaded' || status === 'missing';
-                  }).length === 0}
-                >
-                  Select All This Page
-                </Button>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  onClick={handleClearSelection}
-                  disabled={checkedBoxes.length === 0}
-                >
-                  Clear
-                </Button>
-                <Button
-                  variant="contained"
-                  color="error"
-                  size="small"
-                  startIcon={<DeleteIcon />}
-                  onClick={handleDeleteClick}
-                  disabled={selectedForDeletion.length === 0 || deleteLoading}
-                >
-                  Delete {selectedForDeletion.length > 0 ? `${selectedForDeletion.length}` : 'Selected'}
-                </Button>
-              </Box>
-            )}
-
-            {/* Pagination - Always visible at top */}
-            {totalPages > 1 && (
-              <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
-                <Pagination
-                  count={totalPages}
-                  page={page}
-                  onChange={handlePageChange}
-                  color="primary"
-                  size={isMobile ? 'small' : 'medium'}
-                  siblingCount={isMobile ? 0 : 1}
-                />
-              </Box>
-            )}
-          </Box>
-
-          {/* Progress bar */}
-          {fetchingAllVideos && <LinearProgress />}
-        </Box>
+          onHideDownloadedChange={(hide) => {
+            setHideDownloaded(hide);
+            setPage(1);
+          }}
+          onRefreshClick={handleRefreshClick}
+          onDownloadClick={handleDownloadClick}
+          onSelectAll={handleSelectAll}
+          onClearSelection={handleClearSelection}
+          onDeleteClick={handleDeleteClick}
+          onPageChange={handlePageChange}
+        />
 
         {/* Content area */}
         <Box sx={{ p: 2 }} {...(isMobile ? handlers : {})}>
@@ -1224,182 +444,50 @@ function ChannelVideos({ token }: ChannelVideosProps) {
               {/* View mode content */}
               {viewMode === 'grid' && (
                 <Grid container spacing={2}>
-                  {paginatedVideos.map(renderVideoCard)}
+                  {paginatedVideos.map((video) => (
+                    <VideoCard
+                      key={video.youtube_id}
+                      video={video}
+                      isMobile={isMobile}
+                      checkedBoxes={checkedBoxes}
+                      hoveredVideo={hoveredVideo}
+                      selectedForDeletion={selectedForDeletion}
+                      onCheckChange={handleCheckChange}
+                      onHoverChange={setHoveredVideo}
+                      onToggleDeletion={toggleDeletionSelection}
+                    />
+                  ))}
                 </Grid>
               )}
 
               {viewMode === 'list' && (
                 <Box>
-                  {paginatedVideos.map(renderVideoListItem)}
+                  {paginatedVideos.map((video) => (
+                    <VideoListItem
+                      key={video.youtube_id}
+                      video={video}
+                      checkedBoxes={checkedBoxes}
+                      selectedForDeletion={selectedForDeletion}
+                      onCheckChange={handleCheckChange}
+                      onToggleDeletion={toggleDeletionSelection}
+                    />
+                  ))}
                 </Box>
               )}
 
               {viewMode === 'table' && (
-                <TableContainer>
-                  <Table size="small">
-                    <TableHead>
-                      <TableRow>
-                        <TableCell padding="checkbox">
-                          <Checkbox
-                            indeterminate={checkedBoxes.length > 0 && checkedBoxes.length < paginatedVideos.length}
-                            checked={paginatedVideos.length > 0 && checkedBoxes.length === paginatedVideos.length}
-                            onChange={(e) => {
-                              if (e.target.checked) {
-                                handleSelectAll();
-                              } else {
-                                handleClearSelection();
-                              }
-                            }}
-                          />
-                        </TableCell>
-                        <TableCell>Thumbnail</TableCell>
-                        <TableCell onClick={() => handleSortChange('title')} sx={{ cursor: 'pointer' }}>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                            Title
-                            {sortBy === 'title' && (
-                              sortOrder === 'asc' ? <ArrowUpwardIcon fontSize="small" /> : <ArrowDownwardIcon fontSize="small" />
-                            )}
-                          </Box>
-                        </TableCell>
-                        <TableCell onClick={() => handleSortChange('date')} sx={{ cursor: 'pointer' }}>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                            Published
-                            {sortBy === 'date' && (
-                              sortOrder === 'asc' ? <ArrowUpwardIcon fontSize="small" /> : <ArrowDownwardIcon fontSize="small" />
-                            )}
-                          </Box>
-                        </TableCell>
-                        <TableCell onClick={() => handleSortChange('duration')} sx={{ cursor: 'pointer' }}>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                            Duration
-                            {sortBy === 'duration' && (
-                              sortOrder === 'asc' ? <ArrowUpwardIcon fontSize="small" /> : <ArrowDownwardIcon fontSize="small" />
-                            )}
-                          </Box>
-                        </TableCell>
-                        <TableCell onClick={() => handleSortChange('size')} sx={{ cursor: 'pointer' }}>
-                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                            Size
-                            {sortBy === 'size' && (
-                              sortOrder === 'asc' ? <ArrowUpwardIcon fontSize="small" /> : <ArrowDownwardIcon fontSize="small" />
-                            )}
-                          </Box>
-                        </TableCell>
-                        <TableCell>Status</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {paginatedVideos.map((video) => {
-                        const status = getVideoStatus(video);
-                        const isSelectable = (status === 'never_downloaded' || status === 'missing') && !video.youtube_removed;
-                        const isChecked = checkedBoxes.includes(video.youtube_id);
-                        const mediaTypeInfo = getMediaTypeInfo(video.media_type);
-
-                        return (
-                          <TableRow
-                            key={video.youtube_id}
-                            hover
-                            sx={{
-                              opacity: status === 'members_only' ? 0.6 : 1,
-                              cursor: isSelectable ? 'pointer' : 'default',
-                            }}
-                          >
-                            <TableCell padding="checkbox">
-                              {isSelectable && (
-                                <Checkbox
-                                  checked={isChecked}
-                                  onChange={(e) => handleCheckChange(video.youtube_id, e.target.checked)}
-                                />
-                              )}
-                              {status === 'downloaded' && (
-                                <IconButton
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    toggleDeletionSelection(video.youtube_id);
-                                  }}
-                                  sx={{
-                                    color: selectedForDeletion.includes(video.youtube_id) ? 'error.main' : 'action.active',
-                                    '&:hover': {
-                                      color: 'error.main',
-                                      bgcolor: 'error.light',
-                                    },
-                                  }}
-                                  size="small"
-                                >
-                                  <DeleteIcon fontSize="small" />
-                                </IconButton>
-                              )}
-                            </TableCell>
-                            <TableCell>
-                              <Box sx={{ position: 'relative', display: 'inline-block' }}>
-                                <img
-                                  src={video.thumbnail}
-                                  alt={decodeHtml(video.title)}
-                                  style={{ width: 120, height: 67, objectFit: 'cover', borderRadius: 4, display: 'block' }}
-                                  loading="lazy"
-                                />
-                                {video.youtube_removed && (
-                                  <Box
-                                    sx={{
-                                      position: 'absolute',
-                                      top: 0,
-                                      left: 0,
-                                      right: 0,
-                                      backgroundColor: 'rgba(211, 47, 47, 0.95)',
-                                      color: 'white',
-                                      padding: '2px 4px',
-                                      fontSize: '0.65rem',
-                                      fontWeight: 'bold',
-                                      textAlign: 'center',
-                                      borderTopLeftRadius: 4,
-                                      borderTopRightRadius: 4,
-                                    }}
-                                  >
-                                    Removed From YouTube
-                                  </Box>
-                                )}
-                              </Box>
-                            </TableCell>
-                            <TableCell>
-                              <Typography variant="body2" sx={{ mb: 0.5 }}>
-                                {decodeHtml(video.title)}
-                              </Typography>
-                            </TableCell>
-                            <TableCell>
-                              {new Date(video.publishedAt).toLocaleDateString()}
-                            </TableCell>
-                            <TableCell>
-                              {formatDuration(video.duration)}
-                            </TableCell>
-                            <TableCell>
-                              {video.fileSize ? formatFileSize(video.fileSize) : '-'}
-                            </TableCell>
-                            <TableCell>
-                              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-                                {mediaTypeInfo && (
-                                  <Chip
-                                    size="small"
-                                    icon={mediaTypeInfo.icon}
-                                    label={mediaTypeInfo.label}
-                                    color={mediaTypeInfo.color}
-                                    variant="outlined"
-                                  />
-                                )}
-                                <Chip
-                                  icon={getStatusIcon(status)}
-                                  label={getStatusLabel(status)}
-                                  size="small"
-                                  color={getStatusColor(status)}
-                                  variant={status === 'downloaded' ? 'filled' : 'outlined'}
-                                />
-                              </Box>
-                            </TableCell>
-                          </TableRow>
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
+                <VideoTableView
+                  videos={paginatedVideos}
+                  checkedBoxes={checkedBoxes}
+                  selectedForDeletion={selectedForDeletion}
+                  sortBy={sortBy}
+                  sortOrder={sortOrder}
+                  onCheckChange={handleCheckChange}
+                  onSelectAll={handleSelectAll}
+                  onClearSelection={handleClearSelection}
+                  onSortChange={handleSortChange}
+                  onToggleDeletion={toggleDeletionSelection}
+                />
               )}
 
               {/* Pagination */}
@@ -1423,89 +511,29 @@ function ChannelVideos({ token }: ChannelVideosProps) {
       {renderMobileDrawer()}
 
       {/* Dialogs and Snackbars */}
-      <DownloadSettingsDialog
-        open={downloadDialogOpen}
-        onClose={() => setDownloadDialogOpen(false)}
-        onConfirm={handleDownloadConfirm}
+      <ChannelVideosDialogs
+        downloadDialogOpen={downloadDialogOpen}
+        refreshConfirmOpen={refreshConfirmOpen}
+        deleteDialogOpen={deleteDialogOpen}
+        fetchAllError={fetchAllError}
+        mobileTooltip={mobileTooltip}
+        successMessage={successMessage}
+        errorMessage={errorMessage}
         videoCount={checkedBoxes.length}
         missingVideoCount={getMissingVideoCount()}
+        selectedForDeletion={selectedForDeletion.length}
         defaultResolution={defaultResolution}
-        mode="manual"
+        onDownloadDialogClose={() => setDownloadDialogOpen(false)}
+        onDownloadConfirm={handleDownloadConfirm}
+        onRefreshCancel={handleRefreshCancel}
+        onRefreshConfirm={handleRefreshConfirm}
+        onDeleteCancel={handleDeleteCancel}
+        onDeleteConfirm={handleDeleteConfirm}
+        onFetchAllErrorClose={clearFetchAllError}
+        onMobileTooltipClose={() => setMobileTooltip(null)}
+        onSuccessMessageClose={() => setSuccessMessage(null)}
+        onErrorMessageClose={() => setErrorMessage(null)}
       />
-
-      {/* Refresh Confirmation Dialog */}
-      <Dialog
-        open={refreshConfirmOpen}
-        onClose={handleRefreshCancel}
-        aria-labelledby="refresh-dialog-title"
-        aria-describedby="refresh-dialog-description"
-      >
-        <DialogTitle id="refresh-dialog-title">
-          Refresh Channel Videos
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText id="refresh-dialog-description">
-            Refresh will fetch data for all videos for this Channel. This may take some time to complete.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleRefreshCancel} color="primary">
-            Cancel
-          </Button>
-          <Button onClick={handleRefreshConfirm} color="primary" variant="contained">
-            Continue
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      <Snackbar
-        open={fetchAllError !== null}
-        autoHideDuration={6000}
-        onClose={() => setFetchAllError(null)}
-      >
-        <Alert onClose={() => setFetchAllError(null)} severity="error">
-          {fetchAllError}
-        </Alert>
-      </Snackbar>
-
-      <Snackbar
-        open={mobileTooltip !== null}
-        autoHideDuration={8000}
-        onClose={() => setMobileTooltip(null)}
-      >
-        <Alert onClose={() => setMobileTooltip(null)} severity="info">
-          {mobileTooltip}
-        </Alert>
-      </Snackbar>
-
-      {/* Delete Confirmation Dialog */}
-      <DeleteVideosDialog
-        open={deleteDialogOpen}
-        onClose={handleDeleteCancel}
-        onConfirm={handleDeleteConfirm}
-        videoCount={selectedForDeletion.length}
-      />
-
-      {/* Success/Error Snackbars for Deletion */}
-      <Snackbar
-        open={successMessage !== null}
-        autoHideDuration={6000}
-        onClose={() => setSuccessMessage(null)}
-      >
-        <Alert onClose={() => setSuccessMessage(null)} severity="success">
-          {successMessage}
-        </Alert>
-      </Snackbar>
-
-      <Snackbar
-        open={errorMessage !== null}
-        autoHideDuration={6000}
-        onClose={() => setErrorMessage(null)}
-      >
-        <Alert onClose={() => setErrorMessage(null)} severity="error">
-          {errorMessage}
-        </Alert>
-      </Snackbar>
     </>
   );
 }

--- a/client/src/components/ChannelPage/ChannelVideosDialogs.tsx
+++ b/client/src/components/ChannelPage/ChannelVideosDialogs.tsx
@@ -25,6 +25,8 @@ interface ChannelVideosDialogsProps {
   missingVideoCount: number;
   selectedForDeletion: number;
   defaultResolution: string;
+  selectedTab: string;
+  tabLabel: string;
   onDownloadDialogClose: () => void;
   onDownloadConfirm: (settings: DownloadSettings | null) => void;
   onRefreshCancel: () => void;
@@ -49,6 +51,8 @@ function ChannelVideosDialogs({
   missingVideoCount,
   selectedForDeletion,
   defaultResolution,
+  selectedTab,
+  tabLabel,
   onDownloadDialogClose,
   onDownloadConfirm,
   onRefreshCancel,
@@ -81,11 +85,11 @@ function ChannelVideosDialogs({
         aria-describedby="refresh-dialog-description"
       >
         <DialogTitle id="refresh-dialog-title">
-          Refresh Channel Videos
+          Fetch All {tabLabel} Videos
         </DialogTitle>
         <DialogContent>
           <DialogContentText id="refresh-dialog-description">
-            Refresh will fetch data for all videos for this Channel. This may take some time to complete.
+            This will fetch all &apos;{tabLabel}&apos; videos for this Channel. This may take some time to complete.
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/client/src/components/ChannelPage/ChannelVideosDialogs.tsx
+++ b/client/src/components/ChannelPage/ChannelVideosDialogs.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+  Snackbar,
+  Alert,
+} from '@mui/material';
+import DownloadSettingsDialog from '../DownloadManager/ManualDownload/DownloadSettingsDialog';
+import DeleteVideosDialog from '../shared/DeleteVideosDialog';
+import { DownloadSettings } from '../DownloadManager/ManualDownload/types';
+
+interface ChannelVideosDialogsProps {
+  downloadDialogOpen: boolean;
+  refreshConfirmOpen: boolean;
+  deleteDialogOpen: boolean;
+  fetchAllError: string | null;
+  mobileTooltip: string | null;
+  successMessage: string | null;
+  errorMessage: string | null;
+  videoCount: number;
+  missingVideoCount: number;
+  selectedForDeletion: number;
+  defaultResolution: string;
+  onDownloadDialogClose: () => void;
+  onDownloadConfirm: (settings: DownloadSettings | null) => void;
+  onRefreshCancel: () => void;
+  onRefreshConfirm: () => void;
+  onDeleteCancel: () => void;
+  onDeleteConfirm: () => void;
+  onFetchAllErrorClose: () => void;
+  onMobileTooltipClose: () => void;
+  onSuccessMessageClose: () => void;
+  onErrorMessageClose: () => void;
+}
+
+function ChannelVideosDialogs({
+  downloadDialogOpen,
+  refreshConfirmOpen,
+  deleteDialogOpen,
+  fetchAllError,
+  mobileTooltip,
+  successMessage,
+  errorMessage,
+  videoCount,
+  missingVideoCount,
+  selectedForDeletion,
+  defaultResolution,
+  onDownloadDialogClose,
+  onDownloadConfirm,
+  onRefreshCancel,
+  onRefreshConfirm,
+  onDeleteCancel,
+  onDeleteConfirm,
+  onFetchAllErrorClose,
+  onMobileTooltipClose,
+  onSuccessMessageClose,
+  onErrorMessageClose,
+}: ChannelVideosDialogsProps) {
+  return (
+    <>
+      {/* Download Settings Dialog */}
+      <DownloadSettingsDialog
+        open={downloadDialogOpen}
+        onClose={onDownloadDialogClose}
+        onConfirm={onDownloadConfirm}
+        videoCount={videoCount}
+        missingVideoCount={missingVideoCount}
+        defaultResolution={defaultResolution}
+        mode="manual"
+      />
+
+      {/* Refresh Confirmation Dialog */}
+      <Dialog
+        open={refreshConfirmOpen}
+        onClose={onRefreshCancel}
+        aria-labelledby="refresh-dialog-title"
+        aria-describedby="refresh-dialog-description"
+      >
+        <DialogTitle id="refresh-dialog-title">
+          Refresh Channel Videos
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="refresh-dialog-description">
+            Refresh will fetch data for all videos for this Channel. This may take some time to complete.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onRefreshCancel} color="primary">
+            Cancel
+          </Button>
+          <Button onClick={onRefreshConfirm} color="primary" variant="contained">
+            Continue
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <DeleteVideosDialog
+        open={deleteDialogOpen}
+        onClose={onDeleteCancel}
+        onConfirm={onDeleteConfirm}
+        videoCount={selectedForDeletion}
+      />
+
+      {/* Fetch All Error Snackbar */}
+      <Snackbar
+        open={fetchAllError !== null}
+        autoHideDuration={6000}
+        onClose={onFetchAllErrorClose}
+      >
+        <Alert onClose={onFetchAllErrorClose} severity="error">
+          {fetchAllError}
+        </Alert>
+      </Snackbar>
+
+      {/* Mobile Tooltip Snackbar */}
+      <Snackbar
+        open={mobileTooltip !== null}
+        autoHideDuration={8000}
+        onClose={onMobileTooltipClose}
+      >
+        <Alert onClose={onMobileTooltipClose} severity="info">
+          {mobileTooltip}
+        </Alert>
+      </Snackbar>
+
+      {/* Success Message Snackbar */}
+      <Snackbar
+        open={successMessage !== null}
+        autoHideDuration={6000}
+        onClose={onSuccessMessageClose}
+      >
+        <Alert onClose={onSuccessMessageClose} severity="success">
+          {successMessage}
+        </Alert>
+      </Snackbar>
+
+      {/* Error Message Snackbar */}
+      <Snackbar
+        open={errorMessage !== null}
+        autoHideDuration={6000}
+        onClose={onErrorMessageClose}
+      >
+        <Alert onClose={onErrorMessageClose} severity="error">
+          {errorMessage}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}
+
+export default ChannelVideosDialogs;

--- a/client/src/components/ChannelPage/ChannelVideosHeader.tsx
+++ b/client/src/components/ChannelPage/ChannelVideosHeader.tsx
@@ -78,14 +78,12 @@ function ChannelVideosHeader({
   onDeleteClick,
   onInfoIconClick,
 }: ChannelVideosHeaderProps) {
-  const tooltipText = "Enable this if you want videos from this tab to automatically download when scheduled channel downloads occur, or when you trigger channel downloads from the Manage Downloads page";
-
-  const getInfoIcon = () => {
+  const renderInfoIcon = (message: string) => {
     const handleClick = (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
       if (isMobile) {
-        onInfoIconClick(tooltipText);
+        onInfoIconClick(message);
       }
     };
 
@@ -102,13 +100,20 @@ function ChannelVideosHeader({
     }
 
     return (
-      <Tooltip title={tooltipText} arrow placement="top">
-        <IconButton size="small" sx={{ ml: 0.5, p: 0.5 }}>
+      <Tooltip title={message} arrow placement="top">
+        <IconButton size="small" sx={{ ml: 0.5, p: 0.5 }} onClick={(e) => e.stopPropagation()}>
           <InfoIcon fontSize="small" />
         </IconButton>
       </Tooltip>
     );
   };
+
+  const autoDownloadTooltip = "Enable this if you want videos from this tab to automatically download when scheduled channel downloads occur, or when you trigger channel downloads from the Manage Downloads page";
+
+  const dateTooltipBase = "Publish dates come from yt-dlp and may be approximate when YouTube only provides relative times. Videos remain sorted to match YouTube.";
+  const dateTooltipText = selectedTab === 'shorts'
+    ? "Shorts do not expose publish dates via yt-dlp, so dates are hidden. " + dateTooltipBase
+    : dateTooltipBase;
 
   return (
     <Box
@@ -128,11 +133,12 @@ function ChannelVideosHeader({
             {totalCount > 0 && (
               <Chip label={totalCount} size="small" color="primary" />
             )}
-            {oldestVideoDate && !isMobile && (
+            {oldestVideoDate && selectedTab !== 'shorts' && !isMobile && (
               <Typography variant="caption" color="text.secondary">
                 Oldest: {new Date(oldestVideoDate).toLocaleDateString()}
               </Typography>
             )}
+            {renderInfoIcon(dateTooltipText)}
           </Box>
 
           <Button
@@ -158,7 +164,7 @@ function ChannelVideosHeader({
             }
             label="Enable Channel Downloads for this tab"
           />
-          {getInfoIcon()}
+          {renderInfoIcon(autoDownloadTooltip)}
         </Box>
 
         {/* Search and filters */}

--- a/client/src/components/ChannelPage/ChannelVideosHeader.tsx
+++ b/client/src/components/ChannelPage/ChannelVideosHeader.tsx
@@ -11,8 +11,8 @@ import {
   Switch,
   Tooltip,
   Chip,
-  Pagination,
   LinearProgress,
+  IconButton,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import ViewModuleIcon from '@mui/icons-material/ViewModule';
@@ -21,6 +21,7 @@ import ViewListIcon from '@mui/icons-material/ViewList';
 import DownloadIcon from '@mui/icons-material/Download';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import DeleteIcon from '@mui/icons-material/Delete';
+import InfoIcon from '@mui/icons-material/Info';
 import { getVideoStatus } from '../../utils/videoStatus';
 import { ChannelVideo } from '../../types/ChannelVideo';
 
@@ -38,17 +39,18 @@ interface ChannelVideosHeaderProps {
   selectedForDeletion: string[];
   deleteLoading: boolean;
   paginatedVideos: ChannelVideo[];
-  page: number;
-  totalPages: number;
+  autoDownloadsEnabled: boolean;
+  selectedTab: string;
   onViewModeChange: (event: React.MouseEvent<HTMLElement>, newMode: ViewMode | null) => void;
   onSearchChange: (query: string) => void;
   onHideDownloadedChange: (hide: boolean) => void;
+  onAutoDownloadChange: (enabled: boolean) => void;
   onRefreshClick: () => void;
   onDownloadClick: () => void;
   onSelectAll: () => void;
   onClearSelection: () => void;
   onDeleteClick: () => void;
-  onPageChange: (event: React.ChangeEvent<unknown>, value: number) => void;
+  onInfoIconClick: (tooltip: string) => void;
 }
 
 function ChannelVideosHeader({
@@ -63,18 +65,51 @@ function ChannelVideosHeader({
   selectedForDeletion,
   deleteLoading,
   paginatedVideos,
-  page,
-  totalPages,
+  autoDownloadsEnabled,
+  selectedTab,
   onViewModeChange,
   onSearchChange,
   onHideDownloadedChange,
+  onAutoDownloadChange,
   onRefreshClick,
   onDownloadClick,
   onSelectAll,
   onClearSelection,
   onDeleteClick,
-  onPageChange,
+  onInfoIconClick,
 }: ChannelVideosHeaderProps) {
+  const tooltipText = "Enable this if you want videos from this tab to automatically download when scheduled channel downloads occur, or when you trigger channel downloads from the Manage Downloads page";
+
+  const getInfoIcon = () => {
+    const handleClick = (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (isMobile) {
+        onInfoIconClick(tooltipText);
+      }
+    };
+
+    if (isMobile) {
+      return (
+        <IconButton
+          size="small"
+          sx={{ ml: 0.5, p: 0.5 }}
+          onClick={handleClick}
+        >
+          <InfoIcon fontSize="small" />
+        </IconButton>
+      );
+    }
+
+    return (
+      <Tooltip title={tooltipText} arrow placement="top">
+        <IconButton size="small" sx={{ ml: 0.5, p: 0.5 }}>
+          <InfoIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    );
+  };
+
   return (
     <Box
       sx={{
@@ -107,8 +142,23 @@ function ChannelVideosHeader({
             disabled={fetchingAllVideos}
             startIcon={<RefreshIcon />}
           >
-            {fetchingAllVideos ? 'Refreshing...' : 'Refresh'}
+            {fetchingAllVideos ? 'Fetching...' : 'Fetch All'}
           </Button>
+        </Box>
+
+        {/* Auto-download setting for this tab */}
+        <Box sx={{ mb: 2, display: 'flex', alignItems: 'center' }}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={autoDownloadsEnabled}
+                onChange={(e) => onAutoDownloadChange(e.target.checked)}
+                size="small"
+              />
+            }
+            label="Enable Channel Downloads for this tab"
+          />
+          {getInfoIcon()}
         </Box>
 
         {/* Search and filters */}
@@ -211,20 +261,6 @@ function ChannelVideosHeader({
             >
               Delete {selectedForDeletion.length > 0 ? `${selectedForDeletion.length}` : 'Selected'}
             </Button>
-          </Box>
-        )}
-
-        {/* Pagination - Always visible at top */}
-        {totalPages > 1 && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
-            <Pagination
-              count={totalPages}
-              page={page}
-              onChange={onPageChange}
-              color="primary"
-              size={isMobile ? 'small' : 'medium'}
-              siblingCount={isMobile ? 0 : 1}
-            />
           </Box>
         )}
       </Box>

--- a/client/src/components/ChannelPage/ChannelVideosHeader.tsx
+++ b/client/src/components/ChannelPage/ChannelVideosHeader.tsx
@@ -1,0 +1,238 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  TextField,
+  InputAdornment,
+  ToggleButton,
+  ToggleButtonGroup,
+  FormControlLabel,
+  Switch,
+  Tooltip,
+  Chip,
+  Pagination,
+  LinearProgress,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
+import TableChartIcon from '@mui/icons-material/TableChart';
+import ViewListIcon from '@mui/icons-material/ViewList';
+import DownloadIcon from '@mui/icons-material/Download';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { getVideoStatus } from '../../utils/videoStatus';
+import { ChannelVideo } from '../../types/ChannelVideo';
+
+type ViewMode = 'table' | 'grid' | 'list';
+
+interface ChannelVideosHeaderProps {
+  isMobile: boolean;
+  viewMode: ViewMode;
+  searchQuery: string;
+  hideDownloaded: boolean;
+  totalCount: number;
+  oldestVideoDate: string | null;
+  fetchingAllVideos: boolean;
+  checkedBoxes: string[];
+  selectedForDeletion: string[];
+  deleteLoading: boolean;
+  paginatedVideos: ChannelVideo[];
+  page: number;
+  totalPages: number;
+  onViewModeChange: (event: React.MouseEvent<HTMLElement>, newMode: ViewMode | null) => void;
+  onSearchChange: (query: string) => void;
+  onHideDownloadedChange: (hide: boolean) => void;
+  onRefreshClick: () => void;
+  onDownloadClick: () => void;
+  onSelectAll: () => void;
+  onClearSelection: () => void;
+  onDeleteClick: () => void;
+  onPageChange: (event: React.ChangeEvent<unknown>, value: number) => void;
+}
+
+function ChannelVideosHeader({
+  isMobile,
+  viewMode,
+  searchQuery,
+  hideDownloaded,
+  totalCount,
+  oldestVideoDate,
+  fetchingAllVideos,
+  checkedBoxes,
+  selectedForDeletion,
+  deleteLoading,
+  paginatedVideos,
+  page,
+  totalPages,
+  onViewModeChange,
+  onSearchChange,
+  onHideDownloadedChange,
+  onRefreshClick,
+  onDownloadClick,
+  onSelectAll,
+  onClearSelection,
+  onDeleteClick,
+  onPageChange,
+}: ChannelVideosHeaderProps) {
+  return (
+    <Box
+      sx={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 10,
+        bgcolor: 'background.paper',
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Box sx={{ p: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            <Typography variant="h6">Channel Videos</Typography>
+            {totalCount > 0 && (
+              <Chip label={totalCount} size="small" color="primary" />
+            )}
+            {oldestVideoDate && !isMobile && (
+              <Typography variant="caption" color="text.secondary">
+                Oldest: {new Date(oldestVideoDate).toLocaleDateString()}
+              </Typography>
+            )}
+          </Box>
+
+          <Button
+            onClick={onRefreshClick}
+            variant="outlined"
+            size="small"
+            disabled={fetchingAllVideos}
+            startIcon={<RefreshIcon />}
+          >
+            {fetchingAllVideos ? 'Refreshing...' : 'Refresh'}
+          </Button>
+        </Box>
+
+        {/* Search and filters */}
+        <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center' }}>
+          <TextField
+            placeholder="Search videos..."
+            size="small"
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              ),
+            }}
+            sx={{ flexGrow: 1, minWidth: 200 }}
+          />
+
+          {/* View mode toggle - mobile shows list/grid, desktop shows table/grid */}
+          <ToggleButtonGroup
+            value={viewMode}
+            exclusive
+            onChange={onViewModeChange}
+            size="small"
+          >
+            {!isMobile && (
+              <ToggleButton value="table">
+                <Tooltip title="Table View">
+                  <TableChartIcon fontSize="small" />
+                </Tooltip>
+              </ToggleButton>
+            )}
+            <ToggleButton value="grid">
+              <Tooltip title="Grid View">
+                <ViewModuleIcon fontSize="small" />
+              </Tooltip>
+            </ToggleButton>
+            {isMobile && (
+              <ToggleButton value="list">
+                <Tooltip title="List View">
+                  <ViewListIcon fontSize="small" />
+                </Tooltip>
+              </ToggleButton>
+            )}
+          </ToggleButtonGroup>
+
+          {!isMobile && (
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={hideDownloaded}
+                  onChange={(e) => onHideDownloadedChange(e.target.checked)}
+                  size="small"
+                />
+              }
+              label="Hide Downloaded"
+            />
+          )}
+        </Box>
+
+        {/* Action buttons for desktop */}
+        {!isMobile && (
+          <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={<DownloadIcon />}
+              onClick={onDownloadClick}
+              disabled={checkedBoxes.length === 0}
+            >
+              Download {checkedBoxes.length > 0 ? `${checkedBoxes.length} ${checkedBoxes.length === 1 ? 'Video' : 'Videos'}` : 'Selected'}
+            </Button>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={onSelectAll}
+              disabled={checkedBoxes.length === 0 && paginatedVideos.filter(v => {
+                const status = getVideoStatus(v);
+                return status === 'never_downloaded' || status === 'missing';
+              }).length === 0}
+            >
+              Select All This Page
+            </Button>
+            <Button
+              variant="outlined"
+              size="small"
+              onClick={onClearSelection}
+              disabled={checkedBoxes.length === 0}
+            >
+              Clear
+            </Button>
+            <Button
+              variant="contained"
+              color="error"
+              size="small"
+              startIcon={<DeleteIcon />}
+              onClick={onDeleteClick}
+              disabled={selectedForDeletion.length === 0 || deleteLoading}
+            >
+              Delete {selectedForDeletion.length > 0 ? `${selectedForDeletion.length}` : 'Selected'}
+            </Button>
+          </Box>
+        )}
+
+        {/* Pagination - Always visible at top */}
+        {totalPages > 1 && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2, pt: 2, borderTop: '1px solid', borderColor: 'divider' }}>
+            <Pagination
+              count={totalPages}
+              page={page}
+              onChange={onPageChange}
+              color="primary"
+              size={isMobile ? 'small' : 'medium'}
+              siblingCount={isMobile ? 0 : 1}
+            />
+          </Box>
+        )}
+      </Box>
+
+      {/* Progress bar */}
+      {fetchingAllVideos && <LinearProgress />}
+    </Box>
+  );
+}
+
+export default ChannelVideosHeader;

--- a/client/src/components/ChannelPage/StillLiveDot.tsx
+++ b/client/src/components/ChannelPage/StillLiveDot.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { Tooltip, Chip } from '@mui/material';
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+
+interface StillLiveDotProps {
+  isMobile?: boolean;
+  onMobileClick?: (message: string) => void;
+}
+
+function StillLiveDot({ isMobile = false, onMobileClick }: StillLiveDotProps) {
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const message = "Cannot download while still airing";
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (isMobile && onMobileClick) {
+      onMobileClick(message);
+    } else {
+      setTooltipOpen(!tooltipOpen);
+      // Auto-close tooltip after 2 seconds
+      setTimeout(() => setTooltipOpen(false), 2000);
+    }
+  };
+
+  const liveDot = (
+    <Chip
+      icon={<FiberManualRecordIcon sx={{ fontSize: 12, animation: 'pulse 2s infinite' }} />}
+      label="LIVE"
+      size="small"
+      onClick={handleClick}
+      sx={{
+        bgcolor: 'error.main',
+        color: 'white',
+        fontWeight: 'bold',
+        cursor: 'pointer',
+        '&:hover': {
+          bgcolor: 'error.dark',
+        },
+        '@keyframes pulse': {
+          '0%': {
+            opacity: 1,
+          },
+          '50%': {
+            opacity: 0.6,
+          },
+          '100%': {
+            opacity: 1,
+          },
+        },
+      }}
+    />
+  );
+
+  if (isMobile) {
+    return liveDot;
+  }
+
+  return (
+    <Tooltip
+      title={message}
+      open={tooltipOpen}
+      onClose={() => setTooltipOpen(false)}
+      disableHoverListener
+      disableFocusListener
+      disableTouchListener
+    >
+      {liveDot}
+    </Tooltip>
+  );
+}
+
+export default StillLiveDot;

--- a/client/src/components/ChannelPage/VideoCard.tsx
+++ b/client/src/components/ChannelPage/VideoCard.tsx
@@ -228,7 +228,8 @@ function VideoCard({
 
             <Box sx={{ mt: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
               {/* Date, size, and status - same line on mobile, separate on desktop */}
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+              {video.media_type !== 'short' && video.publishedAt && (
                 <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                   <CalendarTodayIcon sx={{ fontSize: 12 }} />
                   {isMobile
@@ -236,6 +237,7 @@ function VideoCard({
                     : new Date(video.publishedAt).toLocaleDateString()
                   }
                 </Typography>
+              )}
                 {video.fileSize && (
                   <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                     <StorageIcon sx={{ fontSize: 12 }} />

--- a/client/src/components/ChannelPage/VideoCard.tsx
+++ b/client/src/components/ChannelPage/VideoCard.tsx
@@ -1,0 +1,262 @@
+import React from 'react';
+import {
+  Card,
+  Box,
+  Typography,
+  Checkbox,
+  Chip,
+  IconButton,
+  Grid,
+  Fade,
+} from '@mui/material';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import StorageIcon from '@mui/icons-material/Storage';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useTheme } from '@mui/material/styles';
+import { formatDuration } from '../../utils';
+import { ChannelVideo } from '../../types/ChannelVideo';
+import { formatFileSize, decodeHtml } from '../../utils/formatters';
+import { getVideoStatus, getStatusColor, getStatusIcon, getStatusLabel, getMediaTypeInfo } from '../../utils/videoStatus';
+
+interface VideoCardProps {
+  video: ChannelVideo;
+  isMobile: boolean;
+  checkedBoxes: string[];
+  hoveredVideo: string | null;
+  selectedForDeletion: string[];
+  onCheckChange: (videoId: string, isChecked: boolean) => void;
+  onHoverChange: (videoId: string | null) => void;
+  onToggleDeletion: (youtubeId: string) => void;
+}
+
+function VideoCard({
+  video,
+  isMobile,
+  checkedBoxes,
+  hoveredVideo,
+  selectedForDeletion,
+  onCheckChange,
+  onHoverChange,
+  onToggleDeletion,
+}: VideoCardProps) {
+  const theme = useTheme();
+  const status = getVideoStatus(video);
+  const isSelectable = status === 'never_downloaded' || status === 'missing';
+  const isChecked = checkedBoxes.includes(video.youtube_id);
+  const mediaTypeInfo = getMediaTypeInfo(video.media_type);
+
+  return (
+    <Fade in timeout={300} key={video.youtube_id}>
+      <Grid item xs={12} sm={6} md={4} lg={3}>
+        <Card
+          sx={{
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            position: 'relative',
+            transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+            cursor: isSelectable ? 'pointer' : 'default',
+            opacity: status === 'members_only' ? 0.7 : 1,
+            transform: hoveredVideo === video.youtube_id ? 'translateY(-4px)' : 'translateY(0)',
+            boxShadow: hoveredVideo === video.youtube_id ? theme.shadows[8] : theme.shadows[1],
+            '&:hover': {
+              boxShadow: theme.shadows[4],
+            },
+          }}
+          onMouseEnter={() => onHoverChange(video.youtube_id)}
+          onMouseLeave={() => onHoverChange(null)}
+          onClick={() => isSelectable && onCheckChange(video.youtube_id, !isChecked)}
+        >
+          {/* Thumbnail with overlay */}
+          <Box sx={{ position: 'relative', paddingTop: isMobile ? '52%' : '56.25%', bgcolor: 'grey.900' }}>
+            <img
+              src={video.thumbnail}
+              alt={decodeHtml(video.title)}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                objectFit: 'cover',
+              }}
+              loading="lazy"
+            />
+
+            {/* YouTube Removed Banner */}
+            {video.youtube_removed ? (
+              <Box
+                sx={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  backgroundColor: 'rgba(211, 47, 47, 0.95)',
+                  color: 'white',
+                  padding: '4px 8px',
+                  fontSize: '0.75rem',
+                  fontWeight: 'bold',
+                  textAlign: 'center',
+                  zIndex: 2,
+                }}
+              >
+                Removed From YouTube
+              </Box>
+            ) : null}
+
+            {/* Duration overlay */}
+            <Chip
+              label={formatDuration(video.duration)}
+              size="small"
+              sx={{
+                position: 'absolute',
+                bottom: 8,
+                right: 8,
+                bgcolor: 'rgba(0,0,0,0.8)',
+                color: 'white',
+                fontSize: '0.75rem',
+                height: 22,
+              }}
+            />
+
+            {/* Selection overlay for download */}
+            {isSelectable && (
+              <Box
+                sx={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  bgcolor: isChecked ? 'rgba(25, 118, 210, 0.3)' : 'transparent',
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  justifyContent: 'flex-start',
+                  p: 1,
+                  transition: 'background-color 0.2s',
+                }}
+              >
+                <Checkbox
+                  checked={isChecked}
+                  onClick={(e) => e.stopPropagation()}
+                  onChange={(e) => {
+                    e.stopPropagation();
+                    onCheckChange(video.youtube_id, e.target.checked);
+                  }}
+                  sx={{
+                    color: 'white',
+                    bgcolor: 'rgba(0,0,0,0.5)',
+                    '&.Mui-checked': {
+                      color: 'primary.main',
+                    },
+                    '&:hover': {
+                      bgcolor: 'rgba(0,0,0,0.7)',
+                    },
+                  }}
+                />
+              </Box>
+            )}
+
+            {/* Delete icon for downloaded videos */}
+            {status === 'downloaded' && (
+              <IconButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleDeletion(video.youtube_id);
+                }}
+                sx={{
+                  position: 'absolute',
+                  top: 8,
+                  right: 8,
+                  bgcolor: selectedForDeletion.includes(video.youtube_id) ? 'error.main' : 'rgba(0,0,0,0.6)',
+                  color: 'white',
+                  '&:hover': {
+                    bgcolor: selectedForDeletion.includes(video.youtube_id) ? 'error.dark' : 'rgba(0,0,0,0.8)',
+                  },
+                  transition: 'all 0.2s',
+                  zIndex: 3,
+                }}
+                size="small"
+              >
+                <DeleteIcon fontSize="small" />
+              </IconButton>
+            )}
+          </Box>
+
+          {/* Card content */}
+          <Box sx={{ p: isMobile ? 1.5 : 2, flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
+            <Typography
+              variant="body2"
+              sx={{
+                mb: 1,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                lineHeight: 1.3,
+                minHeight: '2.6em',
+              }}
+              title={decodeHtml(video.title)}
+            >
+              {decodeHtml(video.title)}
+            </Typography>
+
+            <Box sx={{ mt: 'auto', display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {/* Date, size, and status - same line on mobile, separate on desktop */}
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <CalendarTodayIcon sx={{ fontSize: 12 }} />
+                  {isMobile
+                    ? new Date(video.publishedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+                    : new Date(video.publishedAt).toLocaleDateString()
+                  }
+                </Typography>
+                {video.fileSize && (
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <StorageIcon sx={{ fontSize: 12 }} />
+                    {formatFileSize(video.fileSize)}
+                  </Typography>
+                )}
+                {mediaTypeInfo && (
+                  <Chip
+                    size="small"
+                    icon={mediaTypeInfo.icon}
+                    label={mediaTypeInfo.label}
+                    color={mediaTypeInfo.color}
+                    variant="outlined"
+                    sx={{ height: 20, fontSize: '0.7rem' }}
+                  />
+                )}
+                {isMobile && (
+                  <Chip
+                    icon={getStatusIcon(status)}
+                    label={getStatusLabel(status)}
+                    size="small"
+                    color={getStatusColor(status)}
+                    variant={status === 'downloaded' ? 'filled' : 'outlined'}
+                    sx={{ height: 20, fontSize: '0.7rem' }}
+                  />
+                )}
+              </Box>
+
+              {/* Status chip for desktop only */}
+              {!isMobile && (
+                <Chip
+                  icon={getStatusIcon(status)}
+                  label={getStatusLabel(status)}
+                  size="small"
+                  color={getStatusColor(status)}
+                  variant={status === 'downloaded' ? 'filled' : 'outlined'}
+                  sx={{ width: 'fit-content' }}
+                />
+              )}
+            </Box>
+          </Box>
+        </Card>
+      </Grid>
+    </Fade>
+  );
+}
+
+export default VideoCard;

--- a/client/src/components/ChannelPage/VideoListItem.tsx
+++ b/client/src/components/ChannelPage/VideoListItem.tsx
@@ -205,11 +205,13 @@ function VideoListItem({
           </Typography>
 
           {/* Date, Size, and Status on same line */}
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mt: 'auto' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mt: 'auto' }}>
+          {video.media_type !== 'short' && video.publishedAt && (
             <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.3, fontSize: '0.7rem' }}>
               <CalendarTodayIcon sx={{ fontSize: 11 }} />
               {new Date(video.publishedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: '2-digit' })}
             </Typography>
+          )}
             {video.fileSize && (
               <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.3, fontSize: '0.7rem' }}>
                 <StorageIcon sx={{ fontSize: 11 }} />

--- a/client/src/components/ChannelPage/VideoListItem.tsx
+++ b/client/src/components/ChannelPage/VideoListItem.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import {
+  Card,
+  Box,
+  Typography,
+  Checkbox,
+  Chip,
+  IconButton,
+  CardContent,
+  Fade,
+} from '@mui/material';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import StorageIcon from '@mui/icons-material/Storage';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useTheme } from '@mui/material/styles';
+import { formatDuration } from '../../utils';
+import { ChannelVideo } from '../../types/ChannelVideo';
+import { formatFileSize, decodeHtml } from '../../utils/formatters';
+import { getVideoStatus, getStatusColor, getStatusIcon, getStatusLabel, getMediaTypeInfo } from '../../utils/videoStatus';
+
+interface VideoListItemProps {
+  video: ChannelVideo;
+  checkedBoxes: string[];
+  selectedForDeletion: string[];
+  onCheckChange: (videoId: string, isChecked: boolean) => void;
+  onToggleDeletion: (youtubeId: string) => void;
+}
+
+function VideoListItem({
+  video,
+  checkedBoxes,
+  selectedForDeletion,
+  onCheckChange,
+  onToggleDeletion,
+}: VideoListItemProps) {
+  const theme = useTheme();
+  const status = getVideoStatus(video);
+  const isSelectable = status === 'never_downloaded' || status === 'missing';
+  const isChecked = checkedBoxes.includes(video.youtube_id);
+  const mediaTypeInfo = getMediaTypeInfo(video.media_type);
+
+  return (
+    <Fade in timeout={300} key={video.youtube_id}>
+      <Card
+        sx={{
+          mb: 1.5,
+          display: 'flex',
+          position: 'relative',
+          transition: 'all 0.2s ease',
+          cursor: isSelectable ? 'pointer' : 'default',
+          opacity: status === 'members_only' ? 0.7 : 1,
+          '&:hover': {
+            boxShadow: theme.shadows[3],
+          },
+        }}
+        onClick={() => isSelectable && onCheckChange(video.youtube_id, !isChecked)}
+      >
+        {/* Thumbnail */}
+        <Box
+          sx={{
+            position: 'relative',
+            width: 120,
+            minWidth: 120,
+            height: 90,
+            bgcolor: 'grey.900',
+          }}
+        >
+          <img
+            src={video.thumbnail}
+            alt={decodeHtml(video.title)}
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+            }}
+            loading="lazy"
+          />
+
+          {/* YouTube Removed Banner */}
+          {video.youtube_removed ? (
+            <Box
+              sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                backgroundColor: 'rgba(211, 47, 47, 0.95)',
+                color: 'white',
+                padding: '2px 4px',
+                fontSize: '0.65rem',
+                fontWeight: 'bold',
+                textAlign: 'center',
+                zIndex: 2,
+              }}
+            >
+              Removed From YouTube
+            </Box>
+          ) : null}
+
+          {/* Duration overlay */}
+          <Chip
+            label={formatDuration(video.duration)}
+            size="small"
+            sx={{
+              position: 'absolute',
+              bottom: 4,
+              right: 4,
+              bgcolor: 'rgba(0,0,0,0.8)',
+              color: 'white',
+              fontSize: '0.7rem',
+              height: 18,
+              '& .MuiChip-label': { px: 0.5 },
+            }}
+          />
+
+          {/* Checkbox for selectable videos */}
+          {isSelectable && (
+            <Checkbox
+              checked={isChecked}
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => {
+                e.stopPropagation();
+                onCheckChange(video.youtube_id, e.target.checked);
+              }}
+              sx={{
+                position: 'absolute',
+                top: 2,
+                left: 2,
+                color: 'white',
+                bgcolor: 'rgba(0,0,0,0.5)',
+                padding: 0.5,
+                '&.Mui-checked': {
+                  color: 'primary.main',
+                  bgcolor: 'rgba(0,0,0,0.7)',
+                },
+                '& .MuiSvgIcon-root': { fontSize: 20 },
+              }}
+            />
+          )}
+
+          {/* Delete icon for downloaded videos */}
+          {status === 'downloaded' && (
+            <IconButton
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleDeletion(video.youtube_id);
+              }}
+              sx={{
+                position: 'absolute',
+                top: 2,
+                left: 2,
+                bgcolor: selectedForDeletion.includes(video.youtube_id) ? 'error.main' : 'rgba(0,0,0,0.6)',
+                color: 'white',
+                padding: 0.5,
+                '&:hover': {
+                  bgcolor: selectedForDeletion.includes(video.youtube_id) ? 'error.dark' : 'rgba(0,0,0,0.8)',
+                },
+                transition: 'all 0.2s',
+              }}
+              size="small"
+            >
+              <DeleteIcon sx={{ fontSize: 18 }} />
+            </IconButton>
+          )}
+        </Box>
+
+        {/* Content */}
+        <CardContent sx={{ flex: 1, py: 1, px: 1.5, '&:last-child': { pb: 1 } }}>
+          {/* Title */}
+          <Typography
+            variant="body2"
+            sx={{
+              mb: 0.5,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              lineHeight: 1.3,
+              fontSize: '0.875rem',
+            }}
+            title={decodeHtml(video.title)}
+          >
+            {decodeHtml(video.title)}
+          </Typography>
+
+          {/* Date, Size, and Status on same line */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mt: 'auto' }}>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.3, fontSize: '0.7rem' }}>
+              <CalendarTodayIcon sx={{ fontSize: 11 }} />
+              {new Date(video.publishedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: '2-digit' })}
+            </Typography>
+            {video.fileSize && (
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', gap: 0.3, fontSize: '0.7rem' }}>
+                <StorageIcon sx={{ fontSize: 11 }} />
+                {formatFileSize(video.fileSize)}
+              </Typography>
+            )}
+            {mediaTypeInfo && (
+              <Chip
+                size="small"
+                icon={mediaTypeInfo.icon}
+                label={mediaTypeInfo.label}
+                color={mediaTypeInfo.color}
+                variant="outlined"
+                sx={{
+                  height: 18,
+                  fontSize: '0.7rem',
+                  '& .MuiChip-icon': { fontSize: 14, ml: 0.5 },
+                  '& .MuiChip-label': { px: 0.6 },
+                }}
+              />
+            )}
+            <Chip
+              icon={getStatusIcon(status)}
+              label={getStatusLabel(status)}
+              size="small"
+              color={getStatusColor(status)}
+              variant={status === 'downloaded' ? 'filled' : 'outlined'}
+              sx={{
+                height: 20,
+                fontSize: '0.7rem',
+                '& .MuiChip-icon': { fontSize: 14, ml: 0.5 },
+                '& .MuiChip-label': { px: 0.75 },
+              }}
+            />
+          </Box>
+        </CardContent>
+      </Card>
+    </Fade>
+  );
+}
+
+export default VideoListItem;

--- a/client/src/components/ChannelPage/VideoTableView.tsx
+++ b/client/src/components/ChannelPage/VideoTableView.tsx
@@ -194,7 +194,9 @@ function VideoTableView({
                   </Typography>
                 </TableCell>
                 <TableCell>
-                  {new Date(video.publishedAt).toLocaleDateString()}
+                  {video.media_type === 'short' || !video.publishedAt
+                    ? 'N/A'
+                    : new Date(video.publishedAt).toLocaleDateString()}
                 </TableCell>
                 <TableCell>
                   {video.media_type === 'short' ? 'N/A' : formatDuration(video.duration)}

--- a/client/src/components/ChannelPage/VideoTableView.tsx
+++ b/client/src/components/ChannelPage/VideoTableView.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Checkbox,
+  Box,
+  Typography,
+  Chip,
+  IconButton,
+} from '@mui/material';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { formatDuration } from '../../utils';
+import { ChannelVideo } from '../../types/ChannelVideo';
+import { formatFileSize, decodeHtml } from '../../utils/formatters';
+import { getVideoStatus, getStatusColor, getStatusIcon, getStatusLabel, getMediaTypeInfo } from '../../utils/videoStatus';
+
+type SortBy = 'date' | 'title' | 'duration' | 'size';
+type SortOrder = 'asc' | 'desc';
+
+interface VideoTableViewProps {
+  videos: ChannelVideo[];
+  checkedBoxes: string[];
+  selectedForDeletion: string[];
+  sortBy: SortBy;
+  sortOrder: SortOrder;
+  onCheckChange: (videoId: string, isChecked: boolean) => void;
+  onSelectAll: () => void;
+  onClearSelection: () => void;
+  onSortChange: (newSortBy: SortBy) => void;
+  onToggleDeletion: (youtubeId: string) => void;
+}
+
+function VideoTableView({
+  videos,
+  checkedBoxes,
+  selectedForDeletion,
+  sortBy,
+  sortOrder,
+  onCheckChange,
+  onSelectAll,
+  onClearSelection,
+  onSortChange,
+  onToggleDeletion,
+}: VideoTableViewProps) {
+  return (
+    <TableContainer>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell padding="checkbox">
+              <Checkbox
+                indeterminate={checkedBoxes.length > 0 && checkedBoxes.length < videos.length}
+                checked={videos.length > 0 && checkedBoxes.length === videos.length}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    onSelectAll();
+                  } else {
+                    onClearSelection();
+                  }
+                }}
+              />
+            </TableCell>
+            <TableCell>Thumbnail</TableCell>
+            <TableCell onClick={() => onSortChange('title')} sx={{ cursor: 'pointer' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                Title
+                {sortBy === 'title' && (
+                  sortOrder === 'asc' ? <ArrowUpwardIcon fontSize="small" /> : <ArrowDownwardIcon fontSize="small" />
+                )}
+              </Box>
+            </TableCell>
+            <TableCell onClick={() => onSortChange('date')} sx={{ cursor: 'pointer' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                Published
+                {sortBy === 'date' && (
+                  sortOrder === 'asc' ? <ArrowUpwardIcon fontSize="small" /> : <ArrowDownwardIcon fontSize="small" />
+                )}
+              </Box>
+            </TableCell>
+            <TableCell onClick={() => onSortChange('duration')} sx={{ cursor: 'pointer' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                Duration
+                {sortBy === 'duration' && (
+                  sortOrder === 'asc' ? <ArrowUpwardIcon fontSize="small" /> : <ArrowDownwardIcon fontSize="small" />
+                )}
+              </Box>
+            </TableCell>
+            <TableCell onClick={() => onSortChange('size')} sx={{ cursor: 'pointer' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                Size
+                {sortBy === 'size' && (
+                  sortOrder === 'asc' ? <ArrowUpwardIcon fontSize="small" /> : <ArrowDownwardIcon fontSize="small" />
+                )}
+              </Box>
+            </TableCell>
+            <TableCell>Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {videos.map((video) => {
+            const status = getVideoStatus(video);
+            const isSelectable = (status === 'never_downloaded' || status === 'missing') && !video.youtube_removed;
+            const isChecked = checkedBoxes.includes(video.youtube_id);
+            const mediaTypeInfo = getMediaTypeInfo(video.media_type);
+
+            return (
+              <TableRow
+                key={video.youtube_id}
+                hover
+                sx={{
+                  opacity: status === 'members_only' ? 0.6 : 1,
+                  cursor: isSelectable ? 'pointer' : 'default',
+                }}
+              >
+                <TableCell padding="checkbox">
+                  {isSelectable && (
+                    <Checkbox
+                      checked={isChecked}
+                      onChange={(e) => onCheckChange(video.youtube_id, e.target.checked)}
+                    />
+                  )}
+                  {status === 'downloaded' && (
+                    <IconButton
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onToggleDeletion(video.youtube_id);
+                      }}
+                      sx={{
+                        color: selectedForDeletion.includes(video.youtube_id) ? 'error.main' : 'action.active',
+                        '&:hover': {
+                          color: 'error.main',
+                          bgcolor: 'error.light',
+                        },
+                      }}
+                      size="small"
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Box sx={{ position: 'relative', display: 'inline-block' }}>
+                    <img
+                      src={video.thumbnail}
+                      alt={decodeHtml(video.title)}
+                      style={{ width: 120, height: 67, objectFit: 'cover', borderRadius: 4, display: 'block' }}
+                      loading="lazy"
+                    />
+                    {video.youtube_removed && (
+                      <Box
+                        sx={{
+                          position: 'absolute',
+                          top: 0,
+                          left: 0,
+                          right: 0,
+                          backgroundColor: 'rgba(211, 47, 47, 0.95)',
+                          color: 'white',
+                          padding: '2px 4px',
+                          fontSize: '0.65rem',
+                          fontWeight: 'bold',
+                          textAlign: 'center',
+                          borderTopLeftRadius: 4,
+                          borderTopRightRadius: 4,
+                        }}
+                      >
+                        Removed From YouTube
+                      </Box>
+                    )}
+                  </Box>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ mb: 0.5 }}>
+                    {decodeHtml(video.title)}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  {new Date(video.publishedAt).toLocaleDateString()}
+                </TableCell>
+                <TableCell>
+                  {formatDuration(video.duration)}
+                </TableCell>
+                <TableCell>
+                  {video.fileSize ? formatFileSize(video.fileSize) : '-'}
+                </TableCell>
+                <TableCell>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                    {mediaTypeInfo && (
+                      <Chip
+                        size="small"
+                        icon={mediaTypeInfo.icon}
+                        label={mediaTypeInfo.label}
+                        color={mediaTypeInfo.color}
+                        variant="outlined"
+                      />
+                    )}
+                    <Chip
+                      icon={getStatusIcon(status)}
+                      label={getStatusLabel(status)}
+                      size="small"
+                      color={getStatusColor(status)}
+                      variant={status === 'downloaded' ? 'filled' : 'outlined'}
+                    />
+                  </Box>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+export default VideoTableView;

--- a/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
@@ -1,20 +1,17 @@
-import { render, screen, waitFor, fireEvent, within, act } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import ChannelVideos from '../ChannelVideos';
-import { BrowserRouter } from 'react-router-dom';
-import { ChannelVideo } from '../../../types/ChannelVideo';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import ChannelVideos from '../ChannelVideos';
+import { ChannelVideo } from '../../../types/ChannelVideo';
+import { renderWithProviders, createMockWebSocketContext } from '../../../test-utils';
 
 // Mock Material-UI hooks
 jest.mock('@mui/material/useMediaQuery');
 jest.mock('@mui/material/styles', () => ({
   ...jest.requireActual('@mui/material/styles'),
   useTheme: () => ({
-    breakpoints: {
-      down: (key: string) => key === 'sm', // Force grid view by making it think it's desktop but prefer grid
-    },
-    shadows: Array(25).fill('0px 0px 0px 0px rgba(0,0,0,0)'),
+    breakpoints: { down: () => false },
     zIndex: { fab: 1050 },
   }),
 }));
@@ -24,3287 +21,545 @@ const mockNavigate = jest.fn();
 const mockParams = { channel_id: 'UC123456' };
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
   useParams: () => mockParams,
+  useNavigate: () => mockNavigate,
 }));
 
 // Mock react-swipeable
 jest.mock('react-swipeable', () => ({
-  useSwipeable: jest.fn(() => ({})),
+  useSwipeable: () => ({}),
 }));
 
-// Mock DownloadSettingsDialog
-jest.mock('../../DownloadManager/ManualDownload/DownloadSettingsDialog', () => ({
+// Mock child components
+jest.mock('../VideoCard', () => ({
   __esModule: true,
-  default: function MockDownloadSettingsDialog({ open, onClose, onConfirm }: any) {
+  default: function MockVideoCard({ video }: any) {
     const React = require('react');
-    if (!open) return null;
-    return React.createElement('div', { 'data-testid': 'download-settings-dialog' },
-      React.createElement('button', {
-        onClick: () => onConfirm(null),
-        'data-testid': 'dialog-confirm'
-      }, 'Confirm'),
-      React.createElement('button', {
-        onClick: onClose,
-        'data-testid': 'dialog-cancel'
-      }, 'Cancel')
-    );
+    return React.createElement('div', {
+      'data-testid': `video-card-${video.youtube_id}`
+    }, video.title);
   }
 }));
 
-// Mock DeleteVideosDialog
-jest.mock('../../shared/DeleteVideosDialog', () => ({
+jest.mock('../VideoListItem', () => ({
   __esModule: true,
-  default: function MockDeleteVideosDialog({ open, onClose, onConfirm }: any) {
+  default: function MockVideoListItem({ video }: any) {
     const React = require('react');
-    if (!open) return null;
-    return React.createElement('div', { 'data-testid': 'delete-videos-dialog' },
-      React.createElement('button', {
-        onClick: onConfirm,
-        'data-testid': 'delete-confirm'
-      }, 'Delete Videos'),
-      React.createElement('button', {
-        onClick: onClose,
-        'data-testid': 'delete-cancel'
-      }, 'Cancel')
-    );
+    return React.createElement('div', {
+      'data-testid': `video-list-item-${video.youtube_id}`
+    }, video.title);
   }
 }));
 
-// Mock useVideoDeletion hook
+jest.mock('../VideoTableView', () => ({
+  __esModule: true,
+  default: function MockVideoTableView({ videos }: any) {
+    const React = require('react');
+    return React.createElement('div', {
+      'data-testid': 'video-table-view'
+    }, `Table with ${videos.length} videos`);
+  }
+}));
+
+jest.mock('../ChannelVideosHeader', () => ({
+  __esModule: true,
+  default: function MockChannelVideosHeader(props: any) {
+    const React = require('react');
+    return React.createElement('div', {
+      'data-testid': 'channel-videos-header',
+      'data-view-mode': props.viewMode
+    }, 'Header');
+  }
+}));
+
+jest.mock('../ChannelVideosDialogs', () => ({
+  __esModule: true,
+  default: function MockChannelVideosDialogs() {
+    const React = require('react');
+    return React.createElement('div', {
+      'data-testid': 'channel-videos-dialogs'
+    });
+  }
+}));
+
+// Mock custom hooks
+const mockRefetchVideos = jest.fn();
+const mockRefreshVideos = jest.fn();
+const mockClearError = jest.fn();
+const mockTriggerDownloads = jest.fn();
 const mockDeleteVideosByYoutubeIds = jest.fn();
-jest.mock('../../shared/useVideoDeletion', () => ({
-  useVideoDeletion: () => ({
-    deleteVideosByYoutubeIds: mockDeleteVideosByYoutubeIds,
-    deleteVideos: jest.fn(),
-    loading: false,
-    error: null,
-  }),
+
+jest.mock('../hooks/useChannelVideos', () => ({
+  useChannelVideos: jest.fn(),
 }));
 
-// Mock utils
-jest.mock('../../../utils', () => ({
-  formatDuration: jest.fn((duration: number | null) => {
-    if (!duration) return 'Unknown';
-    const hours = Math.floor(duration / 3600);
-    const minutes = Math.floor((duration % 3600) / 60);
-    return hours > 0 ? `${hours}h${minutes}m` : `${minutes}m`;
-  }),
+jest.mock('../hooks/useRefreshChannelVideos', () => ({
+  useRefreshChannelVideos: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useConfig', () => ({
+  useConfig: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useTriggerDownloads', () => ({
+  useTriggerDownloads: jest.fn(),
+}));
+
+jest.mock('../../shared/useVideoDeletion', () => ({
+  useVideoDeletion: jest.fn(),
 }));
 
 // Mock fetch
 const mockFetch = jest.fn();
 global.fetch = mockFetch as any;
 
-// Mock window.scrollTo
-global.scrollTo = jest.fn();
-
-// Helper to setup standard fetch mocks
-const setupFetchMocks = (videosResponse: any, configResponse: any = { preferredResolution: '1080p' }) => {
-  // Add default pagination data if not provided
-  const enrichedResponse = {
-    ...videosResponse,
-    totalCount: videosResponse.totalCount ?? (videosResponse.videos?.length || 0),
-    oldestVideoDate: videosResponse.oldestVideoDate ?? null,
-  };
-
-  // Mock videos fetch (can be called multiple times due to React effects)
-  mockFetch
-    .mockImplementation((url: string) => {
-      if (url.includes('/getchannelvideos/')) {
-        return Promise.resolve({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(enrichedResponse),
-        });
-      } else if (url.includes('/getconfig')) {
-        return Promise.resolve({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(configResponse),
-        });
-      }
-      return Promise.reject(new Error('Unexpected fetch URL: ' + url));
-    });
-};
-
+const { useChannelVideos } = require('../hooks/useChannelVideos');
+const { useRefreshChannelVideos } = require('../hooks/useRefreshChannelVideos');
+const { useVideoDeletion } = require('../../shared/useVideoDeletion');
+const { useConfig } = require('../../../hooks/useConfig');
+const { useTriggerDownloads } = require('../../../hooks/useTriggerDownloads');
 
 describe('ChannelVideos Component', () => {
   const mockToken = 'test-token';
+
   const mockVideos: ChannelVideo[] = [
     {
-      title: 'Video Title 1',
+      title: 'Test Video 1',
       youtube_id: 'video1',
-      publishedAt: '2024-01-15T10:00:00Z',
-      thumbnail: 'https://example.com/thumb1.jpg',
+      publishedAt: '2023-01-01T00:00:00Z',
+      thumbnail: 'https://i.ytimg.com/vi/video1/mqdefault.jpg',
       added: false,
-      duration: 3600,
-      availability: null,
+      duration: 300,
+      media_type: 'video',
+      live_status: null,
     },
     {
-      title: 'Video Title 2 &amp; More',
+      title: 'Test Video 2',
       youtube_id: 'video2',
-      publishedAt: '2024-01-14T10:00:00Z',
-      thumbnail: 'https://example.com/thumb2.jpg',
+      publishedAt: '2023-01-02T00:00:00Z',
+      thumbnail: 'https://i.ytimg.com/vi/video2/mqdefault.jpg',
       added: true,
-      duration: 1800,
-      availability: null,
+      removed: false,
+      duration: 600,
+      media_type: 'video',
+      live_status: null,
     },
     {
-      title: 'Members Only Video',
-      youtube_id: 'video3',
-      publishedAt: '2024-01-13T10:00:00Z',
-      thumbnail: 'https://example.com/thumb3.jpg',
+      title: 'Test Short 1',
+      youtube_id: 'short1',
+      publishedAt: '2023-01-03T00:00:00Z',
+      thumbnail: 'https://i.ytimg.com/vi/short1/mqdefault.jpg',
       added: false,
-      duration: 2400,
-      availability: 'subscriber_only',
+      duration: 30,
+      media_type: 'short',
+      live_status: null,
     },
   ];
+
+  const renderChannelVideos = (props = {}) => {
+    const wsCtx = createMockWebSocketContext();
+    return renderWithProviders(
+      <ChannelVideos token={mockToken} {...props} />,
+      { websocketValue: wsCtx }
+    );
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetch.mockReset();
-    mockDeleteVideosByYoutubeIds.mockReset();
-    (useMediaQuery as jest.Mock).mockReturnValue(false); // Default to desktop
+    (useMediaQuery as jest.Mock).mockReturnValue(false);
     mockNavigate.mockClear();
-  });
 
-  describe('Initial Rendering', () => {
-    test('renders component with title', () => {
-      mockFetch
-        .mockImplementation((url: string) => {
-          if (url.includes('/getchannelvideos/')) {
-            return Promise.resolve({
-              ok: true,
-              json: jest.fn().mockResolvedValueOnce({ videos: [], totalCount: 0 }),
-            });
-          } else if (url.includes('/getconfig')) {
-            return Promise.resolve({
-              ok: true,
-              json: jest.fn().mockResolvedValueOnce({ preferredResolution: '1080p' }),
-            });
-          }
-          return Promise.reject(new Error('Unexpected fetch URL: ' + url));
-        });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+    // Default mock responses
+    useChannelVideos.mockReturnValue({
+      videos: [],
+      totalCount: 0,
+      oldestVideoDate: null,
+      videoFailed: false,
+      autoDownloadsEnabled: false,
+      loading: false,
+      refetch: mockRefetchVideos,
     });
 
-    test('shows loading skeletons when videos are loading', () => {
-      mockFetch
-        .mockImplementation((url: string) => {
-          if (url.includes('/getchannelvideos/')) {
-            return Promise.resolve({
-              ok: true,
-              json: jest.fn().mockResolvedValueOnce({ videos: [], totalCount: 0 }),
-            });
-          } else if (url.includes('/getconfig')) {
-            return Promise.resolve({
-              ok: true,
-              json: jest.fn().mockResolvedValueOnce({ preferredResolution: '1080p' }),
-            });
-          }
-          return Promise.reject(new Error('Unexpected fetch URL: ' + url));
-        });
+    useRefreshChannelVideos.mockReturnValue({
+      refreshVideos: mockRefreshVideos,
+      loading: false,
+      error: null,
+      clearError: mockClearError,
+    });
 
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
+    useVideoDeletion.mockReturnValue({
+      deleteVideosByYoutubeIds: mockDeleteVideosByYoutubeIds,
+      loading: false,
+    });
 
+    useConfig.mockReturnValue({
+      config: { preferredResolution: '1080' },
+    });
+
+    useTriggerDownloads.mockReturnValue({
+      triggerDownloads: mockTriggerDownloads,
+    });
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ availableTabs: ['videos'] }),
+    });
+  });
+
+  describe('Component Rendering', () => {
+    test('renders without crashing', () => {
+      renderChannelVideos();
+      expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
+    });
+
+    test('renders with loading state initially', () => {
+      useChannelVideos.mockReturnValue({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: true,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
       expect(screen.getByText('Loading channel videos...')).toBeInTheDocument();
     });
 
-    test('fetches channel videos with correct parameters', async () => {
-      setupFetchMocks({ videos: mockVideos, totalCount: mockVideos.length });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('/getchannelvideos/UC123456'),
-          {
-            headers: {
-              'x-access-token': mockToken,
-            },
-          }
-        );
+    test('renders videos in grid view by default on desktop', () => {
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
       });
+
+      renderChannelVideos();
+      expect(screen.getByTestId('video-card-video1')).toBeInTheDocument();
+      expect(screen.getByTestId('video-card-video2')).toBeInTheDocument();
+      expect(screen.getByTestId('video-card-short1')).toBeInTheDocument();
     });
 
-    test('handles null token properly', async () => {
-      // When token is null, getconfig is not fetched
-      mockFetch.mockImplementation((url: string) => {
-        if (url.includes('/getchannelvideos/')) {
-          return Promise.resolve({
-            ok: true,
-            json: jest.fn().mockResolvedValueOnce({ videos: mockVideos, totalCount: mockVideos.length }),
-          });
-        }
-        return Promise.reject(new Error('Unexpected fetch URL: ' + url));
+    test('shows no videos message when empty', () => {
+      renderChannelVideos();
+      expect(screen.getByText('No videos found')).toBeInTheDocument();
+    });
+
+    test('shows error message when fetch fails', () => {
+      useChannelVideos.mockReturnValue({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+        videoFailed: true,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
       });
 
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={null} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('/getchannelvideos/UC123456'),
-          {
-            headers: {
-              'x-access-token': '',
-            },
-          }
-        );
-      });
+      renderChannelVideos();
+      expect(screen.getByText('Failed to fetch channel videos. Please try again later.')).toBeInTheDocument();
     });
   });
 
-  describe('Video Display', () => {
-    test('displays videos after successful fetch', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
+  describe('Tab Management', () => {
+    test('fetches available tabs on mount', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({ availableTabs: ['videos', 'shorts', 'streams'] }),
       });
 
-      expect(screen.getByText('Video Title 2 & More')).toBeInTheDocument();
-      expect(screen.getByText('Members Only Video')).toBeInTheDocument();
-    });
-
-    test('decodes HTML entities in video titles', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
+      renderChannelVideos();
 
       await waitFor(() => {
-        expect(screen.getByText('Video Title 2 & More')).toBeInTheDocument();
+        expect(mockFetch).toHaveBeenCalledWith(
+          '/api/channels/UC123456/tabs',
+          expect.objectContaining({
+            headers: { 'x-access-token': mockToken },
+          })
+        );
       });
     });
 
-    test('formats video duration correctly', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
+    test('displays tabs when multiple tabs are available', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({ availableTabs: ['videos', 'shorts', 'streams'] }),
       });
 
-      // Check that formatDuration was called correctly
-      const { formatDuration } = require('../../../utils');
-      expect(formatDuration).toHaveBeenCalledWith(3600);
-      expect(formatDuration).toHaveBeenCalledWith(1800);
-      expect(formatDuration).toHaveBeenCalledWith(2400);
+      renderChannelVideos();
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Videos/i })).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
     });
 
-    test('displays thumbnails with correct src and alt text', async () => {
-      setupFetchMocks({ videos: mockVideos });
+    test('does not display tabs when only one tab available', () => {
+      renderChannelVideos();
+      expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    });
 
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
+    test('handles tab change', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({ availableTabs: ['videos', 'shorts'] }),
+      });
+
+      renderChannelVideos();
 
       await waitFor(() => {
-        const thumb1 = screen.getByAltText('Video Title 1');
-        expect(thumb1).toHaveAttribute('src', 'https://example.com/thumb1.jpg');
+        expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('tab', { name: /Shorts/i }));
+
+      // Verify that useChannelVideos was called with the new tab
+      await waitFor(() => {
+        expect(useChannelVideos).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tabType: 'shorts',
+          })
+        );
       });
     });
 
-    test('shows check icon for downloaded videos', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 2 & More')).toBeInTheDocument();
+    test('prevents tab change while videos are loading', async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({ availableTabs: ['videos', 'shorts'] }),
       });
 
-      // Check for the "Downloaded" status chip for downloaded videos
-      const downloadedChips = screen.getAllByText('Downloaded');
-      expect(downloadedChips.length).toBeGreaterThan(0);
+      useChannelVideos.mockReturnValue({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: true,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      });
+
+      const shortsTab = screen.getByRole('tab', { name: /Shorts/i });
+      await user.click(shortsTab);
+
+      // Tab should not change when loading - we can't really test this with current setup
+      // since React state changes happen internally
     });
+  });
 
-    test('shows "Members Only" for subscriber-only videos', async () => {
-      setupFetchMocks({ videos: mockVideos });
+  describe('View Modes', () => {
+    test('renders in list view on mobile by default', () => {
+      (useMediaQuery as jest.Mock).mockReturnValue(true);
 
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getAllByText('Members Only')[0]).toBeInTheDocument();
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
       });
+
+      renderChannelVideos();
+
+      expect(screen.getByTestId('video-list-item-video1')).toBeInTheDocument();
     });
   });
 
   describe('Pagination', () => {
-    const manyVideos: ChannelVideo[] = [];
-    for (let i = 0; i < 25; i++) {
-      manyVideos.push({
-        title: `Video ${i + 1}`,
-        youtube_id: `video${i + 1}`,
-        publishedAt: '2024-01-15T10:00:00Z',
-        thumbnail: `https://example.com/thumb${i + 1}.jpg`,
-        added: false,
-        duration: 1800,
-        availability: null,
-      });
-    }
-
-    test('displays pagination controls when videos exceed page limit', async () => {
-      // Server returns first 16 videos with totalCount of 25
-      setupFetchMocks({ videos: manyVideos.slice(0, 16), totalCount: 25 });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getAllByRole('navigation').length).toBeGreaterThan(0);
-      });
-
-      // We now have two pagination controls (top and bottom), use the first one
-      const paginations = screen.getAllByRole('navigation');
-      const pagination = paginations[0];
-      const page1 = within(pagination).getByText('1');
-      const page2 = within(pagination).getByText('2');
-      expect(page1).toBeInTheDocument();
-      expect(page2).toBeInTheDocument();
-    });
-
-    test('shows correct number of videos per page on desktop', async () => {
-      // Server returns first 16 videos
-      setupFetchMocks({ videos: manyVideos.slice(0, 16), totalCount: 25 });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 1')).toBeInTheDocument();
-      });
-
-      // Should show 16 videos on desktop
-      expect(screen.getByText('Video 16')).toBeInTheDocument();
-      expect(screen.queryByText('Video 17')).not.toBeInTheDocument();
-    });
-
-    test('changes page when pagination is clicked', async () => {
-      // First call returns page 1
-      setupFetchMocks({ videos: manyVideos.slice(0, 16), totalCount: 25 });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 1')).toBeInTheDocument();
-      });
-
-      // Mock second page fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: manyVideos.slice(16, 25),
-          totalCount: 25,
-        }),
-      });
-
-      // We now have two pagination controls (top and bottom), use the first one
-      const paginations = screen.getAllByRole('navigation');
-      const pagination = paginations[0];
-      const page2Button = within(pagination).getByText('2');
-      fireEvent.click(page2Button);
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 17')).toBeInTheDocument();
-      });
-      expect(screen.queryByText('Video 1')).not.toBeInTheDocument();
-    });
-
-    test('shows pagination at both top and bottom when there are multiple pages', async () => {
-      // Server returns first 16 videos with totalCount of 25
-      setupFetchMocks({ videos: manyVideos.slice(0, 16), totalCount: 25 });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getAllByRole('navigation').length).toBe(2);
-      });
-
-      // Both pagination controls should have the same page buttons
-      const paginations = screen.getAllByRole('navigation');
-      const topPagination = paginations[0];
-      const bottomPagination = paginations[1];
-
-      expect(within(topPagination).getByText('1')).toBeInTheDocument();
-      expect(within(topPagination).getByText('2')).toBeInTheDocument();
-      expect(within(bottomPagination).getByText('1')).toBeInTheDocument();
-      expect(within(bottomPagination).getByText('2')).toBeInTheDocument();
-    });
-
-    test('does not show pagination when only one page exists', async () => {
-      // Only 3 videos - less than pageSize of 16, so only 1 page
-      setupFetchMocks({ videos: mockVideos, totalCount: 3 });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // When there's only 1 page, pagination should not be visible
-      // Verify by checking that there's no page 2 button
-      const allButtons = screen.getAllByRole('button');
-      const page2Button = allButtons.find(btn => btn.textContent === '2');
-      expect(page2Button).toBeUndefined();
-    });
-  });
-
-  describe('Hide Downloaded Videos', () => {
-    test('shows hide downloaded checkbox', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByRole('checkbox', { name: /hide downloaded/i })).toBeInTheDocument();
-      });
-    });
-
-    test('filters out downloaded videos when checkbox is checked', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 2 & More')).toBeInTheDocument();
-      });
-
-      // Mock the fetch with hideDownloaded=true
-      const filteredVideos = mockVideos.filter(v => !v.added);
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: filteredVideos,
-          totalCount: filteredVideos.length,
-        }),
-      });
-
-      const checkbox = screen.getByRole('checkbox', { name: /hide downloaded/i });
-      fireEvent.click(checkbox);
-
-      await waitFor(() => {
-        expect(screen.queryByText('Video Title 2 & More')).not.toBeInTheDocument();
-      });
-      expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-    });
-
-    test('resets page to 1 when hiding downloaded videos', async () => {
-      const manyVideos: ChannelVideo[] = [];
-      for (let i = 0; i < 20; i++) {
-        manyVideos.push({
-          title: `Video ${i + 1}`,
-          youtube_id: `video${i + 1}`,
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: `https://example.com/thumb${i + 1}.jpg`,
-          added: i < 5, // First 5 are downloaded
-          duration: 1800,
-          availability: null,
-        });
-      }
-
-      setupFetchMocks({ videos: manyVideos.slice(0, 16), totalCount: 20 });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getAllByRole('navigation').length).toBeGreaterThan(0);
-      });
-
-      // Mock page 2 fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: manyVideos.slice(16, 20),
-          totalCount: 20,
-        }),
-      });
-
-      // We now have two pagination controls (top and bottom), use the first one
-      const paginations = screen.getAllByRole('navigation');
-      const pagination = paginations[0];
-      const page2Button = within(pagination).getByText('2');
-      fireEvent.click(page2Button);
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 17')).toBeInTheDocument();
-      });
-
-      // Mock filtered fetch
-      const filteredVideos = manyVideos.filter(v => !v.added);
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: filteredVideos.slice(0, 16),
-          totalCount: filteredVideos.length,
-        }),
-      });
-
-      const checkbox = screen.getByRole('checkbox', { name: /hide downloaded/i });
-      fireEvent.click(checkbox);
-
-      // Should reset to page 1 and show non-downloaded videos
-      await waitFor(() => {
-        expect(screen.getByText('Video 6')).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe('Video Selection', () => {
-    test('shows checkboxes for non-downloaded videos', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      const checkboxes = screen.getAllByRole('checkbox');
-      // Should have checkboxes for non-downloaded videos plus hide downloaded checkbox
-      expect(checkboxes.length).toBeGreaterThan(1);
-    });
-
-    test('handles checkbox selection and deselection', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Get all checkboxes and find the one for Video Title 1 (not the hide downloaded checkbox)
-      // First, find the Hide Downloaded checkbox to exclude it
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-
-      expect(videoCheckboxes.length).toBeGreaterThan(0);
-      const checkbox = videoCheckboxes[0];
-
-      expect(checkbox).not.toBeChecked();
-
-      fireEvent.click(checkbox);
-      expect(checkbox).toBeChecked();
-
-      fireEvent.click(checkbox);
-      expect(checkbox).not.toBeChecked();
-    });
-
-    test('does not show checkbox for members-only videos', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Members Only Video')).toBeInTheDocument();
-      });
-
-      // Check that Members Only status is shown
-      const membersOnlyChips = screen.getAllByText(/members only/i);
-      expect(membersOnlyChips.length).toBeGreaterThan(0);
-
-      // Members-only videos might still have checkboxes but they should be disabled
-      // Actually looking at the component, members-only videos don't get checkboxes at all (isSelectable is false)
-      // We have 3 videos: Video 1 (selectable), Video 2 (downloaded, not selectable), Members Only (not selectable)
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-
-      // Only Video 1 should have a checkbox
-      expect(videoCheckboxes.length).toBeGreaterThanOrEqual(1);
-    });
-  });
-
-  describe('Bulk Actions', () => {
-    test('renders Select All button and enables it after selecting a video', async () => {
-      setupFetchMocks({ videos: mockVideos });
-      const user = userEvent.setup();
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Buttons should always be present
-      const selectAllButton = screen.getByRole('button', { name: /select all/i });
-      expect(selectAllButton).toBeInTheDocument();
-
-      // Select All might be enabled if there are selectable videos
-      // (depends on implementation detail of when it's disabled)
-
-      // Get all checkboxes - there should be checkboxes in video cards and the Hide Downloaded switch
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-
-      // Filter to get only checkboxes that are not the Hide Downloaded switch
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-
-      // Should have at least one checkbox for Video Title 1
-      expect(videoCheckboxes.length).toBeGreaterThan(0);
-
-      // Click the first video checkbox using userEvent for proper simulation
-      const checkbox = videoCheckboxes[0];
-      await user.click(checkbox);
-
-      // Verify checkbox is checked
-      await waitFor(() => {
-        expect(checkbox).toBeChecked();
-      });
-
-      // Clear button should be enabled after selection
-      const clearButton = screen.getByRole('button', { name: /clear/i });
-      expect(clearButton).not.toBeDisabled();
-    });
-
-    test('selects all undownloaded non-members videos on current page', async () => {
-      setupFetchMocks({ videos: mockVideos });
-      const user = userEvent.setup();
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Select All button should be present
-      const selectAllButton = screen.getByRole('button', { name: /select all/i });
-      expect(selectAllButton).toBeInTheDocument();
-
-      // Get all checkboxes that are not the "Hide Downloaded" checkbox
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-
-      // Click the first video checkbox
-      const checkbox = videoCheckboxes[0];
-      await user.click(checkbox);
-
-      // Wait for checkbox to be checked
-      await waitFor(() => {
-        expect(checkbox).toBeChecked();
-      });
-
-      // Click Select All button
-      await user.click(selectAllButton);
-
-      // Verify Video Title 1 checkbox is still checked
-      expect(checkbox).toBeChecked();
-    });
-
-    test('Clear Selection button clears all selected videos', async () => {
-      setupFetchMocks({ videos: mockVideos });
-      const user = userEvent.setup();
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Get the video checkbox
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-
-      const checkbox = videoCheckboxes[0];
-      await user.click(checkbox);
-
-      // Wait for checkbox to be checked
-      await waitFor(() => {
-        expect(checkbox).toBeChecked();
-      });
-
-      // Buttons should be present
-      const selectAllButton = screen.getByRole('button', { name: /select all/i });
-      const clearButton = screen.getByRole('button', { name: /clear/i });
-
-      expect(selectAllButton).toBeInTheDocument();
-      expect(clearButton).toBeInTheDocument();
-
-      await user.click(selectAllButton);
-      await user.click(clearButton);
-
-      // After clearing, checkbox should be unchecked
-      expect(checkbox).not.toBeChecked();
-    });
-
-    test('Download Selected button shows count of selected videos', async () => {
-      setupFetchMocks({ videos: mockVideos });
-      const user = userEvent.setup();
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Download button should be present but disabled initially
-      const downloadButton = screen.getByRole('button', { name: /download/i });
-      expect(downloadButton).toBeInTheDocument();
-      expect(downloadButton).toBeDisabled();
-
-      // Get the video checkbox
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-
-      const checkbox = videoCheckboxes[0];
-      await user.click(checkbox);
-
-      // Wait for checkbox to be checked
-      await waitFor(() => {
-        expect(checkbox).toBeChecked();
-      });
-
-      // Check the download button text now shows count with capital V for "Video"
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Download 1 Video/i })).toBeInTheDocument();
-      });
-
-      // Button should now be enabled
-      expect(downloadButton).not.toBeDisabled();
-    });
-
-    test('triggers download and navigates when Download Selected is clicked', async () => {
-      const enrichedResponse = {
+    test('displays pagination when multiple pages exist', () => {
+      useChannelVideos.mockReturnValue({
         videos: mockVideos,
-        totalCount: mockVideos.length,
-        oldestVideoDate: null,
-      };
-
-      mockFetch.mockImplementation((url: string) => {
-        if (url.includes('/getchannelvideos/')) {
-          return Promise.resolve({
-            ok: true,
-            json: jest.fn().mockResolvedValueOnce(enrichedResponse),
-          });
-        } else if (url.includes('/config')) {
-          return Promise.resolve({
-            ok: true,
-            json: jest.fn().mockResolvedValueOnce({ preferredResolution: '1080p' }),
-          });
-        } else if (url.includes('/triggerspecificdownloads')) {
-          return Promise.resolve({
-            ok: true,
-            json: jest.fn().mockResolvedValueOnce({}),
-          });
-        }
-        return Promise.reject(new Error('Unexpected fetch URL: ' + url));
+        totalCount: 32,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
       });
 
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
+      renderChannelVideos();
 
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Get the video checkbox
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-
-      const checkbox = videoCheckboxes[0];
-      const user = userEvent.setup();
-      await user.click(checkbox);
-
-      // Wait for checkbox to be checked
-      await waitFor(() => {
-        expect(checkbox).toBeChecked();
-      });
-
-      // Download button should show count with capital V for "Video"
-      const downloadButton = await screen.findByRole('button', { name: /Download 1 Video/i });
-      await user.click(downloadButton);
-
-      // Dialog should now be open
-      await waitFor(() => {
-        expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
-      });
-
-      // Click confirm in the dialog
-      const confirmButton = screen.getByTestId('dialog-confirm');
-      fireEvent.click(confirmButton);
-
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          '/triggerspecificdownloads',
-          expect.objectContaining({
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'x-access-token': mockToken,
-            },
-            body: JSON.stringify({ urls: ['https://www.youtube.com/watch?v=video1'] }),
-          })
-        );
-      });
-
-      expect(mockNavigate).toHaveBeenCalledWith('/downloads');
-    });
-
-    test('cancels download when dialog is cancelled', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Get the video checkbox
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-
-      const checkbox = videoCheckboxes[0];
-      const user = userEvent.setup();
-      await user.click(checkbox);
-
-      // Wait for checkbox to be checked
-      await waitFor(() => {
-        expect(checkbox).toBeChecked();
-      });
-
-      // Download button should show count with capital V for "Video"
-      const downloadButton = await screen.findByRole('button', { name: /Download 1 Video/i });
-      await user.click(downloadButton);
-
-      // Dialog should now be open
-      await waitFor(() => {
-        expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
-      });
-
-      // Click cancel in the dialog
-      const cancelButton = screen.getByTestId('dialog-cancel');
-      fireEvent.click(cancelButton);
-
-      // Dialog should close
-      await waitFor(() => {
-        expect(screen.queryByTestId('download-settings-dialog')).not.toBeInTheDocument();
-      });
-
-      // Fetch should not have been called for download
-      expect(mockFetch).toHaveBeenCalledTimes(2); // Initial video fetch + config fetch
-      expect(mockNavigate).not.toHaveBeenCalled();
-    });
-
-    test('selects missing videos (downloaded but removed)', async () => {
-      const videosWithMissing: ChannelVideo[] = [
-        {
-          title: 'Missing Video',
-          youtube_id: 'missing1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/missing.jpg',
-          added: true,
-          removed: true,  // Video was downloaded but file removed
-          duration: 300,
-          availability: null,
-        },
-        {
-          title: 'Downloaded Video',
-          youtube_id: 'downloaded1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/downloaded.jpg',
-          added: true,
-          removed: false,  // Video still exists
-          duration: 400,
-          availability: null,
-        }
-      ];
-
-      setupFetchMocks({ videos: videosWithMissing });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Missing Video')).toBeInTheDocument();
-      });
-
-      // Get the checkbox for the missing video
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-
-      // The missing video should have a checkbox since it's selectable
-      expect(videoCheckboxes.length).toBeGreaterThan(0);
-      const missingCheckbox = videoCheckboxes[0];
-      const user = userEvent.setup();
-
-      await user.click(missingCheckbox);
-
-      // Wait for checkbox to be checked
-      await waitFor(() => {
-        expect(missingCheckbox).toBeChecked();
-      });
-
-      // Buttons should be present
-      expect(screen.getByRole('button', { name: /select all/i })).toBeInTheDocument();
-
-      const selectAllButton = screen.getByRole('button', { name: /select all/i });
-      fireEvent.click(selectAllButton);
-
-      // Should select the missing video
-      expect(missingCheckbox).toBeChecked();
-
-      // Downloaded video should show as "Downloaded" status
-      const downloadedStatuses = screen.getAllByText('Downloaded');
-      expect(downloadedStatuses.length).toBeGreaterThan(0);
-    });
-
-    test('buttons are disabled when no selectable videos', async () => {
-      setupFetchMocks({ videos: [mockVideos[1]] }); // Only downloaded video (not selectable)
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 2 & More')).toBeInTheDocument();
-      });
-
-      // Downloaded videos don't have checkboxes, so there's nothing to select
-      // Verify no checkbox is available for downloaded videos
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      // Only the "Hide Downloaded" checkbox should be present
-      expect(allCheckboxes).toHaveLength(1);
-
-      // Buttons should be present but disabled
-      const selectAllButton = screen.getByRole('button', { name: /select all/i });
-      const clearButton = screen.getByRole('button', { name: /clear/i });
-      const downloadButton = screen.getByRole('button', { name: /download/i });
-
-      expect(selectAllButton).toBeDisabled();
-      expect(clearButton).toBeDisabled();
-      expect(downloadButton).toBeDisabled();
+      const paginationElements = screen.getAllByRole('navigation');
+      expect(paginationElements.length).toBeGreaterThan(0);
     });
   });
 
   describe('Error Handling', () => {
-    test('displays error alert when video fetch fails', async () => {
-      setupFetchMocks({ videoFail: true, videos: [] });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Failed to fetch channel videos. Please try again later.')).toBeInTheDocument();
-      });
-    });
-
-    test('handles network error gracefully', async () => {
+    test('handles tab fetch error gracefully', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
       mockFetch.mockRejectedValueOnce(new Error('Network error'));
-      mockFetch.mockRejectedValueOnce(new Error('Network error')); // For config fetch
 
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
+      renderChannelVideos();
 
       await waitFor(() => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Error fetching available tabs:',
+          expect.any(Error)
+        );
       });
 
       consoleErrorSpy.mockRestore();
     });
 
-    test('handles non-ok response', async () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      mockFetch.mockImplementation((url: string) => {
-        if (url.includes('/getchannelvideos/')) {
-          return Promise.resolve({
-            ok: false,
-            statusText: 'Not Found',
-          });
-        } else if (url.includes('/getconfig')) {
-          return Promise.resolve({
-            ok: true,
-            json: jest.fn().mockResolvedValueOnce({ preferredResolution: '1080p' }),
-          });
-        }
-        return Promise.reject(new Error('Unexpected fetch URL: ' + url));
+    test('handles non-ok tab response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Not Found',
       });
 
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
+      renderChannelVideos();
 
+      // Should still render without tabs
       await waitFor(() => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));
+        expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
       });
-
-      consoleErrorSpy.mockRestore();
-    });
-
-    test('handles old response format without videos key', async () => {
-      setupFetchMocks({ videoFail: false }); // Response without videos key
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      // Should render without error, with empty videos list
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalled();
-      });
-
-      // Should show the loading/empty state
-      expect(screen.getByText('Loading channel videos...')).toBeInTheDocument();
     });
   });
 
-  describe('Mobile View', () => {
+  describe('Edge Cases', () => {
+    test('handles null token', () => {
+      renderChannelVideos({ token: null });
+
+      expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
+    });
+
+    test('handles empty tabs array from server', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({ availableTabs: [] }),
+      });
+
+      renderChannelVideos();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
+      });
+
+      // Should not display tabs
+      expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    });
+
+    test('handles undefined channelAutoDownloadTabs prop', () => {
+      renderChannelVideos({ channelAutoDownloadTabs: undefined });
+
+      expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
+    });
+
+    test('initializes tab auto-download status from prop', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({ availableTabs: ['videos', 'shorts', 'streams'] }),
+      });
+
+      renderChannelVideos({ channelAutoDownloadTabs: 'video,short' });
+
+      // Component should initialize the tab auto-download status
+      // This is internal state so we can't directly test it, but we can verify it rendered
+      await waitFor(() => {
+        expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Data Fetching', () => {
+    test('calls useChannelVideos hook with correct parameters', () => {
+      renderChannelVideos();
+
+      expect(useChannelVideos).toHaveBeenCalledWith({
+        channelId: 'UC123456',
+        page: 1,
+        pageSize: 16, // Desktop default
+        hideDownloaded: false,
+        searchQuery: '',
+        sortBy: 'date',
+        sortOrder: 'desc',
+        tabType: 'videos',
+        token: mockToken,
+      });
+    });
+
+    test('calls useRefreshChannelVideos hook with correct parameters', () => {
+      renderChannelVideos();
+
+      expect(useRefreshChannelVideos).toHaveBeenCalledWith(
+        'UC123456',
+        1, // page
+        16, // pageSize
+        false, // hideDownloaded
+        'videos', // tabType
+        mockToken
+      );
+    });
+  });
+
+  describe('Loading Skeletons', () => {
+    test('displays skeleton loaders while fetching videos', () => {
+      useChannelVideos.mockReturnValue({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: true,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      expect(screen.getByText('Loading channel videos...')).toBeInTheDocument();
+      // Skeletons are MUI components, hard to test directly
+    });
+  });
+
+  describe('Mobile Features', () => {
     beforeEach(() => {
       (useMediaQuery as jest.Mock).mockReturnValue(true);
     });
 
-    test('shows 8 videos per page on mobile', async () => {
-      const manyVideos: ChannelVideo[] = [];
-      for (let i = 0; i < 12; i++) {
-        manyVideos.push({
-          title: `Video ${i + 1}`,
-          youtube_id: `video${i + 1}`,
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: `https://example.com/thumb${i + 1}.jpg`,
-          added: false,
-          duration: 1800,
-          availability: null,
-        });
-      }
+    test('uses mobile page size', () => {
+      renderChannelVideos();
 
-      // Server returns first 8 videos for mobile
-      setupFetchMocks({ videos: manyVideos.slice(0, 8), totalCount: 12 });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
+      expect(useChannelVideos).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageSize: 8, // Mobile page size
+        })
       );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 1')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText('Video 8')).toBeInTheDocument();
-      expect(screen.queryByText('Video 9')).not.toBeInTheDocument();
     });
 
-    test('renders mobile list layout by default', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        // Mobile view defaults to list view now
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
+    test('renders list view by default on mobile', () => {
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
       });
 
-      // Should have multiple video titles displayed in list
-      expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      expect(screen.getByText('Video Title 2 & More')).toBeInTheDocument();
-      expect(screen.getByText('Members Only Video')).toBeInTheDocument();
-    });
+      renderChannelVideos();
 
-    test('displays members-only badge instead of tooltip', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Members Only Video')).toBeInTheDocument();
-      });
-
-      // Members-only videos show as chips/badges in the new UI
-      const membersOnlyLabels = screen.getAllByText(/members only/i);
-      expect(membersOnlyLabels.length).toBeGreaterThan(0);
-    });
-
-    test('shows FAB for mobile when videos selected', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Get the video checkbox
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-
-      const checkbox = videoCheckboxes[0];
-
-      // Trigger both click and change events as the component uses onChange
-      fireEvent.click(checkbox);
-      fireEvent.change(checkbox, { target: { checked: true } });
-
-      // Wait for checkbox to be checked
-      await waitFor(() => {
-        expect(checkbox).toBeChecked();
-      });
-
-      // On mobile, a FAB (Floating Action Button) should appear instead of inline buttons
-      // The FAB contains a badge with download icon
-      await waitFor(() => {
-        const downloadIcon = screen.getByTestId('DownloadIcon');
-        expect(downloadIcon).toBeInTheDocument();
-      });
-    });
-
-    test('toggles between list and grid view on mobile', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Find the view toggle buttons
-      const toggleButtons = screen.getAllByRole('button');
-      const gridButton = toggleButtons.find(btn => btn.getAttribute('value') === 'grid');
-      const listButton = toggleButtons.find(btn => btn.getAttribute('value') === 'list');
-
-      // List view should be default on mobile
-      expect(listButton).toHaveAttribute('aria-pressed', 'true');
-      expect(gridButton).toHaveAttribute('aria-pressed', 'false');
-
-      // Click grid button
-      if (gridButton) {
-        fireEvent.click(gridButton);
-      }
-
-      // Grid button should now be pressed
-      await waitFor(() => {
-        expect(gridButton).toHaveAttribute('aria-pressed', 'true');
-      });
-
-      // Click list button
-      if (listButton) {
-        fireEvent.click(listButton);
-      }
-
-      // List button should now be pressed again
-      await waitFor(() => {
-        expect(listButton).toHaveAttribute('aria-pressed', 'true');
-      });
+      expect(screen.getByTestId('video-list-item-video1')).toBeInTheDocument();
+      expect(screen.queryByTestId('video-card-video1')).not.toBeInTheDocument();
     });
   });
 
-  describe('Swipe Gestures', () => {
-    const { useSwipeable } = require('react-swipeable');
-
-    test('handles swipe left to go to next page', async () => {
-      const manyVideos: ChannelVideo[] = [];
-      for (let i = 0; i < 20; i++) {
-        manyVideos.push({
-          title: `Video ${i + 1}`,
-          youtube_id: `video${i + 1}`,
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: `https://example.com/thumb${i + 1}.jpg`,
-          added: false,
-          duration: 1800,
-          availability: null,
-        });
-      }
-
-      let swipeHandlers: any = {};
-      useSwipeable.mockImplementation((config: any) => {
-        swipeHandlers = config;
-        return {};
-      });
-
-      setupFetchMocks({ videos: manyVideos.slice(0, 16), totalCount: 20 });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 1')).toBeInTheDocument();
-      });
-
-      // Mock page 2 fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: manyVideos.slice(16, 20),
-          totalCount: 20,
-        }),
-      });
-
-      // Simulate swipe left
-      act(() => {
-        swipeHandlers.onSwipedLeft();
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 17')).toBeInTheDocument();
-      });
-      expect(screen.queryByText('Video 1')).not.toBeInTheDocument();
-    });
-
-    test('handles swipe right to go to previous page', async () => {
-      const manyVideos: ChannelVideo[] = [];
-      for (let i = 0; i < 20; i++) {
-        manyVideos.push({
-          title: `Video ${i + 1}`,
-          youtube_id: `video${i + 1}`,
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: `https://example.com/thumb${i + 1}.jpg`,
-          added: false,
-          duration: 1800,
-          availability: null,
-        });
-      }
-
-      let swipeHandlers: any = {};
-      useSwipeable.mockImplementation((config: any) => {
-        swipeHandlers = config;
-        return {};
-      });
-
-      setupFetchMocks({ videos: manyVideos.slice(0, 16), totalCount: 20 });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 1')).toBeInTheDocument();
-      });
-
-      // Mock page 2 fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: manyVideos.slice(16, 20),
-          totalCount: 20,
-        }),
-      });
-
-      // Go to page 2 first
-      // We now have two pagination controls (top and bottom), use the first one
-      const paginations = screen.getAllByRole('navigation');
-      const pagination = paginations[0];
-      const page2Button = within(pagination).getByText('2');
-      fireEvent.click(page2Button);
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 17')).toBeInTheDocument();
-      });
-
-      // Mock page 1 fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: manyVideos.slice(0, 16),
-          totalCount: 20,
-        }),
-      });
-
-      // Simulate swipe right
-      act(() => {
-        swipeHandlers.onSwipedRight();
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 1')).toBeInTheDocument();
-      });
-      expect(screen.queryByText('Video 17')).not.toBeInTheDocument();
-    });
-
-    test('does not swipe past first page', async () => {
-      let swipeHandlers: any = {};
-      useSwipeable.mockImplementation((config: any) => {
-        swipeHandlers = config;
-        return {};
-      });
-
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Simulate swipe right on first page
-      act(() => {
-        swipeHandlers.onSwipedRight();
-      });
-
-      // Should still be on page 1
-      expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-    });
-
-    test('does not swipe past last page', async () => {
-      let swipeHandlers: any = {};
-      useSwipeable.mockImplementation((config: any) => {
-        swipeHandlers = config;
-        return {};
-      });
-
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Simulate swipe left on last page (only 3 videos, so page 1 is the last)
-      act(() => {
-        swipeHandlers.onSwipedLeft();
-      });
-
-      // Should still show same videos
-      expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-    });
-  });
-
-  describe('Status Display', () => {
-    test('shows members-only badge on desktop for members-only videos', async () => {
-      (useMediaQuery as jest.Mock).mockReturnValue(false);
-
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Members Only Video')).toBeInTheDocument();
-      });
-
-      // Should show Members Only badge/chip
-      const membersOnlyElements = screen.getAllByText(/members only/i);
-      expect(membersOnlyElements.length).toBeGreaterThan(0);
-    });
-
-    test('shows status chips for videos', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Should show various status chips
-      const downloadedChips = screen.getAllByText('Downloaded');
-      expect(downloadedChips.length).toBeGreaterThan(0);
-
-      const notDownloadedChips = screen.getAllByText('Not Downloaded');
-      expect(notDownloadedChips.length).toBeGreaterThan(0);
-    });
-
-    test('shows members only chip for subscriber-only videos', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Members Only Video')).toBeInTheDocument();
-      });
-
-      // Should show Members Only chip
-      const membersOnlyChips = screen.getAllByText(/members only/i);
-      expect(membersOnlyChips.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Date Formatting', () => {
-    test('formats published dates correctly', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('1/15/2024')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText('1/14/2024')).toBeInTheDocument();
-      expect(screen.getByText('1/13/2024')).toBeInTheDocument();
-    });
-  });
-
-  describe('Opacity for Members-Only Videos', () => {
-    test('shows members-only badge for subscriber-only videos', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Members Only Video')).toBeInTheDocument();
-      });
-
-      // Check that the members-only badge is present
-      const badges = screen.getAllByText(/members only/i);
-      expect(badges.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Refresh Channel Videos', () => {
-    test('opens refresh confirmation dialog when refresh button is clicked', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      const refreshButton = screen.getByRole('button', { name: /refresh/i });
-      fireEvent.click(refreshButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Refresh Channel Videos')).toBeInTheDocument();
-      });
-    });
-
-    test('cancels refresh when dialog is cancelled', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      const refreshButton = screen.getByRole('button', { name: /refresh/i });
-      fireEvent.click(refreshButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Refresh Channel Videos')).toBeInTheDocument();
-      });
-
-      const cancelButton = screen.getByRole('button', { name: /cancel/i });
-      fireEvent.click(cancelButton);
-
-      await waitFor(() => {
-        expect(screen.queryByText('Refresh Channel Videos')).not.toBeInTheDocument();
-      });
-    });
-
-    test('fetches all channel videos when refresh is confirmed', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      const refreshButton = screen.getByRole('button', { name: /refresh/i });
-      fireEvent.click(refreshButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Refresh Channel Videos')).toBeInTheDocument();
-      });
-
-      // Mock the fetchallchannelvideos response
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          success: true,
-          videos: mockVideos,
-          totalCount: mockVideos.length,
-          oldestVideoDate: '2024-01-13T10:00:00Z',
-        }),
-      });
-
-      const continueButton = screen.getByRole('button', { name: /continue/i });
-      fireEvent.click(continueButton);
-
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('/fetchallchannelvideos/'),
-          expect.objectContaining({
-            method: 'POST',
-          })
-        );
-      });
-    });
-
-    test('handles 409 conflict error when refresh is already in progress', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      const refreshButton = screen.getByRole('button', { name: /refresh/i });
-      fireEvent.click(refreshButton);
-
-      // Mock 409 conflict response
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 409,
-        json: jest.fn().mockResolvedValueOnce({
-          success: false,
-          error: 'FETCH_IN_PROGRESS',
-        }),
-      });
-
-      const continueButton = screen.getByRole('button', { name: /continue/i });
-      fireEvent.click(continueButton);
-
-      await waitFor(() => {
-        expect(screen.getByText(/already in progress/i)).toBeInTheDocument();
-      });
-    });
-
-    test('handles general error during refresh', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      const refreshButton = screen.getByRole('button', { name: /refresh/i });
-      fireEvent.click(refreshButton);
-
-      // Mock general error response
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        json: jest.fn().mockResolvedValueOnce({
-          success: false,
-          message: 'Server error',
-        }),
-      });
-
-      const continueButton = screen.getByRole('button', { name: /continue/i });
-      fireEvent.click(continueButton);
-
-      await waitFor(() => {
-        expect(screen.getByText(/Server error/i)).toBeInTheDocument();
-      });
-    });
-
-    test('displays error snackbar when refresh fails', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      const refreshButton = screen.getByRole('button', { name: /refresh/i });
-      fireEvent.click(refreshButton);
-
-      // Mock error response
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        json: jest.fn().mockResolvedValueOnce({
-          success: false,
-          message: 'Test error',
-        }),
-      });
-
-      const continueButton = screen.getByRole('button', { name: /continue/i });
-      fireEvent.click(continueButton);
-
-      await waitFor(() => {
-        expect(screen.getByText(/Test error/i)).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe('Sorting', () => {
-    test('changes sort order when clicking same sort column', async () => {
-      (useMediaQuery as jest.Mock).mockReturnValue(false); // Desktop for table view
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Switch to table view
-      const toggleButtons = screen.getAllByRole('button');
-      const tableButton = toggleButtons.find(btn => btn.getAttribute('value') === 'table');
-      if (tableButton) {
-        fireEvent.click(tableButton);
-      }
-
-      await waitFor(() => {
-        expect(screen.getByText('Title')).toBeInTheDocument();
-      });
-
-      // Mock the sorted fetch (ascending)
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: [...mockVideos].sort((a, b) => a.title.localeCompare(b.title)),
-          totalCount: mockVideos.length,
-        }),
-      });
-
-      // Click on Title column header to sort
-      const titleHeader = screen.getByText('Title');
-      fireEvent.click(titleHeader);
-
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('sortBy=title'),
-          expect.anything()
-        );
-      });
-
-      // Mock the sorted fetch (descending)
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: [...mockVideos].sort((a, b) => b.title.localeCompare(a.title)),
-          totalCount: mockVideos.length,
-        }),
-      });
-
-      // Click again to toggle sort order
-      fireEvent.click(titleHeader);
-
-      await waitFor(() => {
-        const fetchCalls = mockFetch.mock.calls;
-        const lastCall = fetchCalls[fetchCalls.length - 1][0] as string;
-        expect(lastCall).toContain('sortBy=title');
-      });
-
-      const fetchCalls = mockFetch.mock.calls;
-      const lastCall = fetchCalls[fetchCalls.length - 1][0] as string;
-      expect(lastCall).toContain('sortOrder=asc');
-    });
-
-    test('sorts by duration when clicking duration column', async () => {
-      (useMediaQuery as jest.Mock).mockReturnValue(false); // Desktop for table view
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Switch to table view
-      const toggleButtons = screen.getAllByRole('button');
-      const tableButton = toggleButtons.find(btn => btn.getAttribute('value') === 'table');
-      if (tableButton) {
-        fireEvent.click(tableButton);
-      }
-
-      await waitFor(() => {
-        expect(screen.getByText('Duration')).toBeInTheDocument();
-      });
-
-      // Mock the sorted fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: mockVideos,
-          totalCount: mockVideos.length,
-        }),
-      });
-
-      const durationHeader = screen.getByText('Duration');
-      fireEvent.click(durationHeader);
-
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('sortBy=duration'),
-          expect.anything()
-        );
-      });
-    });
-
-    test('sorts by size when clicking size column', async () => {
-      (useMediaQuery as jest.Mock).mockReturnValue(false); // Desktop for table view
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Switch to table view
-      const toggleButtons = screen.getAllByRole('button');
-      const tableButton = toggleButtons.find(btn => btn.getAttribute('value') === 'table');
-      if (tableButton) {
-        fireEvent.click(tableButton);
-      }
-
-      await waitFor(() => {
-        expect(screen.getByText('Size')).toBeInTheDocument();
-      });
-
-      // Mock the sorted fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: mockVideos,
-          totalCount: mockVideos.length,
-        }),
-      });
-
-      const sizeHeader = screen.getByText('Size');
-      fireEvent.click(sizeHeader);
-
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('sortBy=size'),
-          expect.anything()
-        );
-      });
-    });
-  });
-
-  describe('Table View', () => {
-    beforeEach(() => {
-      (useMediaQuery as jest.Mock).mockReturnValue(false); // Desktop
-    });
-
-    test('switches to table view when table button is clicked', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Find and click table view button
-      const toggleButtons = screen.getAllByRole('button');
-      const tableButton = toggleButtons.find(btn => btn.getAttribute('value') === 'table');
-
-      if (tableButton) {
-        fireEvent.click(tableButton);
-      }
-
-      await waitFor(() => {
-        expect(screen.getByText('Thumbnail')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText('Title')).toBeInTheDocument();
-      expect(screen.getByText('Published')).toBeInTheDocument();
-    });
-
-    test('displays videos in table format', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Switch to table view
-      const toggleButtons = screen.getAllByRole('button');
-      const tableButton = toggleButtons.find(btn => btn.getAttribute('value') === 'table');
-      if (tableButton) {
-        fireEvent.click(tableButton);
-      }
-
-      await waitFor(() => {
-        const table = screen.getByRole('table');
-        expect(table).toBeInTheDocument();
-      });
-    });
-
-    test('shows checkboxes for selectable videos in table view', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Switch to table view
-      const toggleButtons = screen.getAllByRole('button');
-      const tableButton = toggleButtons.find(btn => btn.getAttribute('value') === 'table');
-      if (tableButton) {
-        fireEvent.click(tableButton);
-      }
-
-      await waitFor(() => {
-        const checkboxes = screen.getAllByRole('checkbox');
-        // Should have at least the hide downloaded checkbox and select-all checkbox
-        expect(checkboxes.length).toBeGreaterThan(1);
-      });
-    });
-
-    test('selects all videos via table header checkbox', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Switch to table view
-      const toggleButtons = screen.getAllByRole('button');
-      const tableButton = toggleButtons.find(btn => btn.getAttribute('value') === 'table');
-      if (tableButton) {
-        fireEvent.click(tableButton);
-      }
-
-      await waitFor(() => {
-        expect(screen.getByRole('table')).toBeInTheDocument();
-      });
-
-      // Find the select-all checkbox in the table header
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const tableCheckboxes = allCheckboxes.filter(cb => {
-        const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-        return cb !== hideDownloadedCheckbox;
-      });
-
-      // The first checkbox in the table should be the select-all
-      const selectAllCheckbox = tableCheckboxes[0];
-      fireEvent.click(selectAllCheckbox);
-
-      // Download button should now show count
-      await waitFor(() => {
-        const downloadButton = screen.getByRole('button', { name: /Download \d+ Video/i });
-        expect(downloadButton).toBeInTheDocument();
-      });
-    });
-
-    test('shows delete icon for downloaded videos in table view', async () => {
-      const downloadedVideos: ChannelVideo[] = [
-        {
-          title: 'Downloaded Video',
-          youtube_id: 'dl_video1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/thumb1.jpg',
-          added: true,
-          removed: false,
-          duration: 3600,
-          availability: null,
-        },
-      ];
-
-      setupFetchMocks({ videos: downloadedVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video')).toBeInTheDocument();
-      });
-
-      // Switch to table view
-      const toggleButtons = screen.getAllByRole('button');
-      const tableButton = toggleButtons.find(btn => btn.getAttribute('value') === 'table');
-      if (tableButton) {
-        fireEvent.click(tableButton);
-      }
-
-      await waitFor(() => {
-        const deleteIcons = screen.getAllByTestId('DeleteIcon');
-        expect(deleteIcons.length).toBeGreaterThan(0);
-      });
-    });
-
-    test('shows youtube removed banner in table view', async () => {
-      const removedVideo: ChannelVideo[] = [
-        {
-          title: 'Removed Video',
-          youtube_id: 'removed1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/thumb1.jpg',
-          added: true,
-          removed: false,
-          duration: 3600,
-          availability: null,
-          youtube_removed: true,
-        },
-      ];
-
-      setupFetchMocks({ videos: removedVideo });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Removed Video')).toBeInTheDocument();
-      });
-
-      // Switch to table view
-      const toggleButtons = screen.getAllByRole('button');
-      const tableButton = toggleButtons.find(btn => btn.getAttribute('value') === 'table');
-      if (tableButton) {
-        fireEvent.click(tableButton);
-      }
-
-      await waitFor(() => {
-        const removedBanners = screen.getAllByText('Removed From YouTube');
-        expect(removedBanners.length).toBeGreaterThan(0);
-      });
-    });
-  });
-
-  describe('Card Click Selection', () => {
-    test('selects video when clicking on card in grid view', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Click on the card by clicking the title (event bubbles to card)
-      const videoTitle = screen.getAllByText('Video Title 1')[0];
-      fireEvent.click(videoTitle);
-
-      // Download button should update to show selection
-      await waitFor(() => {
-        const downloadButton = screen.getByRole('button', { name: /Download 1 Video/i });
-        expect(downloadButton).toBeInTheDocument();
-      });
-    });
-
-    test('deselects video when clicking on selected card in grid view', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Select the video first
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-      const checkbox = videoCheckboxes[0];
-      fireEvent.click(checkbox);
-
-      await waitFor(() => {
-        expect(checkbox).toBeChecked();
-      });
-
-      // Now click the card again to deselect
-      const videoTitle = screen.getAllByText('Video Title 1')[0];
-      fireEvent.click(videoTitle);
-
-      await waitFor(() => {
-        expect(checkbox).not.toBeChecked();
-      });
-    });
-
-    test('selects video when clicking on card in list view (mobile)', async () => {
-      (useMediaQuery as jest.Mock).mockReturnValue(true); // Mobile
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Mobile defaults to list view - click on title to select
-      const videoTitle = screen.getAllByText('Video Title 1')[0];
-      fireEvent.click(videoTitle);
-
-      // Check if FAB appears
-      await waitFor(() => {
-        const downloadIcon = screen.queryByTestId('DownloadIcon');
-        expect(downloadIcon).toBeInTheDocument();
-      });
-    });
-
-    test('does not select when clicking on non-selectable card', async () => {
-      setupFetchMocks({ videos: [mockVideos[1]] }); // Downloaded video (not selectable)
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 2 & More')).toBeInTheDocument();
-      });
-
-      // Click on the non-selectable video title
-      const videoTitle = screen.getAllByText('Video Title 2 & More')[0];
-      fireEvent.click(videoTitle);
-
-      // Download button should remain disabled
-      const downloadButton = screen.getByRole('button', { name: /download/i });
-      expect(downloadButton).toBeDisabled();
-    });
-  });
-
-  describe('Mobile Drawer', () => {
-    beforeEach(() => {
-      (useMediaQuery as jest.Mock).mockReturnValue(true); // Mobile
-    });
-
-    test('opens mobile drawer when FAB is clicked', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Select a video to show FAB
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-      fireEvent.click(videoCheckboxes[0]);
-
-      await waitFor(() => {
-        const downloadIcon = screen.getByTestId('DownloadIcon');
-        expect(downloadIcon).toBeInTheDocument();
-      });
-
-      // Find and click the FAB
-      const allButtons = screen.getAllByRole('button');
-      const fabs = allButtons.filter(btn => btn.classList.contains('MuiFab-root'));
-      const downloadFab = fabs.find(fab => {
-        const downloadIcon = within(fab).queryByTestId('DownloadIcon');
-        return downloadIcon !== null;
-      });
-
-      expect(downloadFab).toBeDefined();
-      fireEvent.click(downloadFab!);
-
-      await waitFor(() => {
-        expect(screen.getByText('Batch Actions')).toBeInTheDocument();
-      });
-    });
-
-    test('closes mobile drawer when close button is clicked', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Select a video and open drawer
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-      fireEvent.click(videoCheckboxes[0]);
-
-      await waitFor(() => {
-        const downloadIcon = screen.getByTestId('DownloadIcon');
-        expect(downloadIcon).toBeInTheDocument();
-      });
-
-      const allButtons = screen.getAllByRole('button');
-      const fabs = allButtons.filter(btn => btn.classList.contains('MuiFab-root'));
-      const downloadFab = fabs.find(fab => within(fab).queryByTestId('DownloadIcon'));
-
-      expect(downloadFab).toBeDefined();
-      fireEvent.click(downloadFab!);
-
-      await waitFor(() => {
-        expect(screen.getByText('Batch Actions')).toBeInTheDocument();
-      });
-
-      // Find the drawer by its role and close it
-      const drawer = screen.getByRole('presentation');
-      const closeButton = within(drawer).getByTestId('CloseIcon');
-      fireEvent.click(closeButton);
-
-      await waitFor(() => {
-        expect(screen.queryByText('Batch Actions')).not.toBeInTheDocument();
-      });
-    });
-
-    test('drawer shows correct selected count', async () => {
-      setupFetchMocks({ videos: mockVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      // Select a video
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const allCheckboxes = screen.getAllByRole('checkbox');
-      const videoCheckboxes = allCheckboxes.filter(cb => cb !== hideDownloadedCheckbox);
-      fireEvent.click(videoCheckboxes[0]);
-
-      await waitFor(() => {
-        const downloadIcon = screen.getByTestId('DownloadIcon');
-        expect(downloadIcon).toBeInTheDocument();
-      });
-
-      // Open drawer
-      const allButtons = screen.getAllByRole('button');
-      const fabs = allButtons.filter(btn => btn.classList.contains('MuiFab-root'));
-      const downloadFab = fabs.find(fab => within(fab).queryByTestId('DownloadIcon'));
-
-      expect(downloadFab).toBeDefined();
-      fireEvent.click(downloadFab!);
-
-      await waitFor(() => {
-        expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe('Search Functionality', () => {
-    test('resets page to 1 when search query changes', async () => {
-      const manyVideos: ChannelVideo[] = [];
-      for (let i = 0; i < 20; i++) {
-        manyVideos.push({
-          title: `Video ${i + 1}`,
-          youtube_id: `video${i + 1}`,
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: `https://example.com/thumb${i + 1}.jpg`,
-          added: false,
-          duration: 1800,
-          availability: null,
-        });
-      }
-
-      setupFetchMocks({ videos: manyVideos.slice(0, 16), totalCount: 20 });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 1')).toBeInTheDocument();
-      });
-
-      // Go to page 2
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: manyVideos.slice(16, 20),
-          totalCount: 20,
-        }),
-      });
-
-      const paginations = screen.getAllByRole('navigation');
-      const pagination = paginations[0];
-      const page2Button = within(pagination).getByText('2');
-      fireEvent.click(page2Button);
-
-      await waitFor(() => {
-        expect(screen.getByText('Video 17')).toBeInTheDocument();
-      });
-
-      // Now search - should reset to page 1
-      const searchResults = manyVideos.filter(v => v.title.includes('5'));
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: searchResults,
-          totalCount: searchResults.length,
-        }),
-      });
-
-      const searchInput = screen.getByPlaceholderText('Search videos...');
-      fireEvent.change(searchInput, { target: { value: '5' } });
-
-      await waitFor(() => {
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining('page=1'),
-          expect.anything()
-        );
-      });
-    });
-  });
-
-  describe('Video Deletion', () => {
-    const downloadedVideos: ChannelVideo[] = [
-      {
-        title: 'Downloaded Video 1',
-        youtube_id: 'dl_video1',
-        publishedAt: '2024-01-15T10:00:00Z',
-        thumbnail: 'https://example.com/thumb1.jpg',
-        added: true,
-        removed: false,
-        duration: 3600,
-        availability: null,
-      },
-      {
-        title: 'Downloaded Video 2',
-        youtube_id: 'dl_video2',
-        publishedAt: '2024-01-14T10:00:00Z',
-        thumbnail: 'https://example.com/thumb2.jpg',
-        added: true,
-        removed: false,
-        duration: 1800,
-        availability: null,
-      },
-    ];
-
-    test('deselects video for deletion when toggle is clicked again', async () => {
-      setupFetchMocks({ videos: downloadedVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Select a video for deletion
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      const videoDeleteIcon = deleteIcons[deleteIcons.length - 1];
-      fireEvent.click(videoDeleteIcon);
-
-      await waitFor(() => {
-        const actionBarButtons = screen.getAllByRole('button');
-        const deleteActionButton = actionBarButtons.find(btn =>
-          btn.textContent?.match(/^Delete\s+1$/)
-        );
-        expect(deleteActionButton).toBeDefined();
-      });
-
-      // Click again to deselect
-      fireEvent.click(videoDeleteIcon);
-
-      await waitFor(() => {
-        const deleteButton = screen.getByRole('button', { name: /Delete Selected/i });
-        expect(deleteButton).toBeDisabled();
-      });
-    });
-
-    test('shows delete button for downloaded videos in grid view', async () => {
-      setupFetchMocks({ videos: downloadedVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Should have delete icons for downloaded videos
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      expect(deleteIcons.length).toBeGreaterThan(0);
-
-      // Should have a Delete Selected button in the action bar (desktop)
-      const deleteButton = screen.getByRole('button', { name: /Delete Selected/i });
-      expect(deleteButton).toBeInTheDocument();
-      expect(deleteButton).toBeDisabled(); // Should be disabled when nothing selected
-    });
-
-    test('toggles video selection for deletion when delete icon is clicked', async () => {
-      setupFetchMocks({ videos: downloadedVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Get delete icons - last ones should be video card icons (not action bar icons)
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      expect(deleteIcons.length).toBeGreaterThan(0);
-
-      // Click the last delete icon (video card icon) - the click event will bubble to its parent button
-      fireEvent.click(deleteIcons[deleteIcons.length - 1]);
-
-      // Wait for the action bar Delete button to update from "Delete Selected" to "Delete 1"
-      await waitFor(() => {
-        const actionBarButtons = screen.getAllByRole('button');
-        const deleteActionButton = actionBarButtons.find(btn =>
-          btn.textContent?.match(/^Delete\s+1$/)
-        );
-        expect(deleteActionButton).toBeDefined();
-      });
-
-      // Verify the button is not disabled
-      const actionBarButtons = screen.getAllByRole('button');
-      const deleteActionButton = actionBarButtons.find(btn =>
-        btn.textContent?.match(/^Delete\s+1$/)
-      );
-      expect(deleteActionButton).not.toBeDisabled();
-    });
-
-    test('opens delete confirmation dialog when delete button is clicked', async () => {
-      setupFetchMocks({ videos: downloadedVideos });
-      const user = userEvent.setup();
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Select a video for deletion by clicking a video card delete icon
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      // Click the last delete icon (video card icon, not action bar) - event will bubble to button
-      fireEvent.click(deleteIcons[deleteIcons.length - 1]);
-
-      // Wait for and click the Delete button in the action bar
-      await waitFor(() => {
-        const actionBarButtons = screen.getAllByRole('button');
-        const deleteActionButton = actionBarButtons.find(btn =>
-          btn.textContent?.match(/^Delete\s+1$/)
-        );
-        expect(deleteActionButton).toBeDefined();
-      });
-
-      const deleteActionButton = screen.getAllByRole('button').find(btn =>
-        btn.textContent?.match(/^Delete\s+1$/)
-      );
-      await user.click(deleteActionButton!);
-
-      // Dialog should be open
-      await waitFor(() => {
-        expect(screen.getByTestId('delete-videos-dialog')).toBeInTheDocument();
-      });
-    });
-
-    test('cancels deletion when dialog is cancelled', async () => {
-      setupFetchMocks({ videos: downloadedVideos });
-      const user = userEvent.setup();
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Select a video for deletion by clicking a video card delete icon
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      // Click the last delete icon (video card icon, not action bar) - event will bubble to button
-      fireEvent.click(deleteIcons[deleteIcons.length - 1]);
-
-      // Wait for and click the Delete button
-      await waitFor(() => {
-        const actionBarButtons = screen.getAllByRole('button');
-        const deleteActionButton = actionBarButtons.find(btn =>
-          btn.textContent?.match(/^Delete\s+1$/)
-        );
-        expect(deleteActionButton).toBeDefined();
-      });
-
-      const deleteActionButton = screen.getAllByRole('button').find(btn =>
-        btn.textContent?.match(/^Delete\s+1$/)
-      );
-      await user.click(deleteActionButton!);
-
-      // Dialog should be open
-      await waitFor(() => {
-        expect(screen.getByTestId('delete-videos-dialog')).toBeInTheDocument();
-      });
-
-      // Cancel the dialog
-      const cancelButton = screen.getByTestId('delete-cancel');
-      await user.click(cancelButton);
-
-      // Dialog should close
-      await waitFor(() => {
-        expect(screen.queryByTestId('delete-videos-dialog')).not.toBeInTheDocument();
-      });
-
-      // deleteVideosByYoutubeIds should not have been called
-      expect(mockDeleteVideosByYoutubeIds).not.toHaveBeenCalled();
-    });
-
-    test('deletes videos successfully when confirmed', async () => {
-      setupFetchMocks({ videos: downloadedVideos });
-      const user = userEvent.setup();
-
-      // Mock successful deletion (for dl_video2, the last video we'll click)
-      mockDeleteVideosByYoutubeIds.mockResolvedValueOnce({
-        success: true,
-        deleted: ['dl_video2'],
-        failed: [],
-      });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Select a video for deletion by clicking a video card delete icon
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      // Click the last delete icon (video card icon, not action bar) - event will bubble to button
-      fireEvent.click(deleteIcons[deleteIcons.length - 1]);
-
-      // Wait for and click the Delete button
-      await waitFor(() => {
-        const actionBarButtons = screen.getAllByRole('button');
-        const deleteActionButton = actionBarButtons.find(btn =>
-          btn.textContent?.match(/^Delete\s+1$/)
-        );
-        expect(deleteActionButton).toBeDefined();
-      });
-
-      const deleteActionButton = screen.getAllByRole('button').find(btn =>
-        btn.textContent?.match(/^Delete\s+1$/)
-      );
-      await user.click(deleteActionButton!);
-
-      // Confirm deletion
-      const confirmButton = await screen.findByTestId('delete-confirm');
-      fireEvent.click(confirmButton);
-
-      // Wait for deletion to complete (we clicked the last video, which is dl_video2)
-      await waitFor(() => {
-        expect(mockDeleteVideosByYoutubeIds).toHaveBeenCalledWith(['dl_video2'], mockToken);
-      });
-
-      // Success message should be shown
-      await waitFor(() => {
-        expect(screen.getByText(/Successfully deleted 1 video/i)).toBeInTheDocument();
-      });
-    });
-
-    test('handles partial deletion (some succeed, some fail)', async () => {
-      setupFetchMocks({ videos: downloadedVideos });
-      const user = userEvent.setup();
-
-      // Mock partial deletion
-      mockDeleteVideosByYoutubeIds.mockResolvedValueOnce({
-        success: false,
-        deleted: ['dl_video1'],
-        failed: [{ youtubeId: 'dl_video2', error: 'File not found' }],
-      });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Select both videos for deletion
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      for (const icon of deleteIcons) {
-        // Click each delete icon - the click event will bubble to its parent button
-        fireEvent.click(icon);
-      }
-
-      // Click the Delete button
-      const deleteActionButton = await screen.findByRole('button', { name: /Delete 2/i });
-      await user.click(deleteActionButton);
-
-      // Confirm deletion
-      const confirmButton = await screen.findByTestId('delete-confirm');
-      fireEvent.click(confirmButton);
-
-      // Wait for deletion to complete
-      await waitFor(() => {
-        expect(mockDeleteVideosByYoutubeIds).toHaveBeenCalledWith(['dl_video1', 'dl_video2'], mockToken);
-      });
-
-      // Partial success message should be shown
-      await waitFor(() => {
-        expect(screen.getByText(/Deleted 1 video, but 1 failed/i)).toBeInTheDocument();
-      });
-    });
-
-    test('handles complete deletion failure', async () => {
-      setupFetchMocks({ videos: downloadedVideos });
-      const user = userEvent.setup();
-
-      // Mock complete deletion failure (for dl_video2, the last video we'll click)
-      mockDeleteVideosByYoutubeIds.mockResolvedValueOnce({
-        success: false,
-        deleted: [],
-        failed: [{ youtubeId: 'dl_video2', error: 'Permission denied' }],
-      });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Select a video for deletion by clicking a video card delete icon
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      // Click the last delete icon (video card icon, not action bar) - event will bubble to button
-      fireEvent.click(deleteIcons[deleteIcons.length - 1]);
-
-      // Wait for and click the Delete button
-      await waitFor(() => {
-        const actionBarButtons = screen.getAllByRole('button');
-        const deleteActionButton = actionBarButtons.find(btn =>
-          btn.textContent?.match(/^Delete\s+1$/)
-        );
-        expect(deleteActionButton).toBeDefined();
-      });
-
-      const deleteActionButton = screen.getAllByRole('button').find(btn =>
-        btn.textContent?.match(/^Delete\s+1$/)
-      );
-      await user.click(deleteActionButton!);
-
-      // Confirm deletion
-      const confirmButton = await screen.findByTestId('delete-confirm');
-      fireEvent.click(confirmButton);
-
-      // Wait for deletion to complete (we clicked the last video, which is dl_video2)
-      await waitFor(() => {
-        expect(mockDeleteVideosByYoutubeIds).toHaveBeenCalledWith(['dl_video2'], mockToken);
-      });
-
-      // Error message should be shown
-      await waitFor(() => {
-        expect(screen.getByText(/Failed to delete videos: Permission denied/i)).toBeInTheDocument();
-      });
-    });
-
-    test('shows error when trying to delete without selection', async () => {
-      setupFetchMocks({ videos: downloadedVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Click the Delete button without selecting any videos
-      const deleteActionButton = screen.getByRole('button', { name: /Delete Selected/i });
-      expect(deleteActionButton).toBeDisabled();
-    });
-
-    test('refreshes video list after successful deletion', async () => {
-      setupFetchMocks({ videos: downloadedVideos });
-      const user = userEvent.setup();
-
-      // Mock successful deletion (for dl_video2, the last video we'll click)
-      mockDeleteVideosByYoutubeIds.mockResolvedValueOnce({
-        success: true,
-        deleted: ['dl_video2'],
-        failed: [],
-      });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Select a video for deletion by clicking a video card delete icon
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      // Click the last delete icon (video card icon, not action bar) - event will bubble to button
-      fireEvent.click(deleteIcons[deleteIcons.length - 1]);
-
-      // Wait for and click the Delete button
-      await waitFor(() => {
-        const actionBarButtons = screen.getAllByRole('button');
-        const deleteActionButton = actionBarButtons.find(btn =>
-          btn.textContent?.match(/^Delete\s+1$/)
-        );
-        expect(deleteActionButton).toBeDefined();
-      });
-
-      const deleteActionButton = screen.getAllByRole('button').find(btn =>
-        btn.textContent?.match(/^Delete\s+1$/)
-      );
-      await user.click(deleteActionButton!);
-
-      // Mock the refresh fetch
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: [downloadedVideos[1]], // Only second video remains
-          totalCount: 1,
-        }),
-      });
-
-      // Confirm deletion
-      const confirmButton = await screen.findByTestId('delete-confirm');
-      fireEvent.click(confirmButton);
-
-      // Wait for deletion and refresh
-      await waitFor(() => {
-        expect(mockDeleteVideosByYoutubeIds).toHaveBeenCalled();
-      });
-
-      // Verify fetch was called to refresh the list
-      await waitFor(() => {
-        const fetchCalls = mockFetch.mock.calls;
-        const refreshCall = fetchCalls.find((call: any) =>
-          call[0].includes('/getchannelvideos/') && fetchCalls.indexOf(call) > 1
-        );
-        expect(refreshCall).toBeDefined();
-      });
-    });
-
-    test('shows delete FAB on mobile when videos selected for deletion', async () => {
-      (useMediaQuery as jest.Mock).mockReturnValue(true); // Mobile
-      setupFetchMocks({ videos: downloadedVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      // Select a video for deletion
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      if (deleteIcons.length > 0) {
-        // Click the last delete icon (video card icon) - event will bubble to button
-        fireEvent.click(deleteIcons[deleteIcons.length - 1]);
-      }
-
-      // Delete FAB should appear
-      await waitFor(() => {
-        const deleteFABIcons = screen.getAllByTestId('DeleteIcon');
-        // Should have multiple delete icons - one for each video thumbnail and one for the FAB
-        expect(deleteFABIcons.length).toBeGreaterThan(downloadedVideos.length);
-      });
-    });
-
-    test('includes delete option in mobile drawer', async () => {
-      (useMediaQuery as jest.Mock).mockReturnValue(true); // Mobile
-
-      // Create videos that can be selected for download
-      const selectableVideos: ChannelVideo[] = [
-        {
-          title: 'Not Downloaded Video',
-          youtube_id: 'not_dl_1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/thumb1.jpg',
-          added: false,
-          duration: 3600,
-          availability: null,
-        },
-      ];
-
-      setupFetchMocks({ videos: selectableVideos });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Not Downloaded Video')).toBeInTheDocument();
-      });
-
-      // Select a video for download by clicking its checkbox
-      const checkboxes = screen.getAllByRole('checkbox');
-      const hideDownloadedCheckbox = screen.queryByRole('checkbox', { name: /hide downloaded/i });
-      const videoCheckboxes = checkboxes.filter(cb => cb !== hideDownloadedCheckbox);
-      if (videoCheckboxes.length > 0) {
-        fireEvent.click(videoCheckboxes[0]);
-      }
-
-      // Wait for download FAB to appear
-      let downloadFab: HTMLElement | undefined;
-      await waitFor(() => {
-        const allButtons = screen.getAllByRole('button');
-        const fabs = allButtons.filter(btn =>
-          btn.classList.contains('MuiFab-root')
-        );
-        // Find the FAB that contains a DownloadIcon
-        downloadFab = fabs.find(fab => {
-          const downloadIcon = within(fab).queryByTestId('DownloadIcon');
-          return downloadIcon !== null;
-        });
-        expect(downloadFab).toBeDefined();
-      });
-
-      // Click the download FAB to open drawer
-      fireEvent.click(downloadFab!);
-
-      // Wait for drawer to open
-      await waitFor(() => {
-        const drawer = screen.queryByRole('presentation');
-        expect(drawer).toBeInTheDocument();
-      });
-
-      // Drawer should have delete option (even if disabled)
-      const deleteText = screen.queryByText(/Delete \d+ Videos?/i);
-      expect(deleteText).toBeInTheDocument();
-    });
-  });
-
-  describe('Media Type Display', () => {
-    test('shows short badge for short videos', async () => {
-      const shortVideo: ChannelVideo[] = [
-        {
-          title: 'Short Video',
-          youtube_id: 'short1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/thumb1.jpg',
-          added: false,
-          duration: 60,
-          availability: null,
-          media_type: 'short',
-        },
-      ];
-
-      setupFetchMocks({ videos: shortVideo });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Short Video')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText('Short')).toBeInTheDocument();
-    });
-
-    test('shows live badge for livestream videos', async () => {
-      const liveVideo: ChannelVideo[] = [
-        {
-          title: 'Live Video',
-          youtube_id: 'live1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/thumb1.jpg',
-          added: false,
-          duration: 7200,
-          availability: null,
-          media_type: 'livestream',
-        },
-      ];
-
-      setupFetchMocks({ videos: liveVideo });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Live Video')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText('Live')).toBeInTheDocument();
-    });
-
-    test('does not show media type badge for regular videos', async () => {
-      setupFetchMocks({ videos: [mockVideos[0]] });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Video Title 1')).toBeInTheDocument();
-      });
-
-      expect(screen.queryByText('Short')).not.toBeInTheDocument();
-      expect(screen.queryByText('Live')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('File Size Formatting', () => {
-    test('formats file size in GB when larger than 1GB', async () => {
-      const largeVideo: ChannelVideo[] = [
-        {
-          title: 'Large Video',
-          youtube_id: 'large1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/thumb1.jpg',
-          added: true,
-          removed: false,
-          duration: 3600,
-          availability: null,
-          fileSize: 2147483648,
-        },
-      ];
-
-      setupFetchMocks({ videos: largeVideo });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Large Video')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText('2.0GB')).toBeInTheDocument();
-    });
-
-    test('formats file size in MB when smaller than 1GB', async () => {
-      const smallVideo: ChannelVideo[] = [
-        {
-          title: 'Small Video',
-          youtube_id: 'small1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/thumb1.jpg',
-          added: true,
-          removed: false,
-          duration: 300,
-          availability: null,
-          fileSize: 52428800,
-        },
-      ];
-
-      setupFetchMocks({ videos: smallVideo });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Small Video')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText('50MB')).toBeInTheDocument();
-    });
-  });
-
-  describe('Success and Error Snackbars', () => {
-    test('closes success snackbar when close button is clicked', async () => {
-      const downloadedVideos: ChannelVideo[] = [
-        {
-          title: 'Downloaded Video 1',
-          youtube_id: 'dl_video1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/thumb1.jpg',
-          added: true,
-          removed: false,
-          duration: 3600,
-          availability: null,
-        },
-      ];
-
-      setupFetchMocks({ videos: downloadedVideos });
-      const user = userEvent.setup();
-
-      mockDeleteVideosByYoutubeIds.mockResolvedValueOnce({
-        success: true,
-        deleted: ['dl_video1'],
-        failed: [],
-      });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      fireEvent.click(deleteIcons[deleteIcons.length - 1]);
-
-      await waitFor(() => {
-        const actionBarButtons = screen.getAllByRole('button');
-        const deleteActionButton = actionBarButtons.find(btn =>
-          btn.textContent?.match(/^Delete\s+1$/)
-        );
-        expect(deleteActionButton).toBeDefined();
-      });
-
-      const deleteActionButton = screen.getAllByRole('button').find(btn =>
-        btn.textContent?.match(/^Delete\s+1$/)
-      );
-      await user.click(deleteActionButton!);
-
-      const confirmButton = await screen.findByTestId('delete-confirm');
-      fireEvent.click(confirmButton);
-
-      await waitFor(() => {
-        expect(screen.getByText(/Successfully deleted 1 video/i)).toBeInTheDocument();
-      });
-
-      // Find and click the close button in the alert
-      const alerts = screen.getAllByRole('alert');
-      const successAlert = alerts.find(alert => alert.textContent?.includes('Successfully deleted'));
-      expect(successAlert).toBeDefined();
-      const closeButton = within(successAlert!).getByRole('button', { name: /close/i });
-      fireEvent.click(closeButton);
-
-      await waitFor(() => {
-        expect(screen.queryByText(/Successfully deleted 1 video/i)).not.toBeInTheDocument();
-      });
-    });
-
-    test('closes error snackbar when close button is clicked', async () => {
-      const downloadedVideos: ChannelVideo[] = [
-        {
-          title: 'Downloaded Video 1',
-          youtube_id: 'dl_video1',
-          publishedAt: '2024-01-15T10:00:00Z',
-          thumbnail: 'https://example.com/thumb1.jpg',
-          added: true,
-          removed: false,
-          duration: 3600,
-          availability: null,
-        },
-      ];
-
-      setupFetchMocks({ videos: downloadedVideos });
-      const user = userEvent.setup();
-
-      mockDeleteVideosByYoutubeIds.mockResolvedValueOnce({
-        success: false,
-        deleted: [],
-        failed: [{ youtubeId: 'dl_video1', error: 'Test error message' }],
-      });
-
-      render(
-        <BrowserRouter>
-          <ChannelVideos token={mockToken} />
-        </BrowserRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText('Downloaded Video 1')).toBeInTheDocument();
-      });
-
-      const deleteIcons = screen.getAllByTestId('DeleteIcon');
-      fireEvent.click(deleteIcons[deleteIcons.length - 1]);
-
-      await waitFor(() => {
-        const actionBarButtons = screen.getAllByRole('button');
-        const deleteActionButton = actionBarButtons.find(btn =>
-          btn.textContent?.match(/^Delete\s+1$/)
-        );
-        expect(deleteActionButton).toBeDefined();
-      });
-
-      const deleteActionButton = screen.getAllByRole('button').find(btn =>
-        btn.textContent?.match(/^Delete\s+1$/)
-      );
-      await user.click(deleteActionButton!);
-
-      const confirmButton = await screen.findByTestId('delete-confirm');
-      fireEvent.click(confirmButton);
-
-      await waitFor(() => {
-        expect(screen.getByText(/Failed to delete videos: Test error message/i)).toBeInTheDocument();
-      });
-
-      // Find and click the close button in the alert
-      const alerts = screen.getAllByRole('alert');
-      const errorAlert = alerts.find(alert => alert.textContent?.includes('Failed to delete'));
-      expect(errorAlert).toBeDefined();
-      const closeButton = within(errorAlert!).getByRole('button', { name: /close/i });
-      fireEvent.click(closeButton);
-
-      await waitFor(() => {
-        expect(screen.queryByText(/Failed to delete videos: Test error message/i)).not.toBeInTheDocument();
-      });
-    });
-  });
 });

--- a/client/src/components/ChannelPage/__tests__/ChannelVideosDialogs.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideosDialogs.test.tsx
@@ -1,0 +1,624 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ChannelVideosDialogs from '../ChannelVideosDialogs';
+import { renderWithProviders } from '../../../test-utils';
+
+// Mock child components
+jest.mock('../../DownloadManager/ManualDownload/DownloadSettingsDialog', () => ({
+  __esModule: true,
+  default: function MockDownloadSettingsDialog(props: any) {
+    const React = require('react');
+    return React.createElement('div', {
+      'data-testid': 'download-settings-dialog',
+      'data-open': props.open,
+      'data-video-count': props.videoCount,
+      'data-missing-count': props.missingVideoCount,
+      onClick: () => {
+        if (props.onConfirm) {
+          props.onConfirm({ resolution: '1080', allowRedownload: false });
+        }
+      }
+    }, 'Download Settings Dialog');
+  }
+}));
+
+jest.mock('../../shared/DeleteVideosDialog', () => ({
+  __esModule: true,
+  default: function MockDeleteVideosDialog(props: any) {
+    const React = require('react');
+    return React.createElement('div', {
+      'data-testid': 'delete-videos-dialog',
+      'data-open': props.open,
+      'data-video-count': props.videoCount
+    }, 'Delete Videos Dialog');
+  }
+}));
+
+describe('ChannelVideosDialogs Component', () => {
+  const defaultProps = {
+    downloadDialogOpen: false,
+    refreshConfirmOpen: false,
+    deleteDialogOpen: false,
+    fetchAllError: null,
+    mobileTooltip: null,
+    successMessage: null,
+    errorMessage: null,
+    videoCount: 0,
+    missingVideoCount: 0,
+    selectedForDeletion: 0,
+    defaultResolution: '1080',
+    selectedTab: 'videos',
+    tabLabel: 'Videos',
+    onDownloadDialogClose: jest.fn(),
+    onDownloadConfirm: jest.fn(),
+    onRefreshCancel: jest.fn(),
+    onRefreshConfirm: jest.fn(),
+    onDeleteCancel: jest.fn(),
+    onDeleteConfirm: jest.fn(),
+    onFetchAllErrorClose: jest.fn(),
+    onMobileTooltipClose: jest.fn(),
+    onSuccessMessageClose: jest.fn(),
+    onErrorMessageClose: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    test('renders without crashing', () => {
+      renderWithProviders(<ChannelVideosDialogs {...defaultProps} />);
+      expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-videos-dialog')).toBeInTheDocument();
+    });
+
+    test('renders all dialog components', () => {
+      renderWithProviders(<ChannelVideosDialogs {...defaultProps} />);
+
+      // Should render DownloadSettingsDialog
+      expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
+
+      // Should render DeleteVideosDialog
+      expect(screen.getByTestId('delete-videos-dialog')).toBeInTheDocument();
+
+      // Should render refresh confirmation dialog (even if closed)
+      expect(screen.queryByText('Fetch All Videos Videos')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Download Settings Dialog', () => {
+    test('passes correct props to DownloadSettingsDialog when closed', () => {
+      renderWithProviders(<ChannelVideosDialogs {...defaultProps} />);
+
+      const dialog = screen.getByTestId('download-settings-dialog');
+      expect(dialog).toHaveAttribute('data-open', 'false');
+      expect(dialog).toHaveAttribute('data-video-count', '0');
+      expect(dialog).toHaveAttribute('data-missing-count', '0');
+    });
+
+    test('passes correct props to DownloadSettingsDialog when open', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          downloadDialogOpen={true}
+          videoCount={5}
+          missingVideoCount={2}
+        />
+      );
+
+      const dialog = screen.getByTestId('download-settings-dialog');
+      expect(dialog).toHaveAttribute('data-open', 'true');
+      expect(dialog).toHaveAttribute('data-video-count', '5');
+      expect(dialog).toHaveAttribute('data-missing-count', '2');
+    });
+
+    test('passes default resolution to DownloadSettingsDialog', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          defaultResolution="720"
+        />
+      );
+
+      // Component should be rendered (mock doesn't check this prop, but it's passed)
+      expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('Refresh Confirmation Dialog', () => {
+    test('does not show refresh dialog when closed', () => {
+      renderWithProviders(<ChannelVideosDialogs {...defaultProps} />);
+
+      expect(screen.queryByText(/Fetch All/)).not.toBeInTheDocument();
+    });
+
+    test('shows refresh dialog when open', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          refreshConfirmOpen={true}
+        />
+      );
+
+      expect(screen.getByText('Fetch All Videos Videos')).toBeInTheDocument();
+    });
+
+    test('displays correct tab label in refresh dialog', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          refreshConfirmOpen={true}
+          tabLabel="Shorts"
+        />
+      );
+
+      expect(screen.getByText('Fetch All Shorts Videos')).toBeInTheDocument();
+      expect(screen.getByText(/This will fetch all 'Shorts' videos for this Channel/)).toBeInTheDocument();
+    });
+
+    test('calls onRefreshCancel when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      const onRefreshCancel = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          refreshConfirmOpen={true}
+          onRefreshCancel={onRefreshCancel}
+        />
+      );
+
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+      await user.click(cancelButton);
+
+      expect(onRefreshCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('calls onRefreshConfirm when Continue is clicked', async () => {
+      const user = userEvent.setup();
+      const onRefreshConfirm = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          refreshConfirmOpen={true}
+          onRefreshConfirm={onRefreshConfirm}
+        />
+      );
+
+      const continueButton = screen.getByRole('button', { name: 'Continue' });
+      await user.click(continueButton);
+
+      expect(onRefreshConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    test('calls onRefreshCancel when dialog is closed by clicking backdrop', () => {
+      const onRefreshCancel = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          refreshConfirmOpen={true}
+          onRefreshCancel={onRefreshCancel}
+        />
+      );
+
+      // MUI Dialog calls onClose when clicking backdrop
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+
+      // onClose is called by MUI when backdrop is clicked
+      // We can't simulate this directly, but we verify the prop is passed
+      expect(onRefreshCancel).toBeDefined();
+    });
+
+    test('has proper accessibility attributes in refresh dialog', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          refreshConfirmOpen={true}
+        />
+      );
+
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-labelledby', 'refresh-dialog-title');
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-describedby', 'refresh-dialog-description');
+    });
+  });
+
+  describe('Delete Confirmation Dialog', () => {
+    test('passes correct props to DeleteVideosDialog when closed', () => {
+      renderWithProviders(<ChannelVideosDialogs {...defaultProps} />);
+
+      const dialog = screen.getByTestId('delete-videos-dialog');
+      expect(dialog).toHaveAttribute('data-open', 'false');
+      expect(dialog).toHaveAttribute('data-video-count', '0');
+    });
+
+    test('passes correct props to DeleteVideosDialog when open', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          deleteDialogOpen={true}
+          selectedForDeletion={3}
+        />
+      );
+
+      const dialog = screen.getByTestId('delete-videos-dialog');
+      expect(dialog).toHaveAttribute('data-open', 'true');
+      expect(dialog).toHaveAttribute('data-video-count', '3');
+    });
+  });
+
+  describe('Snackbar Notifications', () => {
+    test('shows fetch all error snackbar when error exists', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          fetchAllError="Failed to fetch videos"
+        />
+      );
+
+      expect(screen.getByText('Failed to fetch videos')).toBeInTheDocument();
+    });
+
+    test('does not show fetch all error snackbar when error is null', () => {
+      renderWithProviders(<ChannelVideosDialogs {...defaultProps} />);
+
+      // Snackbar should not be visible
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    test('calls onFetchAllErrorClose when error snackbar is closed', async () => {
+      const user = userEvent.setup();
+      const onFetchAllErrorClose = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          fetchAllError="Test error"
+          onFetchAllErrorClose={onFetchAllErrorClose}
+        />
+      );
+
+      const closeButton = screen.getByLabelText('Close');
+      await user.click(closeButton);
+
+      expect(onFetchAllErrorClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('shows mobile tooltip snackbar when message exists', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          mobileTooltip="Tap and hold to select videos"
+        />
+      );
+
+      expect(screen.getByText('Tap and hold to select videos')).toBeInTheDocument();
+    });
+
+    test('calls onMobileTooltipClose when tooltip is closed', async () => {
+      const user = userEvent.setup();
+      const onMobileTooltipClose = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          mobileTooltip="Test tooltip"
+          onMobileTooltipClose={onMobileTooltipClose}
+        />
+      );
+
+      const closeButton = screen.getByLabelText('Close');
+      await user.click(closeButton);
+
+      expect(onMobileTooltipClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('shows success message snackbar when message exists', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          successMessage="Videos downloaded successfully"
+        />
+      );
+
+      expect(screen.getByText('Videos downloaded successfully')).toBeInTheDocument();
+    });
+
+    test('calls onSuccessMessageClose when success snackbar is closed', async () => {
+      const user = userEvent.setup();
+      const onSuccessMessageClose = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          successMessage="Test success"
+          onSuccessMessageClose={onSuccessMessageClose}
+        />
+      );
+
+      const closeButton = screen.getByLabelText('Close');
+      await user.click(closeButton);
+
+      expect(onSuccessMessageClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('shows error message snackbar when message exists', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          errorMessage="Download failed"
+        />
+      );
+
+      expect(screen.getByText('Download failed')).toBeInTheDocument();
+    });
+
+    test('calls onErrorMessageClose when error message snackbar is closed', async () => {
+      const user = userEvent.setup();
+      const onErrorMessageClose = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          errorMessage="Test error"
+          onErrorMessageClose={onErrorMessageClose}
+        />
+      );
+
+      const closeButton = screen.getByLabelText('Close');
+      await user.click(closeButton);
+
+      expect(onErrorMessageClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Snackbar Severity Levels', () => {
+    test('fetch all error shows error severity', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          fetchAllError="Error message"
+        />
+      );
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveClass('MuiAlert-standardError');
+    });
+
+    test('mobile tooltip shows info severity', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          mobileTooltip="Info message"
+        />
+      );
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveClass('MuiAlert-standardInfo');
+    });
+
+    test('success message shows success severity', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          successMessage="Success message"
+        />
+      );
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveClass('MuiAlert-standardSuccess');
+    });
+
+    test('error message shows error severity', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          errorMessage="Error message"
+        />
+      );
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveClass('MuiAlert-standardError');
+    });
+  });
+
+  describe('Multiple Dialogs Open', () => {
+    test('can show multiple snackbars simultaneously', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          fetchAllError="Error 1"
+          successMessage="Success 1"
+        />
+      );
+
+      expect(screen.getByText('Error 1')).toBeInTheDocument();
+      expect(screen.getByText('Success 1')).toBeInTheDocument();
+    });
+
+    test('can show dialog and snackbar simultaneously', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          refreshConfirmOpen={true}
+          successMessage="Operation completed"
+        />
+      );
+
+      expect(screen.getByText('Fetch All Videos Videos')).toBeInTheDocument();
+      expect(screen.getByText('Operation completed')).toBeInTheDocument();
+    });
+  });
+
+  describe('Auto-hide Duration', () => {
+    test('fetch all error has 6000ms auto-hide duration', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          fetchAllError="Test error"
+        />
+      );
+
+      // Snackbar should be visible initially
+      expect(screen.getByText('Test error')).toBeInTheDocument();
+    });
+
+    test('mobile tooltip has 8000ms auto-hide duration', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          mobileTooltip="Test tooltip"
+        />
+      );
+
+      // Snackbar should be visible initially
+      expect(screen.getByText('Test tooltip')).toBeInTheDocument();
+    });
+
+    test('success message has 6000ms auto-hide duration', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          successMessage="Test success"
+        />
+      );
+
+      // Snackbar should be visible initially
+      expect(screen.getByText('Test success')).toBeInTheDocument();
+    });
+
+    test('error message has 6000ms auto-hide duration', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          errorMessage="Test error"
+        />
+      );
+
+      // Snackbar should be visible initially
+      expect(screen.getByText('Test error')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('handles empty string messages', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          successMessage=""
+        />
+      );
+
+      // Empty string is not null, so snackbar will be open but with empty content
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    test('handles tab label with special characters', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          refreshConfirmOpen={true}
+          tabLabel="Live & Upcoming"
+        />
+      );
+
+      expect(screen.getByText('Fetch All Live & Upcoming Videos')).toBeInTheDocument();
+    });
+
+    test('handles zero video count in download dialog', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          downloadDialogOpen={true}
+          videoCount={0}
+        />
+      );
+
+      const dialog = screen.getByTestId('download-settings-dialog');
+      expect(dialog).toHaveAttribute('data-video-count', '0');
+    });
+
+    test('handles large video counts', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          downloadDialogOpen={true}
+          videoCount={1000}
+          selectedForDeletion={500}
+        />
+      );
+
+      const downloadDialog = screen.getByTestId('download-settings-dialog');
+      expect(downloadDialog).toHaveAttribute('data-video-count', '1000');
+
+      const deleteDialog = screen.getByTestId('delete-videos-dialog');
+      expect(deleteDialog).toHaveAttribute('data-video-count', '500');
+    });
+
+    test('handles all dialogs and snackbars open at once', () => {
+      renderWithProviders(
+        <ChannelVideosDialogs
+          {...defaultProps}
+          downloadDialogOpen={true}
+          refreshConfirmOpen={true}
+          deleteDialogOpen={true}
+          fetchAllError="Error 1"
+          mobileTooltip="Tooltip 1"
+          successMessage="Success 1"
+          errorMessage="Error 2"
+        />
+      );
+
+      // All components should render
+      expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-videos-dialog')).toBeInTheDocument();
+      expect(screen.getByText('Fetch All Videos Videos')).toBeInTheDocument();
+
+      // Multiple snackbars should show
+      expect(screen.getByText('Error 1')).toBeInTheDocument();
+      expect(screen.getByText('Tooltip 1')).toBeInTheDocument();
+      expect(screen.getByText('Success 1')).toBeInTheDocument();
+      expect(screen.getByText('Error 2')).toBeInTheDocument();
+    });
+  });
+
+  describe('Prop Type Coverage', () => {
+    test('handles different selected tab values', () => {
+      const { rerender } = renderWithProviders(
+        <ChannelVideosDialogs {...defaultProps} selectedTab="videos" />
+      );
+      expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
+
+      rerender(
+        <ChannelVideosDialogs {...defaultProps} selectedTab="shorts" />
+      );
+      expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
+
+      rerender(
+        <ChannelVideosDialogs {...defaultProps} selectedTab="streams" />
+      );
+      expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
+    });
+
+    test('handles different default resolution values', () => {
+      const resolutions = ['360', '480', '720', '1080', '1440', '2160'];
+
+      resolutions.forEach(resolution => {
+        const { unmount } = renderWithProviders(
+          <ChannelVideosDialogs
+            {...defaultProps}
+            defaultResolution={resolution}
+          />
+        );
+
+        expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
+
+        // Clean up after each iteration
+        unmount();
+      });
+    });
+  });
+});

--- a/client/src/components/ChannelPage/__tests__/ChannelVideosHeader.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideosHeader.test.tsx
@@ -208,26 +208,31 @@ describe('ChannelVideosHeader Component', () => {
       expect(onAutoDownloadChange).toHaveBeenCalledWith(true);
     });
 
-    test('renders info icon for auto-download switch on desktop', () => {
+    test('renders info icons for both date and auto-download on desktop', () => {
       renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
-      const infoIcon = screen.getByTestId('InfoIcon');
-      expect(infoIcon).toBeInTheDocument();
+      const infoIcons = screen.getAllByTestId('InfoIcon');
+      // Should have 2 info icons: one for date tooltip, one for auto-download
+      expect(infoIcons).toHaveLength(2);
     });
 
-    test('info icon shows tooltip on desktop', () => {
-      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
-      expect(screen.getByTestId('InfoIcon')).toBeInTheDocument();
-    });
+    test('info icons are clickable on mobile', async () => {
+      const user = userEvent.setup();
+      const onInfoIconClick = jest.fn();
 
-    test('info icon is rendered on mobile', () => {
       renderWithProviders(
         <ChannelVideosHeader
           {...defaultProps}
           isMobile={true}
+          onInfoIconClick={onInfoIconClick}
         />
       );
 
-      expect(screen.getByTestId('InfoIcon')).toBeInTheDocument();
+      const infoIcons = screen.getAllByTestId('InfoIcon');
+      expect(infoIcons).toHaveLength(2);
+
+      // Click the first info icon (date tooltip)
+      await user.click(infoIcons[0]);
+      expect(onInfoIconClick).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -751,6 +756,45 @@ describe('ChannelVideosHeader Component', () => {
       );
 
       expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+    });
+
+    test('hides oldest video date for shorts tab', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          selectedTab="shorts"
+          oldestVideoDate="2023-01-15T00:00:00Z"
+        />
+      );
+
+      // Should not display oldest date for shorts
+      expect(screen.queryByText(/Oldest:/)).not.toBeInTheDocument();
+    });
+
+    test('shows oldest video date for videos tab', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          selectedTab="videos"
+          oldestVideoDate="2023-01-15T00:00:00Z"
+        />
+      );
+
+      // Should display oldest date for videos tab
+      expect(screen.getByText(/Oldest:/)).toBeInTheDocument();
+    });
+
+    test('shows oldest video date for streams tab', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          selectedTab="streams"
+          oldestVideoDate="2023-01-15T00:00:00Z"
+        />
+      );
+
+      // Should display oldest date for streams tab
+      expect(screen.getByText(/Oldest:/)).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/ChannelPage/__tests__/ChannelVideosHeader.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideosHeader.test.tsx
@@ -1,0 +1,788 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import ChannelVideosHeader from '../ChannelVideosHeader';
+import { ChannelVideo } from '../../../types/ChannelVideo';
+import { renderWithProviders } from '../../../test-utils';
+
+// Mock Material-UI hooks
+jest.mock('@mui/material/useMediaQuery');
+
+const mockVideos: ChannelVideo[] = [
+  {
+    title: 'Test Video 1',
+    youtube_id: 'video1',
+    publishedAt: '2023-01-01T00:00:00Z',
+    thumbnail: 'https://i.ytimg.com/vi/video1/mqdefault.jpg',
+    added: false,
+    duration: 300,
+    media_type: 'video',
+    live_status: null,
+  },
+  {
+    title: 'Test Video 2',
+    youtube_id: 'video2',
+    publishedAt: '2023-01-02T00:00:00Z',
+    thumbnail: 'https://i.ytimg.com/vi/video2/mqdefault.jpg',
+    added: true,
+    removed: false,
+    duration: 600,
+    media_type: 'video',
+    live_status: null,
+  },
+  {
+    title: 'Test Video 3',
+    youtube_id: 'video3',
+    publishedAt: '2023-01-03T00:00:00Z',
+    thumbnail: 'https://i.ytimg.com/vi/video3/mqdefault.jpg',
+    added: true,
+    removed: true,
+    duration: 450,
+    media_type: 'video',
+    live_status: null,
+  },
+];
+
+describe('ChannelVideosHeader Component', () => {
+  const defaultProps = {
+    isMobile: false,
+    viewMode: 'grid' as const,
+    searchQuery: '',
+    hideDownloaded: false,
+    totalCount: 0,
+    oldestVideoDate: null,
+    fetchingAllVideos: false,
+    checkedBoxes: [],
+    selectedForDeletion: [],
+    deleteLoading: false,
+    paginatedVideos: [],
+    autoDownloadsEnabled: false,
+    selectedTab: 'videos',
+    onViewModeChange: jest.fn(),
+    onSearchChange: jest.fn(),
+    onHideDownloadedChange: jest.fn(),
+    onAutoDownloadChange: jest.fn(),
+    onRefreshClick: jest.fn(),
+    onDownloadClick: jest.fn(),
+    onSelectAll: jest.fn(),
+    onClearSelection: jest.fn(),
+    onDeleteClick: jest.fn(),
+    onInfoIconClick: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useMediaQuery as jest.Mock).mockReturnValue(false);
+  });
+
+  describe('Component Rendering', () => {
+    test('renders without crashing', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+    });
+  });
+
+  describe('Video Count Display', () => {
+    test('displays video count chip when totalCount > 0', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} totalCount={42} />
+      );
+      expect(screen.getByText('42')).toBeInTheDocument();
+    });
+
+    test('does not display count chip when totalCount is 0', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} totalCount={0} />);
+      const chips = screen.queryAllByText('0');
+      expect(chips.length).toBe(0);
+    });
+
+    test('displays oldest video date on desktop', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          oldestVideoDate="2023-01-15T00:00:00Z"
+        />
+      );
+      // Verify that "Oldest:" text appears when oldestVideoDate is provided
+      expect(screen.getByText(/Oldest:/)).toBeInTheDocument();
+    });
+
+    test('does not display oldest video date when null', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+      expect(screen.queryByText(/Oldest:/)).not.toBeInTheDocument();
+    });
+
+    test('does not display oldest video date on mobile', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          isMobile={true}
+          oldestVideoDate="2023-01-15T00:00:00Z"
+        />
+      );
+      expect(screen.queryByText(/Oldest:/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Fetch All Button', () => {
+    test('renders fetch all button', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+      expect(screen.getByRole('button', { name: /Fetch All/i })).toBeInTheDocument();
+    });
+
+    test('calls onRefreshClick when fetch all button is clicked', async () => {
+      const user = userEvent.setup();
+      const onRefreshClick = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} onRefreshClick={onRefreshClick} />
+      );
+
+      await user.click(screen.getByRole('button', { name: /Fetch All/i }));
+      expect(onRefreshClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('disables fetch all button when fetching', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} fetchingAllVideos={true} />
+      );
+
+      const button = screen.getByRole('button', { name: /Fetching.../i });
+      expect(button).toBeDisabled();
+    });
+
+    test('shows "Fetching..." text when fetching videos', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} fetchingAllVideos={true} />
+      );
+
+      expect(screen.getByText('Fetching...')).toBeInTheDocument();
+    });
+
+    test('shows "Fetch All" text when not fetching', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} fetchingAllVideos={false} />
+      );
+
+      expect(screen.getByText('Fetch All')).toBeInTheDocument();
+    });
+  });
+
+  describe('Auto-Download Toggle', () => {
+    test('renders auto-download switch', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+      expect(screen.getByRole('checkbox', { name: /Enable Channel Downloads for this tab/i })).toBeInTheDocument();
+    });
+
+    test('auto-download switch reflects enabled state', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} autoDownloadsEnabled={true} />
+      );
+
+      const checkbox = screen.getByRole('checkbox', { name: /Enable Channel Downloads for this tab/i });
+      expect(checkbox).toBeChecked();
+    });
+
+    test('auto-download switch reflects disabled state', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} autoDownloadsEnabled={false} />
+      );
+
+      const checkbox = screen.getByRole('checkbox', { name: /Enable Channel Downloads for this tab/i });
+      expect(checkbox).not.toBeChecked();
+    });
+
+    test('calls onAutoDownloadChange when toggled', async () => {
+      const user = userEvent.setup();
+      const onAutoDownloadChange = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          onAutoDownloadChange={onAutoDownloadChange}
+        />
+      );
+
+      await user.click(screen.getByRole('checkbox', { name: /Enable Channel Downloads for this tab/i }));
+      expect(onAutoDownloadChange).toHaveBeenCalledWith(true);
+    });
+
+    test('renders info icon for auto-download switch on desktop', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+      const infoIcon = screen.getByTestId('InfoIcon');
+      expect(infoIcon).toBeInTheDocument();
+    });
+
+    test('info icon shows tooltip on desktop', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+      expect(screen.getByTestId('InfoIcon')).toBeInTheDocument();
+    });
+
+    test('info icon is rendered on mobile', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          isMobile={true}
+        />
+      );
+
+      expect(screen.getByTestId('InfoIcon')).toBeInTheDocument();
+    });
+  });
+
+  describe('Search Functionality', () => {
+    test('renders search input', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+      expect(screen.getByPlaceholderText('Search videos...')).toBeInTheDocument();
+    });
+
+    test('displays current search query', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} searchQuery="test query" />
+      );
+
+      const input = screen.getByPlaceholderText('Search videos...') as HTMLInputElement;
+      expect(input.value).toBe('test query');
+    });
+
+    test('calls onSearchChange when typing in search input', async () => {
+      const user = userEvent.setup();
+      const onSearchChange = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} onSearchChange={onSearchChange} />
+      );
+
+      const input = screen.getByPlaceholderText('Search videos...');
+      await user.type(input, 'a');
+
+      expect(onSearchChange).toHaveBeenCalledWith('a');
+    });
+
+    test('displays search icon', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+      expect(screen.getByTestId('SearchIcon')).toBeInTheDocument();
+    });
+  });
+
+  describe('View Mode Toggle - Desktop', () => {
+    test('renders table and grid buttons on desktop', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+
+      const buttons = screen.getAllByRole('button');
+      const toggleButtons = buttons.filter(btn =>
+        btn.getAttribute('value') === 'table' ||
+        btn.getAttribute('value') === 'grid'
+      );
+
+      expect(toggleButtons.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('does not render list view button on desktop', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+
+      const buttons = screen.getAllByRole('button');
+      const listButton = buttons.find(btn => btn.getAttribute('value') === 'list');
+
+      expect(listButton).toBeUndefined();
+    });
+
+    test('table view is selected when viewMode is table', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} viewMode="table" />
+      );
+
+      const buttons = screen.getAllByRole('button');
+      const tableButton = buttons.find(btn => btn.getAttribute('value') === 'table');
+
+      expect(tableButton).toHaveClass('Mui-selected');
+    });
+
+    test('grid view is selected when viewMode is grid', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} viewMode="grid" />
+      );
+
+      const buttons = screen.getAllByRole('button');
+      const gridButton = buttons.find(btn => btn.getAttribute('value') === 'grid');
+
+      expect(gridButton).toHaveClass('Mui-selected');
+    });
+
+    test('calls onViewModeChange when view mode is clicked', async () => {
+      const user = userEvent.setup();
+      const onViewModeChange = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          viewMode="grid"
+          onViewModeChange={onViewModeChange}
+        />
+      );
+
+      // Click the table view button (first toggle button)
+      const buttons = screen.getAllByRole('button');
+      const tableButton = buttons.find(btn => btn.getAttribute('value') === 'table');
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      await user.click(tableButton!);
+      expect(onViewModeChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('View Mode Toggle - Mobile', () => {
+    test('renders grid and list buttons on mobile', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} isMobile={true} />
+      );
+
+      const buttons = screen.getAllByRole('button');
+      const toggleButtons = buttons.filter(btn =>
+        btn.getAttribute('value') === 'grid' ||
+        btn.getAttribute('value') === 'list'
+      );
+
+      expect(toggleButtons.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('does not render table view button on mobile', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} isMobile={true} />
+      );
+
+      const buttons = screen.getAllByRole('button');
+      const tableButton = buttons.find(btn => btn.getAttribute('value') === 'table');
+
+      expect(tableButton).toBeUndefined();
+    });
+  });
+
+  describe('Hide Downloaded Toggle - Desktop', () => {
+    test('renders hide downloaded switch on desktop', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+      expect(screen.getByRole('checkbox', { name: /Hide Downloaded/i })).toBeInTheDocument();
+    });
+
+    test('does not render hide downloaded switch on mobile', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} isMobile={true} />
+      );
+      expect(screen.queryByRole('checkbox', { name: /Hide Downloaded/i })).not.toBeInTheDocument();
+    });
+
+    test('hide downloaded switch reflects checked state', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} hideDownloaded={true} />
+      );
+
+      const checkbox = screen.getByRole('checkbox', { name: /Hide Downloaded/i });
+      expect(checkbox).toBeChecked();
+    });
+
+    test('hide downloaded switch reflects unchecked state', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} hideDownloaded={false} />
+      );
+
+      const checkbox = screen.getByRole('checkbox', { name: /Hide Downloaded/i });
+      expect(checkbox).not.toBeChecked();
+    });
+
+    test('calls onHideDownloadedChange when toggled', async () => {
+      const user = userEvent.setup();
+      const onHideDownloadedChange = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          onHideDownloadedChange={onHideDownloadedChange}
+        />
+      );
+
+      await user.click(screen.getByRole('checkbox', { name: /Hide Downloaded/i }));
+      expect(onHideDownloadedChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('Action Buttons - Desktop', () => {
+    test('renders action buttons on desktop', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: /Download Selected/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Select All This Page/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Clear/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Delete Selected/i })).toBeInTheDocument();
+    });
+
+    test('does not render action buttons on mobile', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} isMobile={true} />
+      );
+
+      expect(screen.queryByRole('button', { name: /Download.*Selected/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Select All This Page/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Clear/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Download Button', () => {
+    test('download button is disabled when no videos checked', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} checkedBoxes={[]} />
+      );
+
+      const button = screen.getByRole('button', { name: /Download Selected/i });
+      expect(button).toBeDisabled();
+    });
+
+    test('download button is enabled when videos are checked', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} checkedBoxes={['video1', 'video2']} />
+      );
+
+      const button = screen.getByRole('button', { name: /Download 2 Videos/i });
+      expect(button).not.toBeDisabled();
+    });
+
+    test('displays singular "Video" when one video selected', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} checkedBoxes={['video1']} />
+      );
+
+      expect(screen.getByText(/Download 1 Video/i)).toBeInTheDocument();
+    });
+
+    test('displays plural "Videos" when multiple videos selected', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} checkedBoxes={['video1', 'video2', 'video3']} />
+      );
+
+      expect(screen.getByText(/Download 3 Videos/i)).toBeInTheDocument();
+    });
+
+    test('calls onDownloadClick when clicked', async () => {
+      const user = userEvent.setup();
+      const onDownloadClick = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          checkedBoxes={['video1']}
+          onDownloadClick={onDownloadClick}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /Download 1 Video/i }));
+      expect(onDownloadClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Select All Button', () => {
+    test('select all button is disabled when no checkboxes and no downloadable videos', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          checkedBoxes={[]}
+          paginatedVideos={[]}
+        />
+      );
+
+      const button = screen.getByRole('button', { name: /Select All This Page/i });
+      expect(button).toBeDisabled();
+    });
+
+    test('select all button is enabled when downloadable videos exist', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          checkedBoxes={[]}
+          paginatedVideos={mockVideos}
+        />
+      );
+
+      const button = screen.getByRole('button', { name: /Select All This Page/i });
+      expect(button).not.toBeDisabled();
+    });
+
+    test('select all button is enabled when videos are already checked', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          checkedBoxes={['video1']}
+          paginatedVideos={mockVideos}
+        />
+      );
+
+      const button = screen.getByRole('button', { name: /Select All This Page/i });
+      expect(button).not.toBeDisabled();
+    });
+
+    test('calls onSelectAll when clicked', async () => {
+      const user = userEvent.setup();
+      const onSelectAll = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          checkedBoxes={[]}
+          paginatedVideos={mockVideos}
+          onSelectAll={onSelectAll}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /Select All This Page/i }));
+      expect(onSelectAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Clear Selection Button', () => {
+    test('clear button is disabled when no videos checked', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} checkedBoxes={[]} />
+      );
+
+      const button = screen.getByRole('button', { name: /^Clear$/i });
+      expect(button).toBeDisabled();
+    });
+
+    test('clear button is enabled when videos are checked', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} checkedBoxes={['video1']} />
+      );
+
+      const button = screen.getByRole('button', { name: /^Clear$/i });
+      expect(button).not.toBeDisabled();
+    });
+
+    test('calls onClearSelection when clicked', async () => {
+      const user = userEvent.setup();
+      const onClearSelection = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          checkedBoxes={['video1']}
+          onClearSelection={onClearSelection}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /^Clear$/i }));
+      expect(onClearSelection).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Delete Button', () => {
+    test('delete button is disabled when no videos selected for deletion', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} selectedForDeletion={[]} />
+      );
+
+      const button = screen.getByRole('button', { name: /Delete Selected/i });
+      expect(button).toBeDisabled();
+    });
+
+    test('delete button is enabled when videos are selected for deletion', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} selectedForDeletion={['video1']} />
+      );
+
+      const button = screen.getByRole('button', { name: /Delete 1/i });
+      expect(button).not.toBeDisabled();
+    });
+
+    test('delete button is disabled when delete is loading', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          selectedForDeletion={['video1']}
+          deleteLoading={true}
+        />
+      );
+
+      const button = screen.getByRole('button', { name: /Delete 1/i });
+      expect(button).toBeDisabled();
+    });
+
+    test('displays count of videos to delete', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          selectedForDeletion={['video1', 'video2', 'video3']}
+        />
+      );
+
+      expect(screen.getByText(/Delete 3/i)).toBeInTheDocument();
+    });
+
+    test('calls onDeleteClick when clicked', async () => {
+      const user = userEvent.setup();
+      const onDeleteClick = jest.fn();
+
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          selectedForDeletion={['video1']}
+          onDeleteClick={onDeleteClick}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /Delete 1/i }));
+      expect(onDeleteClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Progress Bar', () => {
+    test('shows progress bar when fetching all videos', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} fetchingAllVideos={true} />
+      );
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    test('does not show progress bar when not fetching', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} fetchingAllVideos={false} />
+      );
+
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('handles empty paginatedVideos array', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} paginatedVideos={[]} />
+      );
+
+      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+    });
+
+    test('handles large video counts', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} totalCount={9999} />
+      );
+
+      expect(screen.getByText('9999')).toBeInTheDocument();
+    });
+
+    test('handles large selection counts', () => {
+      const largeSelection = Array.from({ length: 100 }, (_, i) => `video${i}`);
+
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          checkedBoxes={largeSelection}
+          selectedForDeletion={largeSelection}
+        />
+      );
+
+      expect(screen.getByText(/Download 100 Videos/i)).toBeInTheDocument();
+      expect(screen.getByText(/Delete 100/i)).toBeInTheDocument();
+    });
+
+    test('handles all videos being downloaded', () => {
+      const downloadedVideos: ChannelVideo[] = [
+        {
+          ...mockVideos[0],
+          added: true,
+          removed: false,
+        },
+        {
+          ...mockVideos[1],
+          added: true,
+          removed: false,
+        },
+      ];
+
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          paginatedVideos={downloadedVideos}
+        />
+      );
+
+      const selectAllButton = screen.getByRole('button', { name: /Select All This Page/i });
+      expect(selectAllButton).toBeDisabled();
+    });
+
+    test('handles members-only videos', () => {
+      const membersOnlyVideos: ChannelVideo[] = [
+        {
+          ...mockVideos[0],
+          availability: 'subscriber_only',
+        },
+      ];
+
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          paginatedVideos={membersOnlyVideos}
+        />
+      );
+
+      const selectAllButton = screen.getByRole('button', { name: /Select All This Page/i });
+      expect(selectAllButton).toBeDisabled();
+    });
+  });
+
+  describe('Different Tab Types', () => {
+    test('handles videos tab', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} selectedTab="videos" />
+      );
+
+      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+    });
+
+    test('handles shorts tab', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} selectedTab="shorts" />
+      );
+
+      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+    });
+
+    test('handles streams tab', () => {
+      renderWithProviders(
+        <ChannelVideosHeader {...defaultProps} selectedTab="streams" />
+      );
+
+      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    test('all interactive elements are keyboard accessible', () => {
+      renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
+
+      const buttons = screen.getAllByRole('button');
+      buttons.forEach(button => {
+        expect(button).toBeInTheDocument();
+      });
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      checkboxes.forEach(checkbox => {
+        expect(checkbox).toBeInTheDocument();
+      });
+
+      const textbox = screen.getByRole('textbox');
+      expect(textbox).toBeInTheDocument();
+    });
+
+    test('buttons have appropriate aria labels', () => {
+      renderWithProviders(
+        <ChannelVideosHeader
+          {...defaultProps}
+          checkedBoxes={['video1']}
+          selectedForDeletion={['video2']}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /Download 1 Video/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Delete 1/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/ChannelPage/__tests__/StillLiveDot.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/StillLiveDot.test.tsx
@@ -1,0 +1,166 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import StillLiveDot from '../StillLiveDot';
+import { renderWithProviders } from '../../../test-utils';
+
+describe('StillLiveDot Component', () => {
+  describe('Component Rendering', () => {
+    test('renders without crashing', () => {
+      renderWithProviders(<StillLiveDot />);
+      expect(screen.getByText('LIVE')).toBeInTheDocument();
+    });
+
+    test('renders LIVE label', () => {
+      renderWithProviders(<StillLiveDot />);
+      expect(screen.getByText('LIVE')).toBeInTheDocument();
+    });
+
+    test('renders with icon', () => {
+      renderWithProviders(<StillLiveDot />);
+      expect(screen.getByTestId('FiberManualRecordIcon')).toBeInTheDocument();
+    });
+  });
+
+  describe('Desktop Mode (with Tooltip)', () => {
+    test('renders with tooltip wrapper in desktop mode', () => {
+      renderWithProviders(<StillLiveDot isMobile={false} />);
+      expect(screen.getByText('LIVE')).toBeInTheDocument();
+    });
+
+    test('tooltip is initially closed', () => {
+      renderWithProviders(<StillLiveDot isMobile={false} />);
+      expect(screen.queryByText('Cannot download while still airing')).not.toBeInTheDocument();
+    });
+
+    test('shows tooltip when chip is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<StillLiveDot isMobile={false} />);
+
+      const chip = screen.getByText('LIVE');
+      await user.click(chip);
+
+      await waitFor(() => {
+        expect(screen.getByText('Cannot download while still airing')).toBeInTheDocument();
+      });
+    });
+
+    test('does not call onMobileClick in desktop mode', async () => {
+      const user = userEvent.setup();
+      const onMobileClick = jest.fn();
+
+      renderWithProviders(
+        <StillLiveDot isMobile={false} onMobileClick={onMobileClick} />
+      );
+
+      const chip = screen.getByText('LIVE');
+      await user.click(chip);
+
+      expect(onMobileClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Mobile Mode', () => {
+    test('renders without tooltip wrapper in mobile mode', () => {
+      renderWithProviders(<StillLiveDot isMobile={true} />);
+      expect(screen.getByText('LIVE')).toBeInTheDocument();
+    });
+
+    test('calls onMobileClick when clicked in mobile mode', async () => {
+      const user = userEvent.setup();
+      const onMobileClick = jest.fn();
+
+      renderWithProviders(
+        <StillLiveDot isMobile={true} onMobileClick={onMobileClick} />
+      );
+
+      const chip = screen.getByText('LIVE');
+      await user.click(chip);
+
+      expect(onMobileClick).toHaveBeenCalledTimes(1);
+      expect(onMobileClick).toHaveBeenCalledWith('Cannot download while still airing');
+    });
+
+    test('does not call onMobileClick when callback is not provided', async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(<StillLiveDot isMobile={true} />);
+
+      const chip = screen.getByText('LIVE');
+      await user.click(chip);
+
+      expect(screen.getByText('LIVE')).toBeInTheDocument();
+    });
+
+    test('does not show tooltip in mobile mode', async () => {
+      const user = userEvent.setup();
+      const onMobileClick = jest.fn();
+
+      renderWithProviders(
+        <StillLiveDot isMobile={true} onMobileClick={onMobileClick} />
+      );
+
+      const chip = screen.getByText('LIVE');
+      await user.click(chip);
+
+      expect(screen.queryByText('Cannot download while still airing')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Event Handling', () => {
+    test('prevents event propagation when clicked', async () => {
+      const user = userEvent.setup();
+      const parentClickHandler = jest.fn();
+
+      renderWithProviders(
+        <div onClick={parentClickHandler}>
+          <StillLiveDot />
+        </div>
+      );
+
+      const chip = screen.getByText('LIVE');
+      await user.click(chip);
+
+      expect(parentClickHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Default Props', () => {
+    test('uses desktop mode by default when isMobile is not specified', () => {
+      renderWithProviders(<StillLiveDot />);
+      expect(screen.getByText('LIVE')).toBeInTheDocument();
+    });
+
+    test('handles missing onMobileClick prop gracefully', async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(<StillLiveDot isMobile={false} />);
+
+      const chip = screen.getByText('LIVE');
+      await user.click(chip);
+
+      expect(screen.getByText('LIVE')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    test('chip is interactive', () => {
+      renderWithProviders(<StillLiveDot />);
+      const chip = screen.getByText('LIVE');
+      expect(chip).toBeInTheDocument();
+    });
+
+    test('tooltip has correct message content', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<StillLiveDot isMobile={false} />);
+
+      const chip = screen.getByText('LIVE');
+      await user.click(chip);
+
+      await waitFor(() => {
+        const tooltip = screen.getByText('Cannot download while still airing');
+        expect(tooltip).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
@@ -70,10 +70,12 @@ describe('VideoCard Component', () => {
     });
 
     test('does not render duration chip for shorts', () => {
-      const shortVideo = { ...mockVideo, media_type: 'short' };
+      const shortVideo = { ...mockVideo, media_type: 'short', duration: 45 };
       renderWithProviders(<VideoCard {...defaultProps} video={shortVideo} />);
-      // Verify duration doesn't appear by checking for the CalendarTodayIcon but not duration text
-      expect(screen.getByTestId('CalendarTodayIcon')).toBeInTheDocument();
+      // Shorts should still render "Short" chip (which has ScheduleIcon)
+      expect(screen.getByText('Short')).toBeInTheDocument();
+      // But should not show duration text (like "0:45") since duration chip is hidden
+      expect(screen.queryByText('0:45')).not.toBeInTheDocument();
     });
 
     test('renders published date', () => {
@@ -84,6 +86,14 @@ describe('VideoCard Component', () => {
     test('renders short date format on mobile', () => {
       renderWithProviders(<VideoCard {...defaultProps} isMobile={true} />);
       expect(screen.getByText(/Jan 15/)).toBeInTheDocument();
+    });
+
+    test('does not render published date for shorts', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoCard {...defaultProps} video={shortVideo} />);
+      // Shorts should not show the CalendarTodayIcon or published date
+      expect(screen.queryByTestId('CalendarTodayIcon')).not.toBeInTheDocument();
+      expect(screen.queryByText(/1\/15\/2023/)).not.toBeInTheDocument();
     });
   });
 

--- a/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
@@ -1,0 +1,571 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import VideoCard from '../VideoCard';
+import { ChannelVideo } from '../../../types/ChannelVideo';
+import { renderWithProviders } from '../../../test-utils';
+
+// Mock StillLiveDot component
+jest.mock('../StillLiveDot', () => ({
+  __esModule: true,
+  default: function MockStillLiveDot(props: { isMobile?: boolean; onMobileClick?: (message: string) => void }) {
+    const React = require('react');
+    return React.createElement('div', { 'data-testid': 'still-live-dot' }, 'LIVE');
+  }
+}));
+
+describe('VideoCard Component', () => {
+  const mockVideo: ChannelVideo = {
+    title: 'Test Video Title',
+    youtube_id: 'test123',
+    publishedAt: '2023-01-15T10:30:00Z',
+    thumbnail: 'https://i.ytimg.com/vi/test123/mqdefault.jpg',
+    added: false,
+    duration: 600,
+    media_type: 'video',
+    live_status: null,
+  };
+
+  const defaultProps = {
+    video: mockVideo,
+    isMobile: false,
+    checkedBoxes: [],
+    hoveredVideo: null,
+    selectedForDeletion: [],
+    onCheckChange: jest.fn(),
+    onHoverChange: jest.fn(),
+    onToggleDeletion: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    test('renders without crashing', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.getByText('Test Video Title')).toBeInTheDocument();
+    });
+
+    test('renders video thumbnail', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveAttribute('src', 'https://i.ytimg.com/vi/test123/mqdefault.jpg');
+    });
+
+    test('renders video title with HTML decoding', () => {
+      const videoWithEncodedTitle = {
+        ...mockVideo,
+        title: 'Test &amp; Video &quot;Title&quot;',
+      };
+      renderWithProviders(<VideoCard {...defaultProps} video={videoWithEncodedTitle} />);
+      expect(screen.getByText('Test & Video "Title"')).toBeInTheDocument();
+    });
+
+    test('renders duration chip for regular videos', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      // Duration is 600 seconds = 10 minutes
+      const durationChip = screen.getByText(/10/);
+      expect(durationChip).toBeInTheDocument();
+    });
+
+    test('does not render duration chip for shorts', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoCard {...defaultProps} video={shortVideo} />);
+      // Verify duration doesn't appear by checking for the CalendarTodayIcon but not duration text
+      expect(screen.getByTestId('CalendarTodayIcon')).toBeInTheDocument();
+    });
+
+    test('renders published date', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.getByText(/1\/15\/2023/)).toBeInTheDocument();
+    });
+
+    test('renders short date format on mobile', () => {
+      renderWithProviders(<VideoCard {...defaultProps} isMobile={true} />);
+      expect(screen.getByText(/Jan 15/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Video Status', () => {
+    test('renders "Not Downloaded" status for never downloaded video', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.getByText('Not Downloaded')).toBeInTheDocument();
+    });
+
+    test('renders "Downloaded" status for downloaded video', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoCard {...defaultProps} video={downloadedVideo} />);
+      expect(screen.getByText('Downloaded')).toBeInTheDocument();
+    });
+
+    test('renders "Missing" status for removed video', () => {
+      const removedVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoCard {...defaultProps} video={removedVideo} />);
+      expect(screen.getByText('Missing')).toBeInTheDocument();
+    });
+
+    test('renders "Members Only" status for subscriber-only video', () => {
+      const membersOnlyVideo = { ...mockVideo, availability: 'subscriber_only' };
+      renderWithProviders(<VideoCard {...defaultProps} video={membersOnlyVideo} />);
+      expect(screen.getByText('Members Only')).toBeInTheDocument();
+    });
+  });
+
+  describe('Media Type Indicators', () => {
+    test('renders short chip for short videos', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoCard {...defaultProps} video={shortVideo} />);
+      expect(screen.getByText('Short')).toBeInTheDocument();
+    });
+
+    test('renders live chip for livestream videos', () => {
+      const livestreamVideo = { ...mockVideo, media_type: 'livestream' };
+      renderWithProviders(<VideoCard {...defaultProps} video={livestreamVideo} />);
+      expect(screen.getByText('Live')).toBeInTheDocument();
+    });
+
+    test('does not render media type chip for regular videos', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.queryByText('Short')).not.toBeInTheDocument();
+      expect(screen.queryByText('Live')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('File Size Display', () => {
+    test('renders file size when available', () => {
+      const videoWithSize = { ...mockVideo, fileSize: 1024 * 1024 * 50 };
+      renderWithProviders(<VideoCard {...defaultProps} video={videoWithSize} />);
+      expect(screen.getByText(/50/)).toBeInTheDocument();
+      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+    });
+
+    test('does not render file size when not available', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      const storageIcons = screen.queryAllByTestId('StorageIcon');
+      expect(storageIcons.length).toBe(0);
+    });
+  });
+
+  describe('YouTube Removed Banner', () => {
+    test('shows removed banner when youtube_removed is true', () => {
+      const removedVideo = { ...mockVideo, youtube_removed: true };
+      renderWithProviders(<VideoCard {...defaultProps} video={removedVideo} />);
+      expect(screen.getByText('Removed From YouTube')).toBeInTheDocument();
+    });
+
+    test('does not show removed banner when youtube_removed is false', () => {
+      const notRemovedVideo = { ...mockVideo, youtube_removed: false };
+      renderWithProviders(<VideoCard {...defaultProps} video={notRemovedVideo} />);
+      expect(screen.queryByText('Removed From YouTube')).not.toBeInTheDocument();
+    });
+
+    test('does not show removed banner when youtube_removed is undefined', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.queryByText('Removed From YouTube')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Still Live Videos', () => {
+    test('renders StillLiveDot for videos with live_status is_live', () => {
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+      renderWithProviders(<VideoCard {...defaultProps} video={liveVideo} />);
+      expect(screen.getByTestId('still-live-dot')).toBeInTheDocument();
+    });
+
+    test('renders StillLiveDot for videos with live_status is_upcoming', () => {
+      const upcomingVideo = { ...mockVideo, live_status: 'is_upcoming' };
+      renderWithProviders(<VideoCard {...defaultProps} video={upcomingVideo} />);
+      expect(screen.getByTestId('still-live-dot')).toBeInTheDocument();
+    });
+
+    test('does not render StillLiveDot for videos with live_status was_live', () => {
+      const wasLiveVideo = { ...mockVideo, live_status: 'was_live' };
+      renderWithProviders(<VideoCard {...defaultProps} video={wasLiveVideo} />);
+      expect(screen.queryByTestId('still-live-dot')).not.toBeInTheDocument();
+    });
+
+    test('does not render StillLiveDot for videos with null live_status', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.queryByTestId('still-live-dot')).not.toBeInTheDocument();
+    });
+
+    test('does not render checkbox for still live videos', () => {
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+      renderWithProviders(<VideoCard {...defaultProps} video={liveVideo} />);
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Video Selection (Checkbox)', () => {
+    test('renders checkbox for never downloaded videos', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    });
+
+    test('renders checkbox for missing videos', () => {
+      const missingVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoCard {...defaultProps} video={missingVideo} />);
+      expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    });
+
+    test('does not render checkbox for downloaded videos', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoCard {...defaultProps} video={downloadedVideo} />);
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    test('does not render checkbox for members only videos', () => {
+      const membersOnlyVideo = { ...mockVideo, availability: 'subscriber_only' };
+      renderWithProviders(<VideoCard {...defaultProps} video={membersOnlyVideo} />);
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    test('checkbox is checked when video is in checkedBoxes', () => {
+      renderWithProviders(
+        <VideoCard {...defaultProps} checkedBoxes={['test123']} />
+      );
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toBeChecked();
+    });
+
+    test('checkbox is unchecked when video is not in checkedBoxes', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).not.toBeChecked();
+    });
+
+    test('calls onCheckChange when checkbox is clicked', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoCard {...defaultProps} onCheckChange={onCheckChange} />
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+
+      expect(onCheckChange).toHaveBeenCalledTimes(1);
+      expect(onCheckChange).toHaveBeenCalledWith('test123', true);
+    });
+
+    test('calls onCheckChange with false when checked checkbox is clicked', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoCard
+          {...defaultProps}
+          checkedBoxes={['test123']}
+          onCheckChange={onCheckChange}
+        />
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+
+      expect(onCheckChange).toHaveBeenCalledWith('test123', false);
+    });
+
+    test('checkbox click stops propagation', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoCard {...defaultProps} onCheckChange={onCheckChange} />
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+
+      // Should be called once from checkbox, not from card click
+      expect(onCheckChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Card Click for Selection', () => {
+    test('clicking card toggles selection for selectable videos', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoCard {...defaultProps} onCheckChange={onCheckChange} />
+      );
+
+      const card = screen.getByText('Test Video Title');
+      await user.click(card);
+
+      expect(onCheckChange).toHaveBeenCalledWith('test123', true);
+    });
+
+    test('clicking card does not select downloaded videos', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoCard {...defaultProps} video={downloadedVideo} onCheckChange={onCheckChange} />
+      );
+
+      const card = screen.getByText('Test Video Title');
+      await user.click(card);
+
+      expect(onCheckChange).not.toHaveBeenCalled();
+    });
+
+    test('clicking card does not select still live videos', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+
+      renderWithProviders(
+        <VideoCard {...defaultProps} video={liveVideo} onCheckChange={onCheckChange} />
+      );
+
+      const card = screen.getByText('Test Video Title');
+      await user.click(card);
+
+      expect(onCheckChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Delete Button', () => {
+    test('renders delete button for downloaded videos', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoCard {...defaultProps} video={downloadedVideo} />);
+      expect(screen.getByTestId('DeleteIcon')).toBeInTheDocument();
+    });
+
+    test('does not render delete button for never downloaded videos', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.queryByTestId('DeleteIcon')).not.toBeInTheDocument();
+    });
+
+    test('does not render delete button for missing videos', () => {
+      const missingVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoCard {...defaultProps} video={missingVideo} />);
+      expect(screen.queryByTestId('DeleteIcon')).not.toBeInTheDocument();
+    });
+
+    test('calls onToggleDeletion when delete button is clicked', async () => {
+      const user = userEvent.setup();
+      const onToggleDeletion = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoCard
+          {...defaultProps}
+          video={downloadedVideo}
+          onToggleDeletion={onToggleDeletion}
+        />
+      );
+
+      const deleteButton = screen.getByRole('button');
+      await user.click(deleteButton);
+
+      expect(onToggleDeletion).toHaveBeenCalledTimes(1);
+      expect(onToggleDeletion).toHaveBeenCalledWith('test123');
+    });
+
+    test('delete button click stops propagation', async () => {
+      const user = userEvent.setup();
+      const onToggleDeletion = jest.fn();
+      const onCheckChange = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoCard
+          {...defaultProps}
+          video={downloadedVideo}
+          onToggleDeletion={onToggleDeletion}
+          onCheckChange={onCheckChange}
+        />
+      );
+
+      const deleteButton = screen.getByRole('button');
+      await user.click(deleteButton);
+
+      expect(onToggleDeletion).toHaveBeenCalledTimes(1);
+      expect(onCheckChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Hover Interactions', () => {
+    test('calls onHoverChange when mouse enters card', async () => {
+      const user = userEvent.setup();
+      const onHoverChange = jest.fn();
+
+      const { container } = renderWithProviders(
+        <VideoCard {...defaultProps} onHoverChange={onHoverChange} />
+      );
+
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      const card = container.querySelector('.MuiCard-root');
+      expect(card).toBeTruthy();
+      if (card) {
+        await user.hover(card);
+      }
+      expect(onHoverChange).toHaveBeenCalledWith('test123');
+    });
+
+    test('calls onHoverChange with null when mouse leaves card', async () => {
+      const user = userEvent.setup();
+      const onHoverChange = jest.fn();
+
+      const { container } = renderWithProviders(
+        <VideoCard {...defaultProps} onHoverChange={onHoverChange} />
+      );
+
+      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+      const card = container.querySelector('.MuiCard-root');
+      expect(card).toBeTruthy();
+      if (card) {
+        await user.hover(card);
+        await user.unhover(card);
+      }
+      expect(onHoverChange).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('Mobile Tooltip Callback', () => {
+    test('passes onMobileTooltip to StillLiveDot component', () => {
+      const onMobileTooltip = jest.fn();
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+
+      renderWithProviders(
+        <VideoCard
+          {...defaultProps}
+          video={liveVideo}
+          onMobileTooltip={onMobileTooltip}
+        />
+      );
+
+      expect(screen.getByTestId('still-live-dot')).toBeInTheDocument();
+    });
+  });
+
+  describe('Desktop vs Mobile Layout', () => {
+    test('status chip is inline with date on mobile', () => {
+      renderWithProviders(<VideoCard {...defaultProps} isMobile={true} />);
+      // Both status and date should be visible on mobile
+      expect(screen.getByText('Not Downloaded')).toBeInTheDocument();
+      expect(screen.getByText(/Jan 15/)).toBeInTheDocument();
+    });
+
+    test('status chip is on separate row on desktop', () => {
+      renderWithProviders(<VideoCard {...defaultProps} isMobile={false} />);
+      // Status should be visible on desktop too
+      expect(screen.getByText('Not Downloaded')).toBeInTheDocument();
+      expect(screen.getByText(/1\/15\/2023/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Thumbnail Object Fit', () => {
+    test('uses contain object fit for shorts', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoCard {...defaultProps} video={shortVideo} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveStyle({ objectFit: 'contain' });
+    });
+
+    test('uses cover object fit for regular videos', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveStyle({ objectFit: 'cover' });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('handles video with null duration', () => {
+      const videoNoDuration = { ...mockVideo, duration: 0 };
+      renderWithProviders(<VideoCard {...defaultProps} video={videoNoDuration} />);
+      // Just verify it renders without crashing
+      expect(screen.getByText('Test Video Title')).toBeInTheDocument();
+    });
+
+    test('handles video with long title', () => {
+      const longTitleVideo = {
+        ...mockVideo,
+        title: 'A'.repeat(200),
+      };
+      renderWithProviders(<VideoCard {...defaultProps} video={longTitleVideo} />);
+      expect(screen.getByText('A'.repeat(200))).toBeInTheDocument();
+    });
+
+    test('handles video published in different year', () => {
+      const oldVideo = { ...mockVideo, publishedAt: '2020-12-25T00:00:00Z' };
+      renderWithProviders(<VideoCard {...defaultProps} video={oldVideo} />);
+      expect(screen.getByText(/2020/)).toBeInTheDocument();
+    });
+
+    test('handles video with very large file size', () => {
+      const largeVideo = { ...mockVideo, fileSize: 1024 * 1024 * 1024 * 5.5 };
+      renderWithProviders(<VideoCard {...defaultProps} video={largeVideo} />);
+      // Check for file size presence - look for GB text
+      expect(screen.getByText(/GB/)).toBeInTheDocument();
+      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+    });
+
+    test('handles video in both selectedForDeletion and checkedBoxes', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(
+        <VideoCard
+          {...defaultProps}
+          video={downloadedVideo}
+          selectedForDeletion={['test123']}
+          checkedBoxes={['test123']}
+        />
+      );
+      // Should show delete button since it's downloaded
+      expect(screen.getByTestId('DeleteIcon')).toBeInTheDocument();
+      // Should not show checkbox since it's downloaded
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    test('thumbnail has alt text', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toBeInTheDocument();
+    });
+
+    test('title has title attribute for tooltip', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      const title = screen.getByText('Test Video Title');
+      expect(title).toHaveAttribute('title', 'Test Video Title');
+    });
+
+    test('thumbnail has lazy loading', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveAttribute('loading', 'lazy');
+    });
+  });
+
+  describe('Status Icon Rendering', () => {
+    test('renders CheckCircleIcon for downloaded videos', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoCard {...defaultProps} video={downloadedVideo} />);
+      expect(screen.getByTestId('CheckCircleIcon')).toBeInTheDocument();
+    });
+
+    test('renders CloudOffIcon for missing videos', () => {
+      const missingVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoCard {...defaultProps} video={missingVideo} />);
+      expect(screen.getByTestId('CloudOffIcon')).toBeInTheDocument();
+    });
+
+    test('renders LockIcon for members only videos', () => {
+      const membersOnlyVideo = { ...mockVideo, availability: 'subscriber_only' };
+      renderWithProviders(<VideoCard {...defaultProps} video={membersOnlyVideo} />);
+      expect(screen.getByTestId('LockIcon')).toBeInTheDocument();
+    });
+
+    test('renders NewReleasesIcon for never downloaded videos', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.getByTestId('NewReleasesIcon')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/ChannelPage/__tests__/VideoListItem.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoListItem.test.tsx
@@ -1,0 +1,557 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import VideoListItem from '../VideoListItem';
+import { ChannelVideo } from '../../../types/ChannelVideo';
+import { renderWithProviders } from '../../../test-utils';
+
+// Mock StillLiveDot component
+jest.mock('../StillLiveDot', () => ({
+  __esModule: true,
+  default: function MockStillLiveDot(props: { isMobile?: boolean; onMobileClick?: (message: string) => void }) {
+    const React = require('react');
+    return React.createElement('div', { 'data-testid': 'still-live-dot' }, 'LIVE');
+  }
+}));
+
+describe('VideoListItem Component', () => {
+  const mockVideo: ChannelVideo = {
+    title: 'Test Video Title',
+    youtube_id: 'test123',
+    publishedAt: '2023-01-15T10:30:00Z',
+    thumbnail: 'https://i.ytimg.com/vi/test123/mqdefault.jpg',
+    added: false,
+    duration: 600,
+    media_type: 'video',
+    live_status: null,
+  };
+
+  const defaultProps = {
+    video: mockVideo,
+    checkedBoxes: [],
+    selectedForDeletion: [],
+    onCheckChange: jest.fn(),
+    onToggleDeletion: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    test('renders without crashing', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.getByText('Test Video Title')).toBeInTheDocument();
+    });
+
+    test('renders video thumbnail', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveAttribute('src', 'https://i.ytimg.com/vi/test123/mqdefault.jpg');
+    });
+
+    test('renders video title with HTML decoding', () => {
+      const videoWithEncodedTitle = {
+        ...mockVideo,
+        title: 'Test &amp; Video &quot;Title&quot;',
+      };
+      renderWithProviders(<VideoListItem {...defaultProps} video={videoWithEncodedTitle} />);
+      expect(screen.getByText('Test & Video "Title"')).toBeInTheDocument();
+    });
+
+    test('renders duration chip for regular videos', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      // Duration is 600 seconds = 10 minutes
+      expect(screen.getByText('10m')).toBeInTheDocument();
+    });
+
+    test('does not render duration chip for shorts', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={shortVideo} />);
+      // Verify duration doesn't appear
+      expect(screen.queryByText('10m')).not.toBeInTheDocument();
+    });
+
+    test('renders published date', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.getByText(/Jan 15, 23/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Video Status', () => {
+    test('renders "Not Downloaded" status for never downloaded video', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.getByText('Not Downloaded')).toBeInTheDocument();
+    });
+
+    test('renders "Downloaded" status for downloaded video', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoListItem {...defaultProps} video={downloadedVideo} />);
+      expect(screen.getByText('Downloaded')).toBeInTheDocument();
+    });
+
+    test('renders "Missing" status for removed video', () => {
+      const removedVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoListItem {...defaultProps} video={removedVideo} />);
+      expect(screen.getByText('Missing')).toBeInTheDocument();
+    });
+
+    test('renders "Members Only" status for subscriber-only video', () => {
+      const membersOnlyVideo = { ...mockVideo, availability: 'subscriber_only' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={membersOnlyVideo} />);
+      expect(screen.getByText('Members Only')).toBeInTheDocument();
+    });
+  });
+
+  describe('Media Type Indicators', () => {
+    test('renders short chip for short videos', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={shortVideo} />);
+      expect(screen.getByText('Short')).toBeInTheDocument();
+    });
+
+    test('renders live chip for livestream videos', () => {
+      const livestreamVideo = { ...mockVideo, media_type: 'livestream' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={livestreamVideo} />);
+      expect(screen.getByText('Live')).toBeInTheDocument();
+    });
+
+    test('does not render media type chip for regular videos', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.queryByText('Short')).not.toBeInTheDocument();
+      expect(screen.queryByText('Live')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('File Size Display', () => {
+    test('renders file size when available', () => {
+      const videoWithSize = { ...mockVideo, fileSize: 1024 * 1024 * 50 };
+      renderWithProviders(<VideoListItem {...defaultProps} video={videoWithSize} />);
+      expect(screen.getByText('50MB')).toBeInTheDocument();
+      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+    });
+
+    test('does not render file size when not available', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      const storageIcons = screen.queryAllByTestId('StorageIcon');
+      expect(storageIcons.length).toBe(0);
+    });
+  });
+
+  describe('YouTube Removed Banner', () => {
+    test('shows removed banner when youtube_removed is true', () => {
+      const removedVideo = { ...mockVideo, youtube_removed: true };
+      renderWithProviders(<VideoListItem {...defaultProps} video={removedVideo} />);
+      expect(screen.getByText('Removed From YouTube')).toBeInTheDocument();
+    });
+
+    test('does not show removed banner when youtube_removed is false', () => {
+      const notRemovedVideo = { ...mockVideo, youtube_removed: false };
+      renderWithProviders(<VideoListItem {...defaultProps} video={notRemovedVideo} />);
+      expect(screen.queryByText('Removed From YouTube')).not.toBeInTheDocument();
+    });
+
+    test('does not show removed banner when youtube_removed is undefined', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.queryByText('Removed From YouTube')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Still Live Videos', () => {
+    test('renders StillLiveDot for videos with live_status is_live', () => {
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={liveVideo} />);
+      expect(screen.getByTestId('still-live-dot')).toBeInTheDocument();
+    });
+
+    test('renders StillLiveDot for videos with live_status is_upcoming', () => {
+      const upcomingVideo = { ...mockVideo, live_status: 'is_upcoming' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={upcomingVideo} />);
+      expect(screen.getByTestId('still-live-dot')).toBeInTheDocument();
+    });
+
+    test('does not render StillLiveDot for videos with live_status was_live', () => {
+      const wasLiveVideo = { ...mockVideo, live_status: 'was_live' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={wasLiveVideo} />);
+      expect(screen.queryByTestId('still-live-dot')).not.toBeInTheDocument();
+    });
+
+    test('does not render StillLiveDot for videos with null live_status', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.queryByTestId('still-live-dot')).not.toBeInTheDocument();
+    });
+
+    test('does not render checkbox for still live videos', () => {
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={liveVideo} />);
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    test('passes onMobileTooltip to StillLiveDot component', () => {
+      const onMobileTooltip = jest.fn();
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+
+      renderWithProviders(
+        <VideoListItem
+          {...defaultProps}
+          video={liveVideo}
+          onMobileTooltip={onMobileTooltip}
+        />
+      );
+
+      expect(screen.getByTestId('still-live-dot')).toBeInTheDocument();
+    });
+  });
+
+  describe('Video Selection (Checkbox)', () => {
+    test('renders checkbox for never downloaded videos', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    });
+
+    test('renders checkbox for missing videos', () => {
+      const missingVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoListItem {...defaultProps} video={missingVideo} />);
+      expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    });
+
+    test('does not render checkbox for downloaded videos', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoListItem {...defaultProps} video={downloadedVideo} />);
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    test('does not render checkbox for members only videos', () => {
+      const membersOnlyVideo = { ...mockVideo, availability: 'subscriber_only' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={membersOnlyVideo} />);
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    test('checkbox is checked when video is in checkedBoxes', () => {
+      renderWithProviders(
+        <VideoListItem {...defaultProps} checkedBoxes={['test123']} />
+      );
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toBeChecked();
+    });
+
+    test('checkbox is unchecked when video is not in checkedBoxes', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).not.toBeChecked();
+    });
+
+    test('calls onCheckChange when checkbox is clicked', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoListItem {...defaultProps} onCheckChange={onCheckChange} />
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+
+      expect(onCheckChange).toHaveBeenCalledTimes(1);
+      expect(onCheckChange).toHaveBeenCalledWith('test123', true);
+    });
+
+    test('calls onCheckChange with false when checked checkbox is clicked', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoListItem
+          {...defaultProps}
+          checkedBoxes={['test123']}
+          onCheckChange={onCheckChange}
+        />
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+
+      expect(onCheckChange).toHaveBeenCalledWith('test123', false);
+    });
+
+    test('checkbox click stops propagation', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoListItem {...defaultProps} onCheckChange={onCheckChange} />
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+
+      // Should be called once from checkbox, not from card click
+      expect(onCheckChange).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Card Click for Selection', () => {
+    test('clicking card toggles selection for selectable videos', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoListItem {...defaultProps} onCheckChange={onCheckChange} />
+      );
+
+      const card = screen.getByText('Test Video Title');
+      await user.click(card);
+
+      expect(onCheckChange).toHaveBeenCalledWith('test123', true);
+    });
+
+    test('clicking card does not select downloaded videos', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoListItem {...defaultProps} video={downloadedVideo} onCheckChange={onCheckChange} />
+      );
+
+      const card = screen.getByText('Test Video Title');
+      await user.click(card);
+
+      expect(onCheckChange).not.toHaveBeenCalled();
+    });
+
+    test('clicking card does not select still live videos', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+
+      renderWithProviders(
+        <VideoListItem {...defaultProps} video={liveVideo} onCheckChange={onCheckChange} />
+      );
+
+      const card = screen.getByText('Test Video Title');
+      await user.click(card);
+
+      expect(onCheckChange).not.toHaveBeenCalled();
+    });
+
+    test('clicking card does not select members only videos', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+      const membersOnlyVideo = { ...mockVideo, availability: 'subscriber_only' };
+
+      renderWithProviders(
+        <VideoListItem {...defaultProps} video={membersOnlyVideo} onCheckChange={onCheckChange} />
+      );
+
+      const card = screen.getByText('Test Video Title');
+      await user.click(card);
+
+      expect(onCheckChange).not.toHaveBeenCalled();
+    });
+
+    test('clicking card toggles from checked to unchecked', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoListItem
+          {...defaultProps}
+          checkedBoxes={['test123']}
+          onCheckChange={onCheckChange}
+        />
+      );
+
+      const card = screen.getByText('Test Video Title');
+      await user.click(card);
+
+      expect(onCheckChange).toHaveBeenCalledWith('test123', false);
+    });
+  });
+
+  describe('Delete Button', () => {
+    test('renders delete button for downloaded videos', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoListItem {...defaultProps} video={downloadedVideo} />);
+      expect(screen.getByTestId('DeleteIcon')).toBeInTheDocument();
+    });
+
+    test('does not render delete button for never downloaded videos', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.queryByTestId('DeleteIcon')).not.toBeInTheDocument();
+    });
+
+    test('does not render delete button for missing videos', () => {
+      const missingVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoListItem {...defaultProps} video={missingVideo} />);
+      expect(screen.queryByTestId('DeleteIcon')).not.toBeInTheDocument();
+    });
+
+    test('calls onToggleDeletion when delete button is clicked', async () => {
+      const user = userEvent.setup();
+      const onToggleDeletion = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoListItem
+          {...defaultProps}
+          video={downloadedVideo}
+          onToggleDeletion={onToggleDeletion}
+        />
+      );
+
+      const deleteButton = screen.getByRole('button');
+      await user.click(deleteButton);
+
+      expect(onToggleDeletion).toHaveBeenCalledTimes(1);
+      expect(onToggleDeletion).toHaveBeenCalledWith('test123');
+    });
+
+    test('delete button click stops propagation', async () => {
+      const user = userEvent.setup();
+      const onToggleDeletion = jest.fn();
+      const onCheckChange = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoListItem
+          {...defaultProps}
+          video={downloadedVideo}
+          onToggleDeletion={onToggleDeletion}
+          onCheckChange={onCheckChange}
+        />
+      );
+
+      const deleteButton = screen.getByRole('button');
+      await user.click(deleteButton);
+
+      expect(onToggleDeletion).toHaveBeenCalledTimes(1);
+      expect(onCheckChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Thumbnail Object Fit', () => {
+    test('uses contain object fit for shorts', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={shortVideo} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveStyle({ objectFit: 'contain' });
+    });
+
+    test('uses cover object fit for regular videos', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveStyle({ objectFit: 'cover' });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('handles video with null duration', () => {
+      const videoNoDuration = { ...mockVideo, duration: 0 };
+      renderWithProviders(<VideoListItem {...defaultProps} video={videoNoDuration} />);
+      expect(screen.getByText('Test Video Title')).toBeInTheDocument();
+    });
+
+    test('handles video with long title', () => {
+      const longTitleVideo = {
+        ...mockVideo,
+        title: 'A'.repeat(200),
+      };
+      renderWithProviders(<VideoListItem {...defaultProps} video={longTitleVideo} />);
+      expect(screen.getByText('A'.repeat(200))).toBeInTheDocument();
+    });
+
+    test('handles video published in different year', () => {
+      const oldVideo = { ...mockVideo, publishedAt: '2020-12-25T12:00:00Z' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={oldVideo} />);
+      // Check for date and year (exact date may vary by timezone)
+      expect(screen.getByText(/Dec/)).toBeInTheDocument();
+      expect(screen.getByText(/20/)).toBeInTheDocument();
+    });
+
+    test('handles video with very large file size', () => {
+      const largeVideo = { ...mockVideo, fileSize: 1024 * 1024 * 1024 * 5.5 };
+      renderWithProviders(<VideoListItem {...defaultProps} video={largeVideo} />);
+      expect(screen.getByText('5.5GB')).toBeInTheDocument();
+      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+    });
+
+    test('handles video in both selectedForDeletion and checkedBoxes', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(
+        <VideoListItem
+          {...defaultProps}
+          video={downloadedVideo}
+          selectedForDeletion={['test123']}
+          checkedBoxes={['test123']}
+        />
+      );
+      // Should show delete button since it's downloaded
+      expect(screen.getByTestId('DeleteIcon')).toBeInTheDocument();
+      // Should not show checkbox since it's downloaded
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    test('thumbnail has alt text', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toBeInTheDocument();
+    });
+
+    test('title has title attribute for tooltip', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      const title = screen.getByText('Test Video Title');
+      expect(title).toHaveAttribute('title', 'Test Video Title');
+    });
+
+    test('thumbnail has lazy loading', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveAttribute('loading', 'lazy');
+    });
+
+    test('thumbnail alt text decodes HTML entities', () => {
+      const videoWithEncodedTitle = {
+        ...mockVideo,
+        title: 'Test &amp; Video &lt;Title&gt;',
+      };
+      renderWithProviders(<VideoListItem {...defaultProps} video={videoWithEncodedTitle} />);
+      const img = screen.getByAltText('Test & Video <Title>');
+      expect(img).toBeInTheDocument();
+    });
+  });
+
+  describe('Status Icon Rendering', () => {
+    test('renders CheckCircleIcon for downloaded videos', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoListItem {...defaultProps} video={downloadedVideo} />);
+      expect(screen.getByTestId('CheckCircleIcon')).toBeInTheDocument();
+    });
+
+    test('renders CloudOffIcon for missing videos', () => {
+      const missingVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoListItem {...defaultProps} video={missingVideo} />);
+      expect(screen.getByTestId('CloudOffIcon')).toBeInTheDocument();
+    });
+
+    test('renders LockIcon for members only videos', () => {
+      const membersOnlyVideo = { ...mockVideo, availability: 'subscriber_only' };
+      renderWithProviders(<VideoListItem {...defaultProps} video={membersOnlyVideo} />);
+      expect(screen.getByTestId('LockIcon')).toBeInTheDocument();
+    });
+
+    test('renders NewReleasesIcon for never downloaded videos', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.getByTestId('NewReleasesIcon')).toBeInTheDocument();
+    });
+  });
+
+  describe('Fade Animation', () => {
+    test('renders with fade animation wrapper', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.getByText('Test Video Title')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
@@ -1,0 +1,748 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import VideoTableView from '../VideoTableView';
+import { ChannelVideo } from '../../../types/ChannelVideo';
+import { renderWithProviders } from '../../../test-utils';
+
+// Mock StillLiveDot component
+jest.mock('../StillLiveDot', () => ({
+  __esModule: true,
+  default: function MockStillLiveDot(props: { isMobile?: boolean; onMobileClick?: (message: string) => void }) {
+    const React = require('react');
+    return React.createElement('div', { 'data-testid': 'still-live-dot' }, 'LIVE');
+  }
+}));
+
+describe('VideoTableView Component', () => {
+  const mockVideo: ChannelVideo = {
+    title: 'Test Video Title',
+    youtube_id: 'test123',
+    publishedAt: '2023-01-15T10:30:00Z',
+    thumbnail: 'https://i.ytimg.com/vi/test123/mqdefault.jpg',
+    added: false,
+    duration: 600,
+    fileSize: 1024 * 1024 * 50, // 50MB
+    media_type: 'video',
+    live_status: null,
+  };
+
+  const defaultProps = {
+    videos: [mockVideo],
+    checkedBoxes: [],
+    selectedForDeletion: [],
+    sortBy: 'date' as const,
+    sortOrder: 'desc' as const,
+    onCheckChange: jest.fn(),
+    onSelectAll: jest.fn(),
+    onClearSelection: jest.fn(),
+    onSortChange: jest.fn(),
+    onToggleDeletion: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    test('renders without crashing', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.getByText('Test Video Title')).toBeInTheDocument();
+    });
+
+    test('renders table headers', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.getByText('Thumbnail')).toBeInTheDocument();
+      expect(screen.getByText('Title')).toBeInTheDocument();
+      expect(screen.getByText('Published')).toBeInTheDocument();
+      expect(screen.getByText('Duration')).toBeInTheDocument();
+      expect(screen.getByText('Size')).toBeInTheDocument();
+      expect(screen.getByText('Status')).toBeInTheDocument();
+    });
+
+    test('renders empty table when no videos', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[]} />);
+      expect(screen.queryByText('Test Video Title')).not.toBeInTheDocument();
+    });
+
+    test('renders multiple videos', () => {
+      const videos = [
+        mockVideo,
+        { ...mockVideo, youtube_id: 'test456', title: 'Second Video' },
+        { ...mockVideo, youtube_id: 'test789', title: 'Third Video' },
+      ];
+      renderWithProviders(<VideoTableView {...defaultProps} videos={videos} />);
+      expect(screen.getByText('Test Video Title')).toBeInTheDocument();
+      expect(screen.getByText('Second Video')).toBeInTheDocument();
+      expect(screen.getByText('Third Video')).toBeInTheDocument();
+    });
+  });
+
+  describe('Video Data Display', () => {
+    test('renders video thumbnail', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveAttribute('src', 'https://i.ytimg.com/vi/test123/mqdefault.jpg');
+    });
+
+    test('renders video title with HTML decoding', () => {
+      const videoWithEncodedTitle = {
+        ...mockVideo,
+        title: 'Test &amp; Video &quot;Title&quot;',
+      };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[videoWithEncodedTitle]} />);
+      expect(screen.getByText('Test & Video "Title"')).toBeInTheDocument();
+    });
+
+    test('renders published date', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.getByText(/1\/15\/2023/)).toBeInTheDocument();
+    });
+
+    test('renders duration for regular videos', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      // Duration is 600 seconds = 10 minutes
+      expect(screen.getByText('10m')).toBeInTheDocument();
+    });
+
+    test('renders N/A for short videos duration', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[shortVideo]} />);
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+    });
+
+    test('renders file size when available', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.getByText(/50/)).toBeInTheDocument();
+    });
+
+    test('renders dash when file size is not available', () => {
+      const videoNoSize = { ...mockVideo, fileSize: undefined };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[videoNoSize]} />);
+      expect(screen.getByText('-')).toBeInTheDocument();
+    });
+  });
+
+  describe('Video Status', () => {
+    test('renders "Not Downloaded" status for never downloaded video', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.getByText('Not Downloaded')).toBeInTheDocument();
+    });
+
+    test('renders "Downloaded" status for downloaded video', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[downloadedVideo]} />);
+      expect(screen.getByText('Downloaded')).toBeInTheDocument();
+    });
+
+    test('renders "Missing" status for removed video', () => {
+      const removedVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[removedVideo]} />);
+      expect(screen.getByText('Missing')).toBeInTheDocument();
+    });
+
+    test('renders "Members Only" status for subscriber-only video', () => {
+      const membersOnlyVideo = { ...mockVideo, availability: 'subscriber_only' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[membersOnlyVideo]} />);
+      expect(screen.getByText('Members Only')).toBeInTheDocument();
+    });
+  });
+
+  describe('Media Type Indicators', () => {
+    test('renders short chip for short videos', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[shortVideo]} />);
+      expect(screen.getByText('Short')).toBeInTheDocument();
+    });
+
+    test('renders live chip for livestream videos', () => {
+      const livestreamVideo = { ...mockVideo, media_type: 'livestream' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[livestreamVideo]} />);
+      expect(screen.getByText('Live')).toBeInTheDocument();
+    });
+
+    test('does not render media type chip for regular videos', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.queryByText('Short')).not.toBeInTheDocument();
+      expect(screen.queryByText('Live')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('YouTube Removed Banner', () => {
+    test('shows removed banner when youtube_removed is true', () => {
+      const removedVideo = { ...mockVideo, youtube_removed: true };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[removedVideo]} />);
+      expect(screen.getByText('Removed From YouTube')).toBeInTheDocument();
+    });
+
+    test('does not show removed banner when youtube_removed is false', () => {
+      const notRemovedVideo = { ...mockVideo, youtube_removed: false };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[notRemovedVideo]} />);
+      expect(screen.queryByText('Removed From YouTube')).not.toBeInTheDocument();
+    });
+
+    test('does not show removed banner when youtube_removed is undefined', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.queryByText('Removed From YouTube')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Still Live Videos', () => {
+    test('renders StillLiveDot for videos with live_status is_live', () => {
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[liveVideo]} />);
+      expect(screen.getByTestId('still-live-dot')).toBeInTheDocument();
+    });
+
+    test('renders StillLiveDot for videos with live_status is_upcoming', () => {
+      const upcomingVideo = { ...mockVideo, live_status: 'is_upcoming' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[upcomingVideo]} />);
+      expect(screen.getByTestId('still-live-dot')).toBeInTheDocument();
+    });
+
+    test('does not render StillLiveDot for videos with live_status was_live', () => {
+      const wasLiveVideo = { ...mockVideo, live_status: 'was_live' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[wasLiveVideo]} />);
+      expect(screen.queryByTestId('still-live-dot')).not.toBeInTheDocument();
+    });
+
+    test('does not render StillLiveDot for videos with null live_status', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.queryByTestId('still-live-dot')).not.toBeInTheDocument();
+    });
+
+    test('does not render checkbox for still live videos', () => {
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[liveVideo]} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      // Only the header checkbox should be present
+      expect(checkboxes).toHaveLength(1);
+    });
+
+    test('passes onMobileTooltip to StillLiveDot component', () => {
+      const onMobileTooltip = jest.fn();
+      const liveVideo = { ...mockVideo, live_status: 'is_live' };
+
+      renderWithProviders(
+        <VideoTableView
+          {...defaultProps}
+          videos={[liveVideo]}
+          onMobileTooltip={onMobileTooltip}
+        />
+      );
+
+      expect(screen.getByTestId('still-live-dot')).toBeInTheDocument();
+    });
+  });
+
+  describe('Header Checkbox', () => {
+    test('renders header checkbox', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes.length).toBeGreaterThan(0);
+    });
+
+    test('header checkbox is checked when all videos are selected', () => {
+      renderWithProviders(
+        <VideoTableView {...defaultProps} checkedBoxes={['test123']} />
+      );
+      const checkboxes = screen.getAllByRole('checkbox');
+      const headerCheckbox = checkboxes[0];
+      expect(headerCheckbox).toBeChecked();
+    });
+
+    test('header checkbox is unchecked when no videos are selected', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      const headerCheckbox = checkboxes[0];
+      expect(headerCheckbox).not.toBeChecked();
+    });
+
+    test('header checkbox is indeterminate when some videos are selected', () => {
+      const videos = [
+        mockVideo,
+        { ...mockVideo, youtube_id: 'test456', title: 'Second Video' },
+      ];
+      renderWithProviders(
+        <VideoTableView {...defaultProps} videos={videos} checkedBoxes={['test123']} />
+      );
+      const checkboxes = screen.getAllByRole('checkbox');
+      const headerCheckbox = checkboxes[0];
+      // Testing for indeterminate state
+      expect(headerCheckbox).toHaveAttribute('data-indeterminate', 'true');
+    });
+
+    test('header checkbox is unchecked when videos array is empty', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[]} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      const headerCheckbox = checkboxes[0];
+      expect(headerCheckbox).not.toBeChecked();
+    });
+
+    test('calls onSelectAll when header checkbox is clicked while unchecked', async () => {
+      const user = userEvent.setup();
+      const onSelectAll = jest.fn();
+
+      renderWithProviders(
+        <VideoTableView {...defaultProps} onSelectAll={onSelectAll} />
+      );
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      const headerCheckbox = checkboxes[0];
+      await user.click(headerCheckbox);
+
+      expect(onSelectAll).toHaveBeenCalledTimes(1);
+    });
+
+    test('calls onClearSelection when header checkbox is clicked while checked', async () => {
+      const user = userEvent.setup();
+      const onClearSelection = jest.fn();
+
+      renderWithProviders(
+        <VideoTableView
+          {...defaultProps}
+          checkedBoxes={['test123']}
+          onClearSelection={onClearSelection}
+        />
+      );
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      const headerCheckbox = checkboxes[0];
+      await user.click(headerCheckbox);
+
+      expect(onClearSelection).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Video Row Checkbox', () => {
+    test('renders checkbox for never downloaded videos', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      // Header + 1 video checkbox
+      expect(checkboxes).toHaveLength(2);
+    });
+
+    test('renders checkbox for missing videos', () => {
+      const missingVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[missingVideo]} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      // Header + 1 video checkbox
+      expect(checkboxes).toHaveLength(2);
+    });
+
+    test('does not render checkbox for downloaded videos', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[downloadedVideo]} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      // Only header checkbox
+      expect(checkboxes).toHaveLength(1);
+    });
+
+    test('does not render checkbox for members only videos', () => {
+      const membersOnlyVideo = { ...mockVideo, availability: 'subscriber_only' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[membersOnlyVideo]} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      // Only header checkbox
+      expect(checkboxes).toHaveLength(1);
+    });
+
+    test('does not render checkbox for youtube removed videos', () => {
+      const removedVideo = { ...mockVideo, youtube_removed: true };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[removedVideo]} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      // Only header checkbox
+      expect(checkboxes).toHaveLength(1);
+    });
+
+    test('checkbox is checked when video is in checkedBoxes', () => {
+      renderWithProviders(
+        <VideoTableView {...defaultProps} checkedBoxes={['test123']} />
+      );
+      const checkboxes = screen.getAllByRole('checkbox');
+      const videoCheckbox = checkboxes[1]; // Second checkbox (first is header)
+      expect(videoCheckbox).toBeChecked();
+    });
+
+    test('checkbox is unchecked when video is not in checkedBoxes', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      const checkboxes = screen.getAllByRole('checkbox');
+      const videoCheckbox = checkboxes[1]; // Second checkbox (first is header)
+      expect(videoCheckbox).not.toBeChecked();
+    });
+
+    test('calls onCheckChange when checkbox is clicked', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoTableView {...defaultProps} onCheckChange={onCheckChange} />
+      );
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      const videoCheckbox = checkboxes[1]; // Second checkbox (first is header)
+      await user.click(videoCheckbox);
+
+      expect(onCheckChange).toHaveBeenCalledTimes(1);
+      expect(onCheckChange).toHaveBeenCalledWith('test123', true);
+    });
+
+    test('calls onCheckChange with false when checked checkbox is clicked', async () => {
+      const user = userEvent.setup();
+      const onCheckChange = jest.fn();
+
+      renderWithProviders(
+        <VideoTableView
+          {...defaultProps}
+          checkedBoxes={['test123']}
+          onCheckChange={onCheckChange}
+        />
+      );
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      const videoCheckbox = checkboxes[1]; // Second checkbox (first is header)
+      await user.click(videoCheckbox);
+
+      expect(onCheckChange).toHaveBeenCalledWith('test123', false);
+    });
+  });
+
+  describe('Delete Button', () => {
+    test('renders delete button for downloaded videos', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[downloadedVideo]} />);
+      expect(screen.getByTestId('DeleteIcon')).toBeInTheDocument();
+    });
+
+    test('does not render delete button for never downloaded videos', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.queryByTestId('DeleteIcon')).not.toBeInTheDocument();
+    });
+
+    test('does not render delete button for missing videos', () => {
+      const missingVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[missingVideo]} />);
+      expect(screen.queryByTestId('DeleteIcon')).not.toBeInTheDocument();
+    });
+
+    test('calls onToggleDeletion when delete button is clicked', async () => {
+      const user = userEvent.setup();
+      const onToggleDeletion = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoTableView
+          {...defaultProps}
+          videos={[downloadedVideo]}
+          onToggleDeletion={onToggleDeletion}
+        />
+      );
+
+      const deleteButton = screen.getByRole('button');
+      await user.click(deleteButton);
+
+      expect(onToggleDeletion).toHaveBeenCalledTimes(1);
+      expect(onToggleDeletion).toHaveBeenCalledWith('test123');
+    });
+
+    test('delete button click stops propagation', async () => {
+      const user = userEvent.setup();
+      const onToggleDeletion = jest.fn();
+      const onCheckChange = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoTableView
+          {...defaultProps}
+          videos={[downloadedVideo]}
+          onToggleDeletion={onToggleDeletion}
+          onCheckChange={onCheckChange}
+        />
+      );
+
+      const deleteButton = screen.getByRole('button');
+      await user.click(deleteButton);
+
+      expect(onToggleDeletion).toHaveBeenCalledTimes(1);
+      expect(onCheckChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Sorting', () => {
+    test('displays sort indicator for title when sorted by title ascending', () => {
+      renderWithProviders(
+        <VideoTableView {...defaultProps} sortBy="title" sortOrder="asc" />
+      );
+      expect(screen.getByTestId('ArrowUpwardIcon')).toBeInTheDocument();
+    });
+
+    test('displays sort indicator for title when sorted by title descending', () => {
+      renderWithProviders(
+        <VideoTableView {...defaultProps} sortBy="title" sortOrder="desc" />
+      );
+      expect(screen.getByTestId('ArrowDownwardIcon')).toBeInTheDocument();
+    });
+
+    test('displays sort indicator for date when sorted by date ascending', () => {
+      renderWithProviders(
+        <VideoTableView {...defaultProps} sortBy="date" sortOrder="asc" />
+      );
+      expect(screen.getByTestId('ArrowUpwardIcon')).toBeInTheDocument();
+    });
+
+    test('displays sort indicator for date when sorted by date descending', () => {
+      renderWithProviders(
+        <VideoTableView {...defaultProps} sortBy="date" sortOrder="desc" />
+      );
+      expect(screen.getByTestId('ArrowDownwardIcon')).toBeInTheDocument();
+    });
+
+    test('displays sort indicator for duration when sorted by duration', () => {
+      renderWithProviders(
+        <VideoTableView {...defaultProps} sortBy="duration" sortOrder="asc" />
+      );
+      expect(screen.getByTestId('ArrowUpwardIcon')).toBeInTheDocument();
+    });
+
+    test('displays sort indicator for size when sorted by size', () => {
+      renderWithProviders(
+        <VideoTableView {...defaultProps} sortBy="size" sortOrder="desc" />
+      );
+      expect(screen.getByTestId('ArrowDownwardIcon')).toBeInTheDocument();
+    });
+
+    test('calls onSortChange when title header is clicked', async () => {
+      const user = userEvent.setup();
+      const onSortChange = jest.fn();
+
+      renderWithProviders(
+        <VideoTableView {...defaultProps} onSortChange={onSortChange} />
+      );
+
+      const titleHeader = screen.getByText('Title');
+      await user.click(titleHeader);
+
+      expect(onSortChange).toHaveBeenCalledWith('title');
+    });
+
+    test('calls onSortChange when published header is clicked', async () => {
+      const user = userEvent.setup();
+      const onSortChange = jest.fn();
+
+      renderWithProviders(
+        <VideoTableView {...defaultProps} onSortChange={onSortChange} />
+      );
+
+      const publishedHeader = screen.getByText('Published');
+      await user.click(publishedHeader);
+
+      expect(onSortChange).toHaveBeenCalledWith('date');
+    });
+
+    test('calls onSortChange when duration header is clicked', async () => {
+      const user = userEvent.setup();
+      const onSortChange = jest.fn();
+
+      renderWithProviders(
+        <VideoTableView {...defaultProps} onSortChange={onSortChange} />
+      );
+
+      const durationHeader = screen.getByText('Duration');
+      await user.click(durationHeader);
+
+      expect(onSortChange).toHaveBeenCalledWith('duration');
+    });
+
+    test('calls onSortChange when size header is clicked', async () => {
+      const user = userEvent.setup();
+      const onSortChange = jest.fn();
+
+      renderWithProviders(
+        <VideoTableView {...defaultProps} onSortChange={onSortChange} />
+      );
+
+      const sizeHeader = screen.getByText('Size');
+      await user.click(sizeHeader);
+
+      expect(onSortChange).toHaveBeenCalledWith('size');
+    });
+  });
+
+  describe('Thumbnail Object Fit', () => {
+    test('uses contain object fit for shorts', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[shortVideo]} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveStyle({ objectFit: 'contain' });
+    });
+
+    test('uses cover object fit for regular videos', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveStyle({ objectFit: 'cover' });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('handles video with null duration', () => {
+      const videoNoDuration = { ...mockVideo, duration: 0 };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[videoNoDuration]} />);
+      expect(screen.getByText('Test Video Title')).toBeInTheDocument();
+    });
+
+    test('handles video with long title', () => {
+      const longTitleVideo = {
+        ...mockVideo,
+        title: 'A'.repeat(200),
+      };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[longTitleVideo]} />);
+      expect(screen.getByText('A'.repeat(200))).toBeInTheDocument();
+    });
+
+    test('handles video published in different year', () => {
+      const oldVideo = { ...mockVideo, publishedAt: '2020-12-25T00:00:00Z' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[oldVideo]} />);
+      expect(screen.getByText(/2020/)).toBeInTheDocument();
+    });
+
+    test('handles video with very large file size', () => {
+      const largeVideo = { ...mockVideo, fileSize: 1024 * 1024 * 1024 * 5.5 };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[largeVideo]} />);
+      expect(screen.getByText(/GB/)).toBeInTheDocument();
+    });
+
+    test('handles video in both selectedForDeletion and checkedBoxes', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(
+        <VideoTableView
+          {...defaultProps}
+          videos={[downloadedVideo]}
+          selectedForDeletion={['test123']}
+          checkedBoxes={['test123']}
+        />
+      );
+      // Should show delete button since it's downloaded
+      expect(screen.getByTestId('DeleteIcon')).toBeInTheDocument();
+      // Should not show video checkbox since it's downloaded (only header checkbox)
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    test('thumbnail has alt text', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toBeInTheDocument();
+    });
+
+    test('thumbnail has lazy loading', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      const img = screen.getByAltText('Test Video Title');
+      expect(img).toHaveAttribute('loading', 'lazy');
+    });
+
+    test('thumbnail alt text decodes HTML entities', () => {
+      const videoWithEncodedTitle = {
+        ...mockVideo,
+        title: 'Test &amp; Video &lt;Title&gt;',
+      };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[videoWithEncodedTitle]} />);
+      const img = screen.getByAltText('Test & Video <Title>');
+      expect(img).toBeInTheDocument();
+    });
+  });
+
+  describe('Status Icon Rendering', () => {
+    test('renders CheckCircleIcon for downloaded videos', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[downloadedVideo]} />);
+      expect(screen.getByTestId('CheckCircleIcon')).toBeInTheDocument();
+    });
+
+    test('renders CloudOffIcon for missing videos', () => {
+      const missingVideo = { ...mockVideo, added: true, removed: true };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[missingVideo]} />);
+      expect(screen.getByTestId('CloudOffIcon')).toBeInTheDocument();
+    });
+
+    test('renders LockIcon for members only videos', () => {
+      const membersOnlyVideo = { ...mockVideo, availability: 'subscriber_only' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[membersOnlyVideo]} />);
+      expect(screen.getByTestId('LockIcon')).toBeInTheDocument();
+    });
+
+    test('renders NewReleasesIcon for never downloaded videos', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.getByTestId('NewReleasesIcon')).toBeInTheDocument();
+    });
+  });
+
+  describe('Table Structure', () => {
+    test('renders table with correct structure', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      const table = screen.getByRole('table');
+      expect(table).toBeInTheDocument();
+    });
+
+    test('renders table head with correct number of columns', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      const headerCells = screen.getAllByRole('columnheader');
+      // Checkbox, Thumbnail, Title, Published, Duration, Size, Status
+      expect(headerCells).toHaveLength(7);
+    });
+
+    test('renders table rows for each video', () => {
+      const videos = [
+        mockVideo,
+        { ...mockVideo, youtube_id: 'test456', title: 'Second Video' },
+      ];
+      renderWithProviders(<VideoTableView {...defaultProps} videos={videos} />);
+      const rows = screen.getAllByRole('row');
+      // Header row + 2 video rows
+      expect(rows).toHaveLength(3);
+    });
+  });
+
+  describe('Multiple Videos Selection', () => {
+    test('handles selection of multiple videos', () => {
+      const videos = [
+        mockVideo,
+        { ...mockVideo, youtube_id: 'test456', title: 'Second Video' },
+        { ...mockVideo, youtube_id: 'test789', title: 'Third Video' },
+      ];
+      renderWithProviders(
+        <VideoTableView
+          {...defaultProps}
+          videos={videos}
+          checkedBoxes={['test123', 'test789']}
+        />
+      );
+      const checkboxes = screen.getAllByRole('checkbox');
+      // Header checkbox should be indeterminate
+      expect(checkboxes[0]).toHaveAttribute('data-indeterminate', 'true');
+      // First and third video checkboxes should be checked
+      expect(checkboxes[1]).toBeChecked();
+      expect(checkboxes[2]).not.toBeChecked();
+      expect(checkboxes[3]).toBeChecked();
+    });
+
+    test('handles all videos selected', () => {
+      const videos = [
+        mockVideo,
+        { ...mockVideo, youtube_id: 'test456', title: 'Second Video' },
+      ];
+      renderWithProviders(
+        <VideoTableView
+          {...defaultProps}
+          videos={videos}
+          checkedBoxes={['test123', 'test456']}
+        />
+      );
+      const checkboxes = screen.getAllByRole('checkbox');
+      // All checkboxes should be checked
+      expect(checkboxes[0]).toBeChecked();
+      expect(checkboxes[1]).toBeChecked();
+      expect(checkboxes[2]).toBeChecked();
+    });
+  });
+});

--- a/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
@@ -99,6 +99,25 @@ describe('VideoTableView Component', () => {
       expect(screen.getByText(/1\/15\/2023/)).toBeInTheDocument();
     });
 
+    test('renders N/A for published date when video is a short', () => {
+      const shortVideo = { ...mockVideo, media_type: 'short' };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[shortVideo]} />);
+      const allNAs = screen.getAllByText('N/A');
+      expect(allNAs.length).toBeGreaterThan(0);
+    });
+
+    test('renders N/A for published date when publishedAt is null', () => {
+      const videoNoDate = { ...mockVideo, publishedAt: null };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[videoNoDate]} />);
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+    });
+
+    test('renders N/A for published date when publishedAt is undefined', () => {
+      const videoNoDate = { ...mockVideo, publishedAt: undefined };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[videoNoDate]} />);
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+    });
+
     test('renders duration for regular videos', () => {
       renderWithProviders(<VideoTableView {...defaultProps} />);
       // Duration is 600 seconds = 10 minutes
@@ -108,7 +127,9 @@ describe('VideoTableView Component', () => {
     test('renders N/A for short videos duration', () => {
       const shortVideo = { ...mockVideo, media_type: 'short' };
       renderWithProviders(<VideoTableView {...defaultProps} videos={[shortVideo]} />);
-      expect(screen.getByText('N/A')).toBeInTheDocument();
+      const allNAs = screen.getAllByText('N/A');
+      // Shorts should have N/A for both published date and duration
+      expect(allNAs.length).toBeGreaterThanOrEqual(2);
     });
 
     test('renders file size when available', () => {

--- a/client/src/components/ChannelPage/hooks/__tests__/useChannelVideos.test.ts
+++ b/client/src/components/ChannelPage/hooks/__tests__/useChannelVideos.test.ts
@@ -1,0 +1,737 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useChannelVideos } from '../useChannelVideos';
+import { ChannelVideo } from '../../../../types/ChannelVideo';
+
+// Mock fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+describe('useChannelVideos', () => {
+  const mockToken = 'test-token-123';
+  const mockChannelId = 'UC123456789';
+
+  const defaultParams = {
+    channelId: mockChannelId,
+    page: 1,
+    pageSize: 16,
+    hideDownloaded: false,
+    searchQuery: '',
+    sortBy: 'date',
+    sortOrder: 'desc',
+    tabType: 'videos',
+    token: mockToken,
+  };
+
+  const mockVideos: ChannelVideo[] = [
+    {
+      title: 'Test Video 1',
+      youtube_id: 'video1',
+      publishedAt: '2023-01-01T00:00:00Z',
+      thumbnail: 'https://i.ytimg.com/vi/video1/mqdefault.jpg',
+      added: false,
+      duration: 300,
+      media_type: 'video',
+      live_status: null,
+    },
+    {
+      title: 'Test Video 2',
+      youtube_id: 'video2',
+      publishedAt: '2023-01-02T00:00:00Z',
+      thumbnail: 'https://i.ytimg.com/vi/video2/mqdefault.jpg',
+      added: true,
+      removed: false,
+      duration: 600,
+      media_type: 'video',
+      live_status: null,
+    },
+  ];
+
+  const mockResponse = {
+    videos: mockVideos,
+    totalCount: 2,
+    oldestVideoDate: '2023-01-01T00:00:00Z',
+    videoFail: false,
+    autoDownloadsEnabled: true,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  describe('Initial State', () => {
+    test('returns default state values before fetch completes', () => {
+      mockFetch.mockImplementation(() => new Promise(() => {})); // Never resolves
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      expect(result.current.videos).toEqual([]);
+      expect(result.current.totalCount).toBe(0);
+      expect(result.current.oldestVideoDate).toBeNull();
+      expect(result.current.videoFailed).toBe(false);
+      expect(result.current.loading).toBe(true);
+      expect(result.current.error).toBeNull();
+      expect(result.current.autoDownloadsEnabled).toBe(false);
+      expect(typeof result.current.refetch).toBe('function');
+    });
+  });
+
+  describe('Successful Data Fetching', () => {
+    test('fetches and returns channel videos successfully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.videos).toEqual(mockVideos);
+      expect(result.current.totalCount).toBe(2);
+      expect(result.current.oldestVideoDate).toBe('2023-01-01T00:00:00Z');
+      expect(result.current.videoFailed).toBe(false);
+      expect(result.current.autoDownloadsEnabled).toBe(true);
+      expect(result.current.error).toBeNull();
+    });
+
+    test('constructs correct API URL with query parameters', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      renderHook(() =>
+        useChannelVideos({
+          ...defaultParams,
+          page: 2,
+          pageSize: 8,
+          hideDownloaded: true,
+          searchQuery: 'test query',
+          sortBy: 'title',
+          sortOrder: 'asc',
+          tabType: 'shorts',
+        })
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      const callArgs = mockFetch.mock.calls[0];
+      const url = callArgs[0];
+
+      expect(url).toContain(`/getchannelvideos/${mockChannelId}`);
+      expect(url).toContain('page=2');
+      expect(url).toContain('pageSize=8');
+      expect(url).toContain('hideDownloaded=true');
+      expect(url).toContain('searchQuery=test+query');
+      expect(url).toContain('sortBy=title');
+      expect(url).toContain('sortOrder=asc');
+      expect(url).toContain('tabType=shorts');
+    });
+
+    test('includes correct authentication header', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: {
+            'x-access-token': mockToken,
+          },
+        })
+      );
+    });
+
+    test('handles empty videos array', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          videos: [],
+          totalCount: 0,
+          oldestVideoDate: null,
+          videoFail: false,
+          autoDownloadsEnabled: false,
+        }),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.videos).toEqual([]);
+      expect(result.current.totalCount).toBe(0);
+      expect(result.current.oldestVideoDate).toBeNull();
+    });
+
+    test('handles undefined videos in response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          totalCount: 0,
+          videoFail: false,
+        }),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Should not update videos when undefined
+      expect(result.current.videos).toEqual([]);
+    });
+
+    test('handles null videos in response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          videos: null,
+          totalCount: 0,
+          videoFail: false,
+        }),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.videos).toEqual([]);
+    });
+
+    test('handles missing optional fields in response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          videos: mockVideos,
+        }),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.videos).toEqual(mockVideos);
+      expect(result.current.totalCount).toBe(0);
+      expect(result.current.oldestVideoDate).toBeNull();
+      expect(result.current.videoFailed).toBe(false);
+      expect(result.current.autoDownloadsEnabled).toBe(false);
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('handles network errors', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const networkError = new Error('Network error');
+
+      mockFetch.mockRejectedValueOnce(networkError);
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toEqual(networkError);
+      expect(result.current.videos).toEqual([]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error fetching channel videos:',
+        networkError
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('handles non-ok response status', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Not Found',
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('Not Found');
+      expect(result.current.videos).toEqual([]);
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('handles non-Error exceptions', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockFetch.mockRejectedValueOnce('string error');
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('Unknown error');
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('clears previous error on successful refetch', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      // First call fails
+      mockFetch.mockRejectedValueOnce(new Error('First error'));
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
+
+      // Second call succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      await result.current.refetch();
+
+      await waitFor(() => {
+        expect(result.current.error).toBeNull();
+      });
+
+      expect(result.current.videos).toEqual(mockVideos);
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('Conditional Fetching', () => {
+    test('does not fetch when channelId is undefined', () => {
+      renderHook(() =>
+        useChannelVideos({
+          ...defaultParams,
+          channelId: undefined,
+        })
+      );
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test('does not fetch when token is null', () => {
+      renderHook(() =>
+        useChannelVideos({
+          ...defaultParams,
+          token: null,
+        })
+      );
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test('does not fetch when both channelId and token are missing', () => {
+      renderHook(() =>
+        useChannelVideos({
+          ...defaultParams,
+          channelId: undefined,
+          token: null,
+        })
+      );
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Refetch Functionality', () => {
+    test('refetch triggers a new fetch request', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      await result.current.refetch();
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    test('refetch sets loading state', async () => {
+      let resolvePromise: (value: any) => void;
+      const promise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      mockFetch.mockReturnValueOnce(promise);
+
+      const refetchPromise = result.current.refetch();
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(true);
+      });
+
+      resolvePromise!({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      await refetchPromise;
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+    });
+  });
+
+  describe('Dependency Changes', () => {
+    test('refetches when page changes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const { rerender } = renderHook(
+        ({ params }) => useChannelVideos(params),
+        {
+          initialProps: { params: defaultParams },
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ params: { ...defaultParams, page: 2 } });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    test('refetches when pageSize changes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const { rerender } = renderHook(
+        ({ params }) => useChannelVideos(params),
+        {
+          initialProps: { params: defaultParams },
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ params: { ...defaultParams, pageSize: 8 } });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    test('refetches when hideDownloaded changes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const { rerender } = renderHook(
+        ({ params }) => useChannelVideos(params),
+        {
+          initialProps: { params: defaultParams },
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ params: { ...defaultParams, hideDownloaded: true } });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    test('refetches when searchQuery changes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const { rerender } = renderHook(
+        ({ params }) => useChannelVideos(params),
+        {
+          initialProps: { params: defaultParams },
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ params: { ...defaultParams, searchQuery: 'test' } });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    test('refetches when sortBy changes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const { rerender } = renderHook(
+        ({ params }) => useChannelVideos(params),
+        {
+          initialProps: { params: defaultParams },
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ params: { ...defaultParams, sortBy: 'title' } });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    test('refetches when sortOrder changes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const { rerender } = renderHook(
+        ({ params }) => useChannelVideos(params),
+        {
+          initialProps: { params: defaultParams },
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ params: { ...defaultParams, sortOrder: 'asc' } });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    test('refetches when tabType changes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const { rerender } = renderHook(
+        ({ params }) => useChannelVideos(params),
+        {
+          initialProps: { params: defaultParams },
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ params: { ...defaultParams, tabType: 'shorts' } });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    test('refetches when channelId changes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const { rerender } = renderHook(
+        ({ params }) => useChannelVideos(params),
+        {
+          initialProps: { params: defaultParams },
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ params: { ...defaultParams, channelId: 'UC987654321' } });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    test('refetches when token changes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const { rerender } = renderHook(
+        ({ params }) => useChannelVideos(params),
+        {
+          initialProps: { params: defaultParams },
+        }
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      rerender({ params: { ...defaultParams, token: 'new-token' } });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('Loading State Management', () => {
+    test('sets loading to true during fetch', async () => {
+      let resolvePromise: (value: any) => void;
+      const promise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      mockFetch.mockReturnValueOnce(promise);
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      expect(result.current.loading).toBe(true);
+
+      resolvePromise!({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+    });
+
+    test('sets loading to false after successful fetch', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.videos).toEqual(mockVideos);
+    });
+
+    test('sets loading to false after failed fetch', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockFetch.mockRejectedValueOnce(new Error('Fetch error'));
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBeTruthy();
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('VideoFailed Flag', () => {
+    test('sets videoFailed to true when response indicates failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          ...mockResponse,
+          videoFail: true,
+        }),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.videoFailed).toBe(true);
+    });
+
+    test('sets videoFailed to false when not in response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          videos: mockVideos,
+        }),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.videoFailed).toBe(false);
+    });
+  });
+});

--- a/client/src/components/ChannelPage/hooks/__tests__/useRefreshChannelVideos.test.ts
+++ b/client/src/components/ChannelPage/hooks/__tests__/useRefreshChannelVideos.test.ts
@@ -1,0 +1,630 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useRefreshChannelVideos } from '../useRefreshChannelVideos';
+import { ChannelVideo } from '../../../../types/ChannelVideo';
+
+// Mock fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+describe('useRefreshChannelVideos', () => {
+  const mockToken = 'test-token-123';
+  const mockChannelId = 'UC123456789';
+
+  const mockVideos: ChannelVideo[] = [
+    {
+      title: 'Test Video 1',
+      youtube_id: 'video1',
+      publishedAt: '2023-01-01T00:00:00Z',
+      thumbnail: 'https://i.ytimg.com/vi/video1/mqdefault.jpg',
+      added: false,
+      duration: 300,
+      media_type: 'video',
+      live_status: null,
+    },
+    {
+      title: 'Test Video 2',
+      youtube_id: 'video2',
+      publishedAt: '2023-01-02T00:00:00Z',
+      thumbnail: 'https://i.ytimg.com/vi/video2/mqdefault.jpg',
+      added: true,
+      removed: false,
+      duration: 600,
+      media_type: 'video',
+      live_status: null,
+    },
+  ];
+
+  const mockSuccessResponse = {
+    success: true,
+    videos: mockVideos,
+    totalCount: 2,
+    oldestVideoDate: '2023-01-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  describe('Initial State', () => {
+    test('returns default state values on initialization', () => {
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(typeof result.current.refreshVideos).toBe('function');
+      expect(typeof result.current.clearError).toBe('function');
+    });
+  });
+
+  describe('Successful Refresh', () => {
+    test('successfully refreshes channel videos', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockSuccessResponse),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toEqual({
+        videos: mockVideos,
+        totalCount: 2,
+        oldestVideoDate: '2023-01-01T00:00:00Z',
+      });
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    test('constructs correct API URL with query parameters', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockSuccessResponse),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 2, 8, true, 'shorts', mockToken)
+      );
+
+      await act(async () => {
+        await result.current.refreshVideos();
+      });
+
+      const callArgs = mockFetch.mock.calls[0];
+      const url = callArgs[0];
+
+      expect(url).toContain(`/fetchallchannelvideos/${mockChannelId}`);
+      expect(url).toContain('page=2');
+      expect(url).toContain('pageSize=8');
+      expect(url).toContain('hideDownloaded=true');
+      expect(url).toContain('tabType=shorts');
+    });
+
+    test('includes correct authentication header and POST method', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockSuccessResponse),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      await act(async () => {
+        await result.current.refreshVideos();
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'x-access-token': mockToken,
+          },
+        })
+      );
+    });
+
+    test('handles empty videos array', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          success: true,
+          videos: [],
+          totalCount: 0,
+          oldestVideoDate: null,
+        }),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toEqual({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+      });
+    });
+
+    test('handles missing optional fields in response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          success: true,
+        }),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toEqual({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+      });
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('handles 409 conflict error (fetch in progress)', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: jest.fn().mockResolvedValueOnce({
+          success: false,
+          error: 'FETCH_IN_PROGRESS',
+        }),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toBeNull();
+      expect(result.current.error).toBe(
+        'A fetch operation is already in progress for this channel. Please wait for it to complete.'
+      );
+      expect(result.current.loading).toBe(false);
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('handles error with FETCH_IN_PROGRESS message', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce({
+          success: false,
+          error: 'FETCH_IN_PROGRESS',
+        }),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toBeNull();
+      expect(result.current.error).toBe(
+        'A fetch operation is already in progress for this channel. Please wait for it to complete.'
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('handles non-ok response with custom message', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: jest.fn().mockResolvedValueOnce({
+          success: false,
+          message: 'Internal server error',
+        }),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toBeNull();
+      expect(result.current.error).toBe('Internal server error');
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('handles non-ok response with success: false', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce({
+          success: false,
+        }),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toBeNull();
+      expect(result.current.error).toBe('Failed to fetch all videos');
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('handles network errors', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const networkError = new Error('Network error');
+
+      mockFetch.mockRejectedValueOnce(networkError);
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toBeNull();
+      expect(result.current.error).toBe('Network error');
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error fetching all videos:',
+        networkError
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('handles error without message property', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockFetch.mockRejectedValueOnce({ status: 500 });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toBeNull();
+      expect(result.current.error).toBe('Failed to fetch all videos for channel');
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('clears previous error on successful refresh', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      // First call fails
+      mockFetch.mockRejectedValueOnce(new Error('First error'));
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      await act(async () => {
+        await result.current.refreshVideos();
+      });
+
+      expect(result.current.error).toBe('First error');
+
+      // Second call succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockSuccessResponse),
+      });
+
+      await act(async () => {
+        await result.current.refreshVideos();
+      });
+
+      expect(result.current.error).toBeNull();
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('Conditional Refresh', () => {
+    test('returns null when channelId is undefined', async () => {
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(undefined, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test('returns null when token is null', async () => {
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', null)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test('returns null when both channelId and token are missing', async () => {
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(undefined, 1, 16, false, 'videos', null)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(refreshResult).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Loading State Management', () => {
+    test('sets loading to true during refresh', async () => {
+      let resolvePromise: (value: any) => void;
+      const promise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      mockFetch.mockReturnValueOnce(promise);
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      expect(result.current.loading).toBe(false);
+
+      act(() => {
+        result.current.refreshVideos();
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(true);
+      });
+
+      act(() => {
+        resolvePromise!({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSuccessResponse),
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+    });
+
+    test('sets loading to false after successful refresh', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockSuccessResponse),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(result.current.loading).toBe(false);
+      expect(refreshResult).toEqual({
+        videos: mockVideos,
+        totalCount: 2,
+        oldestVideoDate: '2023-01-01T00:00:00Z',
+      });
+    });
+
+    test('sets loading to false after failed refresh', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockFetch.mockRejectedValueOnce(new Error('Fetch error'));
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      await act(async () => {
+        await result.current.refreshVideos();
+      });
+
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBe('Fetch error');
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('ClearError Functionality', () => {
+    test('clears error when clearError is called', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockFetch.mockRejectedValueOnce(new Error('Test error'));
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult;
+      await act(async () => {
+        refreshResult = await result.current.refreshVideos();
+      });
+
+      expect(result.current.error).toBe('Test error');
+      expect(refreshResult).toBeNull();
+
+      act(() => {
+        result.current.clearError();
+      });
+
+      expect(result.current.error).toBeNull();
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('clearError does nothing when no error exists', () => {
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      expect(result.current.error).toBeNull();
+
+      act(() => {
+        result.current.clearError();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('Callback Stability', () => {
+    test('refreshVideos function changes when dependencies change', () => {
+      const { result, rerender } = renderHook(
+        ({ channelId, page, pageSize, hideDownloaded, tabType, token }) =>
+          useRefreshChannelVideos(channelId, page, pageSize, hideDownloaded, tabType, token),
+        {
+          initialProps: {
+            channelId: mockChannelId,
+            page: 1,
+            pageSize: 16,
+            hideDownloaded: false,
+            tabType: 'videos',
+            token: mockToken,
+          },
+        }
+      );
+
+      const firstRefreshFn = result.current.refreshVideos;
+
+      rerender({
+        channelId: mockChannelId,
+        page: 2,
+        pageSize: 16,
+        hideDownloaded: false,
+        tabType: 'videos',
+        token: mockToken,
+      });
+
+      expect(result.current.refreshVideos).not.toBe(firstRefreshFn);
+    });
+
+    test('clearError function remains stable across rerenders', () => {
+      const { result, rerender } = renderHook(
+        ({ channelId, page }) =>
+          useRefreshChannelVideos(channelId, page, 16, false, 'videos', mockToken),
+        {
+          initialProps: { channelId: mockChannelId, page: 1 },
+        }
+      );
+
+      const firstClearErrorFn = result.current.clearError;
+
+      rerender({ channelId: mockChannelId, page: 2 });
+
+      expect(result.current.clearError).toBe(firstClearErrorFn);
+    });
+  });
+
+  describe('Multiple Sequential Calls', () => {
+    test('can handle multiple sequential refresh calls', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockSuccessResponse),
+      });
+
+      const { result } = renderHook(() =>
+        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+      );
+
+      let refreshResult1;
+      await act(async () => {
+        refreshResult1 = await result.current.refreshVideos();
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(refreshResult1).toEqual({
+        videos: mockVideos,
+        totalCount: 2,
+        oldestVideoDate: '2023-01-01T00:00:00Z',
+      });
+
+      let refreshResult2;
+      await act(async () => {
+        refreshResult2 = await result.current.refreshVideos();
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(refreshResult2).toEqual(refreshResult1);
+
+      let refreshResult3;
+      await act(async () => {
+        refreshResult3 = await result.current.refreshVideos();
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(refreshResult3).toEqual(refreshResult1);
+    });
+  });
+});

--- a/client/src/components/ChannelPage/hooks/useChannelVideos.ts
+++ b/client/src/components/ChannelPage/hooks/useChannelVideos.ts
@@ -1,0 +1,97 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ChannelVideo } from '../../../types/ChannelVideo';
+
+interface UseChannelVideosParams {
+  channelId: string | undefined;
+  page: number;
+  pageSize: number;
+  hideDownloaded: boolean;
+  searchQuery: string;
+  sortBy: string;
+  sortOrder: string;
+  token: string | null;
+}
+
+interface UseChannelVideosResult {
+  videos: ChannelVideo[];
+  totalCount: number;
+  oldestVideoDate: string | null;
+  videoFailed: boolean;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+export function useChannelVideos({
+  channelId,
+  page,
+  pageSize,
+  hideDownloaded,
+  searchQuery,
+  sortBy,
+  sortOrder,
+  token,
+}: UseChannelVideosParams): UseChannelVideosResult {
+  const [videos, setVideos] = useState<ChannelVideo[]>([]);
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const [oldestVideoDate, setOldestVideoDate] = useState<string | null>(null);
+  const [videoFailed, setVideoFailed] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchVideos = useCallback(async () => {
+    if (!channelId || !token) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const queryParams = new URLSearchParams({
+        page: page.toString(),
+        pageSize: pageSize.toString(),
+        hideDownloaded: hideDownloaded.toString(),
+        searchQuery: searchQuery,
+        sortBy: sortBy,
+        sortOrder: sortOrder,
+      });
+
+      const response = await fetch(`/getchannelvideos/${channelId}?${queryParams}`, {
+        headers: {
+          'x-access-token': token,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(response.statusText);
+      }
+
+      const data = await response.json();
+
+      if (data.videos !== undefined) {
+        setVideos(data.videos || []);
+      }
+      setVideoFailed(data.videoFail || false);
+      setTotalCount(data.totalCount || 0);
+      setOldestVideoDate(data.oldestVideoDate || null);
+    } catch (err) {
+      console.error('Error fetching channel videos:', err);
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setLoading(false);
+    }
+  }, [channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, token]);
+
+  useEffect(() => {
+    fetchVideos();
+  }, [fetchVideos]);
+
+  return {
+    videos,
+    totalCount,
+    oldestVideoDate,
+    videoFailed,
+    loading,
+    error,
+    refetch: fetchVideos,
+  };
+}

--- a/client/src/components/ChannelPage/hooks/useChannelVideos.ts
+++ b/client/src/components/ChannelPage/hooks/useChannelVideos.ts
@@ -9,6 +9,7 @@ interface UseChannelVideosParams {
   searchQuery: string;
   sortBy: string;
   sortOrder: string;
+  tabType: string;
   token: string | null;
 }
 
@@ -19,6 +20,7 @@ interface UseChannelVideosResult {
   videoFailed: boolean;
   loading: boolean;
   error: Error | null;
+  autoDownloadsEnabled: boolean;
   refetch: () => Promise<void>;
 }
 
@@ -30,6 +32,7 @@ export function useChannelVideos({
   searchQuery,
   sortBy,
   sortOrder,
+  tabType,
   token,
 }: UseChannelVideosParams): UseChannelVideosResult {
   const [videos, setVideos] = useState<ChannelVideo[]>([]);
@@ -38,6 +41,7 @@ export function useChannelVideos({
   const [videoFailed, setVideoFailed] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
+  const [autoDownloadsEnabled, setAutoDownloadsEnabled] = useState<boolean>(false);
 
   const fetchVideos = useCallback(async () => {
     if (!channelId || !token) return;
@@ -53,6 +57,7 @@ export function useChannelVideos({
         searchQuery: searchQuery,
         sortBy: sortBy,
         sortOrder: sortOrder,
+        tabType: tabType,
       });
 
       const response = await fetch(`/getchannelvideos/${channelId}?${queryParams}`, {
@@ -73,13 +78,14 @@ export function useChannelVideos({
       setVideoFailed(data.videoFail || false);
       setTotalCount(data.totalCount || 0);
       setOldestVideoDate(data.oldestVideoDate || null);
+      setAutoDownloadsEnabled(data.autoDownloadsEnabled || false);
     } catch (err) {
       console.error('Error fetching channel videos:', err);
       setError(err instanceof Error ? err : new Error('Unknown error'));
     } finally {
       setLoading(false);
     }
-  }, [channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, token]);
+  }, [channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, token]);
 
   useEffect(() => {
     fetchVideos();
@@ -92,6 +98,7 @@ export function useChannelVideos({
     videoFailed,
     loading,
     error,
+    autoDownloadsEnabled,
     refetch: fetchVideos,
   };
 }

--- a/client/src/components/ChannelPage/hooks/useRefreshChannelVideos.ts
+++ b/client/src/components/ChannelPage/hooks/useRefreshChannelVideos.ts
@@ -1,0 +1,77 @@
+import { useState, useCallback } from 'react';
+import { ChannelVideo } from '../../../types/ChannelVideo';
+
+interface RefreshResult {
+  videos: ChannelVideo[];
+  totalCount: number;
+  oldestVideoDate: string | null;
+}
+
+interface UseRefreshChannelVideosResult {
+  refreshVideos: () => Promise<RefreshResult | null>;
+  loading: boolean;
+  error: string | null;
+  clearError: () => void;
+}
+
+export function useRefreshChannelVideos(
+  channelId: string | undefined,
+  page: number,
+  pageSize: number,
+  hideDownloaded: boolean,
+  token: string | null
+): UseRefreshChannelVideosResult {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshVideos = useCallback(async (): Promise<RefreshResult | null> => {
+    if (!channelId || !token) return null;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/fetchallchannelvideos/${channelId}?page=${page}&pageSize=${pageSize}&hideDownloaded=${hideDownloaded}`,
+        {
+          method: 'POST',
+          headers: {
+            'x-access-token': token,
+          },
+        }
+      );
+
+      const data = await response.json();
+
+      if (!response.ok || !data.success) {
+        if (response.status === 409 || data.error === 'FETCH_IN_PROGRESS') {
+          throw new Error('A fetch operation is already in progress for this channel. Please wait for it to complete.');
+        }
+        throw new Error(data.message || 'Failed to fetch all videos');
+      }
+
+      return {
+        videos: data.videos || [],
+        totalCount: data.totalCount || 0,
+        oldestVideoDate: data.oldestVideoDate || null,
+      };
+    } catch (err: any) {
+      console.error('Error fetching all videos:', err);
+      setError(err.message || 'Failed to fetch all videos for channel');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, [channelId, page, pageSize, hideDownloaded, token]);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return {
+    refreshVideos,
+    loading,
+    error,
+    clearError,
+  };
+}

--- a/client/src/components/ChannelPage/hooks/useRefreshChannelVideos.ts
+++ b/client/src/components/ChannelPage/hooks/useRefreshChannelVideos.ts
@@ -19,6 +19,7 @@ export function useRefreshChannelVideos(
   page: number,
   pageSize: number,
   hideDownloaded: boolean,
+  tabType: string,
   token: string | null
 ): UseRefreshChannelVideosResult {
   const [loading, setLoading] = useState<boolean>(false);
@@ -32,7 +33,7 @@ export function useRefreshChannelVideos(
 
     try {
       const response = await fetch(
-        `/fetchallchannelvideos/${channelId}?page=${page}&pageSize=${pageSize}&hideDownloaded=${hideDownloaded}`,
+        `/fetchallchannelvideos/${channelId}?page=${page}&pageSize=${pageSize}&hideDownloaded=${hideDownloaded}&tabType=${tabType}`,
         {
           method: 'POST',
           headers: {
@@ -62,7 +63,7 @@ export function useRefreshChannelVideos(
     } finally {
       setLoading(false);
     }
-  }, [channelId, page, pageSize, hideDownloaded, token]);
+  }, [channelId, page, pageSize, hideDownloaded, tabType, token]);
 
   const clearError = useCallback(() => {
     setError(null);

--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -1205,7 +1205,7 @@ function Configuration({ token }: ConfigurationProps) {
                   }
                   label="Enable Automatic Downloads"
                 />
-                {getInfoIcon('Check to enable automatic scheduled downloading of videos from your Channels.')}
+                {getInfoIcon('Enable automatic scheduled downloading of videos from your channels. Only channels and tabs that are enabled for automatic downloads will be downloaded on your schedule.')}
               </Box>
             </Grid>
 

--- a/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
@@ -157,7 +157,7 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
           <Alert severity="info" sx={{ mb: 2 }}>
             <Typography variant="body2">
               {mode === 'channel'
-                ? 'This will download any new videos from all channels.'
+                ? 'This will download any new videos from all channels and tabs that are enabled for automatic downloads.'
                 : videoCount === 1
                 ? 'You are about to download 1 video.'
                 : `You are about to download ${videoCount} videos.`}

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/DownloadSettingsDialog.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/DownloadSettingsDialog.test.tsx
@@ -47,7 +47,7 @@ describe('DownloadSettingsDialog', () => {
     test('renders channel mode alert', () => {
       render(<DownloadSettingsDialog {...defaultProps} mode="channel" />);
 
-      expect(screen.getByText('This will download any new videos from all channels.')).toBeInTheDocument();
+      expect(screen.getByText('This will download any new videos from all channels and tabs that are enabled for automatic downloads.')).toBeInTheDocument();
     });
 
     test('renders custom settings toggle', () => {

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -541,6 +541,7 @@ function VideosPage({ token }: VideosPageProps) {
                               borderColor='grey.500'
                               overflow='hidden'
                               position='relative'
+                              bgcolor='grey.900'
                             >
                               {imageErrors[video.youtubeId] ? (
                                 <Box
@@ -568,11 +569,11 @@ function VideosPage({ token }: VideosPageProps) {
                                   alt='thumbnail'
                                   style={{
                                     position: 'absolute',
-                                    top: '50%',
-                                    left: '50%',
-                                    transform: 'translate(-50%, -50%)',
-                                    maxWidth: '100%',
-                                    maxHeight: '100%',
+                                    top: 0,
+                                    left: 0,
+                                    width: '100%',
+                                    height: '100%',
+                                    objectFit: video.media_type === 'short' ? 'contain' : 'cover',
                                     filter: video.removed ? 'grayscale(100%) brightness(0.6)' : 'none',
                                   }}
                                   onError={() =>
@@ -779,6 +780,7 @@ function VideosPage({ token }: VideosPageProps) {
                               justifyContent='center'
                               position='relative'
                               overflow='hidden'
+                              bgcolor='grey.900'
                             >
                               {imageErrors[video.youtubeId] ? (
                                 <Typography
@@ -793,9 +795,10 @@ function VideosPage({ token }: VideosPageProps) {
                                 <img
                                   src={`/images/videothumb-${video.youtubeId}.jpg`}
                                   alt='thumbnail'
-                                  width='256'
-                                  height='144'
                                   style={{
+                                    width: '100%',
+                                    height: '100%',
+                                    objectFit: video.media_type === 'short' ? 'contain' : 'cover',
                                     filter: video.removed ? 'grayscale(100%) brightness(0.6)' : 'none',
                                   }}
                                   onError={() =>

--- a/client/src/components/__tests__/ChannelManager.test.tsx
+++ b/client/src/components/__tests__/ChannelManager.test.tsx
@@ -518,6 +518,98 @@ describe('ChannelManager Component', () => {
     });
   });
 
+  describe('Auto Download Badges', () => {
+    test('displays video badge for channels with video auto-download enabled', async () => {
+      const channelWithVideoTab: Channel[] = [
+        { url: 'https://www.youtube.com/@TestChannel/videos', uploader: 'Test Channel', channel_id: 'UC123', auto_download_enabled_tabs: 'video' }
+      ];
+      mockGetChannelsOnce(channelWithVideoTab);
+      renderChannelManager();
+      await screen.findByText('Test Channel');
+      expect(screen.getByText('Videos')).toBeInTheDocument();
+    });
+
+    test('displays shorts badge for channels with shorts auto-download enabled', async () => {
+      const channelWithShortsTab: Channel[] = [
+        { url: 'https://www.youtube.com/@TestChannel/videos', uploader: 'Test Channel', channel_id: 'UC123', auto_download_enabled_tabs: 'short' }
+      ];
+      mockGetChannelsOnce(channelWithShortsTab);
+      renderChannelManager();
+      await screen.findByText('Test Channel');
+      expect(screen.getByText('Shorts')).toBeInTheDocument();
+    });
+
+    test('displays live badge for channels with livestream auto-download enabled', async () => {
+      const channelWithLiveTab: Channel[] = [
+        { url: 'https://www.youtube.com/@TestChannel/videos', uploader: 'Test Channel', channel_id: 'UC123', auto_download_enabled_tabs: 'livestream' }
+      ];
+      mockGetChannelsOnce(channelWithLiveTab);
+      renderChannelManager();
+      await screen.findByText('Test Channel');
+      expect(screen.getByText('Live')).toBeInTheDocument();
+    });
+
+    test('displays multiple badges for channels with multiple tabs enabled', async () => {
+      const channelWithMultipleTabs: Channel[] = [
+        { url: 'https://www.youtube.com/@TestChannel/videos', uploader: 'Test Channel', channel_id: 'UC123', auto_download_enabled_tabs: 'video,short,livestream' }
+      ];
+      mockGetChannelsOnce(channelWithMultipleTabs);
+      renderChannelManager();
+      await screen.findByText('Test Channel');
+      expect(screen.getByText('Videos')).toBeInTheDocument();
+      expect(screen.getByText('Shorts')).toBeInTheDocument();
+      expect(screen.getByText('Live')).toBeInTheDocument();
+    });
+
+    test('handles tabs with whitespace in the comma-separated string', async () => {
+      const channelWithSpaces: Channel[] = [
+        { url: 'https://www.youtube.com/@TestChannel/videos', uploader: 'Test Channel', channel_id: 'UC123', auto_download_enabled_tabs: 'video , short , livestream' }
+      ];
+      mockGetChannelsOnce(channelWithSpaces);
+      renderChannelManager();
+      await screen.findByText('Test Channel');
+      expect(screen.getByText('Videos')).toBeInTheDocument();
+      expect(screen.getByText('Shorts')).toBeInTheDocument();
+      expect(screen.getByText('Live')).toBeInTheDocument();
+    });
+
+    test('does not render badges when auto_download_enabled_tabs is undefined', async () => {
+      const channelWithoutTabs: Channel[] = [
+        { url: 'https://www.youtube.com/@TestChannel/videos', uploader: 'Test Channel', channel_id: 'UC123' }
+      ];
+      mockGetChannelsOnce(channelWithoutTabs);
+      renderChannelManager();
+      await screen.findByText('Test Channel');
+      expect(screen.queryByText('Videos')).not.toBeInTheDocument();
+      expect(screen.queryByText('Shorts')).not.toBeInTheDocument();
+      expect(screen.queryByText('Live')).not.toBeInTheDocument();
+    });
+
+    test('does not render badges when auto_download_enabled_tabs is empty string', async () => {
+      const channelWithEmptyTabs: Channel[] = [
+        { url: 'https://www.youtube.com/@TestChannel/videos', uploader: 'Test Channel', channel_id: 'UC123', auto_download_enabled_tabs: '' }
+      ];
+      mockGetChannelsOnce(channelWithEmptyTabs);
+      renderChannelManager();
+      await screen.findByText('Test Channel');
+      expect(screen.queryByText('Videos')).not.toBeInTheDocument();
+      expect(screen.queryByText('Shorts')).not.toBeInTheDocument();
+      expect(screen.queryByText('Live')).not.toBeInTheDocument();
+    });
+
+    test('ignores unknown tab types in the string', async () => {
+      const channelWithUnknownTab: Channel[] = [
+        { url: 'https://www.youtube.com/@TestChannel/videos', uploader: 'Test Channel', channel_id: 'UC123', auto_download_enabled_tabs: 'video,unknown,short' }
+      ];
+      mockGetChannelsOnce(channelWithUnknownTab);
+      renderChannelManager();
+      await screen.findByText('Test Channel');
+      expect(screen.getByText('Videos')).toBeInTheDocument();
+      expect(screen.getByText('Shorts')).toBeInTheDocument();
+      expect(screen.queryByText('unknown')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Edge Cases', () => {
     test('handles empty channel list', async () => {
       mockGetChannelsOnce([]);

--- a/client/src/hooks/useConfig.ts
+++ b/client/src/hooks/useConfig.ts
@@ -1,0 +1,96 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export interface AppConfig {
+  channelAutoDownload: boolean;
+  channelDownloadFrequency: string;
+  channelFilesToDownload: number;
+  preferredResolution: string;
+  videoCodec: string;
+  initialSetup: boolean;
+  plexApiKey: string;
+  youtubeOutputDirectory: string;
+  plexYoutubeLibraryId: string;
+  plexIP: string;
+  plexPort: string;
+  uuid: string;
+  sponsorblockEnabled: boolean;
+  sponsorblockAction: 'remove' | 'mark';
+  sponsorblockCategories: {
+    sponsor: boolean;
+    intro: boolean;
+    outro: boolean;
+    selfpromo: boolean;
+    preview: boolean;
+    filler: boolean;
+    interaction: boolean;
+    music_offtopic: boolean;
+  };
+  sponsorblockApiUrl: string;
+  downloadSocketTimeoutSeconds: number;
+  downloadThrottledRate: string;
+  downloadRetryCount: number;
+  enableStallDetection: boolean;
+  stallDetectionWindowSeconds: number;
+  stallDetectionRateThreshold: string;
+  cookiesEnabled: boolean;
+  customCookiesUploaded: boolean;
+  writeChannelPosters: boolean;
+  writeVideoNfoFiles: boolean;
+  notificationsEnabled: boolean;
+  notificationService: string;
+  discordWebhookUrl: string;
+  autoRemovalEnabled: boolean;
+  autoRemovalFreeSpaceThreshold: string;
+  autoRemovalVideoAgeThreshold: string;
+}
+
+interface UseConfigResult {
+  config: Partial<AppConfig>;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+export function useConfig(token: string | null): UseConfigResult {
+  const [config, setConfig] = useState<Partial<AppConfig>>({});
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchConfig = useCallback(async () => {
+    if (!token) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/getconfig', {
+        headers: {
+          'x-access-token': token,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch config: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      setConfig(data);
+    } catch (err) {
+      console.error('Failed to fetch config:', err);
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  return {
+    config,
+    loading,
+    error,
+    refetch: fetchConfig,
+  };
+}

--- a/client/src/hooks/useTriggerDownloads.ts
+++ b/client/src/hooks/useTriggerDownloads.ts
@@ -1,0 +1,73 @@
+import { useState, useCallback } from 'react';
+
+interface DownloadOverrideSettings {
+  resolution: string;
+  allowRedownload?: boolean;
+}
+
+interface TriggerDownloadsParams {
+  urls: string[];
+  overrideSettings?: DownloadOverrideSettings;
+}
+
+interface UseTriggerDownloadsResult {
+  triggerDownloads: (params: TriggerDownloadsParams) => Promise<boolean>;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useTriggerDownloads(token: string | null): UseTriggerDownloadsResult {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const triggerDownloads = useCallback(
+    async ({ urls, overrideSettings }: TriggerDownloadsParams): Promise<boolean> => {
+      if (!token) {
+        setError(new Error('No authentication token provided'));
+        return false;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const requestBody: any = { urls };
+
+        if (overrideSettings) {
+          requestBody.overrideSettings = {
+            resolution: overrideSettings.resolution,
+            allowRedownload: overrideSettings.allowRedownload,
+          };
+        }
+
+        const response = await fetch('/triggerspecificdownloads', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-access-token': token,
+          },
+          body: JSON.stringify(requestBody),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to trigger downloads: ${response.statusText}`);
+        }
+
+        return true;
+      } catch (err) {
+        console.error('Error triggering downloads:', err);
+        setError(err instanceof Error ? err : new Error('Unknown error'));
+        return false;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [token]
+  );
+
+  return {
+    triggerDownloads,
+    loading,
+    error,
+  };
+}

--- a/client/src/types/Channel.ts
+++ b/client/src/types/Channel.ts
@@ -4,4 +4,5 @@ export interface Channel {
   channel_id?: string;
   description?: string;
   title?: string;
+  auto_download_enabled_tabs?: string;
 }

--- a/client/src/types/ChannelVideo.ts
+++ b/client/src/types/ChannelVideo.ts
@@ -9,7 +9,7 @@
 export interface ChannelVideo {
   title: string;
   youtube_id: string;
-  publishedAt: string;
+  publishedAt: string | null | undefined;
   thumbnail: string;
   added: boolean;
   removed?: boolean;

--- a/client/src/types/ChannelVideo.ts
+++ b/client/src/types/ChannelVideo.ts
@@ -18,4 +18,5 @@ export interface ChannelVideo {
   availability?: string | null;
   fileSize?: number | null;
   media_type?: string | null;
+  live_status?: string | null;
 }

--- a/client/src/utils/formatters.ts
+++ b/client/src/utils/formatters.ts
@@ -1,0 +1,17 @@
+export const formatFileSize = (bytes: number | null | undefined): string => {
+  if (!bytes) {
+    return '';
+  }
+  const gb = bytes / (1024 * 1024 * 1024);
+  if (gb >= 1) {
+    return `${gb.toFixed(1)}GB`;
+  }
+  const mb = bytes / (1024 * 1024);
+  return `${mb.toFixed(0)}MB`;
+};
+
+export const decodeHtml = (html: string): string => {
+  const txt = document.createElement('textarea');
+  txt.innerHTML = html;
+  return txt.value;
+};

--- a/client/src/utils/videoStatus.tsx
+++ b/client/src/utils/videoStatus.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CloudOffIcon from '@mui/icons-material/CloudOff';
+import LockIcon from '@mui/icons-material/Lock';
+import NewReleasesIcon from '@mui/icons-material/NewReleases';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import VideoLibraryIcon from '@mui/icons-material/VideoLibrary';
+import { ChannelVideo } from '../types/ChannelVideo';
+
+export type VideoStatus = 'never_downloaded' | 'downloaded' | 'missing' | 'members_only';
+
+export const getVideoStatus = (video: ChannelVideo): VideoStatus => {
+  if (video.availability === 'subscriber_only') {
+    return 'members_only';
+  }
+  if (!video.added) {
+    return 'never_downloaded';
+  }
+  if (video.removed) {
+    return 'missing';
+  }
+  return 'downloaded';
+};
+
+export const getStatusColor = (status: VideoStatus) => {
+  switch (status) {
+    case 'downloaded':
+      return 'success';
+    case 'missing':
+      return 'warning';
+    case 'members_only':
+      return 'default';
+    default:
+      return 'info';
+  }
+};
+
+export const getStatusIcon = (status: VideoStatus) => {
+  switch (status) {
+    case 'downloaded':
+      return <CheckCircleIcon fontSize="small" />;
+    case 'missing':
+      return <CloudOffIcon fontSize="small" />;
+    case 'members_only':
+      return <LockIcon fontSize="small" />;
+    default:
+      return <NewReleasesIcon fontSize="small" />;
+  }
+};
+
+export const getStatusLabel = (status: VideoStatus) => {
+  switch (status) {
+    case 'downloaded':
+      return 'Downloaded';
+    case 'missing':
+      return 'Missing';
+    case 'members_only':
+      return 'Members Only';
+    default:
+      return 'Not Downloaded';
+  }
+};
+
+export const getMediaTypeInfo = (mediaType?: string | null) => {
+  switch (mediaType) {
+    case 'short':
+      return {
+        label: 'Short',
+        color: 'secondary' as const,
+        icon: <ScheduleIcon fontSize="small" />,
+      };
+    case 'livestream':
+      return {
+        label: 'Live',
+        color: 'error' as const,
+        icon: <VideoLibraryIcon fontSize="small" />,
+      };
+    default:
+      return null;
+  }
+};

--- a/migrations/20251007051738-add-tabs-support-to-channels.js
+++ b/migrations/20251007051738-add-tabs-support-to-channels.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add available_tabs column to store which tab types the channel has (videos, shorts, streams)
+    await queryInterface.addColumn('channels', 'available_tabs', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+      defaultValue: null
+    });
+
+    // Add auto_download_enabled_tabs column to store which tabs to fetch during automated downloads
+    // Default to 'video' to maintain current behavior
+    await queryInterface.addColumn('channels', 'auto_download_enabled_tabs', {
+      type: Sequelize.TEXT,
+      allowNull: false,
+      defaultValue: 'video'
+    });
+
+    // Backfill existing channels with 'video' for auto_download_enabled_tabs
+    await queryInterface.sequelize.query(
+      "UPDATE channels SET auto_download_enabled_tabs = 'video' WHERE auto_download_enabled_tabs IS NULL OR auto_download_enabled_tabs = ''"
+    );
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('channels', 'available_tabs');
+    await queryInterface.removeColumn('channels', 'auto_download_enabled_tabs');
+  }
+};

--- a/migrations/20251007065623-add-live-status-to-channelvideos.js
+++ b/migrations/20251007065623-add-live-status-to-channelvideos.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('channelvideos', 'live_status', {
+      type: Sequelize.STRING,
+      allowNull: true,
+      defaultValue: null,
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('channelvideos', 'live_status');
+  }
+};

--- a/server/models/channel.js
+++ b/server/models/channel.js
@@ -40,6 +40,16 @@ Channel.init(
       allowNull: false,
       defaultValue: false,
     },
+    available_tabs: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      defaultValue: null,
+    },
+    auto_download_enabled_tabs: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      defaultValue: 'video',
+    },
   },
   {
     sequelize,

--- a/server/models/channelvideo.js
+++ b/server/models/channelvideo.js
@@ -55,6 +55,11 @@ ChannelVideo.init(
       allowNull: true,
       defaultValue: null,
     },
+    live_status: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     sequelize,

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -194,6 +194,7 @@ class ChannelModule {
       title: channel.title,
       description: channel.description,
       url: channel.url,
+      auto_download_enabled_tabs: channel.auto_download_enabled_tabs ?? 'video',
     };
   }
 
@@ -457,6 +458,15 @@ class ChannelModule {
       this.processChannelThumbnail(channelUrl, channelData.id)
     ]);
 
+    // Asynchronously fetch available tabs in the background (fire-and-forget)
+    // This detects which tab types (videos, shorts, streams) the channel has
+    // and caches the result in the database for future use
+    setImmediate(() => {
+      this.getChannelAvailableTabs(channelData.id).catch(err => {
+        console.error(`Error fetching tabs for channel ${channelData.id}:`, err.message);
+      });
+    });
+
     if (emitMessage) {
       console.log('Channel data fetched -- emitting message!');
       MessageEmitter.emitMessage(
@@ -475,6 +485,7 @@ class ChannelModule {
       title: channelData.title,
       description: channelData.description,
       url: channelUrl,
+      auto_download_enabled_tabs: 'video',
     };
   }
 
@@ -570,6 +581,7 @@ class ChannelModule {
         url: channel.url,
         uploader: channel.uploader || '',
         channel_id: channel.channel_id || '',
+        auto_download_enabled_tabs: channel.auto_download_enabled_tabs ?? 'video',
       }));
     } catch (err) {
       console.error('Error reading channels from database:', err);
@@ -628,6 +640,7 @@ class ChannelModule {
 
   /**
    * Generate a temporary file with enabled channel URLs for yt-dlp
+   * Respects the auto_download_enabled_tabs column to generate URLs for each enabled tab type
    * @returns {Promise<string>} - Path to the temporary file
    */
   async generateChannelsFile() {
@@ -635,20 +648,55 @@ class ChannelModule {
     try {
       const channels = await Channel.findAll({
         where: { enabled: true },
-        attributes: ['channel_id', 'url']
+        attributes: ['channel_id', 'url', 'auto_download_enabled_tabs']
       });
 
-      // Use canonical channel URLs with the explicit Videos tab when channel_id exists,
-      // so the auto-download list aligns with the ChannelVideos tab (newest-first Videos only).
-      const urls = channels.map(c => {
-        if (c.channel_id) {
-          const canonical = this.resolveChannelUrlFromId(c.channel_id);
-          return `${canonical}/videos`;
-        }
-        return c.url;
-      }).join('\n');
+      // Generate URLs for each channel, respecting their auto_download_enabled_tabs setting
+      const urls = [];
+      for (const channel of channels) {
+        if (channel.channel_id) {
+          const canonical = this.resolveChannelUrlFromId(channel.channel_id);
 
-      await fsPromises.writeFile(tempFilePath, urls);
+          // Parse the enabled tabs for this channel (empty string means no tabs enabled)
+          const enabledTabs = (channel.auto_download_enabled_tabs ?? '')
+            .split(',')
+            .map(t => t.trim())
+            .filter(tab => tab.length > 0);
+
+          if (enabledTabs.length === 0) {
+            // All tabs disabled for this channel, skip adding URLs
+            continue;
+          }
+
+          // Generate a URL for each enabled tab type
+          for (const tabType of enabledTabs) {
+            // Map the media type back to tab type if needed
+            // auto_download_enabled_tabs stores 'video', 'short', 'livestream'
+            // but we need 'videos', 'shorts', 'streams' for URLs
+            let tabUrl;
+            switch (tabType) {
+            case 'video':
+              tabUrl = 'videos';
+              break;
+            case 'short':
+              tabUrl = 'shorts';
+              break;
+            case 'livestream':
+              tabUrl = 'streams';
+              break;
+            default:
+              tabUrl = 'videos'; // fallback
+            }
+
+            urls.push(`${canonical}/${tabUrl}`);
+          }
+        } else {
+          // Fallback for channels without channel_id
+          urls.push(channel.url);
+        }
+      }
+
+      await fsPromises.writeFile(tempFilePath, urls.join('\n'));
 
       return tempFilePath;
     } catch (err) {
@@ -691,6 +739,7 @@ class ChannelModule {
           publishedAt: video.publishedAt,
           availability: video.availability || null,
           media_type: mediaType,
+          live_status: video.live_status || null,
         });
       }
     }
@@ -787,13 +836,15 @@ class ChannelModule {
    * @param {string} sortBy - Field to sort by: 'date', 'title', 'duration', 'size' (default 'date')
    * @param {string} sortOrder - Sort order: 'asc' or 'desc' (default 'desc')
    * @param {boolean} checkFiles - Whether to check file existence for current page (default false)
+   * @param {string} mediaType - Media type to filter by: 'video', 'short', 'livestream' (default 'video')
    * @returns {Promise<Array>} - Array of video objects with download status
    */
-  async fetchNewestVideosFromDb(channelId, limit = 50, offset = 0, excludeDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', checkFiles = false) {
+  async fetchNewestVideosFromDb(channelId, limit = 50, offset = 0, excludeDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', checkFiles = false, mediaType = 'video') {
     // First get all videos to enrich with download status
     const allChannelVideos = await ChannelVideo.findAll({
       where: {
         channel_id: channelId,
+        media_type: mediaType,
       },
       order: [['publishedAt', 'DESC']],
     });
@@ -879,14 +930,18 @@ class ChannelModule {
    * @param {string} channelId - Channel ID
    * @param {boolean} excludeDownloaded - Whether to exclude downloaded videos (default false)
    * @param {string} searchQuery - Search query to filter videos by title (default '')
+   * @param {string} mediaType - Media type to filter by: 'video', 'short', 'livestream' (default 'video')
    * @returns {Promise<Object>} - Object with totalCount and oldestVideoDate
    */
-  async getChannelVideoStats(channelId, excludeDownloaded = false, searchQuery = '') {
+  async getChannelVideoStats(channelId, excludeDownloaded = false, searchQuery = '', mediaType = 'video') {
     // If we have search or filter, we need to get all videos
     if (excludeDownloaded || searchQuery) {
       // Need to filter by download status and/or search
       const allChannelVideos = await ChannelVideo.findAll({
-        where: { channel_id: channelId },
+        where: {
+          channel_id: channelId,
+          media_type: mediaType,
+        },
         order: [['publishedAt', 'DESC']],
       });
 
@@ -915,11 +970,17 @@ class ChannelModule {
     } else {
       // Fast path - just use database counts when no filters
       const totalCount = await ChannelVideo.count({
-        where: { channel_id: channelId }
+        where: {
+          channel_id: channelId,
+          media_type: mediaType,
+        }
       });
 
       const oldestVideo = await ChannelVideo.findOne({
-        where: { channel_id: channelId },
+        where: {
+          channel_id: channelId,
+          media_type: mediaType,
+        },
         order: [['publishedAt', 'ASC']],
         attributes: ['publishedAt']
       });
@@ -984,6 +1045,7 @@ class ChannelModule {
       duration: entry.duration || 0,
       availability: entry.availability || null,
       media_type: entry.media_type || 'video',
+      live_status: entry.live_status || null,
     };
   }
 
@@ -1096,7 +1158,7 @@ class ChannelModule {
    * @param {string} dataSource - Data source ('cache' or 'yt_dlp')
    * @returns {Object} - Formatted response
    */
-  buildChannelVideosResponse(videos, channel, dataSource = 'cache', stats = null) {
+  buildChannelVideosResponse(videos, channel, dataSource = 'cache', stats = null, autoDownloadsEnabled = false) {
     return {
       videos: videos,
       videoFail: videos.length === 0 && (!stats || stats.totalCount === 0),
@@ -1105,7 +1167,113 @@ class ChannelModule {
       lastFetched: channel ? channel.lastFetched : null,
       totalCount: stats ? stats.totalCount : videos.length,
       oldestVideoDate: stats ? stats.oldestVideoDate : null,
+      autoDownloadsEnabled: autoDownloadsEnabled,
     };
+  }
+
+  /**
+   * Detect which tab types (videos, shorts, streams) are available for a channel.
+   * Caches the result in the channel's available_tabs column.
+   * @param {string} channelId - Channel ID to detect tabs for
+   * @returns {Promise<Array<string>>} - Array of available tab types (e.g., ['videos', 'shorts'])
+   */
+  async getChannelAvailableTabs(channelId) {
+    const channel = await Channel.findOne({
+      where: { channel_id: channelId },
+    });
+
+    if (!channel) {
+      throw new Error('Channel not found in database');
+    }
+
+    // If we already have available_tabs data, return it
+    if (channel.available_tabs) {
+      return channel.available_tabs.split(',');
+    }
+
+    // Otherwise, detect which tabs exist by testing each one
+    const availableTabs = [];
+    const tabTypesToTest = [TAB_TYPES.VIDEOS, TAB_TYPES.SHORTS, TAB_TYPES.LIVE];
+    const canonicalChannelUrl = this.resolveChannelUrlFromId(channelId);
+
+    console.log(`Detecting available tabs for channel ${channelId} (${channel.title})`);
+
+    for (const tabType of tabTypesToTest) {
+      try {
+        const tabUrl = `${canonicalChannelUrl}/${tabType}`;
+
+        // Test if the tab exists by trying to fetch just 1 video
+        await this.withTempFile(`tab-test-${tabType}`, async (outputFilePath) => {
+          await this.executeYtDlpCommand([
+            '--flat-playlist',
+            '--dump-single-json',
+            '--playlist-end', '1',
+            '-4',
+            tabUrl,
+          ], outputFilePath);
+        });
+
+        // If we got here without error, the tab exists
+        availableTabs.push(tabType);
+        console.log(`  ✓ ${tabType} tab exists`);
+      } catch (error) {
+        // Tab doesn't exist or is empty - that's fine
+        console.log(`  ✗ ${tabType} tab not available`);
+      }
+    }
+
+    // Store the result in the database for future use
+    if (availableTabs.length > 0) {
+      channel.available_tabs = availableTabs.join(',');
+      await channel.save();
+    }
+
+    return availableTabs;
+  }
+
+  /**
+   * Update the auto download setting for a specific tab type for a channel
+   * @param {string} channelId - Channel ID
+   * @param {string} tabType - Tab type ('videos', 'shorts', or 'streams')
+   * @param {boolean} enabled - Whether to enable auto downloads for this tab
+   */
+  async updateAutoDownloadForTab(channelId, tabType, enabled) {
+    const channel = await Channel.findOne({
+      where: { channel_id: channelId },
+    });
+
+    if (!channel) {
+      throw new Error('Channel not found in database');
+    }
+
+    // Convert tabType to mediaType
+    const mediaType = MEDIA_TAB_TYPE_MAP[tabType] || 'video';
+
+    // Get current enabled tabs
+    const currentEnabledTabs = (channel.auto_download_enabled_tabs || 'video')
+      .split(',')
+      .map(t => t.trim())
+      .filter(Boolean);
+
+    let newEnabledTabs;
+    if (enabled) {
+      // Add mediaType if not already present
+      if (!currentEnabledTabs.includes(mediaType)) {
+        newEnabledTabs = [...currentEnabledTabs, mediaType];
+      } else {
+        newEnabledTabs = currentEnabledTabs;
+      }
+    } else {
+      // Remove mediaType
+      newEnabledTabs = currentEnabledTabs.filter(t => t !== mediaType);
+    }
+
+    // Update the channel (empty string if no tabs are enabled)
+    channel.auto_download_enabled_tabs = newEnabledTabs.join(',');
+    await channel.save();
+
+    console.log(`Updated auto download for channel ${channelId}, tab ${tabType}: ${enabled ? 'enabled' : 'disabled'}`);
+    console.log(`New auto_download_enabled_tabs: ${channel.auto_download_enabled_tabs}`);
   }
 
   /**
@@ -1119,16 +1287,21 @@ class ChannelModule {
    * @param {string} searchQuery - Search query to filter videos by title (default '')
    * @param {string} sortBy - Field to sort by: 'date', 'title', 'duration', 'size' (default 'date')
    * @param {string} sortOrder - Sort order: 'asc' or 'desc' (default 'desc')
+   * @param {string} tabType - Tab type to fetch: 'videos', 'shorts', or 'streams' (default 'videos')
    * @returns {Promise<Object>} - Response object with videos and metadata
    */
-  async getChannelVideos(channelId, page = 1, pageSize = 50, hideDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc') {
+  async getChannelVideos(channelId, page = 1, pageSize = 50, hideDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', tabType = TAB_TYPES.VIDEOS) {
     const channel = await Channel.findOne({
       where: { channel_id: channelId },
     });
 
+    // Convert tabType to mediaType for database filtering
+    const mediaType = MEDIA_TAB_TYPE_MAP[tabType] || 'video';
+    const autoDownloadsEnabled = channel.auto_download_enabled_tabs.split(',').includes(mediaType);
+
     try {
       // First check if we need to refresh recent videos from YouTube
-      const allVideos = await this.fetchNewestVideosFromDb(channelId, 1, 0, false);
+      const allVideos = await this.fetchNewestVideosFromDb(channelId, 1, 0, false, '', 'date', 'desc', false, mediaType);
       const mostRecentVideoDate = allVideos.length > 0 ? allVideos[0].publishedAt : null;
 
       if (this.shouldRefreshChannelVideos(channel, allVideos.length)) {
@@ -1143,8 +1316,8 @@ class ChannelModule {
           });
 
           try {
-            // Hardcoded for videos tab only right now. We will add support for shorts and live streams later.
-            await this.fetchAndSaveVideosViaYtDlp(channel, channelId, TAB_TYPES.VIDEOS, mostRecentVideoDate);
+            // Fetch videos for the specified tab type
+            await this.fetchAndSaveVideosViaYtDlp(channel, channelId, tabType, mostRecentVideoDate);
           } finally {
             // Clear the active fetch record
             this.activeFetches.delete(channelId);
@@ -1154,7 +1327,7 @@ class ChannelModule {
 
       // Now fetch the requested page of videos with file checking enabled
       const offset = (page - 1) * pageSize;
-      const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true);
+      const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType);
 
       // Check if videos still exist on YouTube and mark as removed if they don't
       const videoValidationModule = require('./videoValidationModule');
@@ -1224,16 +1397,16 @@ class ChannelModule {
       }
 
       // Get stats for the response
-      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery);
+      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType);
 
-      return this.buildChannelVideosResponse(paginatedVideos, channel, 'cache', stats);
+      return this.buildChannelVideosResponse(paginatedVideos, channel, 'cache', stats, autoDownloadsEnabled);
 
     } catch (error) {
       console.error('Error fetching channel videos:', error.message);
       const offset = (page - 1) * pageSize;
-      const cachedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true);
-      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery);
-      return this.buildChannelVideosResponse(cachedVideos, channel, 'cache', stats);
+      const cachedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType);
+      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType);
+      return this.buildChannelVideosResponse(cachedVideos, channel, 'cache', stats, autoDownloadsEnabled);
     }
   }
 
@@ -1280,9 +1453,10 @@ class ChannelModule {
    * @param {number} requestedPage - Page requested by frontend
    * @param {number} requestedPageSize - Page size requested by frontend
    * @param {boolean} hideDownloaded - Whether to hide downloaded videos in response
+   * @param {string} tabType - Tab type to fetch: 'videos', 'shorts', or 'streams' (default 'videos')
    * @returns {Promise<Object>} - Response with success status and paginated data
    */
-  async fetchAllChannelVideos(channelId, requestedPage = 1, requestedPageSize = 50, hideDownloaded = false) {
+  async fetchAllChannelVideos(channelId, requestedPage = 1, requestedPageSize = 50, hideDownloaded = false, tabType = TAB_TYPES.VIDEOS) {
     // Check if there's already an active fetch for this channel
     if (this.activeFetches.has(channelId)) {
       const activeOperation = this.activeFetches.get(channelId);
@@ -1305,11 +1479,11 @@ class ChannelModule {
       }
 
       try {
-        console.log(`Starting full video fetch for channel ${channelId} (${channel.title})`);
+        console.log(`Starting full video fetch for channel ${channelId} (${channel.title}) - tab: ${tabType}`);
         const startTime = Date.now();
 
         // Fetch ALL videos from YouTube (no --playlist-end parameter)
-        const canonicalUrl = `${this.resolveChannelUrlFromId(channelId)}/${TAB_TYPES.VIDEOS}`;
+        const canonicalUrl = `${this.resolveChannelUrlFromId(channelId)}/${tabType}`;
 
         const result = await this.withTempFile('channel-all-videos', async (outputFilePath) => {
           const content = await this.executeYtDlpCommand([
@@ -1328,9 +1502,10 @@ class ChannelModule {
 
         console.log(`Fetched ${result.videos.length} videos from YouTube in ${(Date.now() - startTime) / 1000}s`);
 
-        // Save all videos to database
+        // Save all videos to database with correct media type
+        const mediaType = MEDIA_TAB_TYPE_MAP[tabType] || 'video';
         if (result.videos.length > 0) {
-          await this.insertVideosIntoDb(result.videos, channelId);
+          await this.insertVideosIntoDb(result.videos, channelId, mediaType);
         }
 
         // Update channel metadata
@@ -1343,8 +1518,8 @@ class ChannelModule {
 
         // Get the requested page of videos after the full fetch
         const offset = (requestedPage - 1) * requestedPageSize;
-        const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, requestedPageSize, offset, hideDownloaded);
-        const stats = await this.getChannelVideoStats(channelId, hideDownloaded);
+        const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, requestedPageSize, offset, hideDownloaded, '', 'date', 'desc', false, mediaType);
+        const stats = await this.getChannelVideoStats(channelId, hideDownloaded, '', mediaType);
 
         const elapsedSeconds = (Date.now() - startTime) / 1000;
         console.log(`Full video fetch for channel ${channelId} completed in ${elapsedSeconds}s`);


### PR DESCRIPTION
- Add tabs to channel videos page (Videos, Shorts, Streams) with per-tab auto-download controls
- Ensure disabling all tabs skips auto-downloads in the scheduled channel download job
- Add live status tracking to prevent downloading still-airing livestreams
- Add visual indicators: alarm icons for auto-download enabled tabs, pulsing LIVE badges for active streams
- Update backend API to support tab-based video fetching and per-tab auto-download settings
- Add database migrations for channel tabs support and live status tracking
- Add StillLiveDot component to display LIVE indicator on active streams
- Enhance UI to show auto-download badges in Channel Manager
- Update video cards to use 'contain' object-fit for shorts thumbnails
- Add comprehensive test coverage for new components and hooks
- Update API routes to support /channels/:id/tabs endpoint and per-tab auto-download PATCH endpoint