### PR TITLE
feat(downloads): show 403 errors in UI + new yt-dlp

### DIFF
--- a/server/modules/download/DownloadProgressMonitor.js
+++ b/server/modules/download/DownloadProgressMonitor.js
@@ -451,9 +451,9 @@ class DownloadProgressMonitor {
     // A video is complete when we see various completion indicators
     if (line.includes('Deleting original file')) {
       const lowerLine = line.toLowerCase();
-      const isThumbnailCleanup = ['.webp', '.jpg', '.jpeg', '.png']
+      const isNonVideoCleanup = ['.webp', '.jpg', '.jpeg', '.png', '.vtt', '.srt']
         .some(ext => lowerLine.includes(ext));
-      if (isThumbnailCleanup) {
+      if (isNonVideoCleanup) {
         return true;
       }
     }


### PR DESCRIPTION
This will include the new temporary fix from https://github.com/yt-dlp/yt-dlp/releases/tag/2025.10.22 Which will fix the issue with videos not downloading

- Add failed video tracking with error grouping and warning state display
- Exclude subtitles/thumbnails from video completion counting
- Track video failures from yt-dlp output and separate by fileSize
- Add and update tests