### PR TITLE
feat: add force query string parameter to plex library refresh

### DIFF
--- a/server/modules/__tests__/plexModule.test.js
+++ b/server/modules/__tests__/plexModule.test.js
@@ -153,7 +153,7 @@ describe('plexModule', () => {
       const result = await plexModule.refreshLibrary();
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://127.0.0.1:32400/library/sections/1/refresh?X-Plex-Token=existing-token'
+        'http://127.0.0.1:32400/library/sections/1/refresh?X-Plex-Token=existing-token&force=1'
       );
       expect(result).toBe(mockResponse);
       expect(logger.info).toHaveBeenCalledWith('Refreshing Plex library');
@@ -222,7 +222,7 @@ describe('plexModule', () => {
       await plexModule.refreshLibrary();
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://env-plex:8080/library/sections/1/refresh?X-Plex-Token=existing-token'
+        'http://env-plex:8080/library/sections/1/refresh?X-Plex-Token=existing-token&force=1'
       );
     });
   });

--- a/server/modules/plexModule.js
+++ b/server/modules/plexModule.js
@@ -32,7 +32,7 @@ class PlexModule {
 
   async refreshLibrary() {
     logger.info('Refreshing Plex library');
-    // Example GET http://[plexIP]:[plexPort]/library/sections/[plexYoutubeLibraryId]/refresh?X-Plex-Token=[plexApiKey]
+    // Example GET http://[plexIP]:[plexPort]/library/sections/[plexYoutubeLibraryId]/refresh?X-Plex-Token=[plexApiKey]&force=1
     try {
       const config = configModule.getConfig();
       const baseUrl = this.getBaseUrl(config.plexIP, config, config.plexPort, config.plexViaHttps);
@@ -43,7 +43,7 @@ class PlexModule {
       }
 
       const response = await axios.get(
-        `${baseUrl}/library/sections/${config.plexYoutubeLibraryId}/refresh?X-Plex-Token=${config.plexApiKey}`
+        `${baseUrl}/library/sections/${config.plexYoutubeLibraryId}/refresh?X-Plex-Token=${config.plexApiKey}&force=1`
       );
       logger.info({ libraryId: config.plexYoutubeLibraryId }, 'Plex library refresh initiated successfully');
       return response;


### PR DESCRIPTION
I noticed in the Plex logs that when a manual refresh is triggered on a library, there is a force boolean parameter in the API call which was not present on the Youtarr api call. 

I can update this to be a optional checkbox input on the front end in the integration section, but I don't see this impacting others or breaking existing integrations. 

This resolved my library not refreshing on Unraid. 