### PR TITLE
fix: Set TMPDIR for all yt-dlp invocations

### DIFF
--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -113,7 +113,12 @@ class ChannelModule {
       }
     }
 
-    const ytDlp = spawn('yt-dlp', finalArgs);
+    const ytDlp = spawn('yt-dlp', finalArgs, {
+      env: {
+        ...process.env,
+        TMPDIR: '/tmp'
+      }
+    });
 
     if (outputFile) {
       const writeStream = fs.createWriteStream(outputFile);

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -502,10 +502,7 @@ class DownloadExecutor {
         env: {
           ...process.env,
           YOUTARR_JOB_ID: jobId,
-          // Set TMPDIR to writable location (especially critical for Elfhosted)
-          TMPDIR: tempPathManager.isEnabled()
-            ? tempPathManager.getTempBasePath()
-            : (process.env.TMPDIR || '/tmp')
+          TMPDIR: '/tmp'
         }
       });
 

--- a/server/modules/ytDlpRunner.js
+++ b/server/modules/ytDlpRunner.js
@@ -37,7 +37,11 @@ class YtDlpRunner {
 
       const ytDlpProcess = spawn('yt-dlp', finalArgs, {
         shell: false,
-        timeout: timeoutMs
+        timeout: timeoutMs,
+        env: {
+          ...process.env,
+          TMPDIR: '/tmp'
+        }
       });
 
       let stdout = '';


### PR DESCRIPTION
- Ensure that yt-dlp does not try to write temp files to `/app/` which is not writeable on Elfhosted