### PR TITLE
feat: use video filename for video posters instead of generic poster.jpg

### DIFF
--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -301,7 +301,8 @@ describe('YtdlpCommandBuilder', () => {
       const thumbOutput = result[outputIndices[1] + 1];
       expect(thumbOutput).toContain('thumbnail:');
       expect(thumbOutput).toContain('/mock/youtube/output');
-      expect(thumbOutput).toContain('/poster');
+      // Thumbnail should use same filename as video (without extension)
+      expect(thumbOutput).toContain('%(uploader,channel,uploader_id)s - %(title).76s [%(id)s]');
 
       // Check playlist thumbnail is disabled
       const plThumbOutput = result[outputIndices[2] + 1];

--- a/server/modules/download/ytdlpCommandBuilder.js
+++ b/server/modules/download/ytdlpCommandBuilder.js
@@ -40,10 +40,13 @@ class YtdlpCommandBuilder {
       ? tempPathManager.getTempBasePath()
       : configModule.directoryPath;
 
+    // Use same filename as video file (without extension - yt-dlp adds .jpg)
+    const thumbnailFilename = `${CHANNEL_TEMPLATE} - %(title).76s [%(id)s]`;
+
     if (subFolder) {
-      return path.join(baseOutputPath, subFolder, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, 'poster');
+      return path.join(baseOutputPath, subFolder, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, thumbnailFilename);
     } else {
-      return path.join(baseOutputPath, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, 'poster');
+      return path.join(baseOutputPath, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, thumbnailFilename);
     }
   }
   // Build format string based on resolution and codec preference

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -20,7 +20,8 @@ const jsonPath = path.format({
 });
 
 const videoDirectory = path.dirname(videoPath);
-const imagePath = path.join(videoDirectory, 'poster.jpg'); // assume the image thumbnail is named 'poster.jpg'
+// Poster image uses same filename as video but with .jpg extension
+const imagePath = path.join(videoDirectory, parsedPath.name + '.jpg');
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 


### PR DESCRIPTION
This is the first step towards support for:
- Channels as "TV Shows"
- Placing videos in a flat directory structure where each video does not have it's own subfolder