### PR TITLE
feat: add advanced settings section with proxy and rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,9 +82,9 @@ AUTH_ENABLED=true
 # AUTH_PRESET_PASSWORD=changeme
 
 # Logging Configuration
-# Options: warn (default), info, debug
-# Use 'debug' for troubleshooting, 'warn' for production
-LOG_LEVEL=warn
+# Options: warn, info (default), debug
+# Use 'debug' for troubleshooting, 'info' for production, 'warn' for minimal logging
+LOG_LEVEL=info
 
 # Timezone selection:
 # Controls when scheduled jobs and nightly cleanup tasks run

--- a/client/src/components/Configuration/hooks/__tests__/useConfigSave.test.ts
+++ b/client/src/components/Configuration/hooks/__tests__/useConfigSave.test.ts
@@ -2,6 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useConfigSave } from '../useConfigSave';
 import { ConfigState } from '../../types';
+import { DEFAULT_CONFIG } from '../../../../config/configSchema';
 
 // Mock fetch globally
 global.fetch = jest.fn();
@@ -9,52 +10,13 @@ global.fetch = jest.fn();
 describe('useConfigSave', () => {
   const mockToken = 'test-token-123';
   const mockConfig: ConfigState = {
-    channelAutoDownload: false,
-    channelDownloadFrequency: '6',
-    channelFilesToDownload: 3,
-    preferredResolution: '1080',
-    videoCodec: 'default',
+    ...DEFAULT_CONFIG,
+    youtubeOutputDirectory: '/videos',
     plexApiKey: 'test-plex-key',
     plexYoutubeLibraryId: '1',
     plexIP: '192.168.1.100',
     plexPort: '32400',
-    plexViaHttps: false,
-    sponsorblockEnabled: true,
-    sponsorblockAction: 'remove',
-    sponsorblockCategories: {
-      sponsor: true,
-      intro: false,
-      outro: false,
-      selfpromo: true,
-      preview: false,
-      filler: false,
-      interaction: false,
-      music_offtopic: false,
-    },
-    sponsorblockApiUrl: '',
-    downloadSocketTimeoutSeconds: 30,
-    downloadThrottledRate: '100K',
-    downloadRetryCount: 2,
-    enableStallDetection: true,
-    stallDetectionWindowSeconds: 30,
-    stallDetectionRateThreshold: '100K',
-    cookiesEnabled: false,
-    customCookiesUploaded: false,
-    writeChannelPosters: true,
-    writeVideoNfoFiles: true,
-    notificationsEnabled: false,
-    notificationService: 'discord',
-    discordWebhookUrl: '',
-    autoRemovalEnabled: false,
-    autoRemovalFreeSpaceThreshold: '',
-    autoRemovalVideoAgeThreshold: '',
-    useTmpForDownloads: false,
-    tmpFilePath: '/tmp/youtarr-downloads',
-    subtitlesEnabled: false,
-    subtitleLanguage: 'en',
-    youtubeOutputDirectory: '/videos',
     uuid: 'test-uuid',
-    envAuthApplied: false,
   };
 
   const mockSetInitialConfig = jest.fn();

--- a/client/src/components/Configuration/hooks/__tests__/usePlexConnection.test.ts
+++ b/client/src/components/Configuration/hooks/__tests__/usePlexConnection.test.ts
@@ -2,6 +2,7 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { usePlexConnection } from '../usePlexConnection';
 import { ConfigState } from '../../types';
+import { DEFAULT_CONFIG } from '../../../../config/configSchema';
 
 // Mock fetch globally
 global.fetch = jest.fn();
@@ -13,52 +14,13 @@ describe('usePlexConnection', () => {
   const mockSetSnackbar = jest.fn();
 
   const mockConfig: ConfigState = {
-    channelAutoDownload: false,
-    channelDownloadFrequency: '6',
-    channelFilesToDownload: 3,
-    preferredResolution: '1080',
-    videoCodec: 'default',
+    ...DEFAULT_CONFIG,
+    youtubeOutputDirectory: '/videos',
     plexApiKey: 'test-plex-key',
     plexYoutubeLibraryId: '1',
     plexIP: '192.168.1.100',
     plexPort: '32400',
-    plexViaHttps: false,
-    sponsorblockEnabled: true,
-    sponsorblockAction: 'remove',
-    sponsorblockCategories: {
-      sponsor: true,
-      intro: false,
-      outro: false,
-      selfpromo: true,
-      preview: false,
-      filler: false,
-      interaction: false,
-      music_offtopic: false,
-    },
-    sponsorblockApiUrl: '',
-    downloadSocketTimeoutSeconds: 30,
-    downloadThrottledRate: '100K',
-    downloadRetryCount: 2,
-    enableStallDetection: true,
-    stallDetectionWindowSeconds: 30,
-    stallDetectionRateThreshold: '100K',
-    cookiesEnabled: false,
-    customCookiesUploaded: false,
-    writeChannelPosters: true,
-    writeVideoNfoFiles: true,
-    notificationsEnabled: false,
-    notificationService: 'discord',
-    discordWebhookUrl: '',
-    autoRemovalEnabled: false,
-    autoRemovalFreeSpaceThreshold: '',
-    autoRemovalVideoAgeThreshold: '',
-    useTmpForDownloads: false,
-    tmpFilePath: '/tmp/youtarr-downloads',
-    subtitlesEnabled: false,
-    subtitleLanguage: 'en',
-    youtubeOutputDirectory: '/videos',
     uuid: 'test-uuid',
-    envAuthApplied: false,
   };
 
   beforeEach(() => {

--- a/client/src/components/Configuration/sections/AdvancedSettingsSection.tsx
+++ b/client/src/components/Configuration/sections/AdvancedSettingsSection.tsx
@@ -1,0 +1,116 @@
+import React, { useState, useCallback } from 'react';
+import {
+  TextField,
+  FormHelperText,
+  Grid,
+  Box,
+  Alert,
+  AlertTitle,
+  Typography,
+} from '@mui/material';
+import { ConfigurationAccordion } from '../common/ConfigurationAccordion';
+import { InfoTooltip } from '../common/InfoTooltip';
+import { ConfigState } from '../types';
+import { validateProxyUrl } from '../utils/configValidation';
+
+interface AdvancedSettingsSectionProps {
+  config: ConfigState;
+  onConfigChange: (updates: Partial<ConfigState>) => void;
+  onMobileTooltipClick?: (text: string) => void;
+}
+
+export const AdvancedSettingsSection: React.FC<AdvancedSettingsSectionProps> = ({
+  config,
+  onConfigChange,
+  onMobileTooltipClick,
+}) => {
+  const [proxyError, setProxyError] = useState<string | null>(null);
+
+  const handleProxyChange = useCallback((value: string) => {
+    // Always update the config value so the input remains controlled
+    onConfigChange({ proxy: value });
+
+    // Clear error while typing to allow user to complete the URL
+    setProxyError(null);
+  }, [onConfigChange]);
+
+  const handleProxyBlur = useCallback(() => {
+    // Validate only on blur when user is done typing
+    const error = validateProxyUrl(config.proxy || '');
+    setProxyError(error);
+  }, [config.proxy]);
+
+  return (
+    <ConfigurationAccordion
+      title="Advanced Settings"
+      chipLabel="Advanced"
+      chipColor="default"
+      defaultExpanded={false}
+    >
+      <Alert severity="info" sx={{ mb: 2 }}>
+        <AlertTitle>Advanced Configuration</AlertTitle>
+        <Typography variant="body2">
+          Fine-tune yt-dlp behavior with rate limiting and proxy settings. These settings are applied to all yt-dlp operations.
+        </Typography>
+      </Alert>
+
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6}>
+          <TextField
+            fullWidth
+            label="Sleep Between Requests (seconds)"
+            type="number"
+            inputProps={{ min: 0, max: 30, step: 1 }}
+            value={config.sleepRequests ?? 1}
+            onChange={(e) => {
+              const value = Number(e.target.value);
+              if (value >= 0 && value <= 30) {
+                onConfigChange({ sleepRequests: value });
+              }
+            }}
+            helperText={
+              <Box component="span" sx={{ display: 'flex', alignItems: 'center' }}>
+                Delay between yt-dlp API requests (0-30). Higher values prevent YouTube rate limiting but slow downloads.
+                <InfoTooltip
+                  text="YouTube may block requests if too many are made in a short period. A delay of 1-2 seconds usually works well. Increase to 5-10 seconds if you experience 429 errors or frequent throttling."
+                  onMobileClick={onMobileTooltipClick}
+                />
+              </Box>
+            }
+          />
+        </Grid>
+
+        <Grid item xs={12} md={6}>
+          <TextField
+            fullWidth
+            label="Proxy URL"
+            type="text"
+            value={config.proxy || ''}
+            onChange={(e) => handleProxyChange(e.target.value)}
+            onBlur={handleProxyBlur}
+            error={Boolean(proxyError)}
+            helperText={
+              <Box component="span">
+                {proxyError || (
+                  <Box component="span" sx={{ display: 'flex', alignItems: 'center' }}>
+                    Optional proxy URL (e.g., socks5://user:pass@127.0.0.1:1080/). Leave empty for direct connection.
+                    <InfoTooltip
+                      text="Supported protocols: http://, https://, socks4://, socks5://. Authentication is optional: protocol://user:pass@host:port. Pass empty string to disable proxy."
+                      onMobileClick={onMobileTooltipClick}
+                    />
+                  </Box>
+                )}
+              </Box>
+            }
+          />
+        </Grid>
+
+        <Grid item xs={12}>
+          <FormHelperText sx={{ mt: 1 }}>
+            <strong>Note:</strong> These settings apply to all yt-dlp operations including channel metadata fetching, video downloads, and thumbnail downloads.
+          </FormHelperText>
+        </Grid>
+      </Grid>
+    </ConfigurationAccordion>
+  );
+};

--- a/client/src/components/Configuration/sections/__tests__/AdvancedSettingsSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/AdvancedSettingsSection.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { AdvancedSettingsSection } from '../AdvancedSettingsSection';
+import { renderWithProviders } from '../../../../test-utils';
+import { DEFAULT_CONFIG } from '../../../../config/configSchema';
+import { ConfigState } from '../../types';
+
+const createConfig = (overrides: Partial<ConfigState> = {}): ConfigState => ({
+  ...DEFAULT_CONFIG,
+  ...overrides,
+});
+
+const setup = (
+  overrides: Partial<React.ComponentProps<typeof AdvancedSettingsSection>> = {}
+) => {
+  const user = userEvent.setup();
+  const props: React.ComponentProps<typeof AdvancedSettingsSection> = {
+    config: createConfig(),
+    onConfigChange: jest.fn(),
+    onMobileTooltipClick: jest.fn(),
+    ...overrides,
+  };
+
+  renderWithProviders(<AdvancedSettingsSection {...props} />);
+  return { user, props };
+};
+
+const expandAccordion = async (user: ReturnType<typeof userEvent.setup>) => {
+  const toggle = screen.getByRole('button', { name: /advanced settings/i });
+  await user.click(toggle);
+};
+
+describe('AdvancedSettingsSection', () => {
+  test('renders informational alert content when expanded', async () => {
+    const { user } = setup();
+    await expandAccordion(user);
+
+    expect(screen.getByText('Advanced Configuration')).toBeInTheDocument();
+    expect(screen.getByText(/Fine-tune yt-dlp behavior/i)).toBeInTheDocument();
+  });
+
+  test('updates sleep delay when a value within range is entered', async () => {
+    const user = userEvent.setup();
+    const onConfigChange = jest.fn();
+
+    const ControlledSection: React.FC = () => {
+      const [config, setConfig] = React.useState(createConfig());
+
+      const handleConfigChange = (updates: Partial<ConfigState>) => {
+        setConfig((prev) => ({ ...prev, ...updates }));
+        onConfigChange(updates);
+      };
+
+      return (
+        <AdvancedSettingsSection
+          config={config}
+          onConfigChange={handleConfigChange}
+          onMobileTooltipClick={jest.fn()}
+        />
+      );
+    };
+
+    renderWithProviders(<ControlledSection />);
+    await expandAccordion(user);
+
+    const sleepInput = screen.getByLabelText(/sleep between requests/i);
+    await user.type(sleepInput, '{selectall}{backspace}5');
+
+    expect(onConfigChange).toHaveBeenLastCalledWith({ sleepRequests: 5 });
+  });
+
+  test('ignores sleep values outside of the allowed range', async () => {
+    const onConfigChange = jest.fn();
+    const { user } = setup({ onConfigChange });
+    await expandAccordion(user);
+
+    const sleepInput = screen.getByLabelText(/sleep between requests/i);
+    await user.type(sleepInput, '{selectall}-1');
+
+    expect(onConfigChange).not.toHaveBeenCalledWith({ sleepRequests: -1 });
+  });
+
+  test('validates proxy URL on blur and shows the returned error message', async () => {
+    const { user } = setup({
+      config: createConfig({ proxy: 'invalid-proxy' }),
+    });
+    await expandAccordion(user);
+
+    const proxyInput = screen.getByLabelText(/proxy url/i);
+    await user.click(proxyInput);
+    await user.tab();
+
+    expect(
+      await screen.findByText(/invalid proxy url format/i)
+    ).toBeInTheDocument();
+  });
+
+  test('clears proxy validation errors while editing and propagates text changes', async () => {
+    const onConfigChange = jest.fn();
+    const { user } = setup({
+      config: createConfig({ proxy: 'invalid-proxy' }),
+      onConfigChange,
+    });
+    await expandAccordion(user);
+
+    const proxyInput = screen.getByLabelText(/proxy url/i);
+    await user.click(proxyInput);
+    await user.tab();
+    expect(
+      await screen.findByText(/invalid proxy url format/i)
+    ).toBeInTheDocument();
+
+    await user.click(proxyInput);
+    await user.type(proxyInput, '1');
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/invalid proxy url format/i)
+      ).not.toBeInTheDocument();
+    });
+    expect(onConfigChange).toHaveBeenLastCalledWith({
+      proxy: 'invalid-proxy1',
+    });
+  });
+});

--- a/client/src/components/Configuration/utils/__tests__/configValidation.test.ts
+++ b/client/src/components/Configuration/utils/__tests__/configValidation.test.ts
@@ -1,0 +1,70 @@
+import { validateProxyUrl, validateConfig } from '../configValidation';
+import { DEFAULT_CONFIG, ConfigState } from '../../../../config/configSchema';
+
+const createConfig = (overrides: Partial<ConfigState> = {}): ConfigState => ({
+  ...DEFAULT_CONFIG,
+  sponsorblockCategories: { ...DEFAULT_CONFIG.sponsorblockCategories },
+  ...overrides
+});
+
+describe('validateProxyUrl', () => {
+  test('returns null for empty or whitespace-only values', () => {
+    expect(validateProxyUrl('   ')).toBeNull();
+  });
+
+  test('accepts supported protocols with optional auth and path', () => {
+    const result = validateProxyUrl('https://user:pass@example.com:8443/path');
+    expect(result).toBeNull();
+  });
+
+  test('rejects unsupported proxy protocols', () => {
+    expect(validateProxyUrl('ftp://example.com')).toBe(
+      'Invalid proxy URL format. Must be http://, https://, socks4://, or socks5://'
+    );
+  });
+
+  test('rejects proxies that fail URL parsing despite matching the regex', () => {
+    expect(validateProxyUrl('http://example.com:99999')).toBe('Invalid proxy URL');
+  });
+});
+
+describe('validateConfig', () => {
+  test('requires at least one automatic removal threshold when the feature is enabled', () => {
+    const config = createConfig({
+      autoRemovalEnabled: true,
+      autoRemovalFreeSpaceThreshold: '',
+      autoRemovalVideoAgeThreshold: ''
+    });
+
+    expect(validateConfig(config)).toBe(
+      'Cannot save: Automatic removal is enabled but no thresholds are configured'
+    );
+  });
+
+  test('passes when an automatic removal threshold is configured', () => {
+    const config = createConfig({
+      autoRemovalEnabled: true,
+      autoRemovalFreeSpaceThreshold: '50GB'
+    });
+
+    expect(validateConfig(config)).toBeNull();
+  });
+
+  test('returns proxy validation errors surfaced by validateProxyUrl', () => {
+    const config = createConfig({
+      proxy: 'ftp://example.com'
+    });
+
+    expect(validateConfig(config)).toBe(
+      'Cannot save: Invalid proxy URL format. Must be http://, https://, socks4://, or socks5://'
+    );
+  });
+
+  test('ignores proxy validation when the field only contains whitespace', () => {
+    const config = createConfig({
+      proxy: '   '
+    });
+
+    expect(validateConfig(config)).toBeNull();
+  });
+});

--- a/client/src/components/Configuration/utils/configValidation.ts
+++ b/client/src/components/Configuration/utils/configValidation.ts
@@ -1,0 +1,58 @@
+import { ConfigState } from '../types';
+
+/**
+ * Validate proxy URL format
+ * @param proxy - Proxy URL string
+ * @returns Error message if invalid, null if valid
+ */
+export const validateProxyUrl = (proxy: string): string | null => {
+  if (!proxy || proxy.trim() === '') {
+    return null; // Empty is valid (no proxy)
+  }
+
+  const trimmedProxy = proxy.trim();
+
+  // Valid proxy URL patterns: http://, https://, socks4://, socks5://
+  // With optional authentication: protocol://user:pass@host:port
+  const proxyRegex = /^(https?|socks4|socks5):\/\/([^:@]+:[^:@]+@)?[^:/\s]+(:\d+)?(\/.*)?$/i;
+
+  if (!proxyRegex.test(trimmedProxy)) {
+    return 'Invalid proxy URL format. Must be http://, https://, socks4://, or socks5://';
+  }
+
+  // Additional validation using URL constructor
+  try {
+    new URL(trimmedProxy);
+  } catch {
+    return 'Invalid proxy URL';
+  }
+
+  return null;
+};
+
+/**
+ * Centralized configuration validation
+ * Validates all configuration fields and returns the first error found
+ * @param config - Current configuration state
+ * @returns Error message if validation fails, null if valid
+ */
+export const validateConfig = (config: ConfigState): string | null => {
+  // Auto removal validation
+  if (
+    config.autoRemovalEnabled &&
+    !config.autoRemovalFreeSpaceThreshold &&
+    !config.autoRemovalVideoAgeThreshold
+  ) {
+    return 'Cannot save: Automatic removal is enabled but no thresholds are configured';
+  }
+
+  // Proxy URL validation
+  if (config.proxy && config.proxy.trim()) {
+    const proxyError = validateProxyUrl(config.proxy);
+    if (proxyError) {
+      return `Cannot save: ${proxyError}`;
+    }
+  }
+
+  return null;
+};

--- a/client/src/components/__tests__/Configuration.test.tsx
+++ b/client/src/components/__tests__/Configuration.test.tsx
@@ -2,76 +2,83 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import Configuration from '../../Configuration';
-import { renderWithProviders } from '../../../test-utils';
-import { DEFAULT_CONFIG } from '../../../config/configSchema';
-import { ConfigState } from '../types';
+import Configuration from '../Configuration';
+import { renderWithProviders } from '../../test-utils';
+import { DEFAULT_CONFIG } from '../../config/configSchema';
+import { ConfigState } from '../Configuration/types';
 
 // Mock all section components
-jest.mock('../sections/CoreSettingsSection', () => ({
+jest.mock('../Configuration/sections/CoreSettingsSection', () => ({
   CoreSettingsSection: function MockCoreSettingsSection(props: any) {
     const React = require('react');
     return React.createElement('div', { 'data-testid': 'core-settings-section' }, 'CoreSettingsSection');
   }
 }));
 
-jest.mock('../sections/PlexIntegrationSection', () => ({
+jest.mock('../Configuration/sections/PlexIntegrationSection', () => ({
   PlexIntegrationSection: function MockPlexIntegrationSection(props: any) {
     const React = require('react');
     return React.createElement('div', { 'data-testid': 'plex-integration-section' }, 'PlexIntegrationSection');
   }
 }));
 
-jest.mock('../sections/SponsorBlockSection', () => ({
+jest.mock('../Configuration/sections/SponsorBlockSection', () => ({
   SponsorBlockSection: function MockSponsorBlockSection(props: any) {
     const React = require('react');
     return React.createElement('div', { 'data-testid': 'sponsorblock-section' }, 'SponsorBlockSection');
   }
 }));
 
-jest.mock('../sections/KodiCompatibilitySection', () => ({
+jest.mock('../Configuration/sections/KodiCompatibilitySection', () => ({
   KodiCompatibilitySection: function MockKodiCompatibilitySection(props: any) {
     const React = require('react');
     return React.createElement('div', { 'data-testid': 'kodi-compatibility-section' }, 'KodiCompatibilitySection');
   }
 }));
 
-jest.mock('../sections/CookieConfigSection', () => ({
+jest.mock('../Configuration/sections/CookieConfigSection', () => ({
   CookieConfigSection: function MockCookieConfigSection(props: any) {
     const React = require('react');
     return React.createElement('div', { 'data-testid': 'cookie-config-section' }, 'CookieConfigSection');
   }
 }));
 
-jest.mock('../sections/NotificationsSection', () => ({
+jest.mock('../Configuration/sections/NotificationsSection', () => ({
   NotificationsSection: function MockNotificationsSection(props: any) {
     const React = require('react');
     return React.createElement('div', { 'data-testid': 'notifications-section' }, 'NotificationsSection');
   }
 }));
 
-jest.mock('../sections/DownloadPerformanceSection', () => ({
+jest.mock('../Configuration/sections/DownloadPerformanceSection', () => ({
   DownloadPerformanceSection: function MockDownloadPerformanceSection(props: any) {
     const React = require('react');
     return React.createElement('div', { 'data-testid': 'download-performance-section' }, 'DownloadPerformanceSection');
   }
 }));
 
-jest.mock('../sections/AutoRemovalSection', () => ({
+jest.mock('../Configuration/sections/AdvancedSettingsSection', () => ({
+  AdvancedSettingsSection: function MockAdvancedSettingsSection(props: any) {
+    const React = require('react');
+    return React.createElement('div', { 'data-testid': 'advanced-settings-section' }, 'AdvancedSettingsSection');
+  }
+}));
+
+jest.mock('../Configuration/sections/AutoRemovalSection', () => ({
   AutoRemovalSection: function MockAutoRemovalSection(props: any) {
     const React = require('react');
     return React.createElement('div', { 'data-testid': 'auto-removal-section' }, 'AutoRemovalSection');
   }
 }));
 
-jest.mock('../sections/AccountSecuritySection', () => ({
+jest.mock('../Configuration/sections/AccountSecuritySection', () => ({
   AccountSecuritySection: function MockAccountSecuritySection(props: any) {
     const React = require('react');
     return React.createElement('div', { 'data-testid': 'account-security-section' }, 'AccountSecuritySection');
   }
 }));
 
-jest.mock('../sections/SaveBar', () => ({
+jest.mock('../Configuration/sections/SaveBar', () => ({
   SaveBar: function MockSaveBar(props: any) {
     const React = require('react');
     return React.createElement('div', { 'data-testid': 'save-bar' },
@@ -85,7 +92,7 @@ jest.mock('../sections/SaveBar', () => ({
 }));
 
 // Mock PlexLibrarySelector
-jest.mock('../../PlexLibrarySelector', () => ({
+jest.mock('../PlexLibrarySelector', () => ({
   __esModule: true,
   default: function MockPlexLibrarySelector(props: any) {
     const React = require('react');
@@ -96,7 +103,7 @@ jest.mock('../../PlexLibrarySelector', () => ({
 }));
 
 // Mock PlexAuthDialog
-jest.mock('../../PlexAuthDialog', () => ({
+jest.mock('../PlexAuthDialog', () => ({
   __esModule: true,
   default: function MockPlexAuthDialog(props: any) {
     const React = require('react');
@@ -107,7 +114,7 @@ jest.mock('../../PlexAuthDialog', () => ({
 }));
 
 // Mock ConfigurationSkeleton
-jest.mock('../common/ConfigurationSkeleton', () => ({
+jest.mock('../Configuration/common/ConfigurationSkeleton', () => ({
   __esModule: true,
   default: function MockConfigurationSkeleton() {
     const React = require('react');
@@ -121,16 +128,16 @@ const mockUsePlexConnection = jest.fn();
 const mockUseConfigSave = jest.fn();
 const mockUseStorageStatus = jest.fn();
 
-jest.mock('../../../hooks/useConfig', () => ({
+jest.mock('../../hooks/useConfig', () => ({
   useConfig: (...args: any[]) => mockUseConfig(...args)
 }));
 
-jest.mock('../hooks', () => ({
+jest.mock('../Configuration/hooks', () => ({
   usePlexConnection: (...args: any[]) => mockUsePlexConnection(...args),
   useConfigSave: (...args: any[]) => mockUseConfigSave(...args)
 }));
 
-jest.mock('../../../hooks/useStorageStatus', () => ({
+jest.mock('../../hooks/useStorageStatus', () => ({
   useStorageStatus: (...args: any[]) => mockUseStorageStatus(...args)
 }));
 
@@ -218,6 +225,7 @@ describe('Configuration Component', () => {
       expect(screen.getByTestId('cookie-config-section')).toBeInTheDocument();
       expect(screen.getByTestId('notifications-section')).toBeInTheDocument();
       expect(screen.getByTestId('download-performance-section')).toBeInTheDocument();
+      expect(screen.getByTestId('advanced-settings-section')).toBeInTheDocument();
       expect(screen.getByTestId('auto-removal-section')).toBeInTheDocument();
       expect(screen.getByTestId('account-security-section')).toBeInTheDocument();
       expect(screen.getByTestId('save-bar')).toBeInTheDocument();
@@ -428,26 +436,27 @@ describe('Configuration Component', () => {
     });
   });
 
-  describe('Auto-Removal Validation', () => {
-    test('prevents save when auto-removal enabled without thresholds', () => {
-      const saveConfig = jest.fn();
-      mockUseConfigSave.mockReturnValue(createMockUseConfigSave({ saveConfig }));
-      mockUseConfig.mockReturnValue(createMockUseConfig({
-        config: createConfig({
-          autoRemovalEnabled: true,
-          autoRemovalFreeSpaceThreshold: '',
-          autoRemovalVideoAgeThreshold: '',
-        }),
-      }));
+  describe('Validation', () => {
+    describe('Auto-Removal Validation', () => {
+      test('prevents save when auto-removal enabled without thresholds', () => {
+        const saveConfig = jest.fn();
+        mockUseConfigSave.mockReturnValue(createMockUseConfigSave({ saveConfig }));
+        mockUseConfig.mockReturnValue(createMockUseConfig({
+          config: createConfig({
+            autoRemovalEnabled: true,
+            autoRemovalFreeSpaceThreshold: '',
+            autoRemovalVideoAgeThreshold: '',
+          }),
+        }));
 
-      renderWithProviders(<Configuration token="test-token" />);
+        renderWithProviders(<Configuration token="test-token" />);
 
-      const saveButton = screen.getByTestId('save-button');
+        const saveButton = screen.getByTestId('save-button');
 
-      // Button should be disabled due to validation error
-      expect(saveButton).toBeDisabled();
-      expect(saveConfig).not.toHaveBeenCalled();
-    });
+        // Button should be disabled due to validation error
+        expect(saveButton).toBeDisabled();
+        expect(saveConfig).not.toHaveBeenCalled();
+      });
 
     test('prevents save from confirmation dialog when auto-removal enabled without thresholds', async () => {
       const saveConfig = jest.fn();
@@ -540,6 +549,137 @@ describe('Configuration Component', () => {
 
       await waitFor(() => {
         expect(saveConfig).toHaveBeenCalledTimes(1);
+      });
+    });
+    });
+
+    describe('Proxy Validation', () => {
+      test('prevents save when proxy URL is invalid', () => {
+        const saveConfig = jest.fn();
+        mockUseConfigSave.mockReturnValue(createMockUseConfigSave({ saveConfig }));
+        mockUseConfig.mockReturnValue(createMockUseConfig({
+          config: createConfig({
+            proxy: 'invalid-proxy-url',
+          }),
+        }));
+
+        renderWithProviders(<Configuration token="test-token" />);
+
+        const saveButton = screen.getByTestId('save-button');
+
+        // Button should be disabled due to validation error
+        expect(saveButton).toBeDisabled();
+        expect(saveConfig).not.toHaveBeenCalled();
+      });
+
+      test('allows save when proxy URL is valid HTTP', async () => {
+        const user = userEvent.setup();
+        const saveConfig = jest.fn();
+        mockUseConfigSave.mockReturnValue(createMockUseConfigSave({ saveConfig }));
+        mockUseConfig.mockReturnValue(createMockUseConfig({
+          config: createConfig({
+            proxy: 'http://proxy.example.com:8080',
+          }),
+        }));
+
+        renderWithProviders(<Configuration token="test-token" />);
+
+        const saveButton = screen.getByTestId('save-button');
+        await user.click(saveButton);
+
+        const confirmButton = await screen.findByRole('button', { name: /save configuration/i });
+        await user.click(confirmButton);
+
+        await waitFor(() => {
+          expect(saveConfig).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      test('allows save when proxy URL is valid SOCKS5 with authentication', async () => {
+        const user = userEvent.setup();
+        const saveConfig = jest.fn();
+        mockUseConfigSave.mockReturnValue(createMockUseConfigSave({ saveConfig }));
+        mockUseConfig.mockReturnValue(createMockUseConfig({
+          config: createConfig({
+            proxy: 'socks5://user:pass@127.0.0.1:1080',
+          }),
+        }));
+
+        renderWithProviders(<Configuration token="test-token" />);
+
+        const saveButton = screen.getByTestId('save-button');
+        await user.click(saveButton);
+
+        const confirmButton = await screen.findByRole('button', { name: /save configuration/i });
+        await user.click(confirmButton);
+
+        await waitFor(() => {
+          expect(saveConfig).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      test('allows save when proxy is empty', async () => {
+        const user = userEvent.setup();
+        const saveConfig = jest.fn();
+        mockUseConfigSave.mockReturnValue(createMockUseConfigSave({ saveConfig }));
+        mockUseConfig.mockReturnValue(createMockUseConfig({
+          config: createConfig({
+            proxy: '',
+          }),
+        }));
+
+        renderWithProviders(<Configuration token="test-token" />);
+
+        const saveButton = screen.getByTestId('save-button');
+        await user.click(saveButton);
+
+        const confirmButton = await screen.findByRole('button', { name: /save configuration/i });
+        await user.click(confirmButton);
+
+        await waitFor(() => {
+          expect(saveConfig).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      test('allows save when proxy is undefined', async () => {
+        const user = userEvent.setup();
+        const saveConfig = jest.fn();
+        mockUseConfigSave.mockReturnValue(createMockUseConfigSave({ saveConfig }));
+        mockUseConfig.mockReturnValue(createMockUseConfig({
+          config: createConfig({
+            proxy: undefined,
+          }),
+        }));
+
+        renderWithProviders(<Configuration token="test-token" />);
+
+        const saveButton = screen.getByTestId('save-button');
+        await user.click(saveButton);
+
+        const confirmButton = await screen.findByRole('button', { name: /save configuration/i });
+        await user.click(confirmButton);
+
+        await waitFor(() => {
+          expect(saveConfig).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      test('prevents save when proxy URL has invalid protocol', () => {
+        const saveConfig = jest.fn();
+        mockUseConfigSave.mockReturnValue(createMockUseConfigSave({ saveConfig }));
+        mockUseConfig.mockReturnValue(createMockUseConfig({
+          config: createConfig({
+            proxy: 'ftp://proxy.example.com:8080',
+          }),
+        }));
+
+        renderWithProviders(<Configuration token="test-token" />);
+
+        const saveButton = screen.getByTestId('save-button');
+
+        // Button should be disabled due to validation error
+        expect(saveButton).toBeDisabled();
+        expect(saveConfig).not.toHaveBeenCalled();
       });
     });
   });

--- a/client/src/config/configSchema.ts
+++ b/client/src/config/configSchema.ts
@@ -61,6 +61,10 @@ export const CONFIG_FIELDS = {
   stallDetectionWindowSeconds: { default: 30, trackChanges: true },
   stallDetectionRateThreshold: { default: '100K', trackChanges: true },
 
+  // Advanced settings
+  sleepRequests: { default: 1, trackChanges: true },
+  proxy: { default: '', trackChanges: true },
+
   // Cookies
   cookiesEnabled: { default: false, trackChanges: true },
   customCookiesUploaded: { default: false, trackChanges: true },
@@ -126,6 +130,8 @@ export const DEFAULT_CONFIG: ConfigState = {
   enableStallDetection: CONFIG_FIELDS.enableStallDetection.default,
   stallDetectionWindowSeconds: CONFIG_FIELDS.stallDetectionWindowSeconds.default,
   stallDetectionRateThreshold: CONFIG_FIELDS.stallDetectionRateThreshold.default,
+  sleepRequests: CONFIG_FIELDS.sleepRequests.default,
+  proxy: CONFIG_FIELDS.proxy.default,
   cookiesEnabled: CONFIG_FIELDS.cookiesEnabled.default,
   customCookiesUploaded: CONFIG_FIELDS.customCookiesUploaded.default,
   writeChannelPosters: CONFIG_FIELDS.writeChannelPosters.default,

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -30,6 +30,8 @@
   "enableStallDetection": true,
   "stallDetectionWindowSeconds": 30,
   "stallDetectionRateThreshold": "100K",
+  "sleepRequests": 1,
+  "proxy": "",
   "useTmpForDownloads": false,
   "tmpFilePath": "/tmp/youtarr-downloads",
   "cookiesEnabled": false,

--- a/docker-compose.external-db.yml
+++ b/docker-compose.external-db.yml
@@ -28,7 +28,7 @@ services:
       AUTH_PRESET_USERNAME: ${AUTH_PRESET_USERNAME:-}
       AUTH_PRESET_PASSWORD: ${AUTH_PRESET_PASSWORD:-}
       # Logging configuration
-      LOG_LEVEL: ${LOG_LEVEL:-warn}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
       # This is just informational and lets the app know where the videos will be stored on the host
       YOUTUBE_OUTPUT_DIR: ${YOUTUBE_OUTPUT_DIR}
       # Optional: Custom data path for platforms like Elfhosted (defaults to /usr/src/app/data)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       AUTH_PRESET_USERNAME: ${AUTH_PRESET_USERNAME:-}
       AUTH_PRESET_PASSWORD: ${AUTH_PRESET_PASSWORD:-}
       # Logging configuration
-      LOG_LEVEL: ${LOG_LEVEL:-warn}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
       # This is just informational and lets the app know where the videos will be stored on the host
       YOUTUBE_OUTPUT_DIR: ${YOUTUBE_OUTPUT_DIR}
       # Optional: Custom data path for platforms like Elfhosted (defaults to /usr/src/app/data)

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -222,7 +222,7 @@ You can configure environment variables in three ways:
 | `AUTH_PRESET_USERNAME` | Initial admin username for headless deployments | (empty) |
 | `AUTH_PRESET_PASSWORD` | Initial admin password for headless deployments | (empty) |
 | `AUTH_ENABLED` | Set to `false` to disable authentication | `true` |
-| `LOG_LEVEL` | Logging verbosity: `warn`, `info`, or `debug` | `warn` |
+| `LOG_LEVEL` | Logging verbosity: `warn`, `info`, or `debug` | `info` |
 | `DB_HOST` | Set to external IP when using external DB | `youtarr-db` (internal DB container) |
 | `DB_PORT` | Database port | `3321` |
 | `DB_USER` | Youtarr DB user | `root` |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -64,7 +64,7 @@ If you prefer to use standard `docker compose up` commands (eg. for Portainer, T
    Optionally configure other settings:
    - `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` - For headless deployments (e.g., Unraid)
    - `AUTH_ENABLED=false` - Only if behind external authentication (VPN, reverse proxy)
-   - `LOG_LEVEL` - Set to `debug` for troubleshooting, `warn` for production
+   - `LOG_LEVEL` - Set to `debug` for troubleshooting, `info` for normal/production use (default), `warn` for minimal logging
 
 4. **Start with Docker Compose**:
    ```bash

--- a/docs/SYNOLOGY.md
+++ b/docs/SYNOLOGY.md
@@ -145,7 +145,7 @@ AUTH_PRESET_USERNAME=admin
 AUTH_PRESET_PASSWORD=YourSecurePassword123
 
 # Optional: Logging level (warn, info, debug)
-LOG_LEVEL=warn
+LOG_LEVEL=info
 ```
 
 The `.env.example` file contains detailed comments explaining each variable - refer to it for all available options.

--- a/scripts/_start_template.sh
+++ b/scripts/_start_template.sh
@@ -21,10 +21,10 @@ if [ "$DEV_MODE" == "true" ]; then
   fi
 else
   export YOUTARR_IMAGE=dialmaster/youtarr:latest
-  export LOG_LEVEL=warn
+  export LOG_LEVEL=info
   yt_info "Running in production mode."
   yt_detail "Docker image : $YOUTARR_IMAGE"
-  yt_detail "Log level    : warn"
+  yt_detail "Log level    : info"
 fi
 
 # shellcheck source=scripts/_shared_start_tasks.sh

--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -568,8 +568,9 @@ describe('YtdlpCommandBuilder', () => {
     it('should include cookies args when cookies are available', () => {
       configModule.getCookiesPath.mockReturnValue('/path/to/cookies.txt');
       const result = YtdlpCommandBuilder.getBaseCommandArgs();
-      expect(result[0]).toBe('--cookies');
-      expect(result[1]).toBe('/path/to/cookies.txt');
+      const cookiesIndex = result.indexOf('--cookies');
+      expect(cookiesIndex).toBeGreaterThan(-1);
+      expect(result[cookiesIndex + 1]).toBe('/path/to/cookies.txt');
     });
 
     it('should include sponsorblock args when configured', () => {
@@ -781,8 +782,9 @@ describe('YtdlpCommandBuilder', () => {
     it('should include cookies args when available', () => {
       configModule.getCookiesPath.mockReturnValue('/cookies/file.txt');
       const result = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload();
-      expect(result[0]).toBe('--cookies');
-      expect(result[1]).toBe('/cookies/file.txt');
+      const cookiesIndex = result.indexOf('--cookies');
+      expect(cookiesIndex).toBeGreaterThan(-1);
+      expect(result[cookiesIndex + 1]).toBe('/cookies/file.txt');
     });
 
     it('should include sponsorblock args when configured', () => {


### PR DESCRIPTION
- Add AdvancedSettingsSection for yt-dlp proxy and sleep interval configuration
- Add centralized validation utilities (validateConfig, validateProxyUrl)
- Refactor tests to use DEFAULT_CONFIG and improve mocking patterns
- Move Configuration.test.tsx to parent directory
- Change default LOG_LEVEL from 'warn' to 'info' in .env.example