### PR TITLE
feat: add HTTPS support for Plex server connections

### DIFF
--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -102,6 +102,7 @@ function Configuration({ token }: ConfigurationProps) {
     plexYoutubeLibraryId: '',
     plexIP: '',
     plexPort: '32400',
+    plexViaHttps: false,
     uuid: '',
     sponsorblockEnabled: false,
     sponsorblockAction: 'remove' as 'remove' | 'mark',
@@ -377,6 +378,7 @@ function Configuration({ token }: ConfigurationProps) {
       }
 
       params.set('testPort', normalizedPort);
+      params.set('testUseHttps', String(config.plexViaHttps));
 
       const response = await fetch(`/getplexlibraries?${params}`, {
         headers: {
@@ -390,7 +392,7 @@ function Configuration({ token }: ConfigurationProps) {
         // Plex credentials are auto-saved. Update initial snapshot for those fields.
         setInitialConfig((prev) => (
           prev
-            ? { ...prev, plexIP: config.plexIP, plexApiKey: config.plexApiKey, plexPort: normalizedPort }
+            ? { ...prev, plexIP: config.plexIP, plexApiKey: config.plexApiKey, plexPort: normalizedPort, plexViaHttps: config.plexViaHttps }
             : { ...config, plexPort: normalizedPort }
         ));
         setSnackbar({
@@ -493,6 +495,11 @@ function Configuration({ token }: ConfigurationProps) {
       ...config,
       [event.target.name]: event.target.checked,
     });
+
+    // Mark Plex connection as not tested if plexViaHttps changes
+    if (event.target.name === 'plexViaHttps') {
+      setPlexConnectionStatus('not_tested');
+    }
   };
 
   const runAutoRemovalDryRun = async () => {
@@ -775,6 +782,7 @@ function Configuration({ token }: ConfigurationProps) {
       'plexYoutubeLibraryId',
       'plexIP',
       'plexPort',
+      'plexViaHttps',
       'sponsorblockEnabled',
       'sponsorblockAction',
       'sponsorblockCategories',
@@ -1228,7 +1236,7 @@ function Configuration({ token }: ConfigurationProps) {
               />
             </Grid>
 
-            <Grid item xs={12} md={3}>
+            <Grid item xs={12} md={2}>
               <TextField
                 fullWidth
                 type="number"
@@ -1247,6 +1255,32 @@ function Configuration({ token }: ConfigurationProps) {
                   ? 'Plex port is configured by your platform deployment'
                   : 'Default: 32400'}
               />
+            </Grid>
+
+            <Grid item xs={12} md={4}>
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      name="plexViaHttps"
+                      checked={isPlatformManaged.plexUrl ? false : config.plexViaHttps}
+                      onChange={handleCheckboxChange}
+                      disabled={isPlatformManaged.plexUrl}
+                    />
+                  }
+                  label="Use HTTPS"
+                />
+                {getInfoIcon(
+                  isPlatformManaged.plexUrl
+                    ? 'HTTPS setting managed by platform'
+                    : 'Enable if your Plex server uses HTTPS (e.g., via reverse proxy with SSL/TLS)'
+                )}
+              </Box>
+              <Typography variant="caption" color="text.secondary" sx={{ ml: 4, display: 'block' }}>
+                {isPlatformManaged.plexUrl
+                  ? 'Protocol managed by platform'
+                  : 'Default: HTTP'}
+              </Typography>
             </Grid>
 
             <Grid item xs={12} md={4}>

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -7,6 +7,7 @@
   "videoCodec": "default",
   "plexIP": "",
   "plexPort": "32400",
+  "plexViaHttps": false,
   "plexApiKey": "",
   "plexYoutubeLibraryId": "",
   "downloadSocketTimeoutSeconds": 30,

--- a/server/__tests__/server.additional-routes.test.js
+++ b/server/__tests__/server.additional-routes.test.js
@@ -1252,7 +1252,8 @@ describe('server routes - getplexlibraries with test params', () => {
     expect(plexModuleMock.getLibrariesWithParams).toHaveBeenCalledWith(
       '192.168.1.200',
       'test-api-key',
-      '32400'
+      '32400',
+      false
     );
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual([
@@ -1307,7 +1308,8 @@ describe('server routes - getplexlibraries with test params', () => {
     expect(plexModuleMock.getLibrariesWithParams).toHaveBeenCalledWith(
       '192.168.1.200',
       'test-api-key',
-      '32400'
+      '32400',
+      false
     );
   });
 

--- a/server/modules/configModule.js
+++ b/server/modules/configModule.js
@@ -58,6 +58,11 @@ class ConfigModule extends EventEmitter {
       configModified = true;
     }
 
+    if (this.config.plexViaHttps === undefined) {
+      this.config.plexViaHttps = false;
+      configModified = true;
+    }
+
     // Initialize channel auto-download settings if not present
     if (this.config.channelAutoDownload === undefined) {
       this.config.channelAutoDownload = false;
@@ -266,6 +271,7 @@ class ConfigModule extends EventEmitter {
         channelDownloadFrequency: '0 */6 * * *',
         plexApiKey: '',
         plexPort: '32400',
+        plexViaHttps: false,
         plexLibrarySection: '',
         youtubeApiKey: '',
         sponsorblockEnabled: false,
@@ -421,6 +427,7 @@ class ConfigModule extends EventEmitter {
       // Plex settings - use PLEX_URL if provided
       plexApiKey: '',
       plexPort: '32400',
+      plexViaHttps: false,
       plexLibrarySection: ''
     };
 
@@ -695,6 +702,16 @@ class ConfigModule extends EventEmitter {
         }
         if (!migrated.subtitleLanguage) {
           migrated.subtitleLanguage = 'en';
+        }
+
+        return migrated;
+      },
+      '1.49.1': (cfg) => {
+        const migrated = { ...cfg };
+
+        // Add HTTPS support for Plex connections
+        if (migrated.plexViaHttps === undefined) {
+          migrated.plexViaHttps = false;
         }
 
         return migrated;

--- a/server/server.js
+++ b/server/server.js
@@ -433,6 +433,7 @@ const initialize = async () => {
         const testIP = req.query.testIP;
         const testApiKey = req.query.testApiKey;
         const testPortRaw = req.query.testPort;
+        const testUseHttps = req.query.testUseHttps === 'true';
         const hasTestCredentials = typeof testApiKey === 'string' && testApiKey.length > 0;
         let testPort;
         if (typeof testPortRaw === 'string' && testPortRaw.trim().length > 0) {
@@ -443,7 +444,7 @@ const initialize = async () => {
         let libraries;
         if (hasTestCredentials || typeof testIP === 'string') {
           // Use provided test values instead of saved config
-          libraries = await plexModule.getLibrariesWithParams(testIP, testApiKey, testPort);
+          libraries = await plexModule.getLibrariesWithParams(testIP, testApiKey, testPort, testUseHttps);
 
           // If test was successful (got libraries), auto-save the credentials
           if (libraries && libraries.length > 0 && hasTestCredentials) {
@@ -453,6 +454,9 @@ const initialize = async () => {
             }
             if (testPort) {
               currentConfig.plexPort = testPort;
+            }
+            if (req.query.testUseHttps !== undefined) {
+              currentConfig.plexViaHttps = testUseHttps;
             }
             currentConfig.plexApiKey = testApiKey;
             configModule.updateConfig(currentConfig);


### PR DESCRIPTION
- Add plexViaHttps config option with UI checkbox (defaults to false for backward compatibility)
- Implement protocol selection in plexModule with parameter override support
- Auto-save HTTPS setting during successful connection tests
- Add test coverage and config migration