### PR TITLE
fix: prevent timeout during long video post-processing operations

### DIFF
--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -163,7 +163,7 @@ describe('DownloadExecutor', () => {
     it('should initialize with correct default values', () => {
       expect(executor.tempChannelsFile).toBeNull();
       expect(executor.activityTimeoutMs).toBe(30 * 60 * 1000);
-      expect(executor.maxAbsoluteTimeoutMs).toBe(4 * 60 * 60 * 1000);
+      expect(executor.maxAbsoluteTimeoutMs).toBe(6 * 60 * 60 * 1000);
       expect(executor.currentProcess).toBeNull();
       expect(executor.currentJobId).toBeNull();
       expect(executor.manualTerminationReason).toBeNull();
@@ -1284,7 +1284,7 @@ describe('DownloadExecutor', () => {
 
     it('should have configurable timeout values', () => {
       expect(executor.activityTimeoutMs).toBe(30 * 60 * 1000); // 30 minutes
-      expect(executor.maxAbsoluteTimeoutMs).toBe(4 * 60 * 60 * 1000); // 4 hours
+      expect(executor.maxAbsoluteTimeoutMs).toBe(6 * 60 * 60 * 1000); // 6 hours
     });
 
     it('should track current process for manual termination', async () => {


### PR DESCRIPTION
- Add dynamic inactivity timeout that switches between 30 and 60 minutes based on download phase
- Extend timeout to 60 minutes when post-processing operations start ([Merger], [Metadata], [MoveFiles], [ModifyChapters], [ExtractAudio])
- Reset timeout to 30 minutes when download activity resumes to catch stalls quickly
- Add activity tracking for additional post-processing patterns (SubtitlesConvertor, ThumbnailsConvertor, "Deleting original file")
- Increase absolute maximum runtime from 4 hours to 6 hours for very large downloads
- Reset currentActivityTimeout to default at job start, exit, and error to prevent timeout inflation across jobs
- Update tests to reflect new 6-hour maximum timeout