### PR TITLE
fix: refine ChannelVideos UI for better desktop/mobile experience

### DIFF
--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -445,7 +445,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs }: ChannelVideosProps) {
   });
 
   // Mobile drawer render
-  const renderMobileDrawer = () => (
+  const renderDrawer = () => (
     <Drawer
       anchor="bottom"
       open={mobileDrawerOpen}
@@ -500,8 +500,8 @@ function ChannelVideos({ token, channelAutoDownloadTabs }: ChannelVideosProps) {
   );
 
   // Mobile floating action buttons
-  const renderMobileFAB = () => {
-    if (!isMobile) return null;
+  const renderFAB = () => {
+    // if (!isMobile) return null;
 
     const hasDownloadSelection = checkedBoxes.length > 0;
     const hasDeletionSelection = selectedForDeletion.length > 0;
@@ -725,8 +725,8 @@ function ChannelVideos({ token, channelAutoDownloadTabs }: ChannelVideosProps) {
       </Card>
 
       {/* Mobile components */}
-      {renderMobileFAB()}
-      {renderMobileDrawer()}
+      {renderFAB()}
+      {renderDrawer()}
 
       {/* Dialogs and Snackbars */}
       <ChannelVideosDialogs

--- a/client/src/components/ChannelPage/ChannelVideosHeader.tsx
+++ b/client/src/components/ChannelPage/ChannelVideosHeader.tsx
@@ -127,11 +127,10 @@ function ChannelVideosHeader({
       }}
     >
       <Box sx={{ p: 2 }}>
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }} data-testid="channel-videos-header">
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-            <Typography variant="h6">Channel Videos</Typography>
             {totalCount > 0 && (
-              <Chip label={totalCount} size="small" color="primary" />
+              <Chip label={totalCount + ' ' + (totalCount === 1 ? 'item' : 'items')} size="small" color="primary" />
             )}
             {oldestVideoDate && selectedTab !== 'shorts' && !isMobile && (
               <Typography variant="caption" color="text.secondary">
@@ -163,6 +162,12 @@ function ChannelVideosHeader({
               />
             }
             label="Enable Channel Downloads for this tab"
+            sx={{
+              '& .MuiFormControlLabel-label': {
+                fontSize: isMobile ? '0.75rem' : '1rem',
+                marginRight: -1,
+              }
+            }}
           />
           {renderInfoIcon(autoDownloadTooltip)}
         </Box>
@@ -181,7 +186,7 @@ function ChannelVideosHeader({
                 </InputAdornment>
               ),
             }}
-            sx={{ flexGrow: 1, minWidth: 200 }}
+            sx={{ flexGrow: 1, minWidth: 200, width: isMobile ? '50%' : 'auto' }}
           />
 
           {/* View mode toggle - mobile shows list/grid, desktop shows table/grid */}

--- a/client/src/components/ChannelPage/__tests__/ChannelVideosHeader.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideosHeader.test.tsx
@@ -79,7 +79,7 @@ describe('ChannelVideosHeader Component', () => {
   describe('Component Rendering', () => {
     test('renders without crashing', () => {
       renderWithProviders(<ChannelVideosHeader {...defaultProps} />);
-      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+      expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
     });
   });
 
@@ -88,7 +88,7 @@ describe('ChannelVideosHeader Component', () => {
       renderWithProviders(
         <ChannelVideosHeader {...defaultProps} totalCount={42} />
       );
-      expect(screen.getByText('42')).toBeInTheDocument();
+      expect(screen.getByText('42 items')).toBeInTheDocument();
     });
 
     test('does not display count chip when totalCount is 0', () => {
@@ -662,7 +662,7 @@ describe('ChannelVideosHeader Component', () => {
         <ChannelVideosHeader {...defaultProps} paginatedVideos={[]} />
       );
 
-      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+      expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
     });
 
     test('handles large video counts', () => {
@@ -670,7 +670,7 @@ describe('ChannelVideosHeader Component', () => {
         <ChannelVideosHeader {...defaultProps} totalCount={9999} />
       );
 
-      expect(screen.getByText('9999')).toBeInTheDocument();
+      expect(screen.getByText('9999 items')).toBeInTheDocument();
     });
 
     test('handles large selection counts', () => {
@@ -739,7 +739,7 @@ describe('ChannelVideosHeader Component', () => {
         <ChannelVideosHeader {...defaultProps} selectedTab="videos" />
       );
 
-      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+      expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
     });
 
     test('handles shorts tab', () => {
@@ -747,7 +747,7 @@ describe('ChannelVideosHeader Component', () => {
         <ChannelVideosHeader {...defaultProps} selectedTab="shorts" />
       );
 
-      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+      expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
     });
 
     test('handles streams tab', () => {
@@ -755,7 +755,7 @@ describe('ChannelVideosHeader Component', () => {
         <ChannelVideosHeader {...defaultProps} selectedTab="streams" />
       );
 
-      expect(screen.getByText('Channel Videos')).toBeInTheDocument();
+      expect(screen.getByTestId('channel-videos-header')).toBeInTheDocument();
     });
 
     test('hides oldest video date for shorts tab', () => {


### PR DESCRIPTION
- Remove "Channel Videos" heading, show only item count chip with "X items" label
- Make FAB and drawer available on desktop (remove isMobile guard from FAB)
- Reduce font size of auto-download label on mobile devices
- Set search input width to 50% on mobile for better layout