### PR TITLE
fix: prevent overlapping channel downloads and improve ETA display

### DIFF
--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -1248,7 +1248,7 @@ function Configuration({ token }: ConfigurationProps) {
                     ))}
                   </Select>
                 </FormControl>
-                {getInfoIcon('How many videos (starting from the most recent) should be downloaded for each channel when channel downloads are initiated.')}
+                {getInfoIcon('How many videos (starting from the most recent) should be downloaded for each channel when channel downloads are initiated. Already downloaded videos will not be re-downloaded.')}
               </Box>
             </Grid>
 


### PR DESCRIPTION
- Skip scheduled downloads when a Channel Downloads job is in progress
- Add exponential smoothing to download speed and ETA to reduce UI jitter
- Display ETA in download progress overlay title (e.g., "Video Title · ETA 2m5s")
- Format ETA in human-readable format (hours/minutes/seconds)
- Replace activity-based timeout for long-running downloads
- Clarify configuration tooltip about skipping already downloaded videos
- Reset smoothing state when starting new video downloads
- Add and update tests