### PR TITLE
feat: implement job termination cleanup and video recovery

### DIFF
--- a/client/src/components/DownloadManager/TerminateJobDialog.tsx
+++ b/client/src/components/DownloadManager/TerminateJobDialog.tsx
@@ -50,13 +50,13 @@ const TerminateJobDialog: React.FC<TerminateJobDialogProps> = ({
           </Typography>
           <Box component="ul" sx={{ ml: 2, mb: 2 }}>
             <Typography component="li" variant="body2" color="text.secondary">
-              Stop the current download after completing the current video
+              Stop the current download, terminating the download currently in progress.
             </Typography>
             <Typography component="li" variant="body2" color="text.secondary">
               Save all videos that have already been downloaded
             </Typography>
             <Typography component="li" variant="body2" color="text.secondary">
-              Clean up any partial downloads in progress
+              Clean up the partial video download in progress
             </Typography>
             <Typography component="li" variant="body2" color="text.secondary">
               NOT affect any queued jobs (they will continue after this one)

--- a/client/src/components/DownloadManager/__tests__/TerminateJobDialog.test.tsx
+++ b/client/src/components/DownloadManager/__tests__/TerminateJobDialog.test.tsx
@@ -69,9 +69,9 @@ describe('TerminateJobDialog', () => {
       />
     );
 
-    expect(screen.getByText('Stop the current download after completing the current video')).toBeInTheDocument();
+    expect(screen.getByText('Stop the current download, terminating the download currently in progress.')).toBeInTheDocument();
     expect(screen.getByText('Save all videos that have already been downloaded')).toBeInTheDocument();
-    expect(screen.getByText('Clean up any partial downloads in progress')).toBeInTheDocument();
+    expect(screen.getByText('Clean up the partial video download in progress')).toBeInTheDocument();
     expect(screen.getByText('NOT affect any queued jobs (they will continue after this one)')).toBeInTheDocument();
   });
 

--- a/migrations/20251010162434-add-jobvideodownloads-table.js
+++ b/migrations/20251010162434-add-jobvideodownloads-table.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.createTable('JobVideoDownloads', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false
+      },
+      job_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'Jobs',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      youtube_id: {
+        type: Sequelize.STRING(20),
+        allowNull: false
+      },
+      file_path: {
+        type: Sequelize.TEXT,
+        allowNull: false
+      },
+      status: {
+        type: Sequelize.ENUM('in_progress', 'completed'),
+        allowNull: false,
+        defaultValue: 'in_progress'
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+
+    // Add index on job_id for faster queries
+    await queryInterface.addIndex('JobVideoDownloads', ['job_id']);
+
+    // Add index on status for faster cleanup queries
+    await queryInterface.addIndex('JobVideoDownloads', ['status']);
+
+    // Ensure each job/video pair is unique
+    await queryInterface.addIndex(
+      'JobVideoDownloads',
+      ['job_id', 'youtube_id'],
+      {
+        unique: true,
+        name: 'jobvideodownloads_job_video_unique'
+      }
+    );
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.dropTable('JobVideoDownloads');
+  }
+};

--- a/migrations/20251010201337-add-unique-constraint-videos-youtubeid.js
+++ b/migrations/20251010201337-add-unique-constraint-videos-youtubeid.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Step 1: Remap JobVideos to point to survivor Videos (highest id) for each youtubeId
+    // This prevents FK constraint violations when deleting duplicates
+    await queryInterface.sequelize.query(`
+      UPDATE JobVideos jv
+      INNER JOIN Videos v_old ON jv.video_id = v_old.id
+      INNER JOIN (
+        SELECT youtubeId, MAX(id) as survivor_id
+        FROM Videos
+        GROUP BY youtubeId
+        HAVING COUNT(*) > 1
+      ) survivors ON v_old.youtubeId = survivors.youtubeId
+      SET jv.video_id = survivors.survivor_id
+      WHERE jv.video_id != survivors.survivor_id
+    `);
+
+    // Step 2: Remove duplicate youtubeId entries from Videos
+    // Keep the most recent entry (highest id) for each youtubeId
+    await queryInterface.sequelize.query(`
+      DELETE v1 FROM Videos v1
+      INNER JOIN Videos v2
+      WHERE v1.youtubeId = v2.youtubeId
+      AND v1.id < v2.id
+    `);
+
+    // Step 3: Add unique constraint on youtubeId
+    await queryInterface.addIndex('Videos', ['youtubeId'], {
+      unique: true,
+      name: 'videos_youtubeid_unique'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove the unique constraint
+    await queryInterface.removeIndex('Videos', 'videos_youtubeid_unique');
+  }
+};

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,20 +1,25 @@
 // models/index.js
 const Job = require('./job');
 const JobVideo = require('./jobvideo');
+const JobVideoDownload = require('./jobvideodownload');
 const Video = require('./video');
 const Channel = require('./channel');
 const Session = require('./session');
 
 Job.hasMany(JobVideo, { foreignKey: 'job_id', as: 'jobVideos' });
+Job.hasMany(JobVideoDownload, { foreignKey: 'job_id', as: 'jobVideoDownloads' });
 
 JobVideo.belongsTo(Job, { foreignKey: 'job_id', as: 'job' });
 JobVideo.belongsTo(Video, { foreignKey: 'video_id', as: 'video' });
+
+JobVideoDownload.belongsTo(Job, { foreignKey: 'job_id', as: 'job' });
 
 Video.hasMany(JobVideo, { foreignKey: 'video_id', as: 'jobVideos' });
 
 module.exports = {
   Job,
   JobVideo,
+  JobVideoDownload,
   Video,
   Channel,
   Session,

--- a/server/models/jobvideodownload.js
+++ b/server/models/jobvideodownload.js
@@ -1,0 +1,64 @@
+const { Model, DataTypes } = require('sequelize');
+const { sequelize } = require('../db');
+
+class JobVideoDownload extends Model {}
+
+JobVideoDownload.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false,
+    },
+    job_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'Jobs',
+        key: 'id',
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+    },
+    youtube_id: {
+      type: DataTypes.STRING(20),
+      allowNull: false,
+    },
+    file_path: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.ENUM('in_progress', 'completed'),
+      allowNull: false,
+      defaultValue: 'in_progress',
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'JobVideoDownload',
+    timestamps: false,
+    tableName: 'JobVideoDownloads',
+    indexes: [
+      {
+        fields: ['job_id']
+      },
+      {
+        fields: ['status']
+      },
+      {
+        unique: true,
+        fields: ['job_id', 'youtube_id'],
+        name: 'jobvideodownloads_job_video_unique'
+      }
+    ]
+  }
+);
+
+module.exports = JobVideoDownload;

--- a/server/models/video.js
+++ b/server/models/video.js
@@ -14,6 +14,7 @@ Video.init(
     youtubeId: {
       type: DataTypes.STRING,
       allowNull: false,
+      unique: true,
     },
     youTubeChannelName: {
       type: DataTypes.STRING,

--- a/server/modules/__tests__/messageEmitter.test.js
+++ b/server/modules/__tests__/messageEmitter.test.js
@@ -93,4 +93,19 @@ describe('messageEmitter', () => {
     expect(otherClient.send).not.toHaveBeenCalled();
     expect(closedClient.send).not.toHaveBeenCalled();
   });
+
+  test('handles undefined payload by creating empty object with timestamp', () => {
+    MessageEmitter.emitMessage('broadcast', null, 'server', 'ping');
+
+    broadcastClients.forEach((client) => {
+      expect(client.send).toHaveBeenCalledTimes(1);
+      const sent = JSON.parse(client.send.mock.calls[0][0]);
+      expect(sent).toMatchObject({
+        destination: 'broadcast',
+        source: 'server',
+        type: 'ping',
+        payload: { dateTimeStamp: expect.any(Number) }
+      });
+    });
+  });
 });

--- a/server/modules/messageEmitter.js
+++ b/server/modules/messageEmitter.js
@@ -22,7 +22,15 @@ module.exports = {
       // Only store the final summary or complete/error states, not progress updates
       if (payload.finalSummary ||
           (payload.progress && (payload.progress.state === 'complete' || payload.progress.state === 'error'))) {
-        lastDownloadState = message;
+        // Create a simplified message for replay without progress details
+        // This prevents the progress bar from "replaying" when clients reconnect
+        lastDownloadState = {
+          ...message,
+          payload: {
+            ...message.payload,
+            progress: undefined  // Remove progress object to show only final summary
+          }
+        };
       }
       // Clear the stored state when a new download starts
       if (payload.clearPreviousSummary ||


### PR DESCRIPTION
- Add JobVideoDownloads table to track in-progress downloads per job
- Add unique constraint on Videos.youtubeId to prevent duplicates
- Implement recovery of completed videos from info.json on server restart
- Clean up partial downloads when jobs are terminated
- Update TerminateJobDialog text to clarify current video is terminated