### PR TITLE
fix: relocate config.example.json to /app/server for Elfhosted compat…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,8 @@ COPY --from=build /app/server ./server
 COPY --from=build /app/client/build ./client/build
 COPY --from=build /app/migrations ./migrations
 
-# Copy config.example.json to template directory (won't be shadowed by volume mounts)
-RUN mkdir -p /app/config-templates
-COPY config/config.example.json /app/config-templates/config.example.json
+# Copy config.example.json to server directory (guaranteed to exist and accessible)
+COPY config/config.example.json /app/server/config.example.json
 
 # Copy the new simplified entrypoint script
 COPY scripts/docker-entrypoint-simple.sh /usr/local/bin/docker-entrypoint.sh

--- a/server/modules/__tests__/configModule.test.js
+++ b/server/modules/__tests__/configModule.test.js
@@ -421,7 +421,8 @@ describe('ConfigModule', () => {
       // Arrange
       fs.existsSync.mockImplementation((path) => {
         if (path.includes('config.json') && !path.includes('example')) return false;
-        if (path.includes('/app/config-templates/config.example.json')) return true;
+        // The template path is relative to __dirname (server/modules)
+        if (path.includes('server/config.example.json')) return true;
         return false;
       });
       fs.readFileSync.mockReturnValue(JSON.stringify(defaultTemplate));
@@ -431,7 +432,7 @@ describe('ConfigModule', () => {
 
       // Assert
       expect(logger.info).toHaveBeenCalledWith(
-        expect.objectContaining({ path: '/app/config-templates/config.example.json' }),
+        expect.objectContaining({ path: expect.stringContaining('server/config.example.json') }),
         'Using config.example.json from image template'
       );
     });

--- a/server/modules/configModule.js
+++ b/server/modules/configModule.js
@@ -81,8 +81,8 @@ class ConfigModule extends EventEmitter {
       return volumePath;
     }
 
-    // Fall back to image built-in template
-    const templatePath = '/app/config-templates/config.example.json';
+    // Fall back to image built-in template (guaranteed to exist in /app/server/)
+    const templatePath = path.join(__dirname, '../config.example.json');
     if (fs.existsSync(templatePath)) {
       logger.info({ path: templatePath }, 'Using config.example.json from image template');
       return templatePath;


### PR DESCRIPTION
…ibility

Fixes issue where /app/config-templates was inaccessible on Elfhosted, causing fatal initialization errors. The /app/server directory is guaranteed to exist since it contains the application code.