### PR TITLE
fix: use byte-based truncation for yt-dlp output templates (#404)

### DIFF
--- a/server/modules/__tests__/channelDownloadGrouper.test.js
+++ b/server/modules/__tests__/channelDownloadGrouper.test.js
@@ -578,12 +578,12 @@ describe('ChannelDownloadGrouper', () => {
     it('should build root level path when subfolder is null', () => {
       const template = channelDownloadGrouper.buildOutputPathTemplate(null);
 
-      // Template now uses .76s for title truncation to avoid path length issues
+      // Template uses .NB for byte-based truncation to avoid path length issues with UTF-8
       const expectedPath = path.join(
         '/mock/youtube/output',
-        '%(uploader,channel,uploader_id)s',
-        '%(uploader,channel,uploader_id)s - %(title).76s - %(id)s',
-        '%(uploader,channel,uploader_id)s - %(title).76s [%(id)s].%(ext)s'
+        '%(uploader,channel,uploader_id).80B',
+        '%(uploader,channel,uploader_id).80B - %(title).76B - %(id)s',
+        '%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s].%(ext)s'
       );
 
       expect(template).toBe(expectedPath);
@@ -592,13 +592,13 @@ describe('ChannelDownloadGrouper', () => {
     it('should build subfolder path with __ prefix', () => {
       const template = channelDownloadGrouper.buildOutputPathTemplate('Tech');
 
-      // Template now uses .76s for title truncation to avoid path length issues
+      // Template uses .NB for byte-based truncation to avoid path length issues with UTF-8
       const expectedPath = path.join(
         '/mock/youtube/output',
         '__Tech',
-        '%(uploader,channel,uploader_id)s',
-        '%(uploader,channel,uploader_id)s - %(title).76s - %(id)s',
-        '%(uploader,channel,uploader_id)s - %(title).76s [%(id)s].%(ext)s'
+        '%(uploader,channel,uploader_id).80B',
+        '%(uploader,channel,uploader_id).80B - %(title).76B - %(id)s',
+        '%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s].%(ext)s'
       );
 
       expect(template).toBe(expectedPath);
@@ -621,11 +621,11 @@ describe('ChannelDownloadGrouper', () => {
     it('should build root level thumbnail path when subfolder is null', () => {
       const template = channelDownloadGrouper.buildThumbnailPathTemplate(null);
 
-      // Template now uses .76s for title truncation to avoid path length issues
+      // Template uses .NB for byte-based truncation to avoid path length issues with UTF-8
       const expectedPath = path.join(
         '/mock/youtube/output',
-        '%(uploader,channel,uploader_id)s',
-        '%(uploader,channel,uploader_id)s - %(title).76s - %(id)s',
+        '%(uploader,channel,uploader_id).80B',
+        '%(uploader,channel,uploader_id).80B - %(title).76B - %(id)s',
         'poster'
       );
 
@@ -635,12 +635,12 @@ describe('ChannelDownloadGrouper', () => {
     it('should build subfolder thumbnail path with __ prefix', () => {
       const template = channelDownloadGrouper.buildThumbnailPathTemplate('Tech');
 
-      // Template now uses .76s for title truncation to avoid path length issues
+      // Template uses .NB for byte-based truncation to avoid path length issues with UTF-8
       const expectedPath = path.join(
         '/mock/youtube/output',
         '__Tech',
-        '%(uploader,channel,uploader_id)s',
-        '%(uploader,channel,uploader_id)s - %(title).76s - %(id)s',
+        '%(uploader,channel,uploader_id).80B',
+        '%(uploader,channel,uploader_id).80B - %(title).76B - %(id)s',
         'poster'
       );
 

--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -202,8 +202,8 @@ describe('YtdlpCommandBuilder', () => {
       tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const result = YtdlpCommandBuilder.buildOutputPath();
       expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
-      expect(result).toContain('%(uploader,channel,uploader_id)s');
-      expect(result).toContain('%(title).76s');
+      expect(result).toContain('%(uploader,channel,uploader_id).80B');
+      expect(result).toContain('%(title).76B');
       expect(result).toContain('%(id)s');
       expect(result).toContain('%(ext)s');
     });
@@ -212,7 +212,7 @@ describe('YtdlpCommandBuilder', () => {
       tempPathManager.getTempBasePath.mockReturnValue('/tmp/youtarr-temp');
       const result = YtdlpCommandBuilder.buildOutputPath();
       expect(result).toContain('/tmp/youtarr-temp');
-      expect(result).toContain('%(uploader,channel,uploader_id)s');
+      expect(result).toContain('%(uploader,channel,uploader_id).80B');
     });
 
     it('should include subfolder when provided', () => {
@@ -220,14 +220,14 @@ describe('YtdlpCommandBuilder', () => {
       const result = YtdlpCommandBuilder.buildOutputPath('TechChannel');
       expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
       expect(result).toContain('TechChannel');
-      expect(result).toContain('%(uploader,channel,uploader_id)s');
+      expect(result).toContain('%(uploader,channel,uploader_id).80B');
     });
 
     it('should not include subfolder when null', () => {
       tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const result = YtdlpCommandBuilder.buildOutputPath(null);
       expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
-      expect(result).toContain('%(uploader,channel,uploader_id)s');
+      expect(result).toContain('%(uploader,channel,uploader_id).80B');
     });
 
     it('should use temp path with subfolder', () => {
@@ -243,8 +243,8 @@ describe('YtdlpCommandBuilder', () => {
       tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const result = YtdlpCommandBuilder.buildThumbnailPath();
       expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
-      expect(result).toContain('%(uploader,channel,uploader_id)s');
-      expect(result).toContain('%(title).76s');
+      expect(result).toContain('%(uploader,channel,uploader_id).80B');
+      expect(result).toContain('%(title).76B');
       expect(result).toContain('[%(id)s]');
       // Should NOT contain extension since yt-dlp adds .jpg
       expect(result).not.toMatch(/\.%(ext)s$/);
@@ -254,7 +254,7 @@ describe('YtdlpCommandBuilder', () => {
       tempPathManager.getTempBasePath.mockReturnValue('/tmp/youtarr-temp');
       const result = YtdlpCommandBuilder.buildThumbnailPath();
       expect(result).toContain('/tmp/youtarr-temp');
-      expect(result).toContain('%(uploader,channel,uploader_id)s');
+      expect(result).toContain('%(uploader,channel,uploader_id).80B');
     });
 
     it('should include subfolder when provided', () => {
@@ -262,14 +262,14 @@ describe('YtdlpCommandBuilder', () => {
       const result = YtdlpCommandBuilder.buildThumbnailPath('NewsChannel');
       expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
       expect(result).toContain('NewsChannel');
-      expect(result).toContain('%(uploader,channel,uploader_id)s');
+      expect(result).toContain('%(uploader,channel,uploader_id).80B');
     });
 
     it('should not include subfolder when null', () => {
       tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
       const result = YtdlpCommandBuilder.buildThumbnailPath(null);
       expect(result).toContain('/mock/youtube/output/.youtarr_tmp');
-      expect(result).toContain('%(uploader,channel,uploader_id)s');
+      expect(result).toContain('%(uploader,channel,uploader_id).80B');
     });
 
     it('should match video filename pattern without extension', () => {
@@ -278,8 +278,8 @@ describe('YtdlpCommandBuilder', () => {
       const thumbnailPath = YtdlpCommandBuilder.buildThumbnailPath();
 
       // Thumbnail should have the same pattern as video file but without the .%(ext)s
-      expect(outputPath).toContain('%(uploader,channel,uploader_id)s - %(title).76s [%(id)s].%(ext)s');
-      expect(thumbnailPath).toContain('%(uploader,channel,uploader_id)s - %(title).76s [%(id)s]');
+      expect(outputPath).toContain('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s].%(ext)s');
+      expect(thumbnailPath).toContain('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s]');
     });
   });
 
@@ -599,8 +599,8 @@ describe('YtdlpCommandBuilder', () => {
       // Check main output template
       const mainOutput = result[outputIndices[0] + 1];
       expect(mainOutput).toContain('/mock/youtube/output');
-      expect(mainOutput).toContain('%(uploader,channel,uploader_id)s');
-      expect(mainOutput).toContain('%(title).76s');
+      expect(mainOutput).toContain('%(uploader,channel,uploader_id).80B');
+      expect(mainOutput).toContain('%(title).76B');
       expect(mainOutput).toContain('%(id)s');
       expect(mainOutput).toContain('%(ext)s');
 
@@ -609,7 +609,7 @@ describe('YtdlpCommandBuilder', () => {
       expect(thumbOutput).toContain('thumbnail:');
       expect(thumbOutput).toContain('/mock/youtube/output');
       // Thumbnail should use same filename as video (without extension)
-      expect(thumbOutput).toContain('%(uploader,channel,uploader_id)s - %(title).76s [%(id)s]');
+      expect(thumbOutput).toContain('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s]');
 
       // Check playlist thumbnail is disabled
       const plThumbOutput = result[outputIndices[2] + 1];
@@ -878,13 +878,13 @@ describe('YtdlpCommandBuilder', () => {
 
       // Check that output contains the expected template patterns
       expect(mainOutput).toContain('/mock/youtube/output');
-      expect(mainOutput).toContain('%(uploader,channel,uploader_id)s');
+      expect(mainOutput).toContain('%(uploader,channel,uploader_id).80B');
 
       // Folder should have channel - title - id format
-      expect(mainOutput).toContain('%(uploader,channel,uploader_id)s - %(title).76s - %(id)s');
+      expect(mainOutput).toContain('%(uploader,channel,uploader_id).80B - %(title).76B - %(id)s');
 
       // File should have channel - title [id].ext format
-      expect(mainOutput).toContain('%(uploader,channel,uploader_id)s - %(title).76s [%(id)s].%(ext)s');
+      expect(mainOutput).toContain('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s].%(ext)s');
     });
   });
 

--- a/server/modules/download/ytdlpCommandBuilder.js
+++ b/server/modules/download/ytdlpCommandBuilder.js
@@ -36,7 +36,7 @@ class YtdlpCommandBuilder {
     const baseOutputPath = tempPathManager.getTempBasePath();
 
     // Use same filename as video file (without extension - yt-dlp adds .jpg)
-    const thumbnailFilename = `${CHANNEL_TEMPLATE} - %(title).76s [%(id)s]`;
+    const thumbnailFilename = `${CHANNEL_TEMPLATE} - %(title).76B [%(id)s]`;
 
     if (subFolder) {
       return path.join(baseOutputPath, subFolder, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, thumbnailFilename);

--- a/server/modules/filesystem/__tests__/constants.test.js
+++ b/server/modules/filesystem/__tests__/constants.test.js
@@ -40,13 +40,13 @@ describe('filesystem/constants', () => {
   });
 
   describe('yt-dlp templates', () => {
-    it('CHANNEL_TEMPLATE should use uploader with fallbacks', () => {
-      expect(CHANNEL_TEMPLATE).toBe('%(uploader,channel,uploader_id)s');
+    it('CHANNEL_TEMPLATE should use uploader with fallbacks and byte truncation', () => {
+      expect(CHANNEL_TEMPLATE).toBe('%(uploader,channel,uploader_id).80B');
     });
 
-    it('VIDEO_FOLDER_TEMPLATE should include channel and truncated title', () => {
+    it('VIDEO_FOLDER_TEMPLATE should include channel and byte-truncated title', () => {
       expect(VIDEO_FOLDER_TEMPLATE).toContain(CHANNEL_TEMPLATE);
-      expect(VIDEO_FOLDER_TEMPLATE).toContain('%(title).76s');
+      expect(VIDEO_FOLDER_TEMPLATE).toContain('%(title).76B');
       expect(VIDEO_FOLDER_TEMPLATE).toContain('%(id)s');
     });
 

--- a/server/modules/filesystem/__tests__/pathBuilder.test.js
+++ b/server/modules/filesystem/__tests__/pathBuilder.test.js
@@ -151,14 +151,14 @@ describe('filesystem/pathBuilder', () => {
     it('should build template without subfolder', () => {
       const template = buildOutputTemplate(baseDir, null);
       expect(template).not.toContain('__');
-      expect(template).toContain('%(uploader,channel,uploader_id)s');
+      expect(template).toContain('%(uploader,channel,uploader_id).80B');
       expect(template).toContain('[%(id)s]');
     });
 
     it('should build template with subfolder', () => {
       const template = buildOutputTemplate(baseDir, 'MyFolder');
       expect(template).toContain('__MyFolder');
-      expect(template).toContain('%(uploader,channel,uploader_id)s');
+      expect(template).toContain('%(uploader,channel,uploader_id).80B');
     });
   });
 

--- a/server/modules/filesystem/constants.js
+++ b/server/modules/filesystem/constants.js
@@ -42,22 +42,27 @@ const MEDIA_EXTENSIONS = [...VIDEO_EXTENSIONS, ...AUDIO_EXTENSIONS];
 /**
  * yt-dlp output template for channel folder name
  * Uses uploader with fallback to channel, then uploader_id
+ * Truncated to 80 bytes max to avoid filesystem path length issues with UTF-8 characters
  */
-const CHANNEL_TEMPLATE = '%(uploader,channel,uploader_id)s';
+const CHANNEL_TEMPLATE = '%(uploader,channel,uploader_id).80B';
 
 /**
  * yt-dlp output template for video folder name
  * Format: "ChannelName - VideoTitle - VideoID"
- * Title is truncated to 76 characters to avoid path length issues
+ * Title is truncated to 76 bytes (not characters) to avoid path length issues with UTF-8
+ * Using .NB syntax for byte-based truncation instead of .Ns for character-based
+ * Note: 76 bytes keeps same safety margin as before for Windows path limits (entire path must be <260)
  */
-const VIDEO_FOLDER_TEMPLATE = `${CHANNEL_TEMPLATE} - %(title).76s - %(id)s`;
+const VIDEO_FOLDER_TEMPLATE = `${CHANNEL_TEMPLATE} - %(title).76B - %(id)s`;
 
 /**
  * yt-dlp output template for video file name
  * Format: "ChannelName - VideoTitle [VideoID].ext"
- * Title is truncated to 76 characters to avoid path length issues
+ * Title is truncated to 76 bytes (not characters) to avoid path length issues with UTF-8
+ * Using .NB syntax for byte-based truncation instead of .Ns for character-based
+ * Note: 76 bytes keeps same safety margin as before for Windows path limits (entire path must be <260)
  */
-const VIDEO_FILE_TEMPLATE = `${CHANNEL_TEMPLATE} - %(title).76s [%(id)s].%(ext)s`;
+const VIDEO_FILE_TEMPLATE = `${CHANNEL_TEMPLATE} - %(title).76B [%(id)s].%(ext)s`;
 
 /**
  * Pattern to extract YouTube video ID from filename


### PR DESCRIPTION
- Change title truncation from .76s (characters) to .76B (bytes) to prevent filename length errors with UTF-8 multi-byte characters (Japanese, etc.)
- Add 80-byte truncation to channel name template (previously untruncated)
- Update thumbnail template to use consistent byte-based truncation
- Update tests