### PR TITLE
feat(#287): subfolder enhance / optimize perf

### DIFF
--- a/client/src/components/ChannelManager/components/chips/SubFolderChip.tsx
+++ b/client/src/components/ChannelManager/components/chips/SubFolderChip.tsx
@@ -1,23 +1,38 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
 import FolderIcon from '@mui/icons-material/Folder';
+import { isUsingDefaultSubfolder, isExplicitlyNoSubfolder } from '../../../../utils/channelHelpers';
 
 interface SubFolderChipProps {
   subFolder: string | null | undefined;
 }
 
 const SubFolderChip: React.FC<SubFolderChipProps> = ({ subFolder }) => {
-  if (!subFolder) {
+  // NULL or empty = "root" (backwards compatible, download to root)
+  if (isExplicitlyNoSubfolder(subFolder)) {
     return (
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }} data-testid="subfolder-chip" data-default="true">
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }} data-testid="subfolder-chip" data-default="false" data-root="true">
         <FolderIcon sx={{ fontSize: '0.9rem', color: 'text.secondary' }} data-testid="FolderIcon" />
         <Typography variant="caption" sx={{ fontStyle: 'italic', color: 'text.secondary' }}>
-          default
+          root
         </Typography>
       </Box>
     );
   }
 
+  // ##USE_GLOBAL_DEFAULT## = "global default" (uses global default)
+  if (isUsingDefaultSubfolder(subFolder)) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }} data-testid="subfolder-chip" data-default="true">
+        <FolderIcon sx={{ fontSize: '0.9rem', color: 'text.secondary' }} data-testid="FolderIcon" />
+        <Typography variant="caption" sx={{ fontStyle: 'italic', color: 'text.secondary' }}>
+          global default
+        </Typography>
+      </Box>
+    );
+  }
+
+  // Specific subfolder
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }} data-testid="subfolder-chip" data-default="false">
       <FolderIcon sx={{ fontSize: '0.9rem', color: 'primary.main' }} data-testid="FolderIcon" />

--- a/client/src/components/ChannelManager/components/chips/__tests__/SubFolderChip.test.tsx
+++ b/client/src/components/ChannelManager/components/chips/__tests__/SubFolderChip.test.tsx
@@ -3,35 +3,46 @@ import '@testing-library/jest-dom';
 import SubFolderChip from '../SubFolderChip';
 import { renderWithProviders } from '../../../../../test-utils';
 import { within } from '@testing-library/react';
+import { GLOBAL_DEFAULT_SENTINEL } from '../../../../../utils/channelHelpers';
 
 describe('SubFolderChip', () => {
-  test('renders default subfolder when subFolder is null', () => {
+  test('renders root when subFolder is null (backwards compatible)', () => {
     renderWithProviders(<SubFolderChip subFolder={null} />);
 
     const chip = screen.getByTestId('subfolder-chip');
 
-    expect(chip).toHaveTextContent('default');
-    expect(chip).toHaveAttribute('data-default', 'true');
+    expect(chip).toHaveTextContent('root');
+    expect(chip).toHaveAttribute('data-root', 'true');
     expect(within(chip).getByTestId('FolderIcon')).toBeInTheDocument();
   });
 
-  test('renders default subfolder when subFolder is undefined', () => {
+  test('renders root when subFolder is undefined', () => {
     renderWithProviders(<SubFolderChip subFolder={undefined} />);
 
     const chip = screen.getByTestId('subfolder-chip');
 
-    expect(chip).toHaveTextContent('default');
-    expect(chip).toHaveAttribute('data-default', 'true');
+    expect(chip).toHaveTextContent('root');
+    expect(chip).toHaveAttribute('data-root', 'true');
     expect(within(chip).getByTestId('FolderIcon')).toBeInTheDocument();
   });
 
-  test('renders default subfolder when subFolder is empty string', () => {
+  test('renders root when subFolder is empty string', () => {
     renderWithProviders(<SubFolderChip subFolder="" />);
 
     const chip = screen.getByTestId('subfolder-chip');
 
-    expect(chip).toHaveTextContent('default');
+    expect(chip).toHaveTextContent('root');
+    expect(chip).toHaveAttribute('data-root', 'true');
+  });
+
+  test('renders global default when subFolder is sentinel value', () => {
+    renderWithProviders(<SubFolderChip subFolder={GLOBAL_DEFAULT_SENTINEL} />);
+
+    const chip = screen.getByTestId('subfolder-chip');
+
+    expect(chip).toHaveTextContent('global default');
     expect(chip).toHaveAttribute('data-default', 'true');
+    expect(within(chip).getByTestId('FolderIcon')).toBeInTheDocument();
   });
 
   test('renders custom subfolder with correct format', () => {

--- a/client/src/components/ChannelPage.tsx
+++ b/client/src/components/ChannelPage.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '@mui/material/styles';
 import { Channel } from '../types/Channel';
 import ChannelVideos from './ChannelPage/ChannelVideos';
 import ChannelSettingsDialog from './ChannelPage/ChannelSettingsDialog';
+import { isUsingDefaultSubfolder, isExplicitlyNoSubfolder } from '../utils/channelHelpers';
 
 interface ChannelPageProps {
   token: string | null;
@@ -71,11 +72,26 @@ function ChannelPage({ token }: ChannelPageProps) {
   }
 
   const renderSubFolder = (subFolder: string | null | undefined) => {
-    const displayText = subFolder ? `__${subFolder}/` : 'default';
+    let displayText: string;
+    let isSpecial = false;
+
+    if (isExplicitlyNoSubfolder(subFolder)) {
+      // null/empty = root (backwards compatible)
+      displayText = 'root';
+      isSpecial = true;
+    } else if (isUsingDefaultSubfolder(subFolder)) {
+      // ##USE_GLOBAL_DEFAULT## = use global default
+      displayText = 'global default';
+      isSpecial = true;
+    } else {
+      // Specific subfolder
+      displayText = `__${subFolder}/`;
+    }
+
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
         <FolderIcon sx={{ fontSize: isMobile ? '0.75rem' : '0.85rem', color: 'text.secondary' }} />
-        <Typography sx={{ fontSize: isMobile ? '0.65rem' : '0.75rem', color: 'text.secondary', fontStyle: subFolder ? 'normal' : 'italic' }}>
+        <Typography sx={{ fontSize: isMobile ? '0.65rem' : '0.75rem', color: 'text.secondary', fontStyle: isSpecial ? 'italic' : 'normal' }}>
           {displayText}
         </Typography>
       </Box>

--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -10,7 +10,6 @@ import {
   Select,
   MenuItem,
   TextField,
-  Autocomplete,
   CircularProgress,
   Alert,
   Box,
@@ -27,6 +26,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import InfoIcon from '@mui/icons-material/Info';
 import { useConfig } from '../../hooks/useConfig';
+import { SubfolderAutocomplete } from '../shared/SubfolderAutocomplete';
 
 interface ChannelSettings {
   sub_folder: string | null;
@@ -390,46 +390,27 @@ function ChannelSettingsDialog({
               </Typography>
               <Typography variant="body2" component="div">
                 Subfolders are automatically prefixed with <code>__</code> on the filesystem.
+                Choose &quot;Default Subfolder&quot; to use your global default setting, or &quot;No Subfolder&quot; to explicitly place in the root directory.
               </Typography>
             </Alert>
 
-            <Autocomplete
-              freeSolo
-              options={subfolders}
-              value={settings.sub_folder ? `__${settings.sub_folder}` : ''}
-              onChange={(event, newValue) => {
-                // Strip __ prefix before saving to DB (backend stores clean names)
-                const cleanValue = newValue ? newValue.trim().replace(/^__/, '') : null;
+            <SubfolderAutocomplete
+              mode="channel"
+              value={settings.sub_folder}
+              onChange={(newValue) => {
                 setSettings({
                   ...settings,
-                  sub_folder: cleanValue
+                  sub_folder: newValue
                 });
               }}
-              onInputChange={(event, newInputValue) => {
-                // Strip __ prefix before saving to DB (backend stores clean names)
-                const cleanValue = newInputValue ? newInputValue.trim().replace(/^__/, '') : null;
-                setSettings({
-                  ...settings,
-                  sub_folder: cleanValue
-                });
-              }}
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Subfolder (optional)"
-                  placeholder="SportsChannels"
-                  helperText="Enter a subfolder name (e.g., 'Sports'). Leave empty to place in root."
-                  fullWidth
-                  InputLabelProps={{
-                    shrink: true,
-                  }}
-                />
-              )}
+              subfolders={subfolders}
+              defaultSubfolderDisplay={config.defaultSubfolder || null}
+              label="Subfolder"
+              helperText="Choose where this channel's videos are saved"
             />
 
             <Typography variant="caption" color="text.secondary">
-              Note: Changing the subfolder will move the channel's existing folder and files!
-            </Typography>
+              Note: Changing the subfolder will move the channel's existing folder and files!</Typography>
 
             {/* Download Filters Section */}
             <Divider sx={{ my: 0 }} />

--- a/client/src/components/ChannelPage/ChannelVideosDialogs.tsx
+++ b/client/src/components/ChannelPage/ChannelVideosDialogs.tsx
@@ -14,6 +14,7 @@ import DeleteVideosDialog from '../shared/DeleteVideosDialog';
 import { DownloadSettings } from '../DownloadManager/ManualDownload/types';
 
 export interface ChannelVideosDialogsProps {
+  token: string | null;
   downloadDialogOpen: boolean;
   refreshConfirmOpen: boolean;
   deleteDialogOpen: boolean;
@@ -41,6 +42,7 @@ export interface ChannelVideosDialogsProps {
 }
 
 function ChannelVideosDialogs({
+  token,
   downloadDialogOpen,
   refreshConfirmOpen,
   deleteDialogOpen,
@@ -78,6 +80,7 @@ function ChannelVideosDialogs({
         defaultResolution={defaultResolution}
         defaultResolutionSource={defaultResolutionSource}
         mode="manual"
+        token={token}
       />
 
       {/* Refresh Confirmation Dialog */}

--- a/client/src/components/ChannelPage/__tests__/ChannelVideosDialogs.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideosDialogs.test.tsx
@@ -53,6 +53,7 @@ describe('ChannelVideosDialogs Component', () => {
     defaultResolutionSource: 'global',
     selectedTab: 'videos',
     tabLabel: 'Videos',
+    token: null,
     onDownloadDialogClose: jest.fn(),
     onDownloadConfirm: jest.fn(),
     onRefreshCancel: jest.fn(),

--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -198,6 +198,7 @@ function Configuration({ token }: ConfigurationProps) {
         isPlatformManaged={isPlatformManaged}
         onConfigChange={handleConfigChange}
         onMobileTooltipClick={setMobileTooltip}
+        token={token}
       />
 
       <PlexIntegrationSection

--- a/client/src/components/DownloadManager/ManualDownload/ManualDownload.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/ManualDownload.tsx
@@ -272,6 +272,7 @@ const ManualDownload: React.FC<ManualDownloadProps> = ({ onStartDownload, token,
         defaultResolution={defaultResolution}
         mode="manual"
         defaultResolutionSource="global"
+        token={token}
       />
     </Box>
   );

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/DownloadSettingsDialog.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/DownloadSettingsDialog.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import DownloadSettingsDialog from '../DownloadSettingsDialog';
 
@@ -56,38 +56,43 @@ describe('DownloadSettingsDialog', () => {
       expect(screen.getByLabelText('Use custom settings for this download')).toBeInTheDocument();
     });
 
-    test('renders re-download toggle', () => {
+    test('renders re-download toggle when custom settings enabled', () => {
       render(<DownloadSettingsDialog {...defaultProps} />);
+
+      // Enable custom settings to see re-download toggle
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
 
       expect(screen.getByLabelText('Allow re-downloading previously fetched videos')).toBeInTheDocument();
     });
 
-    test('shows current automatic setting with channel override source', () => {
+    test('shows summary box with quality info', () => {
       render(
         <DownloadSettingsDialog
           {...defaultProps}
           defaultResolution="720"
-          defaultResolutionSource="channel"
         />
       );
 
-      expect(
-        screen.getByText(/Current automatic setting: 720p \(HD\) \(channel override\)/i)
-      ).toBeInTheDocument();
+      // Should show the summary box with quality
+      const summaryBox = screen.getByTestId('settings-summary');
+      expect(summaryBox).toBeInTheDocument();
+      expect(within(summaryBox).getByText('Current Settings')).toBeInTheDocument();
+      expect(within(summaryBox).getByText(/Quality:/)).toBeInTheDocument();
+      expect(within(summaryBox).getByText('720p (HD)')).toBeInTheDocument();
     });
 
-    test('shows current automatic setting with global default source', () => {
+    test('shows summary box with destination info', () => {
       render(
         <DownloadSettingsDialog
           {...defaultProps}
           defaultResolution="1080"
-          defaultResolutionSource="global"
         />
       );
 
-      expect(
-        screen.getByText(/Current automatic setting: 1080p \(Full HD\) \(global default\)/i)
-      ).toBeInTheDocument();
+      // Should show destination behavior
+      expect(screen.getByText(/Destination:/)).toBeInTheDocument();
+      expect(screen.getByText('Per channel settings (or global default)')).toBeInTheDocument();
     });
 
     test('renders warning for missing videos when missingVideoCount is 1 in manual mode', () => {
@@ -144,8 +149,12 @@ describe('DownloadSettingsDialog', () => {
       expect(screen.getByRole('option', { name: '2160p (4K)' })).toBeInTheDocument();
     });
 
-    test('renders video count field in channel mode', () => {
+    test('renders video count field in channel mode when custom settings enabled', () => {
       render(<DownloadSettingsDialog {...defaultProps} mode="channel" />);
+
+      // Enable custom settings to see video count field
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
 
       expect(screen.getByText('Videos Per Channel')).toBeInTheDocument();
       expect(screen.getByLabelText('Number of videos to download per channel')).toBeInTheDocument();
@@ -153,6 +162,10 @@ describe('DownloadSettingsDialog', () => {
 
     test('does not render video count field in manual mode', () => {
       render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
+
+      // Enable custom settings
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
 
       expect(screen.queryByText('Videos Per Channel')).not.toBeInTheDocument();
       expect(screen.queryByLabelText('Number of videos to download per channel')).not.toBeInTheDocument();
@@ -177,12 +190,20 @@ describe('DownloadSettingsDialog', () => {
     test('uses default resolution of 1080', () => {
       render(<DownloadSettingsDialog {...defaultProps} />);
 
+      // Enable custom settings to see resolution select
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
+
       const resolutionSelect = screen.getByLabelText('Maximum Resolution');
       expect(resolutionSelect).toHaveTextContent('1080p (Full HD)');
     });
 
     test('uses custom default resolution when provided', () => {
       render(<DownloadSettingsDialog {...defaultProps} defaultResolution="720" />);
+
+      // Enable custom settings to see resolution select
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
 
       const resolutionSelect = screen.getByLabelText('Maximum Resolution');
       expect(resolutionSelect).toHaveTextContent('720p (HD)');
@@ -191,6 +212,10 @@ describe('DownloadSettingsDialog', () => {
     test('uses default video count of 3 in channel mode', () => {
       render(<DownloadSettingsDialog {...defaultProps} mode="channel" />);
 
+      // Enable custom settings to see video count select
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
+
       const videoCountSelect = screen.getByLabelText('Number of videos to download per channel');
       expect(videoCountSelect).toHaveTextContent('3 videos');
     });
@@ -198,69 +223,84 @@ describe('DownloadSettingsDialog', () => {
     test('uses custom default video count when provided', () => {
       render(<DownloadSettingsDialog {...defaultProps} mode="channel" defaultVideoCount={10} />);
 
+      // Enable custom settings to see video count select
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
+
       const videoCountSelect = screen.getByLabelText('Number of videos to download per channel');
       expect(videoCountSelect).toHaveTextContent('10 videos');
     });
 
-    test('shows default settings info when custom settings disabled', () => {
+    test('shows summary box with quality when custom settings disabled', () => {
       render(<DownloadSettingsDialog {...defaultProps} defaultResolution="720" />);
 
-      expect(screen.getByText(/Using default settings: 720p \(HD\)/i)).toBeInTheDocument();
+      // Summary box should show quality
+      const summaryBox = screen.getByTestId('settings-summary');
+      expect(summaryBox).toBeInTheDocument();
+      expect(within(summaryBox).getByText('720p (HD)')).toBeInTheDocument();
     });
 
-    test('shows default settings info with video count in channel mode', () => {
+    test('shows summary box with video count in channel mode', () => {
       render(<DownloadSettingsDialog {...defaultProps} mode="channel" defaultVideoCount={5} defaultResolution="1080" />);
 
-      expect(screen.getByText(/Using default settings: 5 videos per channel at 1080p \(Full HD\)/i)).toBeInTheDocument();
+      // Summary box should show videos per channel in channel mode
+      expect(screen.getByTestId('settings-summary')).toBeInTheDocument();
+      expect(screen.getByText(/Videos per channel:/)).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
     });
   });
 
   describe('Custom Settings Toggle', () => {
-    test('disables resolution select when custom settings off', () => {
+    test('collapses resolution select when custom settings off', () => {
       render(<DownloadSettingsDialog {...defaultProps} />);
 
-      const resolutionSelect = screen.getByLabelText('Maximum Resolution');
-      // Check that the select is disabled
-      expect(resolutionSelect).toHaveAttribute('aria-disabled', 'true');
+      // Custom settings section should be in collapsed state when custom settings is off
+      // The Collapse component keeps children mounted but hidden
+      const customSettingsToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      expect(customSettingsToggle).not.toBeChecked();
     });
 
-    test('enables resolution select when custom settings on', () => {
+    test('shows resolution select when custom settings on', () => {
       render(<DownloadSettingsDialog {...defaultProps} />);
 
       const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
       fireEvent.click(toggle);
 
       const resolutionSelect = screen.getByLabelText('Maximum Resolution');
-      expect(resolutionSelect).not.toBeDisabled();
+      expect(resolutionSelect).toBeInTheDocument();
+      expect(resolutionSelect).toBeVisible();
     });
 
-    test('applies opacity transition when toggling custom settings', () => {
+    test('shows summary box when custom settings off', () => {
       render(<DownloadSettingsDialog {...defaultProps} />);
 
-      // Find the container using test id
-      const settingsBox = screen.getByTestId('custom-settings-section');
-      expect(settingsBox).toHaveStyle({ opacity: '0.5', transition: 'opacity 0.3s' });
+      // Summary box should be visible when custom settings is off
+      const summaryBox = screen.getByTestId('settings-summary');
+      expect(summaryBox).toBeVisible();
+    });
+
+    test('collapses summary box when custom settings on', () => {
+      render(<DownloadSettingsDialog {...defaultProps} />);
+
+      // Summary should be visible initially
+      const summaryBox = screen.getByTestId('settings-summary');
+      expect(summaryBox).toBeVisible();
 
       const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
       fireEvent.click(toggle);
 
-      expect(settingsBox).toHaveStyle({ opacity: '1', transition: 'opacity 0.3s' });
+      // After toggle, custom settings section should be visible
+      expect(screen.getByTestId('custom-settings-section')).toBeVisible();
     });
 
-    test('shows helper text for video count when custom settings disabled', () => {
-      render(<DownloadSettingsDialog {...defaultProps} mode="channel" defaultVideoCount={5} />);
-
-      expect(screen.getByText('Using default: 5 videos per channel')).toBeInTheDocument();
-    });
-
-    test('does not show helper text for video count when custom settings enabled', () => {
+    test('shows custom settings section when toggle is on', () => {
       render(<DownloadSettingsDialog {...defaultProps} mode="channel" />);
 
       const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
       fireEvent.click(toggle);
 
-      // The helper text "1-50 videos per channel" is no longer shown with dropdown
-      expect(screen.queryByText('1-50 videos per channel')).not.toBeInTheDocument();
+      // Custom settings section should be visible
+      expect(screen.getByTestId('custom-settings-section')).toBeVisible();
     });
   });
 
@@ -364,16 +404,19 @@ describe('DownloadSettingsDialog', () => {
       expect(screen.getByRole('option', { name: '10 videos' })).toBeInTheDocument();
     });
 
-    test('disables dropdown when custom settings are off', () => {
+    test('shows dropdown when custom settings are on', () => {
       render(<DownloadSettingsDialog {...defaultProps} mode="channel" />);
 
-      const videoCountSelect = screen.getByLabelText('Number of videos to download per channel');
-      expect(videoCountSelect).toHaveAttribute('aria-disabled', 'true');
-
+      // Custom settings is off initially
       const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      expect(toggle).not.toBeChecked();
+
+      // Enable custom settings
       fireEvent.click(toggle);
 
-      expect(videoCountSelect).not.toHaveAttribute('aria-disabled', 'true');
+      // Should be visible when custom settings is on
+      const videoCountSelect = screen.getByLabelText('Number of videos to download per channel');
+      expect(videoCountSelect).toBeVisible();
     });
   });
 
@@ -440,6 +483,7 @@ describe('DownloadSettingsDialog', () => {
         resolution: '720',
         videoCount: 0,
         allowRedownload: false,
+        subfolder: null,
       });
     });
 
@@ -526,6 +570,10 @@ describe('DownloadSettingsDialog', () => {
     test('auto-checks re-download toggle when missing videos are present', () => {
       render(<DownloadSettingsDialog {...defaultProps} missingVideoCount={3} />);
 
+      // Enable custom settings to see re-download toggle
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
+
       const redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
       expect(redownloadToggle).toBeChecked();
     });
@@ -533,12 +581,20 @@ describe('DownloadSettingsDialog', () => {
     test('does not auto-check re-download toggle when no missing videos', () => {
       render(<DownloadSettingsDialog {...defaultProps} missingVideoCount={0} />);
 
+      // Enable custom settings to see re-download toggle
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
+
       const redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
       expect(redownloadToggle).not.toBeChecked();
     });
 
     test('calls onConfirm with allowRedownload true when toggle is checked', () => {
       render(<DownloadSettingsDialog {...defaultProps} />);
+
+      // Enable custom settings
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
 
       const redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
       fireEvent.click(redownloadToggle);
@@ -550,13 +606,18 @@ describe('DownloadSettingsDialog', () => {
         resolution: '1080',
         videoCount: 0,
         allowRedownload: true,
+        subfolder: null,
       });
     });
 
-    test('calls onConfirm with settings when only re-download is enabled', () => {
+    test('calls onConfirm with settings when custom settings enabled', () => {
       render(<DownloadSettingsDialog {...defaultProps} defaultResolution="720" />);
 
-      // Only enable re-download, not custom settings
+      // Enable custom settings
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
+
+      // Enable re-download
       const redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
       fireEvent.click(redownloadToggle);
 
@@ -564,14 +625,19 @@ describe('DownloadSettingsDialog', () => {
       fireEvent.click(confirmButton);
 
       expect(mockOnConfirm).toHaveBeenCalledWith({
-        resolution: '720', // Uses default
+        resolution: '720',
         videoCount: 0,
         allowRedownload: true,
+        subfolder: null,
       });
     });
 
     test('saves allowRedownload state to localStorage', () => {
       render(<DownloadSettingsDialog {...defaultProps} />);
+
+      // Enable custom settings
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
 
       const redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
       fireEvent.click(redownloadToggle);
@@ -585,6 +651,10 @@ describe('DownloadSettingsDialog', () => {
 
     test('marks user as having interacted when changing re-download toggle', () => {
       render(<DownloadSettingsDialog {...defaultProps} />);
+
+      // Enable custom settings
+      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(toggle);
 
       const redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
       fireEvent.click(redownloadToggle);
@@ -624,22 +694,24 @@ describe('DownloadSettingsDialog', () => {
       const newCustomToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
       expect(newCustomToggle).not.toBeChecked();
 
+      // Re-enable custom settings to check re-download toggle
+      fireEvent.click(newCustomToggle);
       const newRedownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
       expect(newRedownloadToggle).not.toBeChecked();
     });
 
-    test('preserves defaultResolutionSource when dialog reopens', () => {
+    test('preserves quality in summary when dialog reopens', () => {
       const { rerender } = render(
         <DownloadSettingsDialog
           {...defaultProps}
           defaultResolution="720"
-          defaultResolutionSource="channel"
         />
       );
 
-      expect(
-        screen.getByText(/Current automatic setting: 720p \(HD\) \(channel override\)/i)
-      ).toBeInTheDocument();
+      // Summary should show the quality
+      let summaryBox = screen.getByTestId('settings-summary');
+      expect(summaryBox).toBeInTheDocument();
+      expect(within(summaryBox).getByText('720p (HD)')).toBeInTheDocument();
 
       // Close and reopen
       rerender(
@@ -647,7 +719,6 @@ describe('DownloadSettingsDialog', () => {
           {...defaultProps}
           open={false}
           defaultResolution="720"
-          defaultResolutionSource="channel"
         />
       );
 
@@ -656,20 +727,23 @@ describe('DownloadSettingsDialog', () => {
           {...defaultProps}
           open={true}
           defaultResolution="720"
-          defaultResolutionSource="channel"
         />
       );
 
-      // Should still show channel override
-      expect(
-        screen.getByText(/Current automatic setting: 720p \(HD\) \(channel override\)/i)
-      ).toBeInTheDocument();
+      // Should still show quality in summary
+      summaryBox = screen.getByTestId('settings-summary');
+      expect(summaryBox).toBeInTheDocument();
+      expect(within(summaryBox).getByText('720p (HD)')).toBeInTheDocument();
     });
 
     test('auto-enables redownload toggle again when reopened with missing videos', () => {
       const { rerender } = render(
         <DownloadSettingsDialog {...defaultProps} missingVideoCount={3} />
       );
+
+      // Enable custom settings to see re-download toggle
+      let customToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(customToggle);
 
       // Should be auto-checked
       let redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
@@ -684,6 +758,10 @@ describe('DownloadSettingsDialog', () => {
 
       // Reopen with missing videos again
       rerender(<DownloadSettingsDialog {...defaultProps} open={true} missingVideoCount={3} />);
+
+      // Enable custom settings again
+      customToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      fireEvent.click(customToggle);
 
       // Should be auto-checked again (hasUserInteracted was reset)
       redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
@@ -702,8 +780,9 @@ describe('DownloadSettingsDialog', () => {
     test('handles missing resolution in RESOLUTION_OPTIONS', () => {
       render(<DownloadSettingsDialog {...defaultProps} defaultResolution="9999" />);
 
-      // Should display raw resolution value
-      expect(screen.getByText(/Using default settings: 9999p/i)).toBeInTheDocument();
+      // Summary box should show the raw resolution value
+      expect(screen.getByTestId('settings-summary')).toBeInTheDocument();
+      expect(screen.getByText('9999p')).toBeInTheDocument();
     });
 
     test('handles localStorage being unavailable', () => {

--- a/client/src/components/DownloadManager/ManualDownload/types.ts
+++ b/client/src/components/DownloadManager/ManualDownload/types.ts
@@ -15,6 +15,7 @@ export interface DownloadSettings {
   resolution: string;
   videoCount: number;
   allowRedownload?: boolean;
+  subfolder?: string | null;
 }
 
 export interface ValidationResponse {

--- a/client/src/components/shared/AddSubfolderDialog.tsx
+++ b/client/src/components/shared/AddSubfolderDialog.tsx
@@ -1,0 +1,167 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+} from '@mui/material';
+
+const MAX_SUBFOLDER_LENGTH = 100;
+const VALID_NAME_REGEX = /^[a-zA-Z0-9\s\-_]+$/;
+
+interface AddSubfolderDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onAdd: (subfolderName: string) => void;
+  existingSubfolders: string[];
+}
+
+/**
+ * Dialog for adding a new subfolder name.
+ * Validates input and returns the cleaned subfolder name.
+ */
+export function AddSubfolderDialog({
+  open,
+  onClose,
+  onAdd,
+  existingSubfolders,
+}: AddSubfolderDialogProps) {
+  const [inputValue, setInputValue] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  // Reset state when dialog opens/closes
+  useEffect(() => {
+    if (open) {
+      setInputValue('');
+      setValidationError(null);
+    }
+  }, [open]);
+
+  // Validate input and return cleaned value
+  const validateInput = useCallback(
+    (value: string): { isValid: boolean; cleanedValue: string; error: string | null } => {
+      const cleaned = value.trim();
+
+      // Check empty
+      if (!cleaned) {
+        return { isValid: false, cleanedValue: '', error: 'Subfolder name cannot be empty' };
+      }
+
+      // Reserved prefix
+      if (cleaned.startsWith('__')) {
+        return {
+          isValid: false,
+          cleanedValue: cleaned,
+          error: 'Subfolder names cannot start with __ (reserved prefix)',
+        };
+      }
+
+      // Check length
+      if (cleaned.length > MAX_SUBFOLDER_LENGTH) {
+        return {
+          isValid: false,
+          cleanedValue: cleaned,
+          error: `Name cannot exceed ${MAX_SUBFOLDER_LENGTH} characters`,
+        };
+      }
+
+      // Check invalid characters (must match server rule)
+      if (!VALID_NAME_REGEX.test(cleaned)) {
+        return {
+          isValid: false,
+          cleanedValue: cleaned,
+          error: 'Subfolder name can only contain letters, numbers, spaces, hyphens, and underscores',
+        };
+      }
+
+      // Path traversal safety
+      if (cleaned.includes('..') || cleaned.includes('/') || cleaned.includes('\\')) {
+        return {
+          isValid: false,
+          cleanedValue: cleaned,
+          error: 'Invalid subfolder name',
+        };
+      }
+
+      // Check duplicates (case-insensitive)
+      const lowerCleaned = cleaned.toLowerCase();
+      const isDuplicate = existingSubfolders.some((folder) => {
+        const existingClean = folder.replace(/^__/, '').trim().toLowerCase();
+        return existingClean === lowerCleaned;
+      });
+
+      if (isDuplicate) {
+        return {
+          isValid: false,
+          cleanedValue: cleaned,
+          error: 'A subfolder with this name already exists',
+        };
+      }
+
+      return { isValid: true, cleanedValue: cleaned, error: null };
+    },
+    [existingSubfolders]
+  );
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    setInputValue(newValue);
+
+    // Validate on change
+    const { error } = validateInput(newValue);
+    setValidationError(error);
+  };
+
+  const handleAdd = () => {
+    const { isValid, cleanedValue } = validateInput(inputValue);
+    if (isValid) {
+      onAdd(cleanedValue);
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      const { isValid } = validateInput(inputValue);
+      if (isValid) {
+        handleAdd();
+      }
+    }
+  };
+
+  const { isValid } = validateInput(inputValue);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Add New Subfolder</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          fullWidth
+          label="Subfolder Name"
+          value={inputValue}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          error={!!validationError}
+          helperText={
+            validationError || 'Enter a name for the new subfolder (e.g., Sports, Music)'
+          }
+          InputLabelProps={{ shrink: true }}
+          inputProps={{
+            maxLength: MAX_SUBFOLDER_LENGTH,
+          }}
+          sx={{ mt: 1 }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleAdd} variant="contained" disabled={!isValid}>
+          Add Subfolder
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default AddSubfolderDialog;

--- a/client/src/components/shared/SubfolderAutocomplete.tsx
+++ b/client/src/components/shared/SubfolderAutocomplete.tsx
@@ -1,0 +1,404 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Autocomplete,
+  TextField,
+  Box,
+  Typography,
+  Divider,
+} from '@mui/material';
+import SettingsIcon from '@mui/icons-material/Settings';
+import FolderOffIcon from '@mui/icons-material/FolderOff';
+import AddIcon from '@mui/icons-material/Add';
+import {
+  GLOBAL_DEFAULT_SENTINEL,
+  ROOT_SENTINEL,
+  isUsingDefaultSubfolder,
+  isExplicitlyNoSubfolder,
+  isExplicitlyRoot,
+} from '../../utils/channelHelpers';
+import { AddSubfolderDialog } from './AddSubfolderDialog';
+
+/**
+ * Represents an option in the subfolder autocomplete
+ */
+interface SubfolderOption {
+  label: string;
+  value: string | null;
+  isSpecial: boolean;
+  isAddNew: boolean;
+  group: 'special' | 'subfolders' | 'actions';
+}
+
+type SubfolderMode = 'global' | 'channel' | 'download';
+
+interface SubfolderAutocompleteProps {
+  /** Current value (clean, without __ prefix). null = root (backwards compat), ##USE_GLOBAL_DEFAULT## = use default */
+  value: string | null | undefined;
+  /** Callback when value changes */
+  onChange: (value: string | null) => void;
+  /** List of existing subfolders (with __ prefix from API) */
+  subfolders: string[];
+  /** Global default subfolder for display purposes (without __ prefix) */
+  defaultSubfolderDisplay?: string | null;
+  /** Mode determines available options */
+  mode: SubfolderMode;
+  /** Whether the input is disabled */
+  disabled?: boolean;
+  /** Whether data is loading */
+  loading?: boolean;
+  /** Helper text to display below the input */
+  helperText?: string;
+  /** Label for the input */
+  label?: string;
+}
+
+const ADD_NEW_SENTINEL = '__ADD_NEW__';
+
+/**
+ * Reusable subfolder autocomplete component
+ * Supports three modes:
+ * - 'global': For CoreSettingsSection - shows "No Subfolder (root)" + existing subfolders + Add
+ * - 'channel': For channel settings - adds "Default Subfolder" and "No Subfolder" special options + Add
+ * - 'download': For manual downloads - adds "No override" option plus channel options + Add
+ */
+export function SubfolderAutocomplete({
+  value,
+  onChange,
+  subfolders,
+  defaultSubfolderDisplay,
+  mode,
+  disabled = false,
+  loading = false,
+  helperText,
+  label = 'Subfolder',
+}: SubfolderAutocompleteProps) {
+  // State for the Add Subfolder dialog
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  // Track locally added subfolders (not yet on filesystem)
+  const [localSubfolders, setLocalSubfolders] = useState<string[]>([]);
+
+  // Combine API subfolders with locally added ones
+  const allSubfolders = useMemo(() => {
+    const combined = new Set([...subfolders, ...localSubfolders]);
+    return Array.from(combined).sort();
+  }, [subfolders, localSubfolders]);
+
+  // Build options based on mode
+  const options = useMemo((): SubfolderOption[] => {
+    const opts: SubfolderOption[] = [];
+
+    // Add special options based on mode
+    if (mode === 'global') {
+      // "No Subfolder" option - maps to null (root directory)
+      opts.push({
+        label: 'No Subfolder (root)',
+        value: null,
+        isSpecial: true,
+        isAddNew: false,
+        group: 'special',
+      });
+    } else if (mode === 'channel') {
+      // "No Subfolder" option - maps to null (backwards compatible root)
+      opts.push({
+        label: 'No Subfolder (root)',
+        value: null,
+        isSpecial: true,
+        isAddNew: false,
+        group: 'special',
+      });
+
+      // "Default Subfolder" option - maps to ##USE_GLOBAL_DEFAULT##
+      const defaultLabel = defaultSubfolderDisplay
+        ? `Default Subfolder (__${defaultSubfolderDisplay})`
+        : 'Default Subfolder (root)';
+      opts.push({
+        label: defaultLabel,
+        value: GLOBAL_DEFAULT_SENTINEL,
+        isSpecial: true,
+        isAddNew: false,
+        group: 'special',
+      });
+    } else if (mode === 'download') {
+      // "No override" option - maps to null (no override)
+      opts.push({
+        label: 'No override (use channel settings)',
+        value: null,
+        isSpecial: true,
+        isAddNew: false,
+        group: 'special',
+      });
+
+      // "Root directory" option - explicitly download to root (no subfolder)
+      opts.push({
+        label: 'Root directory (no subfolder)',
+        value: ROOT_SENTINEL,
+        isSpecial: true,
+        isAddNew: false,
+        group: 'special',
+      });
+
+      // "Use Global Default" option - uses global default subfolder
+      opts.push({
+        label: 'Use Global Default Subfolder',
+        value: GLOBAL_DEFAULT_SENTINEL,
+        isSpecial: true,
+        isAddNew: false,
+        group: 'special',
+      });
+    }
+
+    // Add existing subfolders (strip __ prefix from display, store clean value)
+    allSubfolders.forEach((folder) => {
+      const cleanValue = folder.replace(/^__/, '');
+      const displayLabel = folder.startsWith('__') ? folder : `__${folder}`;
+      opts.push({
+        label: displayLabel,
+        value: cleanValue,
+        isSpecial: false,
+        isAddNew: false,
+        group: 'subfolders',
+      });
+    });
+
+    // Add "Add Subfolder" option at the end
+    opts.push({
+      label: 'Add Subfolder',
+      value: ADD_NEW_SENTINEL,
+      isSpecial: false,
+      isAddNew: true,
+      group: 'actions',
+    });
+
+    return opts;
+  }, [mode, allSubfolders, defaultSubfolderDisplay]);
+
+  // Find the current option based on value
+  const currentOption = useMemo((): SubfolderOption | null => {
+    if (mode === 'global') {
+      // For global mode, null/empty means root
+      if (!value) {
+        return options.find((o) => o.value === null && o.isSpecial) || null;
+      }
+      // Find existing subfolder option
+      const existingOption = options.find((o) => o.value === value && !o.isAddNew);
+      if (existingOption) return existingOption;
+      // Custom value (shouldn't happen without freeSolo, but handle gracefully)
+      return {
+        label: `__${value}`,
+        value: value as string,
+        isSpecial: false,
+        isAddNew: false,
+        group: 'subfolders',
+      };
+    }
+
+    if (mode === 'channel') {
+      if (isExplicitlyNoSubfolder(value)) {
+        // null/empty = root (backwards compatible)
+        return options.find((o) => o.value === null && o.isSpecial) || null;
+      }
+      if (isUsingDefaultSubfolder(value)) {
+        // ##USE_GLOBAL_DEFAULT## = use global default
+        return options.find((o) => o.value === GLOBAL_DEFAULT_SENTINEL) || null;
+      }
+      // Specific subfolder
+      const existingOption = options.find((o) => o.value === value && !o.isAddNew);
+      if (existingOption) return existingOption;
+      // Custom value
+      return {
+        label: `__${value}`,
+        value: value as string,
+        isSpecial: false,
+        isAddNew: false,
+        group: 'subfolders',
+      };
+    }
+
+    if (mode === 'download') {
+      if (value === null || value === undefined) {
+        return options.find((o) => o.value === null && o.isSpecial) || null;
+      }
+      if (isExplicitlyRoot(value)) {
+        return options.find((o) => o.value === ROOT_SENTINEL) || null;
+      }
+      if (isUsingDefaultSubfolder(value)) {
+        return options.find((o) => o.value === GLOBAL_DEFAULT_SENTINEL) || null;
+      }
+      // Specific subfolder
+      const existingOption = options.find((o) => o.value === value && !o.isAddNew);
+      if (existingOption) return existingOption;
+      // Custom value
+      return {
+        label: `__${value}`,
+        value: value as string,
+        isSpecial: false,
+        isAddNew: false,
+        group: 'subfolders',
+      };
+    }
+
+    return null;
+  }, [value, options, mode]);
+
+  // Handle option selection
+  const handleChange = (
+    _event: React.SyntheticEvent,
+    newValue: SubfolderOption | null
+  ) => {
+    if (newValue === null) {
+      // Cleared the field - use null for root
+      onChange(null);
+      return;
+    }
+
+    // Check if "Add Subfolder" was clicked
+    if (newValue.isAddNew) {
+      setAddDialogOpen(true);
+      return; // Don't change the current selection
+    }
+
+    // Selected a regular option
+    onChange(newValue.value);
+  };
+
+  // Handle new subfolder addition from dialog
+  const handleAddSubfolder = (newName: string) => {
+    // Add to local list with __ prefix
+    setLocalSubfolders((prev) => [...prev, `__${newName}`]);
+    // Set as the selected value
+    onChange(newName);
+    // Close dialog
+    setAddDialogOpen(false);
+  };
+
+  // Render option with icons for special options
+  const renderOption = (
+    props: React.HTMLAttributes<HTMLLIElement>,
+    option: SubfolderOption
+  ) => {
+    const { key, ...otherProps } = props as { key?: string } & React.HTMLAttributes<HTMLLIElement>;
+
+    // Render "Add Subfolder" distinctly
+    if (option.isAddNew) {
+      return (
+        <li key={key} {...otherProps}>
+          <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', color: 'primary.main' }}>
+            <AddIcon fontSize="small" sx={{ mr: 1 }} />
+            <Typography sx={{ fontWeight: 500 }}>
+              {option.label}
+            </Typography>
+          </Box>
+        </li>
+      );
+    }
+
+    return (
+      <li key={key} {...otherProps}>
+        <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
+          {option.isSpecial && option.value === null && (
+            <FolderOffIcon
+              fontSize="small"
+              sx={{ mr: 1, color: 'text.secondary' }}
+            />
+          )}
+          {option.isSpecial && option.value === ROOT_SENTINEL && (
+            <FolderOffIcon
+              fontSize="small"
+              sx={{ mr: 1, color: 'text.secondary' }}
+            />
+          )}
+          {option.isSpecial && option.value === GLOBAL_DEFAULT_SENTINEL && (
+            <SettingsIcon
+              fontSize="small"
+              sx={{ mr: 1, color: 'text.secondary' }}
+            />
+          )}
+          <Typography
+            sx={{
+              fontStyle: option.isSpecial ? 'italic' : 'normal',
+              color: option.isSpecial ? 'text.secondary' : 'text.primary',
+            }}
+          >
+            {option.label}
+          </Typography>
+        </Box>
+      </li>
+    );
+  };
+
+  // Group options with divider
+  const groupBy = (option: SubfolderOption) => option.group;
+
+  const renderGroup = (params: {
+    key: string;
+    group: string;
+    children?: React.ReactNode;
+  }) => {
+    const hasSubfolders = options.some((o) => o.group === 'subfolders');
+    const hasActions = options.some((o) => o.group === 'actions');
+
+    return (
+      <React.Fragment key={params.key}>
+        {params.children}
+        {/* Divider after special options if there are subfolders or actions */}
+        {params.group === 'special' && (hasSubfolders || hasActions) && (
+          <Divider sx={{ my: 0.5 }} component="li" />
+        )}
+        {/* Divider after subfolders if there are actions */}
+        {params.group === 'subfolders' && hasActions && (
+          <Divider sx={{ my: 0.5 }} component="li" />
+        )}
+      </React.Fragment>
+    );
+  };
+
+  // Filter out the "Add Subfolder" option from being the selected value displayed in the input
+  const filterOptions = (opts: SubfolderOption[]) => opts;
+
+  return (
+    <>
+      <Autocomplete
+        options={options}
+        value={currentOption}
+        onChange={handleChange}
+        disabled={disabled}
+        loading={loading}
+        groupBy={groupBy}
+        renderGroup={renderGroup}
+        renderOption={renderOption}
+        filterOptions={filterOptions}
+        getOptionLabel={(option) => {
+          if (typeof option === 'string') return option;
+          // Don't show "Add Subfolder" label in the input field
+          if (option.isAddNew) return '';
+          return option.label;
+        }}
+        isOptionEqualToValue={(option, val) => {
+          // Never match the "Add Subfolder" option as selected
+          if (option.isAddNew) return false;
+          return option.value === val.value;
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={label}
+            helperText={helperText}
+            fullWidth
+            InputLabelProps={{
+              shrink: true,
+            }}
+          />
+        )}
+        sx={{ width: '100%' }}
+      />
+      <AddSubfolderDialog
+        open={addDialogOpen}
+        onClose={() => setAddDialogOpen(false)}
+        onAdd={handleAddSubfolder}
+        existingSubfolders={allSubfolders}
+      />
+    </>
+  );
+}
+
+export default SubfolderAutocomplete;

--- a/client/src/components/shared/__tests__/AddSubfolderDialog.test.tsx
+++ b/client/src/components/shared/__tests__/AddSubfolderDialog.test.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AddSubfolderDialog from '../AddSubfolderDialog';
+
+describe('AddSubfolderDialog', () => {
+  const mockOnClose = jest.fn();
+  const mockOnAdd = jest.fn();
+
+  const defaultProps = {
+    open: true,
+    onClose: mockOnClose,
+    onAdd: mockOnAdd,
+    existingSubfolders: ['__Sports', '__Music'],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    test('renders dialog when open is true', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      expect(screen.getByText('Add New Subfolder')).toBeInTheDocument();
+      expect(screen.getByLabelText('Subfolder Name')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add Subfolder' })).toBeInTheDocument();
+    });
+
+    test('does not render dialog when open is false', () => {
+      render(<AddSubfolderDialog {...defaultProps} open={false} />);
+
+      expect(screen.queryByText('Add New Subfolder')).not.toBeInTheDocument();
+    });
+
+    test('renders helper text when input is empty', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      expect(
+        screen.getByText('Enter a name for the new subfolder (e.g., Sports, Music)')
+      ).toBeInTheDocument();
+    });
+
+    test('Add button is disabled when input is empty', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const addButton = screen.getByRole('button', { name: 'Add Subfolder' });
+      expect(addButton).toBeDisabled();
+    });
+  });
+
+  describe('Validation', () => {
+    test('shows error for whitespace-only input', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: '   ' } });
+
+      expect(screen.getByText('Subfolder name cannot be empty')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add Subfolder' })).toBeDisabled();
+    });
+
+    test('shows error for duplicate subfolder name (case-insensitive)', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: 'sports' } });
+
+      expect(screen.getByText('A subfolder with this name already exists')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add Subfolder' })).toBeDisabled();
+    });
+
+    test('shows error for reserved __ prefix', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: '__Sports' } });
+
+      expect(screen.getByText('Subfolder names cannot start with __ (reserved prefix)')).toBeInTheDocument();
+    });
+
+    test('shows error for invalid characters', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: 'Sports/2024' } });
+
+      expect(
+        screen.getByText('Subfolder name can only contain letters, numbers, spaces, hyphens, and underscores')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add Subfolder' })).toBeDisabled();
+    });
+
+    test('shows error for name exceeding 100 characters', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: 'a'.repeat(101) } });
+
+      expect(screen.getByText('Name cannot exceed 100 characters')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add Subfolder' })).toBeDisabled();
+    });
+
+    test('allows valid input up to 100 characters', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: 'a'.repeat(100) } });
+
+      expect(screen.queryByText(/cannot exceed/)).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add Subfolder' })).toBeEnabled();
+    });
+
+    test('enables Add button when valid name entered', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: 'Gaming' } });
+
+      expect(screen.getByRole('button', { name: 'Add Subfolder' })).toBeEnabled();
+    });
+  });
+
+  describe('Interaction', () => {
+    test('calls onClose when Cancel clicked', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockOnAdd).not.toHaveBeenCalled();
+    });
+
+    test('calls onAdd with trimmed value when Add clicked', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: '  Gaming  ' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Add Subfolder' }));
+
+      expect(mockOnAdd).toHaveBeenCalledWith('Gaming');
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    test('calls onAdd when Enter key pressed with valid input', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: 'Gaming' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      expect(mockOnAdd).toHaveBeenCalledWith('Gaming');
+    });
+
+    test('does not call onAdd when Enter pressed with invalid input', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: '' } });
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+      expect(mockOnAdd).not.toHaveBeenCalled();
+    });
+
+    test('clears input when dialog reopens', () => {
+      const { rerender } = render(<AddSubfolderDialog {...defaultProps} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: 'Gaming' } });
+
+      // Close and reopen
+      rerender(<AddSubfolderDialog {...defaultProps} open={false} />);
+      rerender(<AddSubfolderDialog {...defaultProps} open={true} />);
+
+      const newInput = screen.getByLabelText('Subfolder Name');
+      expect(newInput).toHaveValue('');
+    });
+
+    test('calls onClose when dialog backdrop is clicked (escape key)', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      const dialog = screen.getByRole('dialog');
+      fireEvent.keyDown(dialog, { key: 'Escape', code: 'Escape' });
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('handles empty existingSubfolders array', () => {
+      render(<AddSubfolderDialog {...defaultProps} existingSubfolders={[]} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: 'Sports' } });
+
+      // Should be valid since there are no existing subfolders
+      expect(screen.getByRole('button', { name: 'Add Subfolder' })).toBeEnabled();
+    });
+
+    test('handles subfolders without __ prefix in existingSubfolders', () => {
+      render(<AddSubfolderDialog {...defaultProps} existingSubfolders={['Sports', 'Music']} />);
+
+      const input = screen.getByLabelText('Subfolder Name');
+      fireEvent.change(input, { target: { value: 'Sports' } });
+
+      expect(screen.getByText('A subfolder with this name already exists')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    test('dialog has proper role', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    test('input has proper label', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      expect(screen.getByLabelText('Subfolder Name')).toBeInTheDocument();
+    });
+
+    test('buttons have proper accessible names', () => {
+      render(<AddSubfolderDialog {...defaultProps} />);
+
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add Subfolder' })).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/shared/__tests__/SubfolderAutocomplete.test.tsx
+++ b/client/src/components/shared/__tests__/SubfolderAutocomplete.test.tsx
@@ -1,0 +1,474 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { SubfolderAutocomplete } from '../SubfolderAutocomplete';
+import { GLOBAL_DEFAULT_SENTINEL, ROOT_SENTINEL } from '../../../utils/channelHelpers';
+
+// Mock AddSubfolderDialog to simplify testing
+jest.mock('../AddSubfolderDialog', () => ({
+  AddSubfolderDialog: function MockAddSubfolderDialog({
+    open,
+    onClose,
+    onAdd,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onAdd: (name: string) => void;
+  }) {
+    const React = require('react');
+    if (!open) return null;
+    return React.createElement('div', { 'data-testid': 'add-subfolder-dialog' },
+      React.createElement('button', {
+        'data-testid': 'dialog-close',
+        onClick: onClose
+      }, 'Close'),
+      React.createElement('button', {
+        'data-testid': 'dialog-add',
+        onClick: () => onAdd('NewFolder')
+      }, 'Add')
+    );
+  }
+}));
+
+describe('SubfolderAutocomplete', () => {
+  const mockOnChange = jest.fn();
+  const defaultSubfolders = ['__Sports', '__Music', '__Tech'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Global Mode', () => {
+    const globalModeProps = {
+      mode: 'global' as const,
+      value: null,
+      onChange: mockOnChange,
+      subfolders: defaultSubfolders,
+    };
+
+    test('renders with correct label', () => {
+      render(<SubfolderAutocomplete {...globalModeProps} />);
+      expect(screen.getByLabelText('Subfolder')).toBeInTheDocument();
+    });
+
+    test('renders with custom label', () => {
+      render(<SubfolderAutocomplete {...globalModeProps} label="Custom Label" />);
+      expect(screen.getByLabelText('Custom Label')).toBeInTheDocument();
+    });
+
+    test('shows "No Subfolder (root)" special option when dropdown opened', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...globalModeProps} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      expect(screen.getByText('No Subfolder (root)')).toBeInTheDocument();
+    });
+
+    test('shows existing subfolders with __ prefix', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...globalModeProps} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      expect(screen.getByText('__Sports')).toBeInTheDocument();
+      expect(screen.getByText('__Music')).toBeInTheDocument();
+      expect(screen.getByText('__Tech')).toBeInTheDocument();
+    });
+
+    test('shows "Add Subfolder" action option', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...globalModeProps} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      expect(screen.getByText('Add Subfolder')).toBeInTheDocument();
+    });
+
+    test('displays null value as "No Subfolder (root)"', () => {
+      render(<SubfolderAutocomplete {...globalModeProps} value={null} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      expect(autocomplete).toHaveValue('No Subfolder (root)');
+    });
+
+    test('displays subfolder value with __ prefix', () => {
+      render(<SubfolderAutocomplete {...globalModeProps} value="Sports" />);
+
+      const autocomplete = screen.getByRole('combobox');
+      expect(autocomplete).toHaveValue('__Sports');
+    });
+
+    test('calls onChange with null when "No Subfolder (root)" selected', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...globalModeProps} value="Sports" />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+      await user.click(screen.getByText('No Subfolder (root)'));
+
+      expect(mockOnChange).toHaveBeenCalledWith(null);
+    });
+
+    test('calls onChange with clean value when subfolder selected', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...globalModeProps} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+      await user.click(screen.getByText('__Sports'));
+
+      expect(mockOnChange).toHaveBeenCalledWith('Sports');
+    });
+  });
+
+  describe('Channel Mode', () => {
+    const channelModeProps = {
+      mode: 'channel' as const,
+      value: null,
+      onChange: mockOnChange,
+      subfolders: defaultSubfolders,
+    };
+
+    test('shows "No Subfolder (root)" special option', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...channelModeProps} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      expect(screen.getByText('No Subfolder (root)')).toBeInTheDocument();
+    });
+
+    test('shows "Default Subfolder (root)" when no defaultSubfolderDisplay', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...channelModeProps} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      expect(screen.getByText('Default Subfolder (root)')).toBeInTheDocument();
+    });
+
+    test('shows "Default Subfolder (__name)" when defaultSubfolderDisplay provided', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...channelModeProps} defaultSubfolderDisplay="Videos" />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      expect(screen.getByText('Default Subfolder (__Videos)')).toBeInTheDocument();
+    });
+
+    test('calls onChange with GLOBAL_DEFAULT_SENTINEL when default option selected', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...channelModeProps} value={null} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+      await user.click(screen.getByText('Default Subfolder (root)'));
+
+      expect(mockOnChange).toHaveBeenCalledWith(GLOBAL_DEFAULT_SENTINEL);
+    });
+
+    test('displays GLOBAL_DEFAULT_SENTINEL as "Default Subfolder"', () => {
+      render(<SubfolderAutocomplete {...channelModeProps} value={GLOBAL_DEFAULT_SENTINEL} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      expect(autocomplete).toHaveValue('Default Subfolder (root)');
+    });
+  });
+
+  describe('Download Mode', () => {
+    const downloadModeProps = {
+      mode: 'download' as const,
+      value: null,
+      onChange: mockOnChange,
+      subfolders: defaultSubfolders,
+    };
+
+    test('shows "No override (use channel settings)" special option', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...downloadModeProps} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      expect(screen.getByText('No override (use channel settings)')).toBeInTheDocument();
+    });
+
+    test('shows "Root directory (no subfolder)" option', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...downloadModeProps} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      expect(screen.getByText('Root directory (no subfolder)')).toBeInTheDocument();
+    });
+
+    test('shows "Use Global Default Subfolder" option', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...downloadModeProps} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      expect(screen.getByText('Use Global Default Subfolder')).toBeInTheDocument();
+    });
+
+    test('calls onChange with ROOT_SENTINEL when root directory selected', async () => {
+      const user = userEvent.setup();
+      render(<SubfolderAutocomplete {...downloadModeProps} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+      await user.click(screen.getByText('Root directory (no subfolder)'));
+
+      expect(mockOnChange).toHaveBeenCalledWith(ROOT_SENTINEL);
+    });
+
+    test('displays ROOT_SENTINEL as "Root directory (no subfolder)"', () => {
+      render(<SubfolderAutocomplete {...downloadModeProps} value={ROOT_SENTINEL} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      expect(autocomplete).toHaveValue('Root directory (no subfolder)');
+    });
+
+    test('displays null as "No override (use channel settings)"', () => {
+      render(<SubfolderAutocomplete {...downloadModeProps} value={null} />);
+
+      const autocomplete = screen.getByRole('combobox');
+      expect(autocomplete).toHaveValue('No override (use channel settings)');
+    });
+  });
+
+  describe('Add Subfolder Dialog', () => {
+    test('opens dialog when "Add Subfolder" clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+        />
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+      await user.click(screen.getByText('Add Subfolder'));
+
+      expect(screen.getByTestId('add-subfolder-dialog')).toBeInTheDocument();
+    });
+
+    test('does not change value when "Add Subfolder" clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+        />
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+      await user.click(screen.getByText('Add Subfolder'));
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+
+    test('closes dialog when close button clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+        />
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+      await user.click(screen.getByText('Add Subfolder'));
+
+      expect(screen.getByTestId('add-subfolder-dialog')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('dialog-close'));
+
+      expect(screen.queryByTestId('add-subfolder-dialog')).not.toBeInTheDocument();
+    });
+
+    test('calls onChange and closes dialog when subfolder added', async () => {
+      const user = userEvent.setup();
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+        />
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+      await user.click(screen.getByText('Add Subfolder'));
+      await user.click(screen.getByTestId('dialog-add'));
+
+      expect(mockOnChange).toHaveBeenCalledWith('NewFolder');
+      expect(screen.queryByTestId('add-subfolder-dialog')).not.toBeInTheDocument();
+    });
+
+    test('newly added subfolder appears in dropdown', async () => {
+      const user = userEvent.setup();
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+        />
+      );
+
+      // Add a new subfolder via dialog
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+      await user.click(screen.getByText('Add Subfolder'));
+      await user.click(screen.getByTestId('dialog-add'));
+
+      // Reopen dropdown and check for the new subfolder
+      await user.click(autocomplete);
+
+      expect(screen.getByText('__NewFolder')).toBeInTheDocument();
+    });
+  });
+
+  describe('State and Props', () => {
+    test('disables autocomplete when disabled prop is true', () => {
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+          disabled={true}
+        />
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      expect(autocomplete).toBeDisabled();
+    });
+
+    test('accepts loading prop without crashing', () => {
+      // MUI Autocomplete handles loading internally with a spinner
+      // This test verifies the component accepts and handles the prop correctly
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+          loading={true}
+        />
+      );
+
+      // Component should render successfully with loading prop
+      const autocomplete = screen.getByRole('combobox');
+      expect(autocomplete).toBeInTheDocument();
+    });
+
+    test('displays helper text when provided', () => {
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+          helperText="Choose a subfolder"
+        />
+      );
+
+      expect(screen.getByText('Choose a subfolder')).toBeInTheDocument();
+    });
+
+    test('handles empty subfolders array', async () => {
+      const user = userEvent.setup();
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={[]}
+        />
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      // Should still show special options and Add Subfolder
+      expect(screen.getByText('No Subfolder (root)')).toBeInTheDocument();
+      expect(screen.getByText('Add Subfolder')).toBeInTheDocument();
+    });
+
+    test('handles undefined value', () => {
+      render(
+        <SubfolderAutocomplete
+          mode="channel"
+          value={undefined}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+        />
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      // undefined should be treated as null (no subfolder)
+      expect(autocomplete).toHaveValue('No Subfolder (root)');
+    });
+
+    test('handles custom subfolder value not in list', () => {
+      // Custom values not in the list are still rendered with __ prefix
+      // This test just verifies the component doesn't crash
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value="CustomFolder"
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+        />
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      // The component creates a synthetic option for values not in the list
+      expect(autocomplete).toHaveValue('__CustomFolder');
+    });
+  });
+
+  describe('Option Selection', () => {
+    test('can select a subfolder from the list', async () => {
+      const user = userEvent.setup();
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+        />
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      await user.click(autocomplete);
+
+      // Select a subfolder
+      await user.click(screen.getByText('__Music'));
+
+      expect(mockOnChange).toHaveBeenCalledWith('Music');
+    });
+  });
+});

--- a/client/src/config/configSchema.ts
+++ b/client/src/config/configSchema.ts
@@ -27,6 +27,7 @@ export const CONFIG_FIELDS = {
   // Video settings
   preferredResolution: { default: '1080', trackChanges: true },
   videoCodec: { default: 'default', trackChanges: true },
+  defaultSubfolder: { default: '', trackChanges: true },
 
   // Plex integration
   plexApiKey: { default: '', trackChanges: true },
@@ -118,6 +119,7 @@ export const DEFAULT_CONFIG: ConfigState = {
   channelFilesToDownload: CONFIG_FIELDS.channelFilesToDownload.default,
   preferredResolution: CONFIG_FIELDS.preferredResolution.default,
   videoCodec: CONFIG_FIELDS.videoCodec.default,
+  defaultSubfolder: CONFIG_FIELDS.defaultSubfolder.default,
   plexApiKey: CONFIG_FIELDS.plexApiKey.default,
   plexYoutubeLibraryId: CONFIG_FIELDS.plexYoutubeLibraryId.default,
   plexIP: CONFIG_FIELDS.plexIP.default,

--- a/client/src/hooks/__tests__/useSubfolders.test.ts
+++ b/client/src/hooks/__tests__/useSubfolders.test.ts
@@ -1,0 +1,367 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useSubfolders } from '../useSubfolders';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('useSubfolders', () => {
+  const mockToken = 'test-token-123';
+  const mockSubfolders = ['__Sports', '__Music', '__Tech'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Suppress console.error for expected errors
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('Initial State', () => {
+    test('returns empty array when token is null', () => {
+      const { result } = renderHook(() => useSubfolders(null));
+
+      expect(result.current.subfolders).toEqual([]);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    test('does not fetch when token is null', () => {
+      renderHook(() => useSubfolders(null));
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test('starts loading when token is provided', () => {
+      mockFetch.mockImplementation(() => new Promise(() => {})); // Never resolves
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      expect(result.current.loading).toBe(true);
+    });
+  });
+
+  describe('Successful Data Fetching', () => {
+    test('fetches and returns subfolders successfully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+      });
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.subfolders).toEqual(mockSubfolders);
+      expect(result.current.error).toBeNull();
+    });
+
+    test('includes correct authentication header', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+      });
+
+      renderHook(() => useSubfolders(mockToken));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/channels/subfolders', {
+        headers: {
+          'x-access-token': mockToken,
+        },
+      });
+    });
+
+    test('handles empty subfolders array', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce([]),
+      });
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.subfolders).toEqual([]);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('handles API error response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Not Found',
+      });
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.subfolders).toEqual([]);
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toContain('Not Found');
+    });
+
+    test('handles network error', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.subfolders).toEqual([]);
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('Network error');
+    });
+
+    test('handles non-Error throw', async () => {
+      mockFetch.mockRejectedValueOnce('String error');
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('Unknown error');
+    });
+  });
+
+  describe('Token Changes', () => {
+    test('re-fetches when token changes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(mockSubfolders),
+      });
+
+      const { result, rerender } = renderHook(
+        ({ token }: { token: string | null }) => useSubfolders(token),
+        { initialProps: { token: mockToken } }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Change to a different token
+      rerender({ token: 'new-token' });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockFetch).toHaveBeenLastCalledWith('/api/channels/subfolders', {
+        headers: {
+          'x-access-token': 'new-token',
+        },
+      });
+    });
+
+    test('does not fetch when token changes to null', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+      });
+
+      const { result, rerender } = renderHook(
+        ({ token }: { token: string | null }) => useSubfolders(token),
+        { initialProps: { token: mockToken } as { token: string | null } }
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Change to null token
+      rerender({ token: null });
+
+      // Should not have made another fetch call
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Refetch Function', () => {
+    test('refetch triggers a new API call', async () => {
+      const firstResponse = ['__Sports'];
+      const secondResponse = ['__Sports', '__Music'];
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(firstResponse),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(secondResponse),
+        });
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.subfolders).toEqual(firstResponse);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      // Call refetch
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result.current.subfolders).toEqual(secondResponse);
+    });
+
+    test('refetch sets loading state correctly', async () => {
+      let resolvePromise: (value: unknown) => void;
+      const promise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        })
+        .mockImplementationOnce(() => promise);
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Start refetch
+      act(() => {
+        result.current.refetch();
+      });
+
+      // Should be loading now
+      expect(result.current.loading).toBe(true);
+
+      // Resolve the promise
+      await act(async () => {
+        resolvePromise!({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+    });
+
+    test('refetch does nothing when token is null', async () => {
+      const { result } = renderHook(() => useSubfolders(null));
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    test('refetch clears previous error', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          statusText: 'Error',
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        });
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      await waitFor(() => {
+        expect(result.current.error).not.toBeNull();
+      });
+
+      // Refetch successfully
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.subfolders).toEqual(mockSubfolders);
+    });
+  });
+
+  describe('Loading State', () => {
+    test('loading transitions correctly during successful fetch', async () => {
+      let resolvePromise: (value: unknown) => void;
+      const promise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      mockFetch.mockImplementationOnce(() => promise);
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      // Should start loading
+      expect(result.current.loading).toBe(true);
+      expect(result.current.subfolders).toEqual([]);
+
+      // Resolve the fetch
+      await act(async () => {
+        resolvePromise!({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.subfolders).toEqual(mockSubfolders);
+    });
+
+    test('loading transitions correctly during failed fetch', async () => {
+      let rejectPromise: (error: Error) => void;
+      const promise = new Promise((_, reject) => {
+        rejectPromise = reject;
+      });
+
+      mockFetch.mockImplementationOnce(() => promise);
+
+      const { result } = renderHook(() => useSubfolders(mockToken));
+
+      // Should start loading
+      expect(result.current.loading).toBe(true);
+
+      // Reject the fetch
+      await act(async () => {
+        rejectPromise!(new Error('Failed'));
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/client/src/hooks/useSubfolders.ts
+++ b/client/src/hooks/useSubfolders.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface UseSubfoldersResult {
+  subfolders: string[];
+  loading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Hook for fetching available subfolders from the API
+ * @param token - Authentication token
+ * @returns Object containing subfolders array, loading state, error, and refetch function
+ */
+export function useSubfolders(token: string | null): UseSubfoldersResult {
+  const [subfolders, setSubfolders] = useState<string[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchSubfolders = useCallback(async () => {
+    if (!token) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/channels/subfolders', {
+        headers: {
+          'x-access-token': token,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch subfolders: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      setSubfolders(data);
+    } catch (err) {
+      console.error('Failed to fetch subfolders:', err);
+      setError(err instanceof Error ? err : new Error('Unknown error'));
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchSubfolders();
+  }, [fetchSubfolders]);
+
+  return {
+    subfolders,
+    loading,
+    error,
+    refetch: fetchSubfolders,
+  };
+}

--- a/client/src/hooks/useTriggerDownloads.ts
+++ b/client/src/hooks/useTriggerDownloads.ts
@@ -3,6 +3,7 @@ import { useState, useCallback } from 'react';
 interface DownloadOverrideSettings {
   resolution: string;
   allowRedownload?: boolean;
+  subfolder?: string | null;
 }
 
 interface TriggerDownloadsParams {
@@ -38,6 +39,7 @@ export function useTriggerDownloads(token: string | null): UseTriggerDownloadsRe
           requestBody.overrideSettings = {
             resolution: overrideSettings.resolution,
             allowRedownload: overrideSettings.allowRedownload,
+            subfolder: overrideSettings.subfolder,
           };
         }
 

--- a/client/src/utils/__tests__/channelHelpers.test.ts
+++ b/client/src/utils/__tests__/channelHelpers.test.ts
@@ -210,8 +210,8 @@ describe('channelHelpers Utility', () => {
   });
 
   describe('formatSubFolderLabel', () => {
-    test('returns "default" for DEFAULT_SUBFOLDER_KEY', () => {
-      expect(formatSubFolderLabel(DEFAULT_SUBFOLDER_KEY)).toBe('default');
+    test('returns "root" for DEFAULT_SUBFOLDER_KEY', () => {
+      expect(formatSubFolderLabel(DEFAULT_SUBFOLDER_KEY)).toBe('root');
     });
 
     test('formats custom key with __ prefix and / suffix', () => {
@@ -238,22 +238,22 @@ describe('channelHelpers Utility', () => {
   });
 
   describe('Integration: normalizeSubFolderKey and formatSubFolderLabel', () => {
-    test('null value normalizes and formats to "default"', () => {
+    test('null value normalizes and formats to "root"', () => {
       const normalized = normalizeSubFolderKey(null);
       const formatted = formatSubFolderLabel(normalized);
-      expect(formatted).toBe('default');
+      expect(formatted).toBe('root');
     });
 
-    test('undefined value normalizes and formats to "default"', () => {
+    test('undefined value normalizes and formats to "root"', () => {
       const normalized = normalizeSubFolderKey(undefined);
       const formatted = formatSubFolderLabel(normalized);
-      expect(formatted).toBe('default');
+      expect(formatted).toBe('root');
     });
 
-    test('empty string normalizes and formats to "default"', () => {
+    test('empty string normalizes and formats to "root"', () => {
       const normalized = normalizeSubFolderKey('');
       const formatted = formatSubFolderLabel(normalized);
-      expect(formatted).toBe('default');
+      expect(formatted).toBe('root');
     });
 
     test('custom value normalizes and formats correctly', () => {

--- a/client/src/utils/channelHelpers.ts
+++ b/client/src/utils/channelHelpers.ts
@@ -61,16 +61,63 @@ export const channelMatchesFilter = (channelName: string, channelUrl: string, fi
 
 export const DEFAULT_SUBFOLDER_KEY = '__default__';
 
+/**
+ * Sentinel value for explicitly specifying "use global default subfolder"
+ * This distinguishes from NULL which means "download to root" (backwards compatible)
+ */
+export const GLOBAL_DEFAULT_SENTINEL = '##USE_GLOBAL_DEFAULT##';
+
+/**
+ * Sentinel value for explicitly specifying "download to root directory"
+ * Used in manual downloads to override channel subfolder settings and download directly to root
+ */
+export const ROOT_SENTINEL = '##ROOT##';
+
 export const normalizeSubFolderKey = (value?: string | null): string => {
+  // null/empty = root (backwards compatible), so use a special key for display
   if (value === undefined || value === null || value === '') {
     return DEFAULT_SUBFOLDER_KEY;
+  }
+  if (value === GLOBAL_DEFAULT_SENTINEL) {
+    return GLOBAL_DEFAULT_SENTINEL;
   }
   return value;
 };
 
 export const formatSubFolderLabel = (key: string): string => {
   if (key === DEFAULT_SUBFOLDER_KEY) {
-    return 'default';
+    return 'root';
+  }
+  if (key === GLOBAL_DEFAULT_SENTINEL) {
+    return 'global default';
   }
   return `__${key}/`;
 };
+
+/**
+ * Check if a subfolder value means "use the global default"
+ * @param value - The subfolder value from database or UI
+ * @returns true if the value means "use default"
+ */
+export const isUsingDefaultSubfolder = (value: string | null | undefined): boolean => {
+  return value === GLOBAL_DEFAULT_SENTINEL;
+};
+
+/**
+ * Check if a subfolder value means "explicitly no subfolder (root)"
+ * @param value - The subfolder value from database or UI
+ * @returns true if the value means "explicitly root"
+ */
+export const isExplicitlyNoSubfolder = (value: string | null | undefined): boolean => {
+  return value === null || value === undefined || value === '';
+};
+
+/**
+ * Check if a subfolder value is the ROOT sentinel (explicit root override in downloads)
+ * @param value - The subfolder value
+ * @returns true if the value is the ROOT sentinel
+ */
+export const isExplicitlyRoot = (value: string | null | undefined): boolean => {
+  return value === ROOT_SENTINEL;
+};
+

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -5,6 +5,7 @@
   "channelDownloadFrequency": "0 * * * *",
   "preferredResolution": "1080",
   "videoCodec": "default",
+  "defaultSubfolder": "",
   "plexIP": "",
   "plexPort": "32400",
   "plexViaHttps": false,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -88,6 +88,21 @@ Configuration can be modified through:
   - `vp9`: YouTube's preferred codec
   - `av1`: Best compression, limited device support
 
+### Default Subfolder
+- **Config Key**: `defaultSubfolder`
+- **Type**: `string`
+- **Default**: `""` (empty - downloads to root directory)
+- **Description**: Default download location for untracked channels and channels set to use "Default Subfolder"
+- **Note**: Subfolders are prefixed with `__` on the filesystem (e.g., setting `Sports` creates `__Sports/`)
+- **Channel Subfolder Semantics**:
+  - **"Default Subfolder"** (NULL in database): Channel uses this global default setting
+  - **"No Subfolder"** (special value): Channel explicitly downloads to root directory, ignoring the global default
+  - **Specific subfolder**: Channel downloads to that specific subfolder
+- **Use Cases**:
+  - Organize untracked manual downloads into a specific folder
+  - Set a default location while allowing individual channels to override
+  - Explicitly place specific channels in the root directory using "No Subfolder"
+
 ### Enable Subtitles
 - **Config Key**: `subtitlesEnabled`
 - **Type**: `boolean`

--- a/migrations/20251127064048-add-folder-name-to-channels.js
+++ b/migrations/20251127064048-add-folder-name-to-channels.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { addColumnIfMissing, removeColumnIfExists } = require('./helpers');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add folder_name column to store the actual sanitized folder name created by yt-dlp
+    // This is needed because yt-dlp sanitizes channel names with --windows-filenames flag,
+    // and the sanitized name may differ from the raw uploader name stored in the database
+    await addColumnIfMissing(queryInterface, 'channels', 'folder_name', {
+      type: Sequelize.STRING(255),
+      allowNull: true,
+      defaultValue: null,
+    });
+  },
+
+  async down(queryInterface) {
+    await removeColumnIfExists(queryInterface, 'channels', 'folder_name');
+  },
+};

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -198,7 +198,7 @@ const createServerModule = ({
             videos: [{ id: 'video-1', title: 'Video 1' }]
           }),
           deleteChannel: jest.fn().mockResolvedValue({ success: true }),
-          getChannelAvailableTabs: jest.fn().mockResolvedValue(['videos', 'shorts', 'streams']),
+          getChannelAvailableTabs: jest.fn().mockResolvedValue({ availableTabs: ['videos', 'shorts', 'streams']}),
           updateAutoDownloadForTab: jest.fn().mockResolvedValue()
         };
 
@@ -679,7 +679,7 @@ describe('server routes - channels', () => {
       expect(channelModuleMock.getChannelAvailableTabs).toHaveBeenCalledWith('channel-1');
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
-        availableTabs: ['videos', 'shorts', 'streams']
+        availableTabs: ['videos', 'shorts', 'streams'],
       });
     });
 

--- a/server/models/channel.js
+++ b/server/models/channel.js
@@ -31,6 +31,11 @@ Channel.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    folder_name: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      defaultValue: null,
+    },
     lastFetchedByTab: {
       type: DataTypes.TEXT,
       allowNull: true,

--- a/server/modules/__tests__/channelDownloadGrouper.test.js
+++ b/server/modules/__tests__/channelDownloadGrouper.test.js
@@ -13,7 +13,8 @@ jest.mock('../configModule', () => ({
   directoryPath: '/mock/youtube/output',
   config: {
     preferredResolution: '1080'
-  }
+  },
+  getDefaultSubfolder: jest.fn().mockReturnValue(null)
 }));
 
 const channelDownloadGrouper = require('../channelDownloadGrouper');
@@ -575,11 +576,12 @@ describe('ChannelDownloadGrouper', () => {
     it('should build root level path when subfolder is null', () => {
       const template = channelDownloadGrouper.buildOutputPathTemplate(null);
 
+      // Template now uses .76s for title truncation to avoid path length issues
       const expectedPath = path.join(
         '/mock/youtube/output',
         '%(uploader,channel,uploader_id)s',
-        '%(uploader,channel,uploader_id)s - %(title)s - %(id)s',
-        '%(uploader,channel,uploader_id)s - %(title)s  [%(id)s].%(ext)s'
+        '%(uploader,channel,uploader_id)s - %(title).76s - %(id)s',
+        '%(uploader,channel,uploader_id)s - %(title).76s [%(id)s].%(ext)s'
       );
 
       expect(template).toBe(expectedPath);
@@ -588,12 +590,13 @@ describe('ChannelDownloadGrouper', () => {
     it('should build subfolder path with __ prefix', () => {
       const template = channelDownloadGrouper.buildOutputPathTemplate('Tech');
 
+      // Template now uses .76s for title truncation to avoid path length issues
       const expectedPath = path.join(
         '/mock/youtube/output',
         '__Tech',
         '%(uploader,channel,uploader_id)s',
-        '%(uploader,channel,uploader_id)s - %(title)s - %(id)s',
-        '%(uploader,channel,uploader_id)s - %(title)s  [%(id)s].%(ext)s'
+        '%(uploader,channel,uploader_id)s - %(title).76s - %(id)s',
+        '%(uploader,channel,uploader_id)s - %(title).76s [%(id)s].%(ext)s'
       );
 
       expect(template).toBe(expectedPath);
@@ -616,10 +619,11 @@ describe('ChannelDownloadGrouper', () => {
     it('should build root level thumbnail path when subfolder is null', () => {
       const template = channelDownloadGrouper.buildThumbnailPathTemplate(null);
 
+      // Template now uses .76s for title truncation to avoid path length issues
       const expectedPath = path.join(
         '/mock/youtube/output',
         '%(uploader,channel,uploader_id)s',
-        '%(uploader,channel,uploader_id)s - %(title)s - %(id)s',
+        '%(uploader,channel,uploader_id)s - %(title).76s - %(id)s',
         'poster'
       );
 
@@ -629,11 +633,12 @@ describe('ChannelDownloadGrouper', () => {
     it('should build subfolder thumbnail path with __ prefix', () => {
       const template = channelDownloadGrouper.buildThumbnailPathTemplate('Tech');
 
+      // Template now uses .76s for title truncation to avoid path length issues
       const expectedPath = path.join(
         '/mock/youtube/output',
         '__Tech',
         '%(uploader,channel,uploader_id)s',
-        '%(uploader,channel,uploader_id)s - %(title)s - %(id)s',
+        '%(uploader,channel,uploader_id)s - %(title).76s - %(id)s',
         'poster'
       );
 

--- a/server/modules/__tests__/channelPoster.test.js
+++ b/server/modules/__tests__/channelPoster.test.js
@@ -40,7 +40,8 @@ describe('Channel Poster Functionality', () => {
         directoryPath: '/videos',
         getImagePath: jest.fn().mockReturnValue('/images'),
         onConfigChange: jest.fn(),
-        getConfig
+        getConfig,
+        getDefaultSubfolder: jest.fn().mockReturnValue(null)
       };
     });
 
@@ -180,7 +181,7 @@ describe('Channel Poster Functionality', () => {
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
           err: testError,
-          channelUploader: 'Test Channel'
+          channelFolderName: 'Test Channel'
         }),
         'Error backfilling poster for channel'
       );

--- a/server/modules/__tests__/channelSettingsModule.test.js
+++ b/server/modules/__tests__/channelSettingsModule.test.js
@@ -32,7 +32,8 @@ jest.mock('../../models/video', () => {
 });
 
 jest.mock('../configModule', () => ({
-  directoryPath: '/test/output'
+  directoryPath: '/test/output',
+  getDefaultSubfolder: jest.fn().mockReturnValue(null)
 }));
 
 jest.mock('../jobModule', () => ({
@@ -361,6 +362,24 @@ describe('ChannelSettingsModule', () => {
       const channel = { ...mockChannel, uploader: 'TestChannel', sub_folder: '' };
       const result = channelSettingsModule.getChannelDirectory(channel);
       expect(result).toBe('/test/output/TestChannel');
+    });
+
+    test('should prefer folder_name over uploader when both exist', () => {
+      const channel = { ...mockChannel, uploader: 'RawChannel#Name', folder_name: 'RawChannel_Name' };
+      const result = channelSettingsModule.getChannelDirectory(channel);
+      expect(result).toBe('/test/output/RawChannel_Name');
+    });
+
+    test('should fall back to uploader when folder_name is null', () => {
+      const channel = { ...mockChannel, uploader: 'TestChannel', folder_name: null };
+      const result = channelSettingsModule.getChannelDirectory(channel);
+      expect(result).toBe('/test/output/TestChannel');
+    });
+
+    test('should use folder_name with subfolder', () => {
+      const channel = { ...mockChannel, uploader: 'RawName#Special', folder_name: 'RawName_Special', sub_folder: 'Music' };
+      const result = channelSettingsModule.getChannelDirectory(channel);
+      expect(result).toBe('/test/output/__Music/RawName_Special');
     });
   });
 
@@ -700,7 +719,8 @@ describe('ChannelSettingsModule', () => {
 
       expect(fs.move).toHaveBeenCalledWith(
         '/test/output/TestChannel',
-        '/test/output/__Music/TestChannel'
+        '/test/output/__Music/TestChannel',
+        { overwrite: true }
       );
       expect(result.success).toBe(true);
     });
@@ -718,7 +738,8 @@ describe('ChannelSettingsModule', () => {
 
       expect(fs.move).toHaveBeenCalledWith(
         '/test/output/__Music/TestChannel',
-        '/test/output/TestChannel'
+        '/test/output/TestChannel',
+        { overwrite: true }
       );
       expect(result.success).toBe(true);
     });
@@ -736,7 +757,8 @@ describe('ChannelSettingsModule', () => {
 
       expect(fs.move).toHaveBeenCalledWith(
         '/test/output/__Music/TestChannel',
-        '/test/output/__Gaming/TestChannel'
+        '/test/output/__Gaming/TestChannel',
+        { overwrite: true }
       );
       expect(result.success).toBe(true);
     });

--- a/server/modules/__tests__/videoDownloadPostProcessFiles.test.js
+++ b/server/modules/__tests__/videoDownloadPostProcessFiles.test.js
@@ -47,6 +47,16 @@ jest.mock('../nfoGenerator', () => ({
   writeVideoNfoFile: jest.fn(),
 }));
 
+jest.mock('../channelSettingsModule', () => ({
+  getGlobalDefaultSentinel: jest.fn(() => '##USE_GLOBAL_DEFAULT##'),
+  resolveEffectiveSubfolder: jest.fn((subFolder) => {
+    // Simulate the real logic: GLOBAL_DEFAULT_SENTINEL uses global default, null/empty -> root
+    if (subFolder === '##USE_GLOBAL_DEFAULT##') return null; // Mock: assume no global default
+    if (subFolder && subFolder.trim() !== '') return subFolder.trim();
+    return null; // null/empty = root (backwards compatible)
+  }),
+}));
+
 const mockTempPathManager = {
   isEnabled: jest.fn(() => false),
   isTempPath: jest.fn(() => false),
@@ -266,7 +276,7 @@ describe('videoDownloadPostProcessFiles', () => {
 
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ filePath: tempPath }),
-      'Error deleting temp file'
+      'Error deleting file'
     );
   });
 

--- a/server/modules/channelFolderNameMigration.js
+++ b/server/modules/channelFolderNameMigration.js
@@ -1,0 +1,81 @@
+const Channel = require('../models/channel');
+const logger = require('../logger');
+
+/**
+ * Migration utility to populate folder_name for existing channels.
+ * Uses yt-dlp to get the authoritative folder name for each channel.
+ * Runs asynchronously on startup to avoid blocking.
+ */
+class ChannelFolderNameMigration {
+  /**
+   * Migrate folder_name for all channels using yt-dlp.
+   * This is idempotent - safe to run multiple times.
+   * Processes channels sequentially to avoid rate limiting.
+   * @returns {Promise<{migrated: number, failed: number}>} - Migration results
+   */
+  async migrateExistingChannels() {
+    // Lazy require to avoid circular dependency at module load time
+    const channelModule = require('./channelModule');
+
+    // Get channels without folder_name
+    const channelsToMigrate = await Channel.findAll({
+      where: { folder_name: null },
+      attributes: ['id', 'channel_id', 'uploader', 'folder_name']
+    });
+
+    if (channelsToMigrate.length === 0) {
+      logger.debug('No channels need folder_name migration');
+      return { migrated: 0, failed: 0 };
+    }
+
+    logger.info(
+      { count: channelsToMigrate.length },
+      'Starting folder_name migration for existing channels using yt-dlp'
+    );
+
+    let migrated = 0;
+    let failed = 0;
+
+    // Process channels sequentially to avoid rate limiting
+    for (const channel of channelsToMigrate) {
+      try {
+        // resolveChannelFolderName calls yt-dlp and saves to database
+        await channelModule.resolveChannelFolderName(channel);
+
+        // Reload channel to check if folder_name was successfully saved
+        await channel.reload();
+
+        if (channel.folder_name) {
+          // Successfully saved folder_name to database
+          logger.info(
+            { channelId: channel.channel_id, folderName: channel.folder_name },
+            'Migrated channel folder_name'
+          );
+          migrated++;
+        } else {
+          // folder_name was not saved (yt-dlp must have failed)
+          logger.warn(
+            { channelId: channel.channel_id, uploader: channel.uploader },
+            'Could not get folder_name from yt-dlp'
+          );
+          failed++;
+        }
+      } catch (err) {
+        logger.error(
+          { err: err.message, channelId: channel.channel_id },
+          'Error migrating folder_name for channel'
+        );
+        failed++;
+      }
+    }
+
+    logger.info(
+      { migrated, failed, total: channelsToMigrate.length },
+      'Completed folder_name migration for existing channels'
+    );
+
+    return { migrated, failed };
+  }
+}
+
+module.exports = new ChannelFolderNameMigration();

--- a/server/modules/configModule.js
+++ b/server/modules/configModule.js
@@ -250,6 +250,16 @@ class ConfigModule extends EventEmitter {
     return this.config;
   }
 
+  /**
+   * Get the default subfolder for downloads
+   * Used for untracked channels and channels set to "use default"
+   * @returns {string|null} - Subfolder name (without __ prefix) or null if not set
+   */
+  getDefaultSubfolder() {
+    const value = this.config.defaultSubfolder;
+    return value && value.trim() !== '' ? value.trim() : null;
+  }
+
   isPlatformDeployment() {
     return !!process.env.DATA_PATH;
   }

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -459,12 +459,13 @@ class DownloadModule {
 
       const resolution = effectiveQuality || configModule.config.preferredResolution || '1080';
       const allowRedownload = overrideSettings.allowRedownload || false;
+      const subfolderOverride = overrideSettings.subfolder !== undefined ? overrideSettings.subfolder : null;
 
       // Persist resolved quality for any subsequent retries of this job
       this.setJobDataValue(jobData, 'effectiveQuality', resolution);
 
       // For manual downloads, we don't apply duration filters but still exclude members-only
-      // Note: Subfolder routing is now handled post-download in videoDownloadPostProcessFiles.js
+      // Subfolder override is passed to post-processor via environment variable
       const args = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload(resolution, allowRedownload);
 
       // Check if any URLs are for videos marked as ignored, and remove them from archive
@@ -512,8 +513,8 @@ class DownloadModule {
         }
       });
 
-      // Pass URL count, URLs, and allowRedownload flag as additional parameters for manual downloads
-      this.downloadExecutor.doDownload(args, jobId, jobType, urls.length, urls, allowRedownload);
+      // Pass URL count, URLs, allowRedownload flag, and subfolder override as additional parameters for manual downloads
+      this.downloadExecutor.doDownload(args, jobId, jobType, urls.length, urls, allowRedownload, false, subfolderOverride);
     }
   }
 

--- a/server/modules/filesystem/__tests__/constants.test.js
+++ b/server/modules/filesystem/__tests__/constants.test.js
@@ -1,0 +1,139 @@
+const {
+  SUBFOLDER_PREFIX,
+  GLOBAL_DEFAULT_SENTINEL,
+  VIDEO_EXTENSIONS,
+  CHANNEL_TEMPLATE,
+  VIDEO_FOLDER_TEMPLATE,
+  VIDEO_FILE_TEMPLATE,
+  YOUTUBE_ID_BRACKET_PATTERN,
+  YOUTUBE_ID_DASH_PATTERN,
+  YOUTUBE_ID_PATTERN,
+  MAIN_VIDEO_FILE_PATTERN,
+  FRAGMENT_FILE_PATTERN
+} = require('../constants');
+
+describe('filesystem/constants', () => {
+  describe('SUBFOLDER_PREFIX', () => {
+    it('should be __', () => {
+      expect(SUBFOLDER_PREFIX).toBe('__');
+    });
+  });
+
+  describe('GLOBAL_DEFAULT_SENTINEL', () => {
+    it('should be ##USE_GLOBAL_DEFAULT##', () => {
+      expect(GLOBAL_DEFAULT_SENTINEL).toBe('##USE_GLOBAL_DEFAULT##');
+    });
+  });
+
+  describe('VIDEO_EXTENSIONS', () => {
+    it('should contain common video extensions', () => {
+      expect(VIDEO_EXTENSIONS).toContain('.mp4');
+      expect(VIDEO_EXTENSIONS).toContain('.webm');
+      expect(VIDEO_EXTENSIONS).toContain('.mkv');
+      expect(VIDEO_EXTENSIONS).toContain('.m4v');
+      expect(VIDEO_EXTENSIONS).toContain('.avi');
+    });
+
+    it('should have .mp4 as highest priority', () => {
+      expect(VIDEO_EXTENSIONS[0]).toBe('.mp4');
+    });
+  });
+
+  describe('yt-dlp templates', () => {
+    it('CHANNEL_TEMPLATE should use uploader with fallbacks', () => {
+      expect(CHANNEL_TEMPLATE).toBe('%(uploader,channel,uploader_id)s');
+    });
+
+    it('VIDEO_FOLDER_TEMPLATE should include channel and truncated title', () => {
+      expect(VIDEO_FOLDER_TEMPLATE).toContain(CHANNEL_TEMPLATE);
+      expect(VIDEO_FOLDER_TEMPLATE).toContain('%(title).76s');
+      expect(VIDEO_FOLDER_TEMPLATE).toContain('%(id)s');
+    });
+
+    it('VIDEO_FILE_TEMPLATE should include bracketed video ID', () => {
+      expect(VIDEO_FILE_TEMPLATE).toContain('[%(id)s]');
+      expect(VIDEO_FILE_TEMPLATE).toContain('%(ext)s');
+    });
+  });
+
+  describe('YOUTUBE_ID_BRACKET_PATTERN', () => {
+    it('should match [VideoID] pattern', () => {
+      const match = 'Channel - Title [dQw4w9WgXcQ].mp4'.match(YOUTUBE_ID_BRACKET_PATTERN);
+      expect(match).not.toBeNull();
+      expect(match[1]).toBe('dQw4w9WgXcQ');
+    });
+
+    it('should match IDs with underscores and hyphens', () => {
+      // YouTube IDs are exactly 11 characters
+      const match = 'Video [a_b-c_d-e_f].mp4'.match(YOUTUBE_ID_BRACKET_PATTERN);
+      expect(match).not.toBeNull();
+      expect(match[1]).toBe('a_b-c_d-e_f');
+    });
+
+    it('should not match without brackets', () => {
+      const match = 'Channel - Title dQw4w9WgXcQ.mp4'.match(YOUTUBE_ID_BRACKET_PATTERN);
+      expect(match).toBeNull();
+    });
+  });
+
+  describe('YOUTUBE_ID_DASH_PATTERN', () => {
+    it('should match " - VideoID" at end of string', () => {
+      const match = 'Channel - Title - dQw4w9WgXcQ'.match(YOUTUBE_ID_DASH_PATTERN);
+      expect(match).not.toBeNull();
+      expect(match[1]).toBe('dQw4w9WgXcQ');
+    });
+
+    it('should not match in middle of string', () => {
+      const match = 'Channel - dQw4w9WgXcQ - Title'.match(YOUTUBE_ID_DASH_PATTERN);
+      expect(match).toBeNull();
+    });
+  });
+
+  describe('YOUTUBE_ID_PATTERN', () => {
+    it('should validate 11-character YouTube IDs', () => {
+      expect(YOUTUBE_ID_PATTERN.test('dQw4w9WgXcQ')).toBe(true);
+    });
+
+    it('should validate 10-12 character IDs', () => {
+      expect(YOUTUBE_ID_PATTERN.test('abcdefghij')).toBe(true);
+      expect(YOUTUBE_ID_PATTERN.test('abcdefghijk')).toBe(true);
+      expect(YOUTUBE_ID_PATTERN.test('abcdefghijkl')).toBe(true);
+    });
+
+    it('should allow hyphens and underscores', () => {
+      expect(YOUTUBE_ID_PATTERN.test('a-b_c-d_e-f')).toBe(true);
+    });
+
+    it('should reject too short IDs', () => {
+      expect(YOUTUBE_ID_PATTERN.test('abc')).toBe(false);
+    });
+
+    it('should reject too long IDs', () => {
+      expect(YOUTUBE_ID_PATTERN.test('abcdefghijklm')).toBe(false);
+    });
+  });
+
+  describe('MAIN_VIDEO_FILE_PATTERN', () => {
+    it('should match main video files', () => {
+      expect(MAIN_VIDEO_FILE_PATTERN.test('Channel - Title [dQw4w9WgXcQ].mp4')).toBe(true);
+      expect(MAIN_VIDEO_FILE_PATTERN.test('Channel - Title [dQw4w9WgXcQ].mkv')).toBe(true);
+      expect(MAIN_VIDEO_FILE_PATTERN.test('Channel - Title [dQw4w9WgXcQ].webm')).toBe(true);
+    });
+
+    it('should not match thumbnails', () => {
+      expect(MAIN_VIDEO_FILE_PATTERN.test('poster.jpg')).toBe(false);
+    });
+  });
+
+  describe('FRAGMENT_FILE_PATTERN', () => {
+    it('should match fragment files', () => {
+      expect(FRAGMENT_FILE_PATTERN.test('video.f137.mp4')).toBe(true);
+      expect(FRAGMENT_FILE_PATTERN.test('video.f140.m4a')).toBe(true);
+      expect(FRAGMENT_FILE_PATTERN.test('video.f248.webm')).toBe(true);
+    });
+
+    it('should not match main video files', () => {
+      expect(FRAGMENT_FILE_PATTERN.test('Channel - Title [dQw4w9WgXcQ].mp4')).toBe(false);
+    });
+  });
+});

--- a/server/modules/filesystem/__tests__/directoryManager.test.js
+++ b/server/modules/filesystem/__tests__/directoryManager.test.js
@@ -1,0 +1,267 @@
+const fs = require('fs-extra');
+const fsPromises = require('fs').promises;
+
+// Mock fs-extra and fs.promises
+jest.mock('fs-extra');
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  promises: {
+    readdir: jest.fn(),
+    rmdir: jest.fn(),
+    access: jest.fn()
+  }
+}));
+
+// Mock logger
+jest.mock('../../../logger', () => ({
+  debug: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn()
+}));
+
+const {
+  ensureDir,
+  ensureDirSync,
+  isDirectoryEmpty,
+  removeIfEmpty,
+  isVideoDirectory,
+  isChannelDirectory,
+  isSubfolderDir,
+  cleanupEmptyChannelDirectory,
+  listDirectory,
+  listSubdirectories,
+  isMainVideoFile
+} = require('../directoryManager');
+
+describe('filesystem/directoryManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('ensureDir', () => {
+    it('should call fs.ensureDir', async () => {
+      fs.ensureDir.mockResolvedValueOnce();
+
+      await ensureDir('/path/to/dir');
+
+      expect(fs.ensureDir).toHaveBeenCalledWith('/path/to/dir');
+    });
+  });
+
+  describe('ensureDirSync', () => {
+    it('should call fs.ensureDirSync', () => {
+      ensureDirSync('/path/to/dir');
+
+      expect(fs.ensureDirSync).toHaveBeenCalledWith('/path/to/dir');
+    });
+  });
+
+  describe('isDirectoryEmpty', () => {
+    it('should return true for empty directory', async () => {
+      fsPromises.readdir.mockResolvedValueOnce([]);
+
+      const result = await isDirectoryEmpty('/path/empty');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for non-empty directory', async () => {
+      fsPromises.readdir.mockResolvedValueOnce(['file1', 'file2']);
+
+      const result = await isDirectoryEmpty('/path/full');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for non-existent directory', async () => {
+      fsPromises.readdir.mockRejectedValueOnce(new Error('Not found'));
+
+      const result = await isDirectoryEmpty('/path/missing');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('removeIfEmpty', () => {
+    it('should remove empty directory', async () => {
+      fsPromises.readdir.mockResolvedValueOnce([]);
+      fsPromises.rmdir.mockResolvedValueOnce();
+
+      const result = await removeIfEmpty('/path/empty');
+
+      expect(result).toBe(true);
+      expect(fsPromises.rmdir).toHaveBeenCalledWith('/path/empty');
+    });
+
+    it('should not remove non-empty directory', async () => {
+      fsPromises.readdir.mockResolvedValueOnce(['file']);
+
+      const result = await removeIfEmpty('/path/full');
+
+      expect(result).toBe(false);
+      expect(fsPromises.rmdir).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isVideoDirectory', () => {
+    it('should return true for video directories', () => {
+      expect(isVideoDirectory('/path/Channel - Title - dQw4w9WgXcQ')).toBe(true);
+      expect(isVideoDirectory('/path/Channel - Long Title Here - abc123defgh')).toBe(true);
+    });
+
+    it('should return false for channel directories', () => {
+      expect(isVideoDirectory('/path/ChannelName')).toBe(false);
+      expect(isVideoDirectory('/path/Channel - Name')).toBe(false);
+    });
+
+    it('should return false for directories without valid video ID', () => {
+      expect(isVideoDirectory('/path/Channel - Title - short')).toBe(false);
+      // 13+ characters is too long
+      expect(isVideoDirectory('/path/Channel - Title - toolong123456')).toBe(false);
+    });
+
+    it('should validate video ID characters', () => {
+      expect(isVideoDirectory('/path/Channel - Title - abc_123-XYZ')).toBe(true);
+      expect(isVideoDirectory('/path/Channel - Title - abc!@#$%^&')).toBe(false);
+    });
+  });
+
+  describe('isChannelDirectory', () => {
+    const baseDir = '/videos';
+
+    it('should return true for direct child of baseDir', () => {
+      expect(isChannelDirectory('/videos/ChannelName', baseDir)).toBe(true);
+    });
+
+    it('should return true for child of subfolder', () => {
+      expect(isChannelDirectory('/videos/__Subfolder/ChannelName', baseDir)).toBe(true);
+    });
+
+    it('should return false for baseDir itself', () => {
+      expect(isChannelDirectory('/videos', baseDir)).toBe(false);
+    });
+
+    it('should return true for paths 2 levels below baseDir (video folders or channels in subfolders)', () => {
+      // Note: This function only checks depth, not directory type.
+      // In practice, callers should check isVideoDirectory first.
+      expect(isChannelDirectory('/videos/Channel/Video - Title - abc123', baseDir)).toBe(true);
+    });
+
+    it('should return true for subfolder directories (1 level below baseDir)', () => {
+      // Subfolder directories ARE 1 level below baseDir
+      expect(isChannelDirectory('/videos/__Subfolder', baseDir)).toBe(true);
+    });
+
+    it('should return false for paths too deep', () => {
+      expect(isChannelDirectory('/videos/Channel/Video/File', baseDir)).toBe(false);
+    });
+  });
+
+  describe('isSubfolderDir', () => {
+    it('should return true for directories starting with __', () => {
+      expect(isSubfolderDir('__MyFolder')).toBe(true);
+      expect(isSubfolderDir('__')).toBe(true);
+    });
+
+    it('should return false for regular directories', () => {
+      expect(isSubfolderDir('MyFolder')).toBe(false);
+      expect(isSubfolderDir('_MyFolder')).toBe(false);
+    });
+
+    it('should return false for null/undefined', () => {
+      expect(isSubfolderDir(null)).toBe(false);
+      expect(isSubfolderDir(undefined)).toBe(false);
+    });
+  });
+
+  describe('cleanupEmptyChannelDirectory', () => {
+    const baseDir = '/videos';
+
+    it('should remove empty channel directory', async () => {
+      fsPromises.access.mockResolvedValueOnce();
+      fsPromises.readdir.mockResolvedValueOnce([]);
+      fsPromises.rmdir.mockResolvedValueOnce();
+
+      await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir);
+
+      expect(fsPromises.rmdir).toHaveBeenCalledWith('/videos/ChannelName');
+    });
+
+    it('should not remove non-channel directory', async () => {
+      await cleanupEmptyChannelDirectory('/videos', baseDir);
+
+      expect(fsPromises.rmdir).not.toHaveBeenCalled();
+    });
+
+    it('should not remove non-empty channel directory', async () => {
+      fsPromises.access.mockResolvedValueOnce();
+      fsPromises.readdir.mockResolvedValueOnce(['video-folder']);
+
+      await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir);
+
+      expect(fsPromises.rmdir).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listDirectory', () => {
+    it('should list directory contents with file types', async () => {
+      const mockEntries = [
+        { name: 'file1', isDirectory: () => false },
+        { name: 'dir1', isDirectory: () => true }
+      ];
+      fsPromises.readdir.mockResolvedValueOnce(mockEntries);
+
+      const result = await listDirectory('/path');
+
+      expect(result).toEqual(mockEntries);
+      expect(fsPromises.readdir).toHaveBeenCalledWith('/path', { withFileTypes: true });
+    });
+
+    it('should return empty array for missing directory', async () => {
+      const error = new Error('Not found');
+      error.code = 'ENOENT';
+      fsPromises.readdir.mockRejectedValueOnce(error);
+
+      const result = await listDirectory('/missing');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('listSubdirectories', () => {
+    it('should return only directories', async () => {
+      const mockEntries = [
+        { name: 'file1', isDirectory: () => false },
+        { name: 'dir1', isDirectory: () => true },
+        { name: 'dir2', isDirectory: () => true }
+      ];
+      fsPromises.readdir.mockResolvedValueOnce(mockEntries);
+
+      const result = await listSubdirectories('/path');
+
+      expect(result).toEqual(['/path/dir1', '/path/dir2']);
+    });
+  });
+
+  describe('isMainVideoFile', () => {
+    it('should return true for main video files', () => {
+      expect(isMainVideoFile('Channel - Title [dQw4w9WgXcQ].mp4')).toBe(true);
+      expect(isMainVideoFile('Channel - Title [dQw4w9WgXcQ].mkv')).toBe(true);
+      expect(isMainVideoFile('Channel - Title [dQw4w9WgXcQ].webm')).toBe(true);
+    });
+
+    it('should return false for fragment files', () => {
+      expect(isMainVideoFile('video.f137.mp4')).toBe(false);
+      expect(isMainVideoFile('video.f140.m4a')).toBe(false);
+    });
+
+    it('should return false for thumbnails', () => {
+      expect(isMainVideoFile('poster.jpg')).toBe(false);
+    });
+
+    it('should return false for info files', () => {
+      expect(isMainVideoFile('Channel - Title [dQw4w9WgXcQ].info.json')).toBe(false);
+    });
+  });
+});

--- a/server/modules/filesystem/__tests__/fileOperations.test.js
+++ b/server/modules/filesystem/__tests__/fileOperations.test.js
@@ -1,0 +1,295 @@
+const fs = require('fs-extra');
+const fsPromises = require('fs').promises;
+
+// Mock fs-extra and fs.promises
+jest.mock('fs-extra');
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  promises: {
+    access: jest.fn(),
+    stat: jest.fn(),
+    utimes: jest.fn(),
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    appendFile: jest.fn()
+  },
+  utimesSync: jest.fn()
+}));
+
+// Mock logger
+jest.mock('../../../logger', () => ({
+  debug: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  error: jest.fn()
+}));
+
+const {
+  sleep,
+  moveWithRetries,
+  safeRemove,
+  safeCopy,
+  pathExists,
+  safeStat,
+  setTimestamp,
+  isFile,
+  isDirectory
+} = require('../fileOperations');
+
+describe('filesystem/fileOperations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('sleep', () => {
+    it('should wait for specified milliseconds', async () => {
+      jest.useFakeTimers();
+      const promise = sleep(100);
+      jest.advanceTimersByTime(100);
+      await promise;
+      jest.useRealTimers();
+    });
+  });
+
+  describe('moveWithRetries', () => {
+    it('should move file successfully on first try', async () => {
+      fs.move.mockResolvedValueOnce();
+
+      await moveWithRetries('/src', '/dest');
+
+      expect(fs.move).toHaveBeenCalledWith('/src', '/dest', { overwrite: true });
+      expect(fs.move).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry on failure', async () => {
+      jest.useFakeTimers();
+      fs.move
+        .mockRejectedValueOnce(new Error('EBUSY'))
+        .mockResolvedValueOnce();
+
+      const promise = moveWithRetries('/src', '/dest', { retries: 2, delayMs: 100 });
+
+      // First attempt fails immediately
+      await Promise.resolve();
+
+      // Advance past first retry delay (100ms)
+      jest.advanceTimersByTime(100);
+
+      await promise;
+
+      expect(fs.move).toHaveBeenCalledTimes(2);
+      jest.useRealTimers();
+    });
+
+    it('should throw after all retries exhausted', async () => {
+      jest.useFakeTimers();
+      const error = new Error('Persistent error');
+      fs.move.mockRejectedValue(error);
+
+      const promise = moveWithRetries('/src', '/dest', { retries: 2, delayMs: 10 });
+
+      // Advance through all retries
+      for (let i = 0; i < 3; i++) {
+        await Promise.resolve();
+        jest.advanceTimersByTime(1000);
+      }
+
+      await expect(promise).rejects.toThrow('Persistent error');
+      jest.useRealTimers();
+    });
+
+    it('should use custom overwrite option', async () => {
+      fs.move.mockResolvedValueOnce();
+
+      await moveWithRetries('/src', '/dest', { overwrite: false });
+
+      expect(fs.move).toHaveBeenCalledWith('/src', '/dest', { overwrite: false });
+    });
+  });
+
+  describe('safeRemove', () => {
+    it('should remove file successfully', async () => {
+      fs.remove.mockResolvedValueOnce();
+
+      await safeRemove('/path/to/file');
+
+      expect(fs.remove).toHaveBeenCalledWith('/path/to/file');
+    });
+
+    it('should ignore ENOENT errors', async () => {
+      const error = new Error('File not found');
+      error.code = 'ENOENT';
+      fs.remove.mockRejectedValueOnce(error);
+
+      await expect(safeRemove('/path/to/file')).resolves.not.toThrow();
+    });
+
+    it('should log warning for other errors', async () => {
+      const logger = require('../../../logger');
+      const error = new Error('Permission denied');
+      error.code = 'EACCES';
+      fs.remove.mockRejectedValueOnce(error);
+
+      await safeRemove('/path/to/file');
+
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('safeCopy', () => {
+    it('should copy file successfully', async () => {
+      fs.copy.mockResolvedValueOnce();
+
+      await safeCopy('/src', '/dest');
+
+      expect(fs.copy).toHaveBeenCalledWith('/src', '/dest', { overwrite: false });
+    });
+
+    it('should use overwrite option', async () => {
+      fs.copy.mockResolvedValueOnce();
+
+      await safeCopy('/src', '/dest', { overwrite: true });
+
+      expect(fs.copy).toHaveBeenCalledWith('/src', '/dest', { overwrite: true });
+    });
+  });
+
+  describe('pathExists', () => {
+    it('should return true when path exists', async () => {
+      fsPromises.access.mockResolvedValueOnce();
+
+      const result = await pathExists('/path/exists');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for ENOENT', async () => {
+      const error = new Error('Not found');
+      error.code = 'ENOENT';
+      fsPromises.access.mockRejectedValueOnce(error);
+
+      const result = await pathExists('/path/missing');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for ENOTDIR', async () => {
+      const error = new Error('Not a directory');
+      error.code = 'ENOTDIR';
+      fsPromises.access.mockRejectedValueOnce(error);
+
+      const result = await pathExists('/path/invalid');
+
+      expect(result).toBe(false);
+    });
+
+    it('should throw for other errors', async () => {
+      const error = new Error('Permission denied');
+      error.code = 'EACCES';
+      fsPromises.access.mockRejectedValueOnce(error);
+
+      await expect(pathExists('/path')).rejects.toThrow('Permission denied');
+    });
+  });
+
+  describe('safeStat', () => {
+    it('should return stats for existing file', async () => {
+      const mockStats = { isFile: () => true, isDirectory: () => false };
+      fsPromises.stat.mockResolvedValueOnce(mockStats);
+
+      const result = await safeStat('/path/file');
+
+      expect(result).toEqual({ path: '/path/file', stats: mockStats });
+    });
+
+    it('should return null for missing file', async () => {
+      const error = new Error('Not found');
+      error.code = 'ENOENT';
+      fsPromises.stat.mockRejectedValueOnce(error);
+
+      const result = await safeStat('/path/missing');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('setTimestamp', () => {
+    it('should set timestamp from Date object', async () => {
+      fsPromises.utimes.mockResolvedValueOnce();
+      const date = new Date('2024-01-01T00:00:00Z');
+
+      await setTimestamp('/path/file', date);
+
+      expect(fsPromises.utimes).toHaveBeenCalledWith('/path/file', date, date);
+    });
+
+    it('should set timestamp from Unix seconds', async () => {
+      fsPromises.utimes.mockResolvedValueOnce();
+      const unixSeconds = 1704067200; // 2024-01-01T00:00:00Z
+
+      await setTimestamp('/path/file', unixSeconds);
+
+      expect(fsPromises.utimes).toHaveBeenCalled();
+      const [, atime] = fsPromises.utimes.mock.calls[0];
+      expect(atime.getTime()).toBe(unixSeconds * 1000);
+    });
+  });
+
+  describe('isFile', () => {
+    it('should return true for files', async () => {
+      fsPromises.stat.mockResolvedValueOnce({
+        isFile: () => true,
+        isDirectory: () => false
+      });
+
+      const result = await isFile('/path/file');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for directories', async () => {
+      fsPromises.stat.mockResolvedValueOnce({
+        isFile: () => false,
+        isDirectory: () => true
+      });
+
+      const result = await isFile('/path/dir');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for missing paths', async () => {
+      const error = new Error('Not found');
+      error.code = 'ENOENT';
+      fsPromises.stat.mockRejectedValueOnce(error);
+
+      const result = await isFile('/path/missing');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isDirectory', () => {
+    it('should return true for directories', async () => {
+      fsPromises.stat.mockResolvedValueOnce({
+        isFile: () => false,
+        isDirectory: () => true
+      });
+
+      const result = await isDirectory('/path/dir');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for files', async () => {
+      fsPromises.stat.mockResolvedValueOnce({
+        isFile: () => true,
+        isDirectory: () => false
+      });
+
+      const result = await isDirectory('/path/file');
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/server/modules/filesystem/__tests__/pathBuilder.test.js
+++ b/server/modules/filesystem/__tests__/pathBuilder.test.js
@@ -1,0 +1,240 @@
+const {
+  buildSubfolderSegment,
+  isSubfolderDirectory,
+  extractSubfolderName,
+  resolveEffectiveSubfolder,
+  resolveChannelFolderName,
+  buildChannelPath,
+  buildVideoPath,
+  buildOutputTemplate,
+  buildThumbnailTemplate,
+  extractYoutubeIdFromPath,
+  isValidYoutubeId,
+  calculateRelocatedPath
+} = require('../pathBuilder');
+const { GLOBAL_DEFAULT_SENTINEL } = require('../constants');
+
+describe('filesystem/pathBuilder', () => {
+  describe('buildSubfolderSegment', () => {
+    it('should add __ prefix to subfolder name', () => {
+      expect(buildSubfolderSegment('MyFolder')).toBe('__MyFolder');
+    });
+
+    it('should trim whitespace', () => {
+      expect(buildSubfolderSegment('  MyFolder  ')).toBe('__MyFolder');
+    });
+
+    it('should return null for null input', () => {
+      expect(buildSubfolderSegment(null)).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+      expect(buildSubfolderSegment('')).toBeNull();
+    });
+
+    it('should return null for whitespace-only string', () => {
+      expect(buildSubfolderSegment('   ')).toBeNull();
+    });
+  });
+
+  describe('isSubfolderDirectory', () => {
+    it('should return true for directories starting with __', () => {
+      expect(isSubfolderDirectory('__MyFolder')).toBe(true);
+      expect(isSubfolderDirectory('__')).toBe(true);
+    });
+
+    it('should return false for regular directories', () => {
+      expect(isSubfolderDirectory('MyFolder')).toBe(false);
+      expect(isSubfolderDirectory('_MyFolder')).toBe(false);
+    });
+
+    it('should return false for null/undefined', () => {
+      expect(isSubfolderDirectory(null)).toBe(false);
+      expect(isSubfolderDirectory(undefined)).toBe(false);
+    });
+  });
+
+  describe('extractSubfolderName', () => {
+    it('should extract name without prefix', () => {
+      expect(extractSubfolderName('__MyFolder')).toBe('MyFolder');
+    });
+
+    it('should return null for non-subfolder directory', () => {
+      expect(extractSubfolderName('MyFolder')).toBeNull();
+    });
+
+    it('should handle just the prefix', () => {
+      expect(extractSubfolderName('__')).toBe('');
+    });
+  });
+
+  describe('resolveEffectiveSubfolder', () => {
+    it('should return global default for GLOBAL_DEFAULT_SENTINEL', () => {
+      expect(resolveEffectiveSubfolder(GLOBAL_DEFAULT_SENTINEL, 'default')).toBe('default');
+    });
+
+    it('should return null for GLOBAL_DEFAULT_SENTINEL when no global default set', () => {
+      expect(resolveEffectiveSubfolder(GLOBAL_DEFAULT_SENTINEL, null)).toBeNull();
+    });
+
+    it('should return channel subfolder when set', () => {
+      expect(resolveEffectiveSubfolder('MyFolder', 'default')).toBe('MyFolder');
+    });
+
+    it('should trim channel subfolder', () => {
+      expect(resolveEffectiveSubfolder('  MyFolder  ', 'default')).toBe('MyFolder');
+    });
+
+    it('should return null (root) when channel subfolder is null (backwards compatible)', () => {
+      expect(resolveEffectiveSubfolder(null, 'default')).toBeNull();
+    });
+
+    it('should return null (root) when channel subfolder is empty (backwards compatible)', () => {
+      expect(resolveEffectiveSubfolder('', 'default')).toBeNull();
+    });
+
+    it('should return null when both are null', () => {
+      expect(resolveEffectiveSubfolder(null, null)).toBeNull();
+    });
+  });
+
+  describe('resolveChannelFolderName', () => {
+    it('should prefer folder_name over uploader', () => {
+      const channel = { folder_name: 'SanitizedName', uploader: 'Original Name' };
+      expect(resolveChannelFolderName(channel)).toBe('SanitizedName');
+    });
+
+    it('should fall back to uploader when folder_name is null', () => {
+      const channel = { folder_name: null, uploader: 'Original Name' };
+      expect(resolveChannelFolderName(channel)).toBe('Original Name');
+    });
+
+    it('should fall back to uploader when folder_name is undefined', () => {
+      const channel = { uploader: 'Original Name' };
+      expect(resolveChannelFolderName(channel)).toBe('Original Name');
+    });
+  });
+
+  describe('buildChannelPath', () => {
+    const baseDir = '/videos';
+
+    it('should build path without subfolder', () => {
+      expect(buildChannelPath(baseDir, null, 'ChannelName')).toBe('/videos/ChannelName');
+    });
+
+    it('should build path with subfolder', () => {
+      expect(buildChannelPath(baseDir, 'MyFolder', 'ChannelName')).toBe('/videos/__MyFolder/ChannelName');
+    });
+
+    it('should handle empty subfolder as no subfolder', () => {
+      expect(buildChannelPath(baseDir, '', 'ChannelName')).toBe('/videos/ChannelName');
+    });
+  });
+
+  describe('buildVideoPath', () => {
+    const baseDir = '/videos';
+
+    it('should build full video path without subfolder', () => {
+      expect(buildVideoPath(baseDir, null, 'ChannelName', 'Video - Title - abc123'))
+        .toBe('/videos/ChannelName/Video - Title - abc123');
+    });
+
+    it('should build full video path with subfolder', () => {
+      expect(buildVideoPath(baseDir, 'MyFolder', 'ChannelName', 'Video - Title - abc123'))
+        .toBe('/videos/__MyFolder/ChannelName/Video - Title - abc123');
+    });
+  });
+
+  describe('buildOutputTemplate', () => {
+    const baseDir = '/videos';
+
+    it('should build template without subfolder', () => {
+      const template = buildOutputTemplate(baseDir, null);
+      expect(template).not.toContain('__');
+      expect(template).toContain('%(uploader,channel,uploader_id)s');
+      expect(template).toContain('[%(id)s]');
+    });
+
+    it('should build template with subfolder', () => {
+      const template = buildOutputTemplate(baseDir, 'MyFolder');
+      expect(template).toContain('__MyFolder');
+      expect(template).toContain('%(uploader,channel,uploader_id)s');
+    });
+  });
+
+  describe('buildThumbnailTemplate', () => {
+    const baseDir = '/videos';
+
+    it('should build thumbnail template without subfolder', () => {
+      const template = buildThumbnailTemplate(baseDir, null);
+      expect(template).toContain('poster');
+      expect(template).not.toContain('__');
+    });
+
+    it('should build thumbnail template with subfolder', () => {
+      const template = buildThumbnailTemplate(baseDir, 'MyFolder');
+      expect(template).toContain('__MyFolder');
+      expect(template).toContain('poster');
+    });
+  });
+
+  describe('extractYoutubeIdFromPath', () => {
+    it('should extract ID from bracketed filename', () => {
+      expect(extractYoutubeIdFromPath('/videos/Channel/Video [dQw4w9WgXcQ].mp4'))
+        .toBe('dQw4w9WgXcQ');
+    });
+
+    it('should extract ID from directory name', () => {
+      expect(extractYoutubeIdFromPath('/videos/Channel/Video - Title - dQw4w9WgXcQ/poster.jpg'))
+        .toBe('dQw4w9WgXcQ');
+    });
+
+    it('should return null when no ID found', () => {
+      expect(extractYoutubeIdFromPath('/videos/Channel/poster.jpg')).toBeNull();
+    });
+
+    it('should handle empty path', () => {
+      expect(extractYoutubeIdFromPath('')).toBeNull();
+    });
+  });
+
+  describe('isValidYoutubeId', () => {
+    it('should validate standard YouTube IDs', () => {
+      expect(isValidYoutubeId('dQw4w9WgXcQ')).toBe(true);
+    });
+
+    it('should validate IDs with hyphens and underscores', () => {
+      expect(isValidYoutubeId('a-b_c-d_e-fg')).toBe(true);
+    });
+
+    it('should reject too short', () => {
+      expect(isValidYoutubeId('abc')).toBe(false);
+    });
+
+    it('should reject too long', () => {
+      expect(isValidYoutubeId('abcdefghijklm')).toBe(false);
+    });
+
+    it('should reject invalid characters', () => {
+      expect(isValidYoutubeId('abc!@#$%^&*')).toBe(false);
+    });
+  });
+
+  describe('calculateRelocatedPath', () => {
+    it('should calculate new path after base change', () => {
+      const oldBase = '/videos/Channel';
+      const newBase = '/videos/__Subfolder/Channel';
+      const original = '/videos/Channel/Video/file.mp4';
+      expect(calculateRelocatedPath(oldBase, newBase, original))
+        .toBe('/videos/__Subfolder/Channel/Video/file.mp4');
+    });
+
+    it('should return null if original does not start with oldBase', () => {
+      expect(calculateRelocatedPath('/videos/A', '/videos/B', '/other/path')).toBeNull();
+    });
+
+    it('should return null for null original', () => {
+      expect(calculateRelocatedPath('/a', '/b', null)).toBeNull();
+    });
+  });
+});

--- a/server/modules/filesystem/__tests__/sanitizer.test.js
+++ b/server/modules/filesystem/__tests__/sanitizer.test.js
@@ -1,0 +1,157 @@
+const {
+  sanitizePathLikeYtDlp,
+  sanitizeNameLikeYtDlp,
+  sanitizePathParts
+} = require('../sanitizer');
+
+describe('sanitizer', () => {
+  describe('sanitizePathParts', () => {
+    it('should skip empty parts', () => {
+      expect(sanitizePathParts(['', 'a', '', 'b', ''])).toEqual(['a', 'b']);
+    });
+
+    it('should skip single dots', () => {
+      expect(sanitizePathParts(['.', 'a', '.', 'b'])).toEqual(['a', 'b']);
+    });
+
+    it('should handle parent directory references', () => {
+      expect(sanitizePathParts(['a', 'b', '..', 'c'])).toEqual(['a', 'c']);
+      expect(sanitizePathParts(['a', '..', '..', 'b'])).toEqual(['..', 'b']);
+      expect(sanitizePathParts(['..', 'a'])).toEqual(['..', 'a']);
+    });
+
+    it('should replace Windows-forbidden characters with #', () => {
+      expect(sanitizePathParts(['file<name'])).toEqual(['file#name']);
+      expect(sanitizePathParts(['file>name'])).toEqual(['file#name']);
+      expect(sanitizePathParts(['file:name'])).toEqual(['file#name']);
+      expect(sanitizePathParts(['file"name'])).toEqual(['file#name']);
+      expect(sanitizePathParts(['file|name'])).toEqual(['file#name']);
+      expect(sanitizePathParts(['file?name'])).toEqual(['file#name']);
+      expect(sanitizePathParts(['file*name'])).toEqual(['file#name']);
+      expect(sanitizePathParts(['file\\name'])).toEqual(['file#name']);
+      expect(sanitizePathParts(['file/name'])).toEqual(['file#name']);
+    });
+
+    it('should replace multiple forbidden characters', () => {
+      expect(sanitizePathParts(['file<>:name'])).toEqual(['file###name']);
+    });
+
+    it('should replace trailing dots with #', () => {
+      expect(sanitizePathParts(['filename.'])).toEqual(['filename#']);
+      expect(sanitizePathParts(['filename..'])).toEqual(['filename.#']);
+      expect(sanitizePathParts(['filename...'])).toEqual(['filename..#']);
+    });
+
+    it('should replace trailing spaces with #', () => {
+      expect(sanitizePathParts(['filename '])).toEqual(['filename#']);
+      expect(sanitizePathParts(['filename  '])).toEqual(['filename #']);
+    });
+
+    it('should replace trailing whitespace and dots', () => {
+      expect(sanitizePathParts(['filename. '])).toEqual(['filename.#']);
+      expect(sanitizePathParts(['filename .'])).toEqual(['filename #']);
+    });
+  });
+
+  describe('sanitizePathLikeYtDlp', () => {
+    it('should return "." for empty input', () => {
+      expect(sanitizePathLikeYtDlp('')).toBe('.');
+      expect(sanitizePathLikeYtDlp(null)).toBe('.');
+      expect(sanitizePathLikeYtDlp(undefined)).toBe('.');
+    });
+
+    it('should preserve leading slash for absolute paths', () => {
+      expect(sanitizePathLikeYtDlp('/home/user/file')).toBe('/home/user/file');
+      expect(sanitizePathLikeYtDlp('/a/b/c')).toBe('/a/b/c');
+    });
+
+    it('should handle relative paths', () => {
+      expect(sanitizePathLikeYtDlp('home/user/file')).toBe('home/user/file');
+      expect(sanitizePathLikeYtDlp('a/b/c')).toBe('a/b/c');
+    });
+
+    it('should sanitize Windows-forbidden characters in path', () => {
+      // Both < and > are forbidden chars, so both get replaced
+      expect(sanitizePathLikeYtDlp('/path/to/file<name>/test')).toBe('/path/to/file#name#/test');
+      expect(sanitizePathLikeYtDlp('/path/file:name')).toBe('/path/file#name');
+      // Single forbidden char
+      expect(sanitizePathLikeYtDlp('/path/to/file<test/file')).toBe('/path/to/file#test/file');
+    });
+
+    it('should handle trailing dots in path segments', () => {
+      expect(sanitizePathLikeYtDlp('/path./to./file.')).toBe('/path#/to#/file#');
+    });
+
+    it('should normalize empty segments and dots', () => {
+      expect(sanitizePathLikeYtDlp('/path//to/./file')).toBe('/path/to/file');
+    });
+
+    it('should handle parent directory references', () => {
+      expect(sanitizePathLikeYtDlp('/path/to/../file')).toBe('/path/file');
+    });
+
+    it('should handle real-world video paths with special chars', () => {
+      // Video title with colon
+      expect(sanitizePathLikeYtDlp('/videos/Channel/Video: The Title [abc123]'))
+        .toBe('/videos/Channel/Video# The Title [abc123]');
+
+      // Video title with question mark
+      expect(sanitizePathLikeYtDlp('/videos/Channel/What is this? [abc123]'))
+        .toBe('/videos/Channel/What is this# [abc123]');
+
+      // Video title with multiple special chars
+      expect(sanitizePathLikeYtDlp('/videos/Channel/Best <Video> Ever! [abc123]'))
+        .toBe('/videos/Channel/Best #Video# Ever! [abc123]');
+    });
+
+    it('should handle channel names with trailing dots', () => {
+      expect(sanitizePathLikeYtDlp('/videos/Channel Inc./video'))
+        .toBe('/videos/Channel Inc#/video');
+    });
+  });
+
+  describe('sanitizeNameLikeYtDlp', () => {
+    it('should return "_" for empty input', () => {
+      expect(sanitizeNameLikeYtDlp('')).toBe('_');
+      expect(sanitizeNameLikeYtDlp(null)).toBe('_');
+      expect(sanitizeNameLikeYtDlp(undefined)).toBe('_');
+    });
+
+    it('should replace Windows-forbidden characters', () => {
+      expect(sanitizeNameLikeYtDlp('file<name')).toBe('file#name');
+      expect(sanitizeNameLikeYtDlp('file>name')).toBe('file#name');
+      expect(sanitizeNameLikeYtDlp('file:name')).toBe('file#name');
+      expect(sanitizeNameLikeYtDlp('file"name')).toBe('file#name');
+      expect(sanitizeNameLikeYtDlp('file|name')).toBe('file#name');
+      expect(sanitizeNameLikeYtDlp('file?name')).toBe('file#name');
+      expect(sanitizeNameLikeYtDlp('file*name')).toBe('file#name');
+    });
+
+    it('should replace only the last trailing dot', () => {
+      // yt-dlp only replaces a SINGLE trailing char, not all of them
+      expect(sanitizeNameLikeYtDlp('filename.')).toBe('filename#');
+      expect(sanitizeNameLikeYtDlp('filename..')).toBe('filename.#');
+      expect(sanitizeNameLikeYtDlp('filename...')).toBe('filename..#');
+    });
+
+    it('should replace only the last trailing space', () => {
+      expect(sanitizeNameLikeYtDlp('filename ')).toBe('filename#');
+      expect(sanitizeNameLikeYtDlp('filename  ')).toBe('filename #');
+    });
+
+    it('should preserve internal dots and spaces', () => {
+      expect(sanitizeNameLikeYtDlp('file.name')).toBe('file.name');
+      expect(sanitizeNameLikeYtDlp('file name')).toBe('file name');
+    });
+
+    it('should handle real-world video titles', () => {
+      expect(sanitizeNameLikeYtDlp('What is Python?')).toBe('What is Python#');
+      // Colon is a forbidden char, so it gets replaced with #
+      expect(sanitizeNameLikeYtDlp('C++ vs C#: The Battle')).toBe('C++ vs C## The Battle');
+      // Only the last trailing dot is replaced
+      expect(sanitizeNameLikeYtDlp('Video Title...')).toBe('Video Title..#');
+      // Real case from user: Fred again . .
+      expect(sanitizeNameLikeYtDlp('Fred again . .')).toBe('Fred again . #');
+    });
+  });
+});

--- a/server/modules/filesystem/constants.js
+++ b/server/modules/filesystem/constants.js
@@ -1,0 +1,92 @@
+/**
+ * Shared constants for file and path operations
+ * Single source of truth for all path-related constants
+ */
+
+/**
+ * Prefix added to subfolder names for namespace safety
+ * Subfolders are stored without this prefix in the database
+ * but always have it when on the filesystem
+ */
+const SUBFOLDER_PREFIX = '__';
+
+/**
+ * Sentinel value for explicitly specifying "use global default subfolder"
+ * This distinguishes from NULL which means "download to root" (backwards compatible)
+ */
+const GLOBAL_DEFAULT_SENTINEL = '##USE_GLOBAL_DEFAULT##';
+
+/**
+ * Sentinel value for explicitly specifying "download to root directory"
+ * Used in manual downloads to override channel subfolder settings and download directly to root
+ */
+const ROOT_SENTINEL = '##ROOT##';
+
+/**
+ * Default video file extensions in priority order
+ * Used when searching for video files with unknown extensions
+ */
+const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mkv', '.m4v', '.avi'];
+
+/**
+ * yt-dlp output template for channel folder name
+ * Uses uploader with fallback to channel, then uploader_id
+ */
+const CHANNEL_TEMPLATE = '%(uploader,channel,uploader_id)s';
+
+/**
+ * yt-dlp output template for video folder name
+ * Format: "ChannelName - VideoTitle - VideoID"
+ * Title is truncated to 76 characters to avoid path length issues
+ */
+const VIDEO_FOLDER_TEMPLATE = `${CHANNEL_TEMPLATE} - %(title).76s - %(id)s`;
+
+/**
+ * yt-dlp output template for video file name
+ * Format: "ChannelName - VideoTitle [VideoID].ext"
+ * Title is truncated to 76 characters to avoid path length issues
+ */
+const VIDEO_FILE_TEMPLATE = `${CHANNEL_TEMPLATE} - %(title).76s [%(id)s].%(ext)s`;
+
+/**
+ * Pattern to extract YouTube video ID from filename
+ * Matches [VideoID] where VideoID is 11 alphanumeric characters (including - and _)
+ */
+const YOUTUBE_ID_BRACKET_PATTERN = /\[([a-zA-Z0-9_-]{11})\]/;
+
+/**
+ * Pattern to extract YouTube video ID from directory name
+ * Matches " - VideoID" at the end of directory name
+ */
+const YOUTUBE_ID_DASH_PATTERN = / - ([a-zA-Z0-9_-]{10,12})$/;
+
+/**
+ * Pattern to validate a YouTube video ID string
+ */
+const YOUTUBE_ID_PATTERN = /^[a-zA-Z0-9_-]{10,12}$/;
+
+/**
+ * Pattern to identify main video files (not fragments)
+ * Matches [VideoID].mp4/mkv/webm but NOT .fXXX.mp4
+ */
+const MAIN_VIDEO_FILE_PATTERN = /\[[a-zA-Z0-9_-]{10,12}\]\.(mp4|mkv|webm)$/;
+
+/**
+ * Pattern to identify video fragment files (to exclude)
+ */
+const FRAGMENT_FILE_PATTERN = /\.f\d+\.(mp4|m4a|webm)$/;
+
+module.exports = {
+  SUBFOLDER_PREFIX,
+  GLOBAL_DEFAULT_SENTINEL,
+  ROOT_SENTINEL,
+  VIDEO_EXTENSIONS,
+  CHANNEL_TEMPLATE,
+  VIDEO_FOLDER_TEMPLATE,
+  VIDEO_FILE_TEMPLATE,
+  YOUTUBE_ID_BRACKET_PATTERN,
+  YOUTUBE_ID_DASH_PATTERN,
+  YOUTUBE_ID_PATTERN,
+  MAIN_VIDEO_FILE_PATTERN,
+  FRAGMENT_FILE_PATTERN
+};

--- a/server/modules/filesystem/directoryManager.js
+++ b/server/modules/filesystem/directoryManager.js
@@ -1,0 +1,286 @@
+/**
+ * Directory management utilities
+ * Creation, validation, cleanup, and traversal operations
+ */
+
+const fs = require('fs-extra');
+const fsPromises = require('fs').promises;
+const path = require('path');
+const logger = require('../../logger');
+const { YOUTUBE_ID_PATTERN, SUBFOLDER_PREFIX, MAIN_VIDEO_FILE_PATTERN, FRAGMENT_FILE_PATTERN } = require('./constants');
+
+/**
+ * Ensure a directory exists, creating it if necessary
+ *
+ * @param {string} dirPath - Directory path to ensure
+ * @returns {Promise<void>}
+ */
+async function ensureDir(dirPath) {
+  await fs.ensureDir(dirPath);
+}
+
+/**
+ * Ensure a directory exists synchronously
+ *
+ * @param {string} dirPath - Directory path to ensure
+ */
+function ensureDirSync(dirPath) {
+  fs.ensureDirSync(dirPath);
+}
+
+/**
+ * Check if a directory is empty
+ *
+ * @param {string} dirPath - Directory path to check
+ * @returns {Promise<boolean>} - True if directory is empty or doesn't exist
+ */
+async function isDirectoryEmpty(dirPath) {
+  try {
+    const entries = await fsPromises.readdir(dirPath);
+    return entries.length === 0;
+  } catch (error) {
+    // Directory doesn't exist or can't be read - treat as "empty" for cleanup purposes
+    logger.debug({ err: error, dirPath }, 'Cannot read directory (may not exist)');
+    return false;
+  }
+}
+
+/**
+ * Remove a directory only if it's empty
+ *
+ * @param {string} dirPath - Directory path to remove
+ * @returns {Promise<boolean>} - True if directory was removed
+ */
+async function removeIfEmpty(dirPath) {
+  try {
+    const isEmpty = await isDirectoryEmpty(dirPath);
+    if (!isEmpty) {
+      return false;
+    }
+    await fsPromises.rmdir(dirPath);
+    logger.debug({ dirPath }, 'Removed empty directory');
+    return true;
+  } catch (error) {
+    logger.debug({ err: error, dirPath }, 'Could not remove directory');
+    return false;
+  }
+}
+
+/**
+ * Check if a directory is a video-specific directory
+ * Video directories follow the pattern: "ChannelName - VideoTitle - VideoID"
+ * where VideoID is the last segment after the final " - " separator
+ *
+ * @param {string} dirPath - Directory path to check
+ * @returns {boolean} - True if it's a video directory
+ */
+function isVideoDirectory(dirPath) {
+  try {
+    const dirName = path.basename(dirPath);
+
+    // Video directories end with " - <VideoID>" where VideoID is typically 11 chars
+    // Pattern: something - something - videoId
+    const parts = dirName.split(' - ');
+    if (parts.length < 3) {
+      return false; // Not enough segments to be a video directory
+    }
+
+    const potentialVideoId = parts[parts.length - 1];
+
+    // YouTube video IDs are 11 characters, alphanumeric plus - and _
+    // Allow 10-12 chars to be flexible with other platforms
+    return YOUTUBE_ID_PATTERN.test(potentialVideoId);
+  } catch (error) {
+    logger.error({ err: error }, 'Error checking if directory is video-specific');
+    return false;
+  }
+}
+
+/**
+ * Check if a directory is a channel-level directory
+ * A channel directory is:
+ * - One level below baseDir (no subfolder): baseDir/channelName
+ * - Two levels below baseDir (with subfolder): baseDir/__subfolder/channelName
+ * We never want to clean up baseDir itself or subfolder directories
+ *
+ * @param {string} dirPath - Directory path to check
+ * @param {string} baseDir - The base output directory
+ * @returns {boolean} - True if it's a channel directory
+ */
+function isChannelDirectory(dirPath, baseDir) {
+  try {
+    // Normalize paths for comparison
+    const normalizedDirPath = path.resolve(dirPath);
+    const normalizedBaseDir = path.resolve(baseDir);
+
+    // Cannot be baseDir itself
+    if (normalizedDirPath === normalizedBaseDir) {
+      return false;
+    }
+
+    // Get the parent directory
+    const parentDir = path.dirname(normalizedDirPath);
+
+    // Check if parent is baseDir (channel without subfolder)
+    if (parentDir === normalizedBaseDir) {
+      return true;
+    }
+
+    // Check if grandparent is baseDir (channel with subfolder)
+    const grandparentDir = path.dirname(parentDir);
+    if (grandparentDir === normalizedBaseDir) {
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    logger.error({ err: error, dirPath }, 'Error checking if directory is channel directory');
+    return false;
+  }
+}
+
+/**
+ * Check if a directory name is a subfolder directory (starts with __ prefix)
+ *
+ * @param {string} dirName - Directory name to check
+ * @returns {boolean} - True if it's a subfolder directory
+ */
+function isSubfolderDir(dirName) {
+  if (!dirName) {
+    return false;
+  }
+  return dirName.startsWith(SUBFOLDER_PREFIX);
+}
+
+/**
+ * Clean up an empty channel directory
+ * Only removes the directory if it's a valid channel directory and empty
+ *
+ * @param {string} channelDir - Channel directory path
+ * @param {string} baseDir - The base output directory
+ * @returns {Promise<void>}
+ */
+async function cleanupEmptyChannelDirectory(channelDir, baseDir) {
+  try {
+    // Verify this is actually a channel directory (not root or subfolder)
+    if (!isChannelDirectory(channelDir, baseDir)) {
+      logger.debug({ channelDir }, 'Not a channel directory, skipping cleanup');
+      return;
+    }
+
+    // Check if directory exists
+    try {
+      await fsPromises.access(channelDir);
+    } catch {
+      logger.debug({ channelDir }, 'Channel directory does not exist');
+      return;
+    }
+
+    // Check if directory is empty
+    const isEmpty = await isDirectoryEmpty(channelDir);
+    if (!isEmpty) {
+      logger.debug({ channelDir }, 'Channel directory not empty, keeping it');
+      return;
+    }
+
+    // Remove empty channel directory
+    await fsPromises.rmdir(channelDir);
+    logger.info({ channelDir }, 'Removed empty channel directory');
+  } catch (error) {
+    logger.error({ err: error, channelDir }, 'Error cleaning up empty channel directory');
+    // Don't throw - this is a best-effort cleanup
+  }
+}
+
+/**
+ * Recursively clean up empty parent directories up to a stop point
+ *
+ * @param {string} startDir - Starting directory to check
+ * @param {string} stopAt - Stop when reaching this directory (don't remove it)
+ * @returns {Promise<void>}
+ */
+async function cleanupEmptyParents(startDir, stopAt) {
+  let currentDir = startDir;
+  const normalizedStopAt = path.resolve(stopAt);
+
+  while (currentDir && path.resolve(currentDir) !== normalizedStopAt) {
+    const isEmpty = await isDirectoryEmpty(currentDir);
+    if (!isEmpty) {
+      break;
+    }
+
+    try {
+      await fsPromises.rmdir(currentDir);
+      logger.debug({ currentDir }, 'Removed empty parent directory');
+      currentDir = path.dirname(currentDir);
+    } catch (error) {
+      logger.debug({ err: error, currentDir }, 'Could not remove parent directory');
+      break;
+    }
+  }
+}
+
+/**
+ * List all entries in a directory
+ *
+ * @param {string} dirPath - Directory to list
+ * @param {Object} options - Options
+ * @param {boolean} options.withFileTypes - Return Dirent objects (default: true)
+ * @returns {Promise<fs.Dirent[]|string[]>} - Directory entries
+ */
+async function listDirectory(dirPath, { withFileTypes = true } = {}) {
+  try {
+    return await fsPromises.readdir(dirPath, { withFileTypes });
+  } catch (error) {
+    if (error.code === 'ENOENT' || error.code === 'ENOTDIR') {
+      return [];
+    }
+    throw error;
+  }
+}
+
+/**
+ * List all subdirectories in a directory
+ *
+ * @param {string} dirPath - Directory to scan
+ * @returns {Promise<string[]>} - Array of full paths to subdirectories
+ */
+async function listSubdirectories(dirPath) {
+  const entries = await listDirectory(dirPath);
+  const dirs = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      dirs.push(path.join(dirPath, entry.name));
+    }
+  }
+
+  return dirs;
+}
+
+/**
+ * Check if a file is a main video file (not a fragment or thumbnail)
+ *
+ * @param {string} filePath - File path to check
+ * @returns {boolean} - True if it's a main video file
+ */
+function isMainVideoFile(filePath) {
+  const filename = path.basename(filePath);
+  // Main video files end with [VideoID].mp4/mkv/webm (not .fXXX.mp4)
+  return MAIN_VIDEO_FILE_PATTERN.test(filename) && !FRAGMENT_FILE_PATTERN.test(filename);
+}
+
+module.exports = {
+  ensureDir,
+  ensureDirSync,
+  isDirectoryEmpty,
+  removeIfEmpty,
+  isVideoDirectory,
+  isChannelDirectory,
+  isSubfolderDir,
+  cleanupEmptyChannelDirectory,
+  cleanupEmptyParents,
+  listDirectory,
+  listSubdirectories,
+  isMainVideoFile
+};

--- a/server/modules/filesystem/fileOperations.js
+++ b/server/modules/filesystem/fileOperations.js
@@ -1,0 +1,224 @@
+/**
+ * Resilient file operations with retries and safe error handling
+ * All I/O operations for files are centralized here
+ */
+
+const fs = require('fs-extra');
+const fsPromises = require('fs').promises;
+const logger = require('../../logger');
+
+/**
+ * Sleep utility for retry delays
+ * @param {number} ms - Milliseconds to sleep
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Move a file or directory with exponential backoff retries
+ * Handles transient filesystem errors that can occur during cross-device moves
+ *
+ * @param {string} src - Source path
+ * @param {string} dest - Destination path
+ * @param {Object} options - Options
+ * @param {number} options.retries - Number of retry attempts (default: 5)
+ * @param {number} options.delayMs - Base delay in milliseconds (default: 200)
+ * @param {boolean} options.overwrite - Whether to overwrite existing (default: true)
+ * @returns {Promise<void>}
+ * @throws {Error} If all retries fail
+ */
+async function moveWithRetries(src, dest, { retries = 5, delayMs = 200, overwrite = true } = {}) {
+  let attempt = 0;
+  let lastError;
+
+  while (attempt <= retries) {
+    try {
+      await fs.move(src, dest, { overwrite });
+      return;
+    } catch (err) {
+      lastError = err;
+      if (attempt === retries) {
+        throw err;
+      }
+      const backoff = delayMs * Math.pow(2, attempt);
+      logger.debug({ src, dest, attempt, backoff }, 'Move failed, retrying after backoff');
+      await sleep(backoff);
+      attempt += 1;
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Remove a file or directory, ignoring ENOENT errors (already deleted)
+ * Safe for cleanup operations where the file may already be gone
+ *
+ * @param {string} filePath - Path to remove
+ * @returns {Promise<void>}
+ */
+async function safeRemove(filePath) {
+  try {
+    await fs.remove(filePath);
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      logger.warn({ err, filePath }, 'Error deleting file');
+    }
+  }
+}
+
+/**
+ * Copy a file with optional overwrite protection
+ *
+ * @param {string} src - Source file path
+ * @param {string} dest - Destination file path
+ * @param {Object} options - Options
+ * @param {boolean} options.overwrite - Whether to overwrite existing (default: false)
+ * @returns {Promise<void>}
+ */
+async function safeCopy(src, dest, { overwrite = false } = {}) {
+  try {
+    await fs.copy(src, dest, { overwrite });
+  } catch (err) {
+    if (err && err.code !== 'ENOENT') {
+      logger.warn({ err, src, dest }, 'Error copying file');
+      throw err;
+    }
+  }
+}
+
+/**
+ * Check if a path exists (file or directory)
+ * Safe version that handles permission errors
+ *
+ * @param {string} targetPath - Path to check
+ * @returns {Promise<boolean>} - True if path exists
+ */
+async function pathExists(targetPath) {
+  try {
+    await fsPromises.access(targetPath);
+    return true;
+  } catch (err) {
+    if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Get file/directory stats, returning null if not found
+ * Safe version that doesn't throw on missing files
+ *
+ * @param {string} filePath - Path to stat
+ * @returns {Promise<{path: string, stats: fs.Stats}|null>} - Stats object or null
+ */
+async function safeStat(filePath) {
+  try {
+    const stats = await fsPromises.stat(filePath);
+    return { path: filePath, stats };
+  } catch (err) {
+    if (!err || (err.code !== 'ENOENT' && err.code !== 'ENOTDIR')) {
+      throw err;
+    }
+    return null;
+  }
+}
+
+/**
+ * Set file timestamps (access time and modification time)
+ *
+ * @param {string} filePath - Path to the file
+ * @param {Date|number} timestamp - The timestamp to set (Date object or Unix time in seconds)
+ * @returns {Promise<void>}
+ */
+async function setTimestamp(filePath, timestamp) {
+  const time = timestamp instanceof Date ? timestamp : new Date(timestamp * 1000);
+  await fsPromises.utimes(filePath, time, time);
+}
+
+/**
+ * Set file timestamps synchronously
+ *
+ * @param {string} filePath - Path to the file
+ * @param {Date|number} timestamp - The timestamp to set (Date object or Unix time in seconds)
+ */
+function setTimestampSync(filePath, timestamp) {
+  const time = timestamp instanceof Date ? timestamp : new Date(timestamp * 1000);
+  require('fs').utimesSync(filePath, time, time);
+}
+
+/**
+ * Read file contents
+ *
+ * @param {string} filePath - Path to the file
+ * @param {string} encoding - File encoding (default: 'utf8')
+ * @returns {Promise<string>} - File contents
+ */
+async function readFile(filePath, encoding = 'utf8') {
+  return fsPromises.readFile(filePath, encoding);
+}
+
+/**
+ * Write file contents
+ *
+ * @param {string} filePath - Path to the file
+ * @param {string|Buffer} content - Content to write
+ * @param {string} encoding - File encoding (default: 'utf8')
+ * @returns {Promise<void>}
+ */
+async function writeFile(filePath, content, encoding = 'utf8') {
+  await fsPromises.writeFile(filePath, content, encoding);
+}
+
+/**
+ * Append content to a file
+ *
+ * @param {string} filePath - Path to the file
+ * @param {string} content - Content to append
+ * @param {string} encoding - File encoding (default: 'utf8')
+ * @returns {Promise<void>}
+ */
+async function appendFile(filePath, content, encoding = 'utf8') {
+  await fsPromises.appendFile(filePath, content, encoding);
+}
+
+/**
+ * Check if a path is a file
+ *
+ * @param {string} filePath - Path to check
+ * @returns {Promise<boolean>} - True if path is a file
+ */
+async function isFile(filePath) {
+  const result = await safeStat(filePath);
+  return result ? result.stats.isFile() : false;
+}
+
+/**
+ * Check if a path is a directory
+ *
+ * @param {string} dirPath - Path to check
+ * @returns {Promise<boolean>} - True if path is a directory
+ */
+async function isDirectory(dirPath) {
+  const result = await safeStat(dirPath);
+  return result ? result.stats.isDirectory() : false;
+}
+
+module.exports = {
+  sleep,
+  moveWithRetries,
+  safeRemove,
+  safeCopy,
+  pathExists,
+  safeStat,
+  setTimestamp,
+  setTimestampSync,
+  readFile,
+  writeFile,
+  appendFile,
+  isFile,
+  isDirectory
+};

--- a/server/modules/filesystem/index.js
+++ b/server/modules/filesystem/index.js
@@ -1,0 +1,44 @@
+/**
+ * Filesystem module - centralized file and path operations
+ *
+ * This module consolidates all file/folder path handling into one place:
+ * - constants: Shared constants (prefixes, patterns, extensions)
+ * - pathBuilder: Pure path construction functions
+ * - fileOperations: Resilient file I/O with retries
+ * - directoryManager: Directory lifecycle management
+ *
+ * Usage:
+ *   const filesystem = require('./filesystem');
+ *   // or import specific modules:
+ *   const { pathBuilder, fileOperations } = require('./filesystem');
+ */
+
+const constants = require('./constants');
+const pathBuilder = require('./pathBuilder');
+const fileOperations = require('./fileOperations');
+const directoryManager = require('./directoryManager');
+const sanitizer = require('./sanitizer');
+
+module.exports = {
+  // Re-export all constants
+  ...constants,
+
+  // Re-export all pathBuilder functions
+  ...pathBuilder,
+
+  // Re-export all fileOperations functions
+  ...fileOperations,
+
+  // Re-export all directoryManager functions
+  ...directoryManager,
+
+  // Re-export all sanitizer functions
+  ...sanitizer,
+
+  // Also export as namespaced modules for explicit imports
+  constants,
+  pathBuilder,
+  fileOperations,
+  directoryManager,
+  sanitizer
+};

--- a/server/modules/filesystem/pathBuilder.js
+++ b/server/modules/filesystem/pathBuilder.js
@@ -1,0 +1,213 @@
+/**
+ * Path building utilities for constructing file and directory paths
+ * Pure functions with no I/O - all path construction logic centralized here
+ */
+
+const path = require('path');
+const {
+  SUBFOLDER_PREFIX,
+  GLOBAL_DEFAULT_SENTINEL,
+  CHANNEL_TEMPLATE,
+  VIDEO_FOLDER_TEMPLATE,
+  VIDEO_FILE_TEMPLATE,
+  YOUTUBE_ID_BRACKET_PATTERN,
+  YOUTUBE_ID_DASH_PATTERN,
+  YOUTUBE_ID_PATTERN
+} = require('./constants');
+
+/**
+ * Build the filesystem segment for a subfolder (adds __ prefix)
+ * @param {string|null} subfolderName - The subfolder name (without prefix)
+ * @returns {string|null} - The prefixed subfolder segment or null
+ */
+function buildSubfolderSegment(subfolderName) {
+  if (!subfolderName || subfolderName.trim() === '') {
+    return null;
+  }
+  return `${SUBFOLDER_PREFIX}${subfolderName.trim()}`;
+}
+
+/**
+ * Check if a directory name is a subfolder (starts with __ prefix)
+ * @param {string} dirName - The directory name to check
+ * @returns {boolean} - True if it's a subfolder directory
+ */
+function isSubfolderDirectory(dirName) {
+  if (!dirName) {
+    return false;
+  }
+  return dirName.startsWith(SUBFOLDER_PREFIX);
+}
+
+/**
+ * Extract the subfolder name from a prefixed directory name
+ * @param {string} dirName - The prefixed directory name (e.g., "__MySubfolder")
+ * @returns {string|null} - The subfolder name without prefix, or null
+ */
+function extractSubfolderName(dirName) {
+  if (!isSubfolderDirectory(dirName)) {
+    return null;
+  }
+  return dirName.substring(SUBFOLDER_PREFIX.length);
+}
+
+/**
+ * Resolve the effective subfolder for a channel
+ * Handles the three-state logic:
+ * - GLOBAL_DEFAULT_SENTINEL -> use global default
+ * - non-empty string -> use that subfolder
+ * - null/empty -> null (download to root, backwards compatible)
+ *
+ * @param {string|null} channelSubFolder - The channel's sub_folder DB value
+ * @param {string|null} globalDefault - The global default subfolder from config
+ * @returns {string|null} - The actual subfolder to use (without __ prefix), or null for root
+ */
+function resolveEffectiveSubfolder(channelSubFolder, globalDefault = null) {
+  // Explicit "use global default" setting
+  if (channelSubFolder === GLOBAL_DEFAULT_SENTINEL) {
+    return globalDefault || null;
+  }
+
+  // Explicit subfolder set - use it
+  if (channelSubFolder && channelSubFolder.trim() !== '') {
+    return channelSubFolder.trim();
+  }
+
+  // NULL or empty - use root (backwards compatible)
+  return null;
+}
+
+/**
+ * Get the folder name to use for a channel
+ * Prefers folder_name (sanitized by yt-dlp) over uploader
+ * @param {Object} channel - Channel object with folder_name and uploader properties
+ * @returns {string} - The folder name to use
+ */
+function resolveChannelFolderName(channel) {
+  return channel.folder_name || channel.uploader;
+}
+
+/**
+ * Build the full path to a channel directory
+ * @param {string} baseDir - The base output directory
+ * @param {string|null} subfolder - The subfolder name (without prefix) or null
+ * @param {string} channelFolderName - The channel folder name
+ * @returns {string} - Full path to the channel directory
+ */
+function buildChannelPath(baseDir, subfolder, channelFolderName) {
+  if (subfolder) {
+    const subfolderSegment = buildSubfolderSegment(subfolder);
+    return path.join(baseDir, subfolderSegment, channelFolderName);
+  }
+  return path.join(baseDir, channelFolderName);
+}
+
+/**
+ * Build the full path to a video directory
+ * @param {string} baseDir - The base output directory
+ * @param {string|null} subfolder - The subfolder name (without prefix) or null
+ * @param {string} channelFolderName - The channel folder name
+ * @param {string} videoFolderName - The video folder name
+ * @returns {string} - Full path to the video directory
+ */
+function buildVideoPath(baseDir, subfolder, channelFolderName, videoFolderName) {
+  const channelPath = buildChannelPath(baseDir, subfolder, channelFolderName);
+  return path.join(channelPath, videoFolderName);
+}
+
+/**
+ * Build yt-dlp output template for video files
+ * @param {string} baseDir - The base output directory
+ * @param {string|null} subfolder - The subfolder name (without prefix) or null
+ * @returns {string} - Path template for yt-dlp -o argument
+ */
+function buildOutputTemplate(baseDir, subfolder) {
+  if (subfolder) {
+    const subfolderSegment = buildSubfolderSegment(subfolder);
+    return path.join(baseDir, subfolderSegment, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, VIDEO_FILE_TEMPLATE);
+  }
+  return path.join(baseDir, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, VIDEO_FILE_TEMPLATE);
+}
+
+/**
+ * Build yt-dlp thumbnail output template
+ * @param {string} baseDir - The base output directory
+ * @param {string|null} subfolder - The subfolder name (without prefix) or null
+ * @returns {string} - Thumbnail path template for yt-dlp
+ */
+function buildThumbnailTemplate(baseDir, subfolder) {
+  if (subfolder) {
+    const subfolderSegment = buildSubfolderSegment(subfolder);
+    return path.join(baseDir, subfolderSegment, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, 'poster');
+  }
+  return path.join(baseDir, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, 'poster');
+}
+
+/**
+ * Extract YouTube video ID from a file path
+ * Tries [VideoID] pattern in filename first, then " - VideoID" in directory name
+ * @param {string} filePath - The file path to extract from
+ * @returns {string|null} - The video ID or null if not found
+ */
+function extractYoutubeIdFromPath(filePath) {
+  try {
+    const filename = path.basename(filePath);
+
+    // Try to extract from [VideoID].ext pattern in filename
+    const bracketMatch = filename.match(YOUTUBE_ID_BRACKET_PATTERN);
+    if (bracketMatch) {
+      return bracketMatch[1];
+    }
+
+    // Try to extract from directory name ending with " - VideoID"
+    const dirname = path.basename(path.dirname(filePath));
+    const dashMatch = dirname.match(YOUTUBE_ID_DASH_PATTERN);
+    if (dashMatch) {
+      return dashMatch[1];
+    }
+
+    return null;
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Check if a string is a valid YouTube video ID
+ * @param {string} str - The string to check
+ * @returns {boolean} - True if valid YouTube ID format
+ */
+function isValidYoutubeId(str) {
+  return YOUTUBE_ID_PATTERN.test(str);
+}
+
+/**
+ * Calculate the new path after moving from oldBase to newBase
+ * Used when relocating files after a subfolder change
+ * @param {string} oldBasePath - The old base path
+ * @param {string} newBasePath - The new base path
+ * @param {string} originalPath - The original full path
+ * @returns {string|null} - The new path, or null if originalPath doesn't start with oldBasePath
+ */
+function calculateRelocatedPath(oldBasePath, newBasePath, originalPath) {
+  if (!originalPath || !originalPath.startsWith(oldBasePath)) {
+    return null;
+  }
+  const relativePath = originalPath.substring(oldBasePath.length);
+  return newBasePath + relativePath;
+}
+
+module.exports = {
+  buildSubfolderSegment,
+  isSubfolderDirectory,
+  extractSubfolderName,
+  resolveEffectiveSubfolder,
+  resolveChannelFolderName,
+  buildChannelPath,
+  buildVideoPath,
+  buildOutputTemplate,
+  buildThumbnailTemplate,
+  extractYoutubeIdFromPath,
+  isValidYoutubeId,
+  calculateRelocatedPath
+};

--- a/server/modules/filesystem/sanitizer.js
+++ b/server/modules/filesystem/sanitizer.js
@@ -1,0 +1,102 @@
+/**
+ * Path/filename sanitization that exactly replicates yt-dlp's --windows-filenames behavior
+ *
+ * This is a direct port of yt-dlp's sanitize_path() and _sanitize_path_parts() functions
+ * from yt_dlp/utils/_utils.py
+ *
+ * Reference: https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/utils/_utils.py
+ */
+
+/**
+ * Sanitize individual path parts for Windows compatibility
+ * Direct port of yt-dlp's _sanitize_path_parts()
+ *
+ * @param {string[]} parts - Array of path segments
+ * @returns {string[]} - Sanitized path segments
+ */
+function sanitizePathParts(parts) {
+  const sanitizedParts = [];
+
+  for (const part of parts) {
+    // Skip empty parts and single dots
+    if (!part || part === '.') {
+      continue;
+    }
+
+    // Handle parent directory references
+    if (part === '..') {
+      if (sanitizedParts.length > 0 && sanitizedParts[sanitizedParts.length - 1] !== '..') {
+        sanitizedParts.pop();
+      } else {
+        sanitizedParts.push('..');
+      }
+      continue;
+    }
+
+    // Replace invalid segments with `#`
+    // - trailing dots and spaces (`asdf...` => `asdf..#`)
+    // - invalid chars (`<>` => `##`)
+    // Regex: [/<>:"\|\\?\*] matches Windows-forbidden characters
+    //        [\s.]$ matches trailing whitespace or dots
+    const sanitizedPart = part.replace(/[/<>:"|\\?*]|[\s.]$/g, '#');
+    sanitizedParts.push(sanitizedPart);
+  }
+
+  return sanitizedParts;
+}
+
+/**
+ * Sanitize a path for Windows compatibility, exactly like yt-dlp does with --windows-filenames
+ *
+ * Direct port of yt-dlp's sanitize_path(s, force=True) behavior on non-Windows systems
+ *
+ * @param {string} s - The path string to sanitize
+ * @returns {string} - The sanitized path
+ */
+function sanitizePathLikeYtDlp(s) {
+  if (!s || typeof s !== 'string') {
+    return '.';
+  }
+
+  // Preserve leading slash for absolute paths (Unix behavior with force=True)
+  const root = s.startsWith('/') ? '/' : '';
+
+  // Split by forward slash and sanitize each part
+  const parts = s.split('/');
+  const sanitizedPath = sanitizePathParts(parts).join('/');
+
+  // Return root + path, or '.' if both are empty
+  return (root || sanitizedPath) ? (root + sanitizedPath) : '.';
+}
+
+/**
+ * Sanitize just a single filename/folder name component (not a full path)
+ * This applies the same character replacement rules but doesn't handle path separators
+ *
+ * Uses the exact same regex as yt-dlp's _sanitize_path_parts():
+ *   re.sub(r'[/<>:"\|\\?\*]|[\s.]$', '#', part)
+ *
+ * Note: [\s.]$ only replaces a SINGLE trailing space/dot, not all of them.
+ * Example: "asdf..." => "asdf..#" (only last dot replaced)
+ *
+ * @param {string} name - The filename or folder name to sanitize
+ * @returns {string} - The sanitized name
+ */
+function sanitizeNameLikeYtDlp(name) {
+  if (!name || typeof name !== 'string') {
+    return '_';
+  }
+
+  // Use the exact same regex as yt-dlp's _sanitize_path_parts
+  // [/<>:"|\\?*] matches Windows-forbidden characters
+  // [\s.]$ matches a single trailing whitespace or dot
+  const sanitized = name.replace(/[/<>:"|\\?*]|[\s.]$/g, '#');
+
+  return sanitized || '_';
+}
+
+module.exports = {
+  sanitizePathLikeYtDlp,
+  sanitizeNameLikeYtDlp,
+  sanitizePathParts
+};

--- a/server/modules/ytDlpRunner.js
+++ b/server/modules/ytDlpRunner.js
@@ -121,21 +121,8 @@ class YtDlpRunner {
    */
   async fetchMetadata(url, timeoutMs = 60000) {
     const YtdlpCommandBuilder = require('./download/ytdlpCommandBuilder');
-    let args = YtdlpCommandBuilder.buildMetadataFetchArgs(url);
-
-    // When fetching metadata, we don't want to use --sleep-requests as we are only making a single request
-    // So we remove it from the args and also remove the arg after it (number of seconds)
-    args = args.filter((arg) => {
-      if (arg.startsWith('--sleep-requests')) {
-        // Strip the next argument as well
-        const index = args.indexOf(arg);
-        if (index !== -1 && index + 1 < args.length) {
-          args.splice(index + 1, 1);
-        }
-        return false;
-      }
-      return true;
-    });
+    // Skip sleep-requests for single metadata fetches - no rate limiting needed
+    const args = YtdlpCommandBuilder.buildMetadataFetchArgs(url, { skipSleepRequests: true });
 
     try {
       const stdout = await this.run(args, { timeoutMs });


### PR DESCRIPTION
Performance: Reduce channel addition time by ~ 4x (adding new channels via UI)
- Replace sequential yt-dlp tab detection with parallel RSS feed checks
  - Uses YouTube RSS playlist IDs (UULF/UUSH/UULV) for instant 404-based detection
- Download channel thumbnails via direct HTTP instead of yt-dlp
- Skip --sleep-requests delay for single metadata fetches
- Cache folder_name in database to avoid repeated yt-dlp lookups
- Show channel UI immediately while tabs detect in background

Subfolder Management:
- Add global default subfolder setting in configuration
  - Shows confirmation dialog with affected channel count
  - Applies to untracked channels and those using "Default Subfolder"
- Implement three-state subfolder model for channels:
  - null/empty = download to root (backwards compatible)
  - ##USE_GLOBAL_DEFAULT## = inherit global default setting
  - specific value = use custom subfolder
- Add subfolder selection to manual downloads

New Components (refactor to improve code quality)
- SubfolderAutocomplete: reusable dropdown with No/Default/existing/Add options
- AddSubfolderDialog: create subfolders with validation
- useSubfolders hook: fetch available subfolders from filesystem
- Extract filesystem module from downloadExecutor (constants, sanitizer, pathBuilder, directoryManager, fileOperations)

Database:
- Add folder_name column to channels table via migration