### PR TITLE
docs: improve AUTH_PRESET credential documentation and validation fee…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Youtarr Environment Variables
 # Copy this file to .env and configure for your setup
 # Example: cp .env.example .env
+#
+# IMPORTANT: After editing .env, you must completely restart your containers:
+#   - Using scripts: ./stop.sh then ./start.sh
+#   - Using Docker Compose: docker compose down then docker compose up -d
 
 # ==============================================================================
 # REQUIRED CONFIGURATION
@@ -70,6 +74,9 @@ AUTH_ENABLED=true
 # where the UI may not be accessible via localhost
 # NOTE: If set, these values OVERRIDE any username and password previously set through the WEB UI
 #       and will continue to do so on each startup
+# These must meet the following validation criteria or they will be ignored:
+#   Username: 3-32 characters (no leading/trailing spaces)
+#   Password: 8-64 characters
 
 # AUTH_PRESET_USERNAME=admin
 # AUTH_PRESET_PASSWORD=changeme

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Eg. for Portainer, TrueNAS, or any Docker-native workflow:
 
    Optionally configure authentication and logging settings (see .env.example for details).
 
+   > **Note:** Changes to `.env` require a complete container restart to take effect:
+   > - Using scripts: `./stop.sh` then `./start.sh`
+   > - Using Docker Compose: `docker compose down` then `docker compose up -d`
+
 3. **Start with Docker Compose**:
    ```bash
    docker compose up -d
@@ -128,6 +132,9 @@ Eg. for Portainer, TrueNAS, or any Docker-native workflow:
 4. **Access the web interface**:
    - Navigate to `http://localhost:3087`
    - If `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` are set in `.env`, login with those credentials
+     - These must meet length criteria or they will be ignored:
+       - `AUTH_PRESET_USERNAME`: 3-32 characters
+       - `AUTH_PRESET_PASSWORD`: 8-64 characters
    - Otherwise you must set your login credentials in UI via localhost on first run and they will be saved to `./config/config.json`
    - Configure Plex (optional) and other settings from the Configuration page
 

--- a/server/server.js
+++ b/server/server.js
@@ -132,11 +132,15 @@ function validateEnvAuthCredentials() {
     return false;
   }
   if (trimmedUsername.length < userNameMinLength || trimmedUsername.length > userNameMaxLength) {
+    logger.error('AUTH_PRESET_USERNAME does not meet length requirements');
+    logger.error(`AUTH_PRESET_USERNAME must be between ${userNameMinLength} and ${userNameMaxLength} characters`);
     return false;
   }
 
   // Password validation (NOT trimmed)
   if (presetPassword.length < passwordMinLength || presetPassword.length > passwordMaxLength) {
+    logger.error('AUTH_PRESET_PASSWORD does not meet length requirements');
+    logger.error(`AUTH_PRESET_PASSWORD must be between ${passwordMinLength} and ${passwordMaxLength} characters`);
     return false;
   }
 


### PR DESCRIPTION
…dback

- Add validation criteria to .env.example for AUTH_PRESET_USERNAME (3-32 chars) and AUTH_PRESET_PASSWORD (8-64 chars)
- Document container restart requirement after .env changes in both .env.example and README.md
- Update README with sub-bullets for AUTH_PRESET credential requirements
- Add error logging in server.js when preset credentials fail validation
- Provide clear restart instructions for both script-based and Docker Compose workflows