### PR TITLE
feat: always stage to hidden temp directory

### DIFF
--- a/client/src/components/Configuration/sections/CoreSettingsSection.tsx
+++ b/client/src/components/Configuration/sections/CoreSettingsSection.tsx
@@ -316,7 +316,7 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
               }
               label={
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  Use tmp dir for download processing
+                  Use external temp directory
                   {isPlatformManaged.useTmpForDownloads && (
                     <Chip
                       label={deploymentEnvironment.platform?.toLowerCase() === "elfhosted" ? "Managed by Elfhosted" : "Platform Managed"}
@@ -330,7 +330,7 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
               text={
                 isPlatformManaged.useTmpForDownloads
                   ? 'This setting is managed by your platform deployment and cannot be changed.'
-                  : 'Downloads to local /tmp first, then moves to final location when complete. Recommended for network-mounted storage (NFS, SMB, cloud mounts) to improve performance and avoid file locking issues with Plex or other processes reading from the same location. Not needed for local drives or SSDs.'
+                  : 'Controls where downloads are staged before moving to final location. When enabled, uses external /tmp path (useful for slow network storage). When disabled, uses a hidden .youtarr_tmp/ folder in your output directory (faster for local/SSD storage). Both options hide in-progress files from media servers.'
               }
               onMobileClick={onMobileTooltipClick}
             />

--- a/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
@@ -470,11 +470,11 @@ describe('CoreSettingsSection Component', () => {
     });
   });
 
-  describe('Use tmp dir for download processing Checkbox', () => {
-    test('renders Use tmp dir checkbox', () => {
+  describe('Use external temp directory Checkbox', () => {
+    test('renders Use external temp directory checkbox', () => {
       const props = createSectionProps();
       renderWithProviders(<CoreSettingsSection {...props} />);
-      expect(screen.getByRole('checkbox', { name: /Use tmp dir for download processing/i })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: /Use external temp directory/i })).toBeInTheDocument();
     });
 
     test('checkbox reflects useTmpForDownloads state', () => {
@@ -482,7 +482,7 @@ describe('CoreSettingsSection Component', () => {
         config: createConfig({ useTmpForDownloads: true })
       });
       renderWithProviders(<CoreSettingsSection {...props} />);
-      const checkbox = screen.getByRole('checkbox', { name: /Use tmp dir for download processing/i });
+      const checkbox = screen.getByRole('checkbox', { name: /Use external temp directory/i });
       expect(checkbox).toBeChecked();
     });
 
@@ -495,7 +495,7 @@ describe('CoreSettingsSection Component', () => {
       });
       renderWithProviders(<CoreSettingsSection {...props} />);
 
-      const checkbox = screen.getByRole('checkbox', { name: /Use tmp dir for download processing/i });
+      const checkbox = screen.getByRole('checkbox', { name: /Use external temp directory/i });
       await user.click(checkbox);
 
       expect(onConfigChange).toHaveBeenCalledWith({ useTmpForDownloads: true });
@@ -506,7 +506,7 @@ describe('CoreSettingsSection Component', () => {
         isPlatformManaged: createPlatformManagedState({ useTmpForDownloads: true })
       });
       renderWithProviders(<CoreSettingsSection {...props} />);
-      const checkbox = screen.getByRole('checkbox', { name: /Use tmp dir for download processing/i });
+      const checkbox = screen.getByRole('checkbox', { name: /Use external temp directory/i });
       expect(checkbox).toBeDisabled();
     });
 
@@ -515,7 +515,7 @@ describe('CoreSettingsSection Component', () => {
         isPlatformManaged: createPlatformManagedState({ useTmpForDownloads: false })
       });
       renderWithProviders(<CoreSettingsSection {...props} />);
-      const checkbox = screen.getByRole('checkbox', { name: /Use tmp dir for download processing/i });
+      const checkbox = screen.getByRole('checkbox', { name: /Use external temp directory/i });
       expect(checkbox).not.toBeDisabled();
     });
 
@@ -701,7 +701,7 @@ describe('CoreSettingsSection Component', () => {
       expect(onConfigChange).toHaveBeenCalledWith({ subtitlesEnabled: true });
 
       // Toggle tmp downloads
-      const tmpCheckbox = screen.getByRole('checkbox', { name: /Use tmp dir for download processing/i });
+      const tmpCheckbox = screen.getByRole('checkbox', { name: /Use external temp directory/i });
       await user.click(tmpCheckbox);
       expect(onConfigChange).toHaveBeenCalledWith({ useTmpForDownloads: true });
 
@@ -750,7 +750,7 @@ describe('CoreSettingsSection Component', () => {
 
       const autoDownload = screen.getByRole('checkbox', { name: /Enable Automatic Downloads/i });
       const subtitles = screen.getByRole('checkbox', { name: /Enable Subtitle Downloads/i });
-      const tmp = screen.getByRole('checkbox', { name: /Use tmp dir for download processing/i });
+      const tmp = screen.getByRole('checkbox', { name: /Use external temp directory/i });
 
       expect(autoDownload).not.toBeChecked();
       expect(subtitles).not.toBeChecked();
@@ -769,7 +769,7 @@ describe('CoreSettingsSection Component', () => {
 
       const autoDownload = screen.getByRole('checkbox', { name: /Enable Automatic Downloads/i });
       const subtitles = screen.getByRole('checkbox', { name: /Enable Subtitle Downloads/i });
-      const tmp = screen.getByRole('checkbox', { name: /Use tmp dir for download processing/i });
+      const tmp = screen.getByRole('checkbox', { name: /Use external temp directory/i });
 
       expect(autoDownload).toBeChecked();
       expect(subtitles).toBeChecked();
@@ -795,7 +795,7 @@ describe('CoreSettingsSection Component', () => {
       renderWithProviders(<CoreSettingsSection {...props} />);
 
       expect(screen.getByRole('checkbox', { name: /Enable Automatic Downloads/i })).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: /Use tmp dir for download processing/i })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: /Use external temp directory/i })).toBeInTheDocument();
       expect(screen.getByRole('checkbox', { name: /Enable Subtitle Downloads/i })).toBeInTheDocument();
     });
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -325,18 +325,21 @@ Configuration can be modified through:
 - **Description**: HTTP/HTTPS proxy for downloads
 - **Format**: `"http://proxy:port"` or `"socks5://proxy:port"`
 
-### Use Temporary Download Directory
+### Use External Temporary Directory
 - **Config Key**: `useTmpForDownloads`
 - **Type**: `boolean`
 - **Default**: `false`
-- **Description**: When `true`, downloads are written to the temporary path specified by `tmpFilePath` before being moved into the final channel folders. Some managed platforms (e.g., ElfHosted) force this value on.
+- **Description**: Controls where downloads are staged before moving to final location:
+  - `false` (default): Downloads are staged in a hidden `.youtarr_tmp/` directory within your output folder. Uses fast atomic renames since source and destination are on the same filesystem. The dot-prefix hides in-progress downloads from media servers like Plex and Jellyfin.
+  - `true`: Downloads are staged in the external path specified by `tmpFilePath` (e.g., `/tmp`). Useful when your output directory is on slow network storage and you want to download to fast local storage first.
+- **Note**: Some managed platforms (e.g., ElfHosted) force this value on.
 
-### Temporary File Path
+### External Temporary File Path
 - **Config Key**: `tmpFilePath`
 - **Type**: `string`
 - **Default**: `"/tmp/youtarr-downloads"`
-- **Description**: Temporary directory for downloads when useTmpForDownloads is enabled
-- **Note**: Internal path in Youtarr container
+- **Description**: External temporary directory for downloads when `useTmpForDownloads` is `true`
+- **Note**: Only used when `useTmpForDownloads` is enabled. Internal path in Youtarr container.
 
 ## Auto-Removal Settings
 

--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -39,9 +39,9 @@ describe('YtdlpCommandBuilder', () => {
     configModule.getConfig.mockReturnValue(mockConfig);
     configModule.getCookiesPath.mockReturnValue(null);
 
-    // Default tempPathManager behavior - disabled
-    tempPathManager.isEnabled.mockReturnValue(false);
-    tempPathManager.getTempBasePath.mockReturnValue(null);
+    // Default tempPathManager behavior - always returns a temp path (staging always enabled)
+    tempPathManager.isEnabled.mockReturnValue(true);
+    tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
   });
 
   describe('buildSponsorblockArgs', () => {
@@ -198,18 +198,17 @@ describe('YtdlpCommandBuilder', () => {
   });
 
   describe('buildOutputPath', () => {
-    it('should build path using configModule.directoryPath when temp path disabled', () => {
-      tempPathManager.isEnabled.mockReturnValue(false);
+    it('should always build path using temp path (staging is always enabled)', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const result = YtdlpCommandBuilder.buildOutputPath();
-      expect(result).toContain('/mock/youtube/output');
+      expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
       expect(result).toContain('%(uploader,channel,uploader_id)s');
       expect(result).toContain('%(title).76s');
       expect(result).toContain('%(id)s');
       expect(result).toContain('%(ext)s');
     });
 
-    it('should build path using temp path when enabled', () => {
-      tempPathManager.isEnabled.mockReturnValue(true);
+    it('should build path using external temp path when configured', () => {
       tempPathManager.getTempBasePath.mockReturnValue('/tmp/youtarr-temp');
       const result = YtdlpCommandBuilder.buildOutputPath();
       expect(result).toContain('/tmp/youtarr-temp');
@@ -217,20 +216,21 @@ describe('YtdlpCommandBuilder', () => {
     });
 
     it('should include subfolder when provided', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const result = YtdlpCommandBuilder.buildOutputPath('TechChannel');
-      expect(result).toContain('/mock/youtube/output');
+      expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
       expect(result).toContain('TechChannel');
       expect(result).toContain('%(uploader,channel,uploader_id)s');
     });
 
     it('should not include subfolder when null', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const result = YtdlpCommandBuilder.buildOutputPath(null);
-      expect(result).toContain('/mock/youtube/output');
+      expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
       expect(result).toContain('%(uploader,channel,uploader_id)s');
     });
 
     it('should use temp path with subfolder', () => {
-      tempPathManager.isEnabled.mockReturnValue(true);
       tempPathManager.getTempBasePath.mockReturnValue('/tmp/downloads');
       const result = YtdlpCommandBuilder.buildOutputPath('GameChannel');
       expect(result).toContain('/tmp/downloads');
@@ -239,10 +239,10 @@ describe('YtdlpCommandBuilder', () => {
   });
 
   describe('buildThumbnailPath', () => {
-    it('should build thumbnail path using configModule.directoryPath when temp path disabled', () => {
-      tempPathManager.isEnabled.mockReturnValue(false);
+    it('should always build thumbnail path using temp path (staging is always enabled)', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const result = YtdlpCommandBuilder.buildThumbnailPath();
-      expect(result).toContain('/mock/youtube/output');
+      expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
       expect(result).toContain('%(uploader,channel,uploader_id)s');
       expect(result).toContain('%(title).76s');
       expect(result).toContain('[%(id)s]');
@@ -250,8 +250,7 @@ describe('YtdlpCommandBuilder', () => {
       expect(result).not.toMatch(/\.%(ext)s$/);
     });
 
-    it('should build thumbnail path using temp path when enabled', () => {
-      tempPathManager.isEnabled.mockReturnValue(true);
+    it('should build thumbnail path using external temp path when configured', () => {
       tempPathManager.getTempBasePath.mockReturnValue('/tmp/youtarr-temp');
       const result = YtdlpCommandBuilder.buildThumbnailPath();
       expect(result).toContain('/tmp/youtarr-temp');
@@ -259,19 +258,22 @@ describe('YtdlpCommandBuilder', () => {
     });
 
     it('should include subfolder when provided', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const result = YtdlpCommandBuilder.buildThumbnailPath('NewsChannel');
-      expect(result).toContain('/mock/youtube/output');
+      expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
       expect(result).toContain('NewsChannel');
       expect(result).toContain('%(uploader,channel,uploader_id)s');
     });
 
     it('should not include subfolder when null', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const result = YtdlpCommandBuilder.buildThumbnailPath(null);
-      expect(result).toContain('/mock/youtube/output');
+      expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
       expect(result).toContain('%(uploader,channel,uploader_id)s');
     });
 
     it('should match video filename pattern without extension', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const outputPath = YtdlpCommandBuilder.buildOutputPath();
       const thumbnailPath = YtdlpCommandBuilder.buildThumbnailPath();
 

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -127,9 +127,10 @@ class DownloadExecutor {
         const videoDir = videoDownload.file_path;
 
         try {
-          // If temp downloads are enabled, also check temp location
+          // Check both final location and temp location for incomplete downloads
           const pathsToCheck = [videoDir];
-          if (tempPathManager.isEnabled()) {
+          // Only convert to temp path if not already a temp path (avoids double-nesting)
+          if (!tempPathManager.isTempPath(videoDir)) {
             const tempDir = tempPathManager.convertFinalToTemp(videoDir);
             pathsToCheck.push(tempDir);
           }

--- a/server/modules/download/ytdlpCommandBuilder.js
+++ b/server/modules/download/ytdlpCommandBuilder.js
@@ -10,13 +10,13 @@ const {
 class YtdlpCommandBuilder {
   /**
    * Build output path with optional subfolder support
+   * Downloads always go to temp path first, then get moved to final location
    * @param {string|null} subFolder - Optional subfolder name
    * @returns {string} - Full output path template
    */
   static buildOutputPath(subFolder = null) {
-    const baseOutputPath = tempPathManager.isEnabled()
-      ? tempPathManager.getTempBasePath()
-      : configModule.directoryPath;
+    // Always use temp path - downloads are staged before moving to final location
+    const baseOutputPath = tempPathManager.getTempBasePath();
 
     if (subFolder) {
       return path.join(baseOutputPath, subFolder, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, VIDEO_FILE_TEMPLATE);
@@ -27,13 +27,13 @@ class YtdlpCommandBuilder {
 
   /**
    * Build thumbnail output path with optional subfolder support
+   * Thumbnails are staged in temp path alongside videos
    * @param {string|null} subFolder - Optional subfolder name
    * @returns {string} - Thumbnail path template
    */
   static buildThumbnailPath(subFolder = null) {
-    const baseOutputPath = tempPathManager.isEnabled()
-      ? tempPathManager.getTempBasePath()
-      : configModule.directoryPath;
+    // Always use temp path - thumbnails are staged with videos
+    const baseOutputPath = tempPathManager.getTempBasePath();
 
     // Use same filename as video file (without extension - yt-dlp adds .jpg)
     const thumbnailFilename = `${CHANNEL_TEMPLATE} - %(title).76s [%(id)s]`;


### PR DESCRIPTION
- Downloads are now always staged in a temporary location before moving to the final destination, preventing media servers from scanning incomplete files and simplifying code paths and file handling
- The useTmpForDownloads setting now controls WHERE to stage: false (default): .youtarr_tmp/ in output directory (fast same-fs moves) true: external /tmp path (useful for slow network storage)
- tempPathManager.isEnabled() now always returns true
- Add .youtarr_tmp hidden directory for local staging
- Remove duplicate non-staging code paths and obviated code