### PR TITLE
fix: change RC tag format from version-based to dev-rc.<sha>

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -27,21 +27,16 @@ jobs:
       - name: Get version info
         id: version
         run: |
-          # Get the current version from package.json
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          
           # Get short SHA for unique RC identifier
           SHORT_SHA=$(git rev-parse --short HEAD)
           
-          # Create RC version: current version + rc + short sha
-          RC_VERSION="${CURRENT_VERSION}-rc.${SHORT_SHA}"
+          # Create RC tag: dev-rc.<sha> (not tied to a specific version)
+          RC_TAG="dev-rc.${SHORT_SHA}"
           
-          echo "current_version=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
-          echo "rc_version=${RC_VERSION}" >> $GITHUB_OUTPUT
+          echo "rc_tag=${RC_TAG}" >> $GITHUB_OUTPUT
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
           
-          echo "📦 Current version: ${CURRENT_VERSION}"
-          echo "🏷️ RC version: ${RC_VERSION}"
+          echo "🏷️ RC tag: ${RC_TAG}"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -81,7 +76,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ vars.DOCKERHUB_USERNAME }}/youtarr:${{ steps.version.outputs.rc_version }}
+            ${{ vars.DOCKERHUB_USERNAME }}/youtarr:${{ steps.version.outputs.rc_tag }}
             ${{ vars.DOCKERHUB_USERNAME }}/youtarr:dev-latest
           no-cache: true
 
@@ -90,13 +85,13 @@ jobs:
           echo "## 🚀 Release Candidate Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Docker Images" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ vars.DOCKERHUB_USERNAME }}/youtarr:${{ steps.version.outputs.rc_version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ vars.DOCKERHUB_USERNAME }}/youtarr:${{ steps.version.outputs.rc_tag }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ vars.DOCKERHUB_USERNAME }}/youtarr:dev-latest\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Pull Commands" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
           echo "# Specific RC version" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull ${{ vars.DOCKERHUB_USERNAME }}/youtarr:${{ steps.version.outputs.rc_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ${{ vars.DOCKERHUB_USERNAME }}/youtarr:${{ steps.version.outputs.rc_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "# Latest dev build" >> $GITHUB_STEP_SUMMARY
           echo "docker pull ${{ vars.DOCKERHUB_USERNAME }}/youtarr:dev-latest" >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ fix/zzz ──────┘
 | Branch | Purpose | Docker Tag |
 |--------|---------|------------|
 | `main` | Stable, released code | `latest`, `vX.X.X` |
-| `dev` | Integration branch for upcoming release | `dev-latest`, `X.X.X-rc.sha` |
+| `dev` | Integration branch for upcoming release | `dev-latest`, `dev-rc.<sha>` |
 | `feature/*`, `fix/*` | Individual changes | None |
 
 ### Workflow Summary
@@ -254,7 +254,7 @@ When you're ready, push your branch and create a pull request **targeting the `d
 3. **Merge to dev**
    - Once approved, your PR is merged to `dev`
    - A release candidate (RC) Docker image is automatically built
-   - RC images are tagged as `dev-latest` and `X.X.X-rc.<commit-sha>`
+   - RC images are tagged as `dev-latest` and `dev-rc.<commit-sha>`
 
 4. **Release to main**
    - When ready, the maintainer creates a PR from `dev` → `main`
@@ -296,7 +296,7 @@ When code is merged to `dev`, an RC build is automatically triggered:
 - Builds multi-architecture Docker images (amd64 + arm64)
 - Pushes to Docker Hub with tags:
   - `dialmaster/youtarr:dev-latest` (always the latest dev build)
-  - `dialmaster/youtarr:X.X.X-rc.<commit-sha>` (specific RC version)
+  - `dialmaster/youtarr:dev-rc.<commit-sha>` (specific RC build)
 
 These RC images allow testing bleeding-edge features before stable release.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -455,7 +455,7 @@ Youtarr uses a **dev → main** branching model:
 | Branch | Purpose | Docker Tag |
 |--------|---------|------------|
 | `main` | Stable, released code | `latest`, `vX.X.X` |
-| `dev` | Integration branch for upcoming release | `dev-latest`, `X.X.X-rc.sha` |
+| `dev` | Integration branch for upcoming release | `dev-latest`, `dev-rc.<sha>` |
 | `feature/*`, `fix/*` | Individual changes | None |
 
 ### Git Workflow
@@ -523,7 +523,7 @@ Releases are automated via GitHub Actions with a two-stage workflow:
 1. Merge your PR to `dev` branch
 2. RC workflow automatically:
    - Builds multi-arch Docker images (amd64 + arm64)
-   - Pushes `dev-latest` and `X.X.X-rc.<sha>` tags to Docker Hub
+   - Pushes `dev-latest` and `dev-rc.<sha>` tags to Docker Hub
 
 **Production Releases (automatic on main merge):**
 1. Maintainer creates PR from `dev` → `main`


### PR DESCRIPTION
The previous format (1.55.0-rc.<sha>) implied the RC was for a specific version, when it's actually just the current state of dev. The new format (dev-rc.<sha>) makes it clear these are dev branch builds, not tied to any particular release version.