### PR TITLE
ui: Change "fetch" to "refresh" on Channel Videos

### DIFF
--- a/client/src/components/ChannelPage/ChannelVideosDialogs.tsx
+++ b/client/src/components/ChannelPage/ChannelVideosDialogs.tsx
@@ -85,11 +85,11 @@ function ChannelVideosDialogs({
         aria-describedby="refresh-dialog-description"
       >
         <DialogTitle id="refresh-dialog-title">
-          Fetch All {tabLabel} Videos
+          Refresh All {tabLabel} Videos
         </DialogTitle>
         <DialogContent>
           <DialogContentText id="refresh-dialog-description">
-            This will fetch all &apos;{tabLabel}&apos; videos for this Channel. This may take some time to complete.
+            This will refresh all &apos;{tabLabel}&apos; videos for this Channel. This may take some time to complete.
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/client/src/components/ChannelPage/ChannelVideosHeader.tsx
+++ b/client/src/components/ChannelPage/ChannelVideosHeader.tsx
@@ -148,7 +148,7 @@ function ChannelVideosHeader({
             disabled={fetchingAllVideos}
             startIcon={<RefreshIcon />}
           >
-            {fetchingAllVideos ? 'Fetching...' : 'Fetch All'}
+            {fetchingAllVideos ? 'Refreshing...' : 'Refresh All'}
           </Button>
         </Box>
 

--- a/client/src/components/ChannelPage/__tests__/ChannelVideosDialogs.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideosDialogs.test.tsx
@@ -83,7 +83,7 @@ describe('ChannelVideosDialogs Component', () => {
       expect(screen.getByTestId('delete-videos-dialog')).toBeInTheDocument();
 
       // Should render refresh confirmation dialog (even if closed)
-      expect(screen.queryByText('Fetch All Videos Videos')).not.toBeInTheDocument();
+      expect(screen.queryByText('Refresh All Videos Videos')).not.toBeInTheDocument();
     });
   });
 
@@ -130,7 +130,7 @@ describe('ChannelVideosDialogs Component', () => {
     test('does not show refresh dialog when closed', () => {
       renderWithProviders(<ChannelVideosDialogs {...defaultProps} />);
 
-      expect(screen.queryByText(/Fetch All/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Refresh All/)).not.toBeInTheDocument();
     });
 
     test('shows refresh dialog when open', () => {
@@ -141,7 +141,7 @@ describe('ChannelVideosDialogs Component', () => {
         />
       );
 
-      expect(screen.getByText('Fetch All Videos Videos')).toBeInTheDocument();
+      expect(screen.getByText('Refresh All Videos Videos')).toBeInTheDocument();
     });
 
     test('displays correct tab label in refresh dialog', () => {
@@ -153,8 +153,8 @@ describe('ChannelVideosDialogs Component', () => {
         />
       );
 
-      expect(screen.getByText('Fetch All Shorts Videos')).toBeInTheDocument();
-      expect(screen.getByText(/This will fetch all 'Shorts' videos for this Channel/)).toBeInTheDocument();
+      expect(screen.getByText('Refresh All Shorts Videos')).toBeInTheDocument();
+      expect(screen.getByText(/This will refresh all 'Shorts' videos for this Channel/)).toBeInTheDocument();
     });
 
     test('calls onRefreshCancel when Cancel is clicked', async () => {
@@ -448,7 +448,7 @@ describe('ChannelVideosDialogs Component', () => {
         />
       );
 
-      expect(screen.getByText('Fetch All Videos Videos')).toBeInTheDocument();
+      expect(screen.getByText('Refresh All Videos Videos')).toBeInTheDocument();
       expect(screen.getByText('Operation completed')).toBeInTheDocument();
     });
   });
@@ -525,7 +525,7 @@ describe('ChannelVideosDialogs Component', () => {
         />
       );
 
-      expect(screen.getByText('Fetch All Live & Upcoming Videos')).toBeInTheDocument();
+      expect(screen.getByText('Refresh All Live & Upcoming Videos')).toBeInTheDocument();
     });
 
     test('handles zero video count in download dialog', () => {
@@ -575,7 +575,7 @@ describe('ChannelVideosDialogs Component', () => {
       // All components should render
       expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
       expect(screen.getByTestId('delete-videos-dialog')).toBeInTheDocument();
-      expect(screen.getByText('Fetch All Videos Videos')).toBeInTheDocument();
+      expect(screen.getByText('Refresh All Videos Videos')).toBeInTheDocument();
 
       // Multiple snackbars should show
       expect(screen.getByText('Error 1')).toBeInTheDocument();

--- a/client/src/components/ChannelPage/__tests__/ChannelVideosHeader.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideosHeader.test.tsx
@@ -125,13 +125,13 @@ describe('ChannelVideosHeader Component', () => {
     });
   });
 
-  describe('Fetch All Button', () => {
-    test('renders fetch all button', () => {
+  describe('Refresh All Button', () => {
+    test('renders refresh all button', () => {
       renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
-      expect(screen.getByRole('button', { name: /Fetch All/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Refresh All/i })).toBeInTheDocument();
     });
 
-    test('calls onRefreshClick when fetch all button is clicked', async () => {
+    test('calls onRefreshClick when refresh all button is clicked', async () => {
       const user = userEvent.setup();
       const onRefreshClick = jest.fn();
 
@@ -139,33 +139,33 @@ describe('ChannelVideosHeader Component', () => {
         <ChannelVideosHeader {...defaultProps} onRefreshClick={onRefreshClick} />
       );
 
-      await user.click(screen.getByRole('button', { name: /Fetch All/i }));
+      await user.click(screen.getByRole('button', { name: /Refresh All/i }));
       expect(onRefreshClick).toHaveBeenCalledTimes(1);
     });
 
-    test('disables fetch all button when fetching', () => {
+    test('disables refresh all button when fetching', () => {
       renderWithProviders(
         <ChannelVideosHeader {...defaultProps} fetchingAllVideos={true} />
       );
 
-      const button = screen.getByRole('button', { name: /Fetching.../i });
+      const button = screen.getByRole('button', { name: /Refreshing.../i });
       expect(button).toBeDisabled();
     });
 
-    test('shows "Fetching..." text when fetching videos', () => {
+    test('shows "Refreshing..." text when fetching videos', () => {
       renderWithProviders(
         <ChannelVideosHeader {...defaultProps} fetchingAllVideos={true} />
       );
 
-      expect(screen.getByText('Fetching...')).toBeInTheDocument();
+      expect(screen.getByText('Refreshing...')).toBeInTheDocument();
     });
 
-    test('shows "Fetch All" text when not fetching', () => {
+    test('shows "Refresh All" text when not fetching', () => {
       renderWithProviders(
         <ChannelVideosHeader {...defaultProps} fetchingAllVideos={false} />
       );
 
-      expect(screen.getByText('Fetch All')).toBeInTheDocument();
+      expect(screen.getByText('Refresh All')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
"Fetch" might have indicated the user was initiating a download. "Refresh" is more clear about just refreshing the listed videos.