### PR TITLE
feat(subtitles): add subtitle download support and fix filename handling

### DIFF
--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -33,6 +33,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import InfoIcon from '@mui/icons-material/Info';
 import PlexLibrarySelector from './PlexLibrarySelector';
 import PlexAuthDialog from './PlexAuthDialog';
+import SubtitleLanguageSelector from './Configuration/SubtitleLanguageSelector';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import axios from 'axios';
@@ -142,6 +143,8 @@ function Configuration({ token }: ConfigurationProps) {
     autoRemovalVideoAgeThreshold: '',
     useTmpForDownloads: false,
     tmpFilePath: '/tmp/youtarr-downloads',
+    subtitlesEnabled: false,
+    subtitleLanguage: 'en',
   });
   const [openPlexLibrarySelector, setOpenPlexLibrarySelector] = useState(false);
   const [openPlexAuthDialog, setOpenPlexAuthDialog] = useState(false);
@@ -965,6 +968,8 @@ function Configuration({ token }: ConfigurationProps) {
       'autoRemovalFreeSpaceThreshold',
       'autoRemovalVideoAgeThreshold',
       'useTmpForDownloads',
+      'subtitlesEnabled',
+      'subtitleLanguage',
     ];
     const changed = keysToCompare.some((k) => {
       return (config as any)[k] !== (initialConfig as any)[k];
@@ -1209,7 +1214,7 @@ function Configuration({ token }: ConfigurationProps) {
                   }
                   label="Enable Automatic Downloads"
                 />
-                {getInfoIcon('Enable automatic scheduled downloading of videos from your channels. Only channels and tabs that are enabled for automatic downloads will be downloaded on your schedule.')}
+                {getInfoIcon('Globally enable or disable automatic scheduled downloading of videos from your channels. Only tabs that are enabled for your Channels will be checked and downloaded.')}
               </Box>
             </Grid>
 
@@ -1243,7 +1248,7 @@ function Configuration({ token }: ConfigurationProps) {
                   <Select
                     value={config.channelFilesToDownload}
                     onChange={handleChannelFilesChange}
-                    label="Files to Download per Channel"
+                    label="Videos to Download per Channel Tab"
                   >
                     {getChannelFilesOptions().map(count => (
                       <MenuItem key={count} value={count}>
@@ -1252,7 +1257,7 @@ function Configuration({ token }: ConfigurationProps) {
                     ))}
                   </Select>
                 </FormControl>
-                {getInfoIcon('How many videos (starting from the most recent) should be downloaded for each channel when channel downloads are initiated. Already downloaded videos will not be re-downloaded.')}
+                {getInfoIcon('How many videos (starting from most recently uploaded) Youtarr will attempt to download per tab when channel downloads run. Already downloaded videos will be skipped.')}
               </Box>
             </Grid>
 
@@ -1296,10 +1301,10 @@ function Configuration({ token }: ConfigurationProps) {
                       <MenuItem value="h265">H.265/HEVC (Balanced)</MenuItem>
                     </Select>
                   </FormControl>
-                  {getInfoIcon('Select your preferred video codec. Youtarr will download this codec when available, but will automatically fall back to other codecs if your preference is not available for a video. H.264 is recommended for Apple TV and maximum device compatibility.')}
+                  {getInfoIcon('Select your preferred video codec. Youtarr will download this codec when available, and fall back to other codecs if your preference is not available for a video. H.264 is recommended for Apple TV and maximum device compatibility. VP9 is the default codec for most YouTube videos.')}
                 </Box>
                 <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
-                  Note: H.264 produces larger file sizes but offers maximum compatibility. This is a preference and will fall back to available codecs.
+                  Note: H.264 produces larger file sizes but offers maximum compatibility for Apple TV. This is a preference and will fall back to available codecs.
                 </Typography>
               </Box>
             </Grid>
@@ -1335,6 +1340,34 @@ function Configuration({ token }: ConfigurationProps) {
               </Box>
             </Grid>
 
+            <Grid item xs={12} md={6}>
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      name="subtitlesEnabled"
+                      checked={config.subtitlesEnabled}
+                      onChange={handleCheckboxChange}
+                    />
+                  }
+                  label="Enable Subtitle Downloads"
+                />
+                {getInfoIcon('Download subtitles in SRT format when available. Manual subtitles are preferred, with auto-generated subtitles as fallback.')}
+              </Box>
+            </Grid>
+
+            {config.subtitlesEnabled && (
+              <Grid item xs={12} md={6}>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  <SubtitleLanguageSelector
+                    value={config.subtitleLanguage}
+                    onChange={(value) => setConfig({ ...config, subtitleLanguage: value })}
+                  />
+                  {getInfoIcon('Select one or more subtitle languages. Subtitles will be downloaded when available; videos without subtitles will still download successfully.')}
+                </Box>
+              </Grid>
+            )}
+
           </Grid>
         </CardContent>
       </Card>
@@ -1363,13 +1396,14 @@ function Configuration({ token }: ConfigurationProps) {
         </AccordionSummary>
         <AccordionDetails>
           <Alert severity="info" sx={{ mb: 2 }}>
-            <AlertTitle>Plex Integration is Optional</AlertTitle>
+            <AlertTitle>Completely Optional Plex Integration</AlertTitle>
             <Typography variant="body2">
-              Youtarr works perfectly without Plex! Plex integration only provides:
               <br />• Automatic library refresh after downloads
               <br />• Direct library selection from Plex server
-              <br /><br />
+              <br />
               If you don't use Plex, your videos will still download to your specified directory.
+              <br />
+              You MUST select a library once connected for automatic refresh to work!
             </Typography>
           </Alert>
 

--- a/client/src/components/Configuration/SubtitleLanguageSelector.tsx
+++ b/client/src/components/Configuration/SubtitleLanguageSelector.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react';
+import {
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Chip,
+  Box,
+  SelectChangeEvent,
+} from '@mui/material';
+
+interface SubtitleLanguageSelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+interface LanguageOption {
+  code: string;
+  label: string;
+}
+
+const LANGUAGE_OPTIONS: LanguageOption[] = [
+  { code: 'en', label: 'English' },
+  { code: 'en-orig', label: 'English (Original/Uploaded)' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'fr', label: 'French' },
+  { code: 'de', label: 'German' },
+  { code: 'ja', label: 'Japanese' },
+  { code: 'pt', label: 'Portuguese' },
+  { code: 'it', label: 'Italian' },
+  { code: 'ru', label: 'Russian' },
+  { code: 'ko', label: 'Korean' },
+  { code: 'zh', label: 'Chinese' },
+  { code: 'ar', label: 'Arabic' },
+  { code: 'hi', label: 'Hindi' },
+];
+
+function SubtitleLanguageSelector({
+  value,
+  onChange,
+  disabled = false,
+}: SubtitleLanguageSelectorProps) {
+  const [selectedLanguages, setSelectedLanguages] = useState<string[]>([]);
+
+  // Convert string value to array when component mounts or value changes
+  useEffect(() => {
+    if (value && value.trim()) {
+      const languages = value.split(',').map((lang) => lang.trim()).filter(Boolean);
+      // Filter out invalid codes
+      const validLanguages = languages.filter((lang) =>
+        LANGUAGE_OPTIONS.some((opt) => opt.code === lang)
+      );
+      setSelectedLanguages(validLanguages.length > 0 ? validLanguages : ['en']);
+    } else {
+      setSelectedLanguages(['en']);
+    }
+  }, [value]);
+
+  const handleChange = (event: SelectChangeEvent<string[]>) => {
+    const newValue = event.target.value as string[];
+
+    // Ensure at least one language is selected
+    if (newValue.length === 0) {
+      setSelectedLanguages(['en']);
+      onChange('en');
+      return;
+    }
+
+    setSelectedLanguages(newValue);
+    onChange(newValue.join(','));
+  };
+
+  const getLanguageLabel = (code: string): string => {
+    const option = LANGUAGE_OPTIONS.find((opt) => opt.code === code);
+    return option ? option.label : code;
+  };
+
+  return (
+    <FormControl fullWidth disabled={disabled}>
+      <InputLabel id="subtitle-language-label">Subtitle Languages</InputLabel>
+      <Select
+        labelId="subtitle-language-label"
+        id="subtitle-language-select"
+        multiple
+        value={selectedLanguages}
+        onChange={handleChange}
+        label="Subtitle Languages"
+        renderValue={(selected) => (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+            {selected.map((code) => (
+              <Chip
+                key={code}
+                label={getLanguageLabel(code)}
+                size="small"
+              />
+            ))}
+          </Box>
+        )}
+      >
+        {LANGUAGE_OPTIONS.map((option) => (
+          <MenuItem key={option.code} value={option.code}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}
+
+export default SubtitleLanguageSelector;

--- a/client/src/components/Configuration/__tests__/SubtitleLanguageSelector.test.tsx
+++ b/client/src/components/Configuration/__tests__/SubtitleLanguageSelector.test.tsx
@@ -1,0 +1,523 @@
+import React from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import SubtitleLanguageSelector from '../SubtitleLanguageSelector';
+import { renderWithProviders } from '../../../test-utils';
+
+describe('SubtitleLanguageSelector Component', () => {
+  const mockOnChange = jest.fn();
+
+  const defaultProps = {
+    value: '',
+    onChange: mockOnChange,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    test('renders without crashing', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} />);
+      expect(screen.getByLabelText('Subtitle Languages')).toBeInTheDocument();
+    });
+
+    test('displays the correct label', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} />);
+      const labels = screen.getAllByText('Subtitle Languages');
+      expect(labels.length).toBeGreaterThan(0);
+    });
+
+    test('shows all 13 language options when dropdown is opened', async () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      fireEvent.mouseDown(select);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'English' })).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('option', { name: 'English (Original/Uploaded)' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Spanish' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'French' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'German' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Japanese' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Portuguese' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Italian' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Russian' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Korean' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Chinese' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Arabic' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Hindi' })).toBeInTheDocument();
+    });
+
+    test('renders with disabled state correctly', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} disabled={true} />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      expect(select).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    test('is not disabled by default', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      expect(select).not.toHaveAttribute('aria-disabled', 'true');
+    });
+  });
+
+  describe('Default Values & Initialization', () => {
+    test('defaults to English when value is empty string', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="" />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+    });
+
+    test('defaults to English when value is whitespace only', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="   " />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+    });
+
+    test('parses comma-separated string values correctly', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en,es,fr" />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+      expect(screen.getByText('French')).toBeInTheDocument();
+    });
+
+    test('handles whitespace in comma-separated values', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en, es , fr" />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+      expect(screen.getByText('French')).toBeInTheDocument();
+    });
+
+    test('filters out invalid language codes', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en,invalid,es" />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+      expect(screen.queryByText('invalid')).not.toBeInTheDocument();
+    });
+
+    test('defaults to English when all codes are invalid', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="invalid1,invalid2" />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+    });
+
+    test('handles single language code', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="ja" />);
+
+      expect(screen.getByText('Japanese')).toBeInTheDocument();
+    });
+
+    test('handles special en-orig language code', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en-orig" />);
+
+      expect(screen.getByText('English (Original/Uploaded)')).toBeInTheDocument();
+    });
+  });
+
+  describe('Language Selection', () => {
+    test('allows selecting multiple languages', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      const spanishOption = await screen.findByRole('option', { name: 'Spanish' });
+      await user.click(spanishOption);
+
+      expect(mockOnChange).toHaveBeenCalledWith('en,es');
+    });
+
+    test('calls onChange with comma-separated string', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      const frenchOption = await screen.findByRole('option', { name: 'French' });
+      await user.click(frenchOption);
+
+      expect(mockOnChange).toHaveBeenCalledWith('en,fr');
+    });
+
+    test('updates displayed chips when languages are selected', async () => {
+      const user = userEvent.setup();
+      const { rerender } = renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      const germanOption = await screen.findByRole('option', { name: 'German' });
+      await user.click(germanOption);
+
+      expect(mockOnChange).toHaveBeenCalledWith('en,de');
+
+      // Rerender with updated value
+      rerender(
+        <SubtitleLanguageSelector value="en,de" onChange={mockOnChange} />
+      );
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('German')).toBeInTheDocument();
+    });
+
+    test('allows selecting all languages', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      // Select a few more languages
+      const spanishOption = await screen.findByRole('option', { name: 'Spanish' });
+      await user.click(spanishOption);
+
+      const japaneseOption = screen.getByRole('option', { name: 'Japanese' });
+      await user.click(japaneseOption);
+
+      const koreanOption = screen.getByRole('option', { name: 'Korean' });
+      await user.click(koreanOption);
+
+      // Should contain all selected languages
+      const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1];
+      expect(lastCall[0]).toContain('en');
+      expect(lastCall[0]).toContain('es');
+      expect(lastCall[0]).toContain('ja');
+      expect(lastCall[0]).toContain('ko');
+    });
+  });
+
+  describe('Minimum Selection Enforcement', () => {
+    test('prevents deselecting all languages', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      // Try to deselect English (the only selected language)
+      const englishOption = await screen.findByRole('option', { name: 'English' });
+      await user.click(englishOption);
+
+      // Should call onChange with 'en' (enforcing at least one selection)
+      expect(mockOnChange).toHaveBeenCalledWith('en');
+    });
+
+    test('automatically selects English if user tries to deselect all', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="es" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      // Try to deselect Spanish (the only selected language)
+      const spanishOption = await screen.findByRole('option', { name: 'Spanish' });
+      await user.click(spanishOption);
+
+      // Should default back to English
+      expect(mockOnChange).toHaveBeenCalledWith('en');
+    });
+
+    test('allows deselecting when multiple languages are selected', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en,es,fr" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      // Deselect Spanish
+      const spanishOption = await screen.findByRole('option', { name: 'Spanish' });
+      await user.click(spanishOption);
+
+      // Should successfully remove Spanish
+      expect(mockOnChange).toHaveBeenCalledWith('en,fr');
+    });
+  });
+
+  describe('Chip Rendering', () => {
+    test('renders chips for each selected language', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en,es,ja" />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+      expect(screen.getByText('Japanese')).toBeInTheDocument();
+    });
+
+    test('shows correct translated labels for language codes', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="de,it,pt" />);
+
+      expect(screen.getByText('German')).toBeInTheDocument();
+      expect(screen.getByText('Italian')).toBeInTheDocument();
+      expect(screen.getByText('Portuguese')).toBeInTheDocument();
+    });
+
+    test('handles special en-orig label correctly', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en-orig,es" />);
+
+      expect(screen.getByText('English (Original/Uploaded)')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+    });
+
+    test('displays chip with code if language not found in options', () => {
+      // Force a scenario where an unknown code might appear (shouldn't happen but test defensively)
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      // All chips should have proper labels
+      expect(screen.getByText('English')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('handles empty comma-separated list', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value=",,," />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+    });
+
+    test('handles duplicate language codes in input', () => {
+      // The component doesn't deduplicate on render - it accepts whatever the parent gives
+      // So we just verify it can render with duplicates without crashing
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en,es" />);
+
+      // Should show both languages
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+    });
+
+    test('handles very long comma-separated list', () => {
+      const allLanguages = 'en,en-orig,es,fr,de,ja,pt,it,ru,ko,zh,ar,hi';
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value={allLanguages} />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('English (Original/Uploaded)')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+      expect(screen.getByText('Hindi')).toBeInTheDocument();
+    });
+
+    test('handles mixed valid and invalid codes', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en,xxx,es,yyy,fr" />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+      expect(screen.getByText('French')).toBeInTheDocument();
+      expect(screen.queryByText('xxx')).not.toBeInTheDocument();
+      expect(screen.queryByText('yyy')).not.toBeInTheDocument();
+    });
+
+    test('handles trailing commas', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en,es," />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+    });
+
+    test('handles leading commas', () => {
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value=",en,es" />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+    });
+
+    test('handles value change after initial render', () => {
+      const { rerender } = renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+
+      // Change the value prop
+      rerender(
+        <SubtitleLanguageSelector value="ja,ko" onChange={mockOnChange} />
+      );
+
+      expect(screen.getByText('Japanese')).toBeInTheDocument();
+      expect(screen.getByText('Korean')).toBeInTheDocument();
+      expect(screen.queryByText('English')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Disabled State', () => {
+    test('cannot open dropdown when disabled', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} disabled={true} />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      // Dropdown should not open, so options should not be visible
+      await waitFor(() => {
+        expect(screen.queryByRole('option', { name: 'Spanish' })).not.toBeInTheDocument();
+      });
+    });
+
+    test('displays chips correctly when disabled', () => {
+      renderWithProviders(
+        <SubtitleLanguageSelector value="en,es,fr" onChange={mockOnChange} disabled={true} />
+      );
+
+      expect(screen.getByText('English')).toBeInTheDocument();
+      expect(screen.getByText('Spanish')).toBeInTheDocument();
+      expect(screen.getByText('French')).toBeInTheDocument();
+    });
+  });
+
+  describe('Integration with MUI Select', () => {
+    test('multiple select works correctly', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      // Select multiple languages
+      const arabicOption = await screen.findByRole('option', { name: 'Arabic' });
+      await user.click(arabicOption);
+
+      const hindiOption = screen.getByRole('option', { name: 'Hindi' });
+      await user.click(hindiOption);
+
+      // onChange should have been called multiple times
+      expect(mockOnChange).toHaveBeenCalled();
+    });
+
+    test('dropdown opens and remains open for multi-select', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+
+      // Open dropdown
+      await user.click(select);
+      await screen.findByRole('option', { name: 'Spanish' });
+      expect(screen.getByRole('option', { name: 'Spanish' })).toBeInTheDocument();
+
+      // Select an option - multi-select keeps dropdown open
+      const spanishOption = screen.getByRole('option', { name: 'Spanish' });
+      await user.click(spanishOption);
+
+      // Multi-select dropdown should remain open after selection
+      expect(screen.getByRole('option', { name: 'French' })).toBeInTheDocument();
+    });
+
+    test('MenuItem selection updates the value', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      const chineseOption = await screen.findByRole('option', { name: 'Chinese' });
+      await user.click(chineseOption);
+
+      expect(mockOnChange).toHaveBeenCalledWith('en,zh');
+    });
+  });
+
+  describe('Language Code to Label Mapping', () => {
+    test('correctly maps all language codes to labels', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'English' })).toBeInTheDocument();
+      });
+
+      // Verify all mappings exist
+      const expectedMappings = [
+        { code: 'en', label: 'English' },
+        { code: 'en-orig', label: 'English (Original/Uploaded)' },
+        { code: 'es', label: 'Spanish' },
+        { code: 'fr', label: 'French' },
+        { code: 'de', label: 'German' },
+        { code: 'ja', label: 'Japanese' },
+        { code: 'pt', label: 'Portuguese' },
+        { code: 'it', label: 'Italian' },
+        { code: 'ru', label: 'Russian' },
+        { code: 'ko', label: 'Korean' },
+        { code: 'zh', label: 'Chinese' },
+        { code: 'ar', label: 'Arabic' },
+        { code: 'hi', label: 'Hindi' },
+      ];
+
+      for (const mapping of expectedMappings) {
+        expect(screen.getByRole('option', { name: mapping.label })).toBeInTheDocument();
+      }
+    });
+
+    test('displays correct chips for all supported languages', () => {
+      const allCodes = 'en,en-orig,es,fr,de,ja,pt,it,ru,ko,zh,ar,hi';
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value={allCodes} />);
+
+      const expectedLabels = [
+        'English',
+        'English (Original/Uploaded)',
+        'Spanish',
+        'French',
+        'German',
+        'Japanese',
+        'Portuguese',
+        'Italian',
+        'Russian',
+        'Korean',
+        'Chinese',
+        'Arabic',
+        'Hindi',
+      ];
+
+      for (const label of expectedLabels) {
+        expect(screen.getByText(label)).toBeInTheDocument();
+      }
+    });
+  });
+
+  describe('onChange Callback Behavior', () => {
+    test('onChange receives correct value when adding language', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      const russianOption = await screen.findByRole('option', { name: 'Russian' });
+      await user.click(russianOption);
+
+      expect(mockOnChange).toHaveBeenCalledTimes(1);
+      expect(mockOnChange).toHaveBeenCalledWith('en,ru');
+    });
+
+    test('onChange receives correct value when removing language', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} value="en,es,fr" />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      const spanishOption = await screen.findByRole('option', { name: 'Spanish' });
+      await user.click(spanishOption);
+
+      expect(mockOnChange).toHaveBeenCalledWith('en,fr');
+    });
+
+    test('onChange not called when disabled', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SubtitleLanguageSelector {...defaultProps} disabled={true} />);
+
+      const select = screen.getByLabelText('Subtitle Languages');
+      await user.click(select);
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/components/__tests__/Configuration.test.tsx
+++ b/client/src/components/__tests__/Configuration.test.tsx
@@ -411,7 +411,7 @@ const renderConfiguration = async ({
       const accordion = screen.getByText('Optional: Plex Media Server Integration');
       fireEvent.click(accordion);
 
-      await screen.findByText('Plex Integration is Optional');
+      await screen.findByText('Completely Optional Plex Integration');
 
       const plexIpInput = screen.getByRole('textbox', { name: /Plex Server IP/i });
       expect(plexIpInput).toHaveValue('192.168.1.100');

--- a/server/modules/configModule.js
+++ b/server/modules/configModule.js
@@ -200,6 +200,17 @@ class ConfigModule extends EventEmitter {
       configModified = true;
     }
 
+    // Initialize subtitle settings if not present
+    if (this.config.subtitlesEnabled === undefined) {
+      this.config.subtitlesEnabled = false;
+      configModified = true;
+    }
+
+    if (!this.config.subtitleLanguage) {
+      this.config.subtitleLanguage = 'en';
+      configModified = true;
+    }
+
     // Check if a UUID exists in the config
     if (!this.config.uuid) {
       // Generate a new UUID
@@ -294,7 +305,9 @@ class ConfigModule extends EventEmitter {
         notificationService: 'discord',
         discordWebhookUrl: '',
         useTmpForDownloads: false,
-        tmpFilePath: '/tmp/youtarr-downloads'
+        tmpFilePath: '/tmp/youtarr-downloads',
+        subtitlesEnabled: false,
+        subtitleLanguage: 'en'
       };
     }
 
@@ -485,6 +498,10 @@ class ConfigModule extends EventEmitter {
     // Temp download settings - disabled by default
     defaultConfig.useTmpForDownloads = false;
     defaultConfig.tmpFilePath = '/tmp/youtarr-downloads';
+
+    // Subtitle settings - disabled by default
+    defaultConfig.subtitlesEnabled = false;
+    defaultConfig.subtitleLanguage = 'en';
 
     // Generate UUID for instance identification
     defaultConfig.uuid = uuidv4();
@@ -697,6 +714,19 @@ class ConfigModule extends EventEmitter {
         }
         if (!migrated.tmpFilePath) {
           migrated.tmpFilePath = '/tmp/youtarr-downloads';
+        }
+
+        return migrated;
+      },
+      '1.43.0': (cfg) => {
+        const migrated = { ...cfg };
+
+        // Add subtitle settings
+        if (migrated.subtitlesEnabled === undefined) {
+          migrated.subtitlesEnabled = false;
+        }
+        if (!migrated.subtitleLanguage) {
+          migrated.subtitleLanguage = 'en';
         }
 
         return migrated;

--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -293,7 +293,7 @@ describe('YtdlpCommandBuilder', () => {
       const mainOutput = result[outputIndices[0] + 1];
       expect(mainOutput).toContain('/mock/youtube/output');
       expect(mainOutput).toContain('%(uploader,channel,uploader_id)s');
-      expect(mainOutput).toContain('%(title)s');
+      expect(mainOutput).toContain('%(title).76s');
       expect(mainOutput).toContain('%(id)s');
       expect(mainOutput).toContain('%(ext)s');
 
@@ -507,10 +507,10 @@ describe('YtdlpCommandBuilder', () => {
       expect(mainOutput).toContain('%(uploader,channel,uploader_id)s');
 
       // Folder should have channel - title - id format
-      expect(mainOutput).toContain('%(uploader,channel,uploader_id)s - %(title)s - %(id)s');
+      expect(mainOutput).toContain('%(uploader,channel,uploader_id)s - %(title).76s - %(id)s');
 
       // File should have channel - title [id].ext format
-      expect(mainOutput).toContain('%(uploader,channel,uploader_id)s - %(title)s  [%(id)s].%(ext)s');
+      expect(mainOutput).toContain('%(uploader,channel,uploader_id)s - %(title).76s [%(id)s].%(ext)s');
     });
   });
 


### PR DESCRIPTION
- Add subtitle download configuration
  - Add SubtitleLanguageSelector component with multi-select for 13 languages
  - Support en-orig for YouTube uploaded subtitles
  - Enforce minimum one language selection, defaulting to English
  - Add subtitlesEnabled and subtitleLanguage to config with migration
- Fix video filename sanitization and path resolution (#243)
  - Replace manual filename sanitization with yt-dlp's --windows-filenames
  - Truncate video titles to 76 chars in templates to prevent long paths
  - Add filesystem search to locate video files instead of guessing paths
  - Add normalizeForDirectoryMatch for fuzzy directory matching
  - Prevents Plex issues with overly long or incorrectly sanitized filenames
- Improve download reliability and error handling
  - Add retry/sleep args to prevent YouTube rate limiting (429 errors)
  - Treat HTTP 403 as warning instead of fatal error (often recoverable)
  - Add channel poster backfilling after downloads complete
  - Fix channel poster copy timing (after temp-to-final move)
  - Use uploader_id as fallback for channel name metadata
- Enhance Configuration UX
  - Improve channel/tab download descriptions for clarity
  - Update video codec preference tooltips
  - Clarify Plex integration as optional with better messaging
- Add and update tests