### PR TITLE
fix: increase video validation timeout from 10s to 60s

### DIFF
--- a/server/modules/__tests__/videoValidationModule.test.js
+++ b/server/modules/__tests__/videoValidationModule.test.js
@@ -422,7 +422,7 @@ describe('VideoValidationModule', () => {
       const result = await videoValidationModule.fetchVideoMetadata(url);
 
       expect(result).toEqual(mockMetadata);
-      expect(ytDlpRunner.fetchMetadata).toHaveBeenCalledWith(url, 10000);
+      expect(ytDlpRunner.fetchMetadata).toHaveBeenCalledWith(url, 60000);
     });
 
     it('should log error and rethrow when fetch fails', async () => {

--- a/server/modules/videoValidationModule.js
+++ b/server/modules/videoValidationModule.js
@@ -79,7 +79,7 @@ class VideoValidationModule {
    * @returns {Promise<Object>} - Video metadata
    */
   async fetchVideoMetadata(url, options = {}) {
-    const { timeoutMs = 10000 } = options;
+    const { timeoutMs = 60000 } = options;
 
     try {
       const metadata = await ytDlpRunner.fetchMetadata(url, timeoutMs);
@@ -238,7 +238,7 @@ class VideoValidationModule {
       }
 
       logger.debug({ videoId }, 'Fetching metadata for video');
-      const metadata = await this.fetchVideoMetadata(canonicalUrl, { timeoutMs: 10000 });
+      const metadata = await this.fetchVideoMetadata(canonicalUrl, { timeoutMs: 60000 });
 
       const isDuplicateVideo = await this.isDuplicate(videoId);
 

--- a/server/modules/ytDlpRunner.js
+++ b/server/modules/ytDlpRunner.js
@@ -119,9 +119,23 @@ class YtDlpRunner {
    * @param {number} timeoutMs - Timeout in milliseconds
    * @returns {Promise<Object>} - Parsed JSON metadata
    */
-  async fetchMetadata(url, timeoutMs = 10000) {
+  async fetchMetadata(url, timeoutMs = 60000) {
     const YtdlpCommandBuilder = require('./download/ytdlpCommandBuilder');
-    const args = YtdlpCommandBuilder.buildMetadataFetchArgs(url);
+    let args = YtdlpCommandBuilder.buildMetadataFetchArgs(url);
+
+    // When fetching metadata, we don't want to use --sleep-requests as we are only making a single request
+    // So we remove it from the args and also remove the arg after it (number of seconds)
+    args = args.filter((arg) => {
+      if (arg.startsWith('--sleep-requests')) {
+        // Strip the next argument as well
+        const index = args.indexOf(arg);
+        if (index !== -1 && index + 1 < args.length) {
+          args.splice(index + 1, 1);
+        }
+        return false;
+      }
+      return true;
+    });
 
     try {
       const stdout = await this.run(args, { timeoutMs });


### PR DESCRIPTION
- Update default timeout from 10000ms to 60000ms
- Remove --sleep-requests flag when fetching metadata (single request operation)
- Update tests