### PR TITLE
fix: resolve coverage badges workflow failure

### DIFF
--- a/.github/workflows/coverage-badges.yml
+++ b/.github/workflows/coverage-badges.yml
@@ -1,9 +1,15 @@
 name: Update Coverage Badges
 
 on:
-  push:
-    branches: [ main ]
+  workflow_run:
+    workflows: ["Production Release"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: coverage-badges-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -12,8 +18,11 @@ jobs:
   update-badges:
     name: Update Coverage Badges
     runs-on: ubuntu-latest
-    # Skip if commit message contains [skip ci]
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    # Run on workflow_dispatch or when Production Release succeeds (skip if commit has [skip ci])
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       !contains(github.event.workflow_run.head_commit.message, '[skip ci]'))
 
     steps:
       - name: Checkout code
@@ -131,6 +140,8 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git add README.md .github/badges/
             git commit -m "chore: update coverage badges [skip ci]"
+            # Pull latest changes before pushing to handle any commits made during workflow run
+            git pull --rebase origin main
             git push
           else
             echo "No changes to coverage badges"


### PR DESCRIPTION
- Change trigger from push to workflow_run to sequence after Production Release
- Add concurrency control to prevent simultaneous badge update runs
- Update job condition to handle both workflow_dispatch and workflow_run events
- Add git pull --rebase before push to handle commits made during workflow run