### PR TITLE
fix: prevent stuck pending jobs blocking download queue

### DIFF
--- a/client/src/components/DownloadManager/DownloadProgress.tsx
+++ b/client/src/components/DownloadManager/DownloadProgress.tsx
@@ -462,7 +462,7 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
               <AccordionDetails sx={{ pt: 0, pb: 1.5 }}>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
                   {pendingJobs.map((job, index) => {
-                    const isChannelDownload = job.jobType === 'Channel Downloads';
+                    const isChannelDownload = job.jobType.includes('Channel Downloads');
                     const label = isChannelDownload ? 'Channel Update' : 'Manual Download';
                     const icon = isChannelDownload ?
                       <PlaylistPlayIcon fontSize="small" /> :
@@ -557,7 +557,7 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
               </Typography>
               <Typography variant="caption" color={(finalSummary.totalFailed && finalSummary.totalFailed > 0) ? 'warning.contrastText' : 'success.contrastText'} sx={{ mt: 0.5, display: 'block' }}>
                 {(() => {
-                  const jobTypeLabel = finalSummary.jobType === 'Channel Downloads'
+                  const jobTypeLabel = finalSummary.jobType.includes('Channel Downloads')
                     ? 'Channel update'
                     : finalSummary.jobType === 'Manually Added Urls'
                     ? 'Manual download'

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -430,8 +430,10 @@ class ChannelModule {
     // Check if a Channel Downloads job is already running
     const jobModule = require('./jobModule');
     const jobs = jobModule.getAllJobs();
+    // Check for both In Progress and Pending channel downloads to prevent accumulation
+    // Note: Pending jobs are terminated on app restart, so they won't get stuck
     const hasRunningChannelDownload = Object.values(jobs).some(
-      job => job.jobType === 'Channel Downloads' &&
+      job => job.jobType.includes('Channel Downloads') &&
              (job.status === 'In Progress' || job.status === 'Pending')
     );
 

--- a/server/modules/download/DownloadProgressMonitor.js
+++ b/server/modules/download/DownloadProgressMonitor.js
@@ -20,7 +20,7 @@ class DownloadProgressMonitor {
       skipped: 0,
       skippedThisChannel: 0
     };
-    this.isChannelDownload = jobType === 'Channel Downloads';
+    this.isChannelDownload = jobType.includes('Channel Downloads');
     this.currentChannelName = '';
     this.currentVideoCompleted = false; // Track if current video is done
     this.channelNameJustSet = false; // Track when channel name is newly set

--- a/server/modules/notificationModule.js
+++ b/server/modules/notificationModule.js
@@ -106,7 +106,7 @@ class NotificationModule {
    */
   formatDownloadMessage(finalSummary, videoData) {
     const { totalDownloaded, jobType } = finalSummary;
-    const isChannelDownload = jobType === 'Channel Downloads';
+    const isChannelDownload = jobType.includes('Channel Downloads');
 
     // Build the title
     let title;

--- a/server/server.js
+++ b/server/server.js
@@ -918,7 +918,7 @@ const initialize = async () => {
       const runningJobs = jobModule.getRunningJobs();
       const channelDownloadJob = runningJobs.find(
         (job) =>
-          job.jobType === 'Channel Downloads' && job.status === 'In Progress'
+          job.jobType.includes('Channel Downloads') && job.status === 'In Progress'
       );
       if (channelDownloadJob) {
         res.status(400).json({ error: 'Job Already Running' });


### PR DESCRIPTION
- Terminate all pending jobs on server restart
  - Jobs cannot be safely resumed (missing URLs and action functions)
  - Prevents stuck jobs from blocking queue indefinitely
- Add safety check in startNextJob() for missing action functions
  - Terminates job and tries next in queue instead of failing silently
- Fix issues with channel downloads showing in various places as "manual downloads"
  - Change jobType === to .includes('Channel Downloads')
- Prevent duplicate channel downloads during long-running jobs
- Add/update tests