### PR TITLE
fix: improve ffmpeg thumbnail processing quality and logging

### DIFF
--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -325,7 +325,7 @@ class ChannelModule {
 
     try {
       execSync(
-        `${configModule.ffmpegPath} -y -i ${realImagePath} -vf "scale=iw*0.4:ih*0.4" ${smallImagePath}`,
+        `${configModule.ffmpegPath} -loglevel error -y -i "${realImagePath}" -vf "scale=iw*0.4:ih*0.4" -q:v 2 "${smallImagePath}"`,
         { stdio: 'inherit' }
       );
       await fsPromises.rename(smallImagePath, realImagePath);

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -97,7 +97,7 @@ async function downloadChannelThumbnailIfMissing(channelId) {
       if (fs.existsSync(channelThumbPath)) {
         const tempPath = channelThumbPath + '.temp';
         execSync(
-          `${configModule.ffmpegPath} -y -i "${channelThumbPath}" -vf "scale=iw*0.4:ih*0.4" "${tempPath}"`,
+          `${configModule.ffmpegPath} -loglevel error -y -i "${channelThumbPath}" -vf "scale=iw*0.4:ih*0.4" -q:v 2 "${tempPath}"`,
           { stdio: 'pipe' }
         );
         fs.renameSync(tempPath, channelThumbPath);


### PR DESCRIPTION
- Add -loglevel error flag to suppress verbose ffmpeg output
- Add -q:v 2 flag to improve JPEG quality after downscaling
- Quote file paths in ffmpeg commands to handle paths with spaces
- Apply changes to both channelModule.js and videoDownloadPostProcessFiles.js