### PR TITLE
feat: add backup and restore scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ docker-compose.override.*
 # Default video download directory and README, all other files excluded
 downloads/*
 !downloads/README.md
+
+# Backup archive location
+backups/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Or remove/comment out the `YOUTARR_IMAGE` line in your `.env` file to use the de
 - [External Database](docs/platforms/external-db.md) - Using existing MariaDB/MySQL
 
 ### Advanced Topics
+- [Backup & Restore](docs/BACKUP_RESTORE.md) - Backup your configuration and database, restore to new systems
 - [Database Management](docs/DATABASE.md) - Database configuration and maintenance
 - [Docker Configuration](docs/DOCKER.md) - Advanced Docker settings
 - [Development Guide](docs/DEVELOPMENT.md) - Contributing and development setup

--- a/docs/BACKUP_RESTORE.md
+++ b/docs/BACKUP_RESTORE.md
@@ -1,0 +1,305 @@
+# Youtarr Backup and Restore
+
+This guide explains how to backup and restore your Youtarr installation, enabling disaster recovery and migration to new systems.
+
+## Requirements
+
+- Docker and Docker Compose (for database operations)
+- `jq` command-line JSON processor (for parsing backup manifest)
+- `tar` and `gzip` (standard on most systems)
+
+On Debian/Ubuntu, install jq with: `sudo apt install jq`
+
+## Quick Start
+
+### Create a Backup
+
+```bash
+# Full backup to default location ./backups/
+./scripts/backup.sh
+
+# Backup to custom location
+./scripts/backup.sh --output-dir /mnt/external/backups
+
+# Skip thumbnails (they auto-regenerate)
+./scripts/backup.sh --skip-images
+```
+
+### Restore from Backup
+
+```bash
+# Stop Youtarr first
+./stop.sh
+
+# Restore from backup
+./scripts/restore.sh ./backups/youtarr-backup-20240115-120000.tar.gz
+
+# Start Youtarr
+./start.sh
+```
+
+## What Gets Backed Up
+
+| Component | Path | Criticality | Typical Size |
+|-----------|------|-------------|--------------|
+| Environment config | `.env` | Critical | ~1KB |
+| App settings | `config/config.json` | Critical | ~2KB |
+| YouTube cookies | `config/cookies.user.txt` | High (if exists) | ~8KB |
+| Download history | `config/complete.list` | Critical | ~2KB |
+| Database | MariaDB dump | Critical | Variable |
+| Video metadata | `jobs/info/*.info.json` | Critical | Variable |
+| Thumbnails | `server/images/*` | Optional | Variable |
+
+**Note:** Video metadata files are critical because they cannot be regenerated - they're only created during the initial download. Thumbnails are optional because they auto-regenerate when channels are accessed.
+
+### What's NOT Backed Up
+
+**Video files in `YOUTUBE_OUTPUT_DIR` are NOT included** - these must be backed up separately by you. This is intentional because:
+
+- Video files can be very large (hundreds of GB to TB)
+- They're typically stored on external/NAS storage
+- They can be re-downloaded if lost (though this takes time)
+
+## Backup Options
+
+### Full Backup to default location ./backups/
+
+```bash
+./scripts/backup.sh
+```
+
+Creates a complete backup including metadata and thumbnails. Best for full disaster recovery.
+
+**Typical size:** 10-200MB depending on your library size
+
+### Skip Thumbnails
+
+```bash
+./scripts/backup.sh --skip-images
+```
+
+Skips channel thumbnail images to reduce backup size. Thumbnails auto-regenerate when channels are accessed, so this is safe to use.
+
+### Custom Output Location
+
+```bash
+./scripts/backup.sh --output-dir /mnt/backup/youtarr
+```
+
+Saves the backup to a different directory (default is `./backups/`).
+
+## Restore Options
+
+### Full Restore
+
+```bash
+./scripts/restore.sh backup.tar.gz
+```
+
+Restores everything from the backup. You'll be prompted to type `RESTORE` (case-sensitive) to confirm.
+
+**Important notes:**
+- The database is completely replaced (DROP + CREATE) - this is not a merge
+- The script may use `sudo` automatically for files with restricted permissions
+- On non-ARM systems, the existing `database/` directory is cleared before import
+
+### Config-Only Restore
+
+```bash
+./scripts/restore.sh backup.tar.gz --skip-db
+```
+
+Restores only configuration files, skipping the database. Useful when:
+- Database is on an external server
+- You only want to restore settings
+
+### Force Restore (No Prompts)
+
+```bash
+./scripts/restore.sh backup.tar.gz --force
+```
+
+Skips the confirmation prompt. Use with caution in scripts.
+
+## Migration Scenarios
+
+### Moving to a New Computer
+
+1. **On the old computer:**
+   ```bash
+   ./scripts/backup.sh --output-dir /mnt/external
+   ```
+
+2. **Copy your video files** from `YOUTUBE_OUTPUT_DIR` to the new location
+
+3. **On the new computer:**
+   ```bash
+   git clone https://github.com/DialmasterOrg/Youtarr.git
+   cd Youtarr
+   ./scripts/restore.sh /path/to/youtarr-backup.tar.gz
+   ```
+
+4. **Update `.env`** if your video path has changed:
+   ```bash
+   # Edit .env and update YOUTUBE_OUTPUT_DIR to the new path
+   nano .env
+   ```
+
+5. **Start Youtarr:**
+   ```bash
+   ./start.sh
+   ```
+
+### Disaster Recovery (System Drive Failure)
+
+If your system drive fails but your video files survive (on external/NAS storage):
+
+1. **Install fresh OS and Docker**
+
+2. **Clone Youtarr:**
+   ```bash
+   git clone https://github.com/DialmasterOrg/Youtarr.git
+   cd Youtarr
+   ```
+
+3. **Restore from your offsite backup:**
+   ```bash
+   ./scripts/restore.sh /path/to/backup.tar.gz
+   ```
+
+4. **Verify video path in `.env`:**
+   ```bash
+   cat .env | grep YOUTUBE_OUTPUT_DIR
+   # Update if the path has changed
+   ```
+
+5. **Start Youtarr:**
+   ```bash
+   ./start.sh
+   ```
+
+Your channels, settings, and download history will be restored. Videos should appear since they reference the same output directory.
+
+### Upgrading to New Hardware
+
+Same as "Moving to a New Computer" - backup, transfer, restore.
+
+## Backup Archive Structure
+
+The backup creates a timestamped `.tar.gz` archive with this structure:
+
+```
+youtarr-backup-YYYYMMDD-HHMMSS/
+  manifest.json           # Backup metadata
+  env.backup              # Your .env file
+  config/
+    config.json           # Application settings
+    cookies.user.txt      # YouTube cookies (if present)
+    complete.list         # Download history
+  database/
+    youtarr.sql           # Full database dump
+  metadata/
+    jobs/info/            # Video metadata files (always included)
+    server/images/        # Thumbnail images (unless --skip-images)
+```
+
+## ARM/Apple Silicon Notes
+
+Youtarr automatically detects ARM architecture (Apple Silicon, Raspberry Pi) and handles it appropriately:
+
+- **Backup:** Works the same on all architectures
+- **Restore:** Uses named volumes for MariaDB on ARM (instead of bind mounts)
+- **Cross-architecture:** You can backup on x86 and restore on ARM (or vice versa)
+
+The database dump is architecture-independent SQL, so migrations between architectures work seamlessly.
+
+## Automated Backups
+
+You can schedule regular backups using cron:
+
+```bash
+# Edit crontab
+crontab -e
+
+# Add daily backup at 3 AM
+0 3 * * * /path/to/Youtarr/scripts/backup.sh --output-dir /mnt/backup/youtarr
+```
+
+Consider these best practices:
+- Store backups on a different drive than your system
+- Use `--skip-images` if you want smaller backups (thumbnails auto-regenerate)
+- Test restores periodically
+
+## Troubleshooting
+
+### "No .env file found"
+
+The backup script requires Youtarr to be initialized first:
+
+```bash
+./start.sh  # Initialize Youtarr
+./stop.sh   # Stop it
+./scripts/backup.sh  # Now backup will work
+```
+
+### "Database failed to become ready"
+
+The database container may take longer to start on some systems:
+
+1. Wait a moment and try again
+2. Check Docker is running: `docker ps`
+3. Check for port conflicts on 3321
+
+### "YOUTUBE_OUTPUT_DIR does not exist"
+
+After restoring, the video path from the backup might not exist on your new system:
+
+1. Edit `.env` and update `YOUTUBE_OUTPUT_DIR` to point to your videos
+2. Or create the directory and copy/mount your videos there
+
+### Restore fails with permission errors
+
+Some files may need elevated permissions:
+
+```bash
+# Run with sudo if needed
+sudo ./scripts/restore.sh backup.tar.gz
+```
+
+### Database import fails
+
+If the database import fails:
+
+1. Try starting Youtarr normally (it will create a fresh database):
+   ```bash
+   ./start.sh
+   ```
+
+2. Then try a config-only restore:
+   ```bash
+   ./stop.sh
+   ./scripts/restore.sh backup.tar.gz --skip-db
+   ./start.sh
+   ```
+
+You'll lose your channel subscriptions but keep your settings. Videos will still exist; you'll need to re-add channels.
+
+## Security Considerations
+
+Backup archives contain sensitive data:
+- Database credentials (in `.env`)
+- Plex API keys (in `config/config.json`)
+- YouTube API keys (if configured)
+- Session data
+
+Store backups securely and consider encrypting them if storing offsite:
+
+```bash
+# Create encrypted backup
+./scripts/backup.sh
+gpg -c backups/youtarr-backup-*.tar.gz
+
+# Decrypt before restore
+gpg -d backup.tar.gz.gpg > backup.tar.gz
+./scripts/restore.sh backup.tar.gz
+```

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,377 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=scripts/_console_output.sh
+source "$SCRIPT_DIR/_console_output.sh"
+
+# Default configuration
+OUTPUT_DIR="$PROJECT_DIR/backups"
+SKIP_IMAGES=false
+
+# Cleanup function for interruptions
+cleanup() {
+    if [[ -n "${STAGING_DIR:-}" ]] && [[ -d "$STAGING_DIR" ]]; then
+        rm -rf "$STAGING_DIR" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+print_usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Creates a backup of Youtarr configuration and database.
+
+Options:
+  --output-dir DIR   Directory to save backup (default: ./backups)
+  --skip-images      Skip server/images/ thumbnail files (~8MB savings)
+                     (Thumbnails auto-regenerate when channels are accessed)
+  --help             Show this help message
+
+What gets backed up:
+  - Environment config (.env)
+  - Application settings (config/config.json)
+  - YouTube cookies (config/cookies.user.txt if present)
+  - Download history (config/complete.list)
+  - Database (full MariaDB dump)
+  - Video metadata (jobs/info/*.info.json)
+  - Thumbnails (server/images/*) - unless --skip-images
+
+NOT backed up: Video files in YOUTUBE_OUTPUT_DIR (user's responsibility)
+
+Examples:
+  $(basename "$0")                          # Full backup to ./backups/
+  $(basename "$0") --output-dir /mnt/backup # Backup to custom location
+  $(basename "$0") --skip-images            # Skip thumbnail files
+EOF
+}
+
+# Function to check if docker compose (v2) or docker-compose (v1) is available
+get_compose_command() {
+    if docker compose version &>/dev/null; then
+        echo "docker compose"
+    elif docker-compose version &>/dev/null; then
+        echo "docker-compose"
+    else
+        echo "Error: Neither 'docker compose' nor 'docker-compose' command found." >&2
+        echo "Please install Docker Compose." >&2
+        exit 1
+    fi
+}
+
+# Get environment variable value from .env file
+get_env_value() {
+    local key="$1"
+    local default="${2:-}"
+    local value
+    value=$(grep -E "^${key}=" "$PROJECT_DIR/.env" 2>/dev/null | head -n1 | cut -d'=' -f2- | sed 's/^"//;s/"$//' || true)
+    if [[ -n "$value" ]]; then
+        echo "$value"
+    else
+        echo "$default"
+    fi
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --skip-images)
+      SKIP_IMAGES=true
+      shift
+      ;;
+    --help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      yt_error "Unknown option: $1"
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+
+yt_banner "Youtarr Backup"
+
+# Verify this is a Youtarr installation
+if [[ ! -f "$PROJECT_DIR/.env" ]]; then
+    yt_error "No .env file found in $PROJECT_DIR"
+    yt_detail "This doesn't appear to be a configured Youtarr installation."
+    yt_detail "Run ./start.sh first to initialize Youtarr, then try again."
+    exit 1
+fi
+
+# Get compose command
+COMPOSE_CMD=$(get_compose_command)
+yt_info "Docker compose command: $COMPOSE_CMD"
+
+# Detect ARM architecture
+ARCH=$(uname -m)
+IS_ARM=false
+if [[ "$ARCH" == "arm64" || "$ARCH" == "aarch64" ]]; then
+    IS_ARM=true
+    yt_info "Detected ARM architecture ($ARCH)"
+fi
+
+# Read database credentials from .env
+DB_USER=$(get_env_value "DB_USER" "root")
+DB_PASSWORD=$(get_env_value "DB_PASSWORD" "123qweasd")
+DB_NAME=$(get_env_value "DB_NAME" "youtarr")
+DB_PORT=$(get_env_value "DB_PORT" "3321")
+
+# Create output directory if it doesn't exist
+mkdir -p "$OUTPUT_DIR"
+
+# Create temporary staging directory
+TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+BACKUP_NAME="youtarr-backup-$TIMESTAMP"
+STAGING_DIR=$(mktemp -d)
+BACKUP_DIR="$STAGING_DIR/$BACKUP_NAME"
+mkdir -p "$BACKUP_DIR"
+
+yt_section "Staging Backup"
+
+# Check if containers are running
+DB_RUNNING=false
+if docker ps --format '{{.Names}}' | grep -q '^youtarr-db$'; then
+    DB_RUNNING=true
+    yt_info "Database container is running."
+else
+    yt_info "Database container is not running."
+fi
+
+# Track what we're backing up for the manifest
+BACKED_UP_ITEMS=()
+
+# Copy .env file (rename to env.backup for safety)
+if [[ -f "$PROJECT_DIR/.env" ]]; then
+    cp "$PROJECT_DIR/.env" "$BACKUP_DIR/env.backup"
+    BACKED_UP_ITEMS+=("env.backup")
+    yt_success "Backed up .env file"
+fi
+
+# Copy config directory
+mkdir -p "$BACKUP_DIR/config"
+USED_SUDO_FOR_CONFIG=false
+
+if [[ -f "$PROJECT_DIR/config/config.json" ]]; then
+    if cp "$PROJECT_DIR/config/config.json" "$BACKUP_DIR/config/" 2>/dev/null; then
+        BACKED_UP_ITEMS+=("config/config.json")
+        yt_success "Backed up config/config.json"
+    elif sudo cp "$PROJECT_DIR/config/config.json" "$BACKUP_DIR/config/" 2>/dev/null; then
+        USED_SUDO_FOR_CONFIG=true
+        BACKED_UP_ITEMS+=("config/config.json")
+        yt_success "Backed up config/config.json (with sudo)"
+    else
+        yt_warn "Could not backup config/config.json (permission denied)"
+    fi
+fi
+
+if [[ -f "$PROJECT_DIR/config/cookies.user.txt" ]]; then
+    if cp "$PROJECT_DIR/config/cookies.user.txt" "$BACKUP_DIR/config/" 2>/dev/null; then
+        BACKED_UP_ITEMS+=("config/cookies.user.txt")
+        yt_success "Backed up config/cookies.user.txt"
+    elif sudo cp "$PROJECT_DIR/config/cookies.user.txt" "$BACKUP_DIR/config/" 2>/dev/null; then
+        USED_SUDO_FOR_CONFIG=true
+        BACKED_UP_ITEMS+=("config/cookies.user.txt")
+        yt_success "Backed up config/cookies.user.txt (with sudo)"
+    else
+        yt_warn "Could not backup config/cookies.user.txt (permission denied)"
+    fi
+fi
+
+if [[ -f "$PROJECT_DIR/config/complete.list" ]]; then
+    if cp "$PROJECT_DIR/config/complete.list" "$BACKUP_DIR/config/" 2>/dev/null; then
+        BACKED_UP_ITEMS+=("config/complete.list")
+        yt_success "Backed up config/complete.list"
+    elif sudo cp "$PROJECT_DIR/config/complete.list" "$BACKUP_DIR/config/" 2>/dev/null; then
+        USED_SUDO_FOR_CONFIG=true
+        BACKED_UP_ITEMS+=("config/complete.list")
+        yt_success "Backed up config/complete.list (with sudo)"
+    else
+        yt_warn "Could not backup config/complete.list (permission denied)"
+    fi
+fi
+
+# Fix ownership if we used sudo for any config files
+if [[ "$USED_SUDO_FOR_CONFIG" == "true" ]]; then
+    sudo chown -R "$(id -u):$(id -g)" "$BACKUP_DIR/config"
+fi
+
+# Database backup
+yt_section "Database Backup"
+mkdir -p "$BACKUP_DIR/database"
+
+# Determine compose args based on architecture (needed for starting/stopping db)
+if [[ "$IS_ARM" == "true" ]]; then
+    COMPOSE_ARGS="-f $PROJECT_DIR/docker-compose.yml -f $PROJECT_DIR/docker-compose.arm.yml"
+else
+    COMPOSE_ARGS="-f $PROJECT_DIR/docker-compose.yml"
+fi
+
+DB_STARTED_FOR_BACKUP=false
+
+if [[ "$DB_RUNNING" == "false" ]]; then
+    yt_info "Starting database container for backup..."
+
+    # Need to set YOUTUBE_OUTPUT_DIR for compose to work
+    export YOUTUBE_OUTPUT_DIR="${YOUTUBE_OUTPUT_DIR:-/tmp}"
+
+    # Start only the database container
+    (cd "$PROJECT_DIR" && $COMPOSE_CMD $COMPOSE_ARGS up -d youtarr-db)
+    DB_STARTED_FOR_BACKUP=true
+
+    # Wait for database to be healthy
+    yt_info "Waiting for database to be ready..."
+    MAX_WAIT=60
+    WAITED=0
+    while [[ $WAITED -lt $MAX_WAIT ]]; do
+        if docker exec youtarr-db mysqladmin ping -h localhost -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" &>/dev/null; then
+            break
+        fi
+        sleep 2
+        WAITED=$((WAITED + 2))
+    done
+
+    if [[ $WAITED -ge $MAX_WAIT ]]; then
+        yt_error "Database failed to become ready within ${MAX_WAIT}s"
+        # Clean up
+        (cd "$PROJECT_DIR" && $COMPOSE_CMD $COMPOSE_ARGS down)
+        rm -rf "$STAGING_DIR"
+        exit 1
+    fi
+
+    yt_success "Database is ready"
+fi
+
+# Perform database dump
+yt_info "Dumping database..."
+if docker exec youtarr-db mysqldump \
+    --single-transaction \
+    -P "$DB_PORT" \
+    -u "$DB_USER" \
+    -p"$DB_PASSWORD" \
+    "$DB_NAME" > "$BACKUP_DIR/database/youtarr.sql" 2>/dev/null; then
+    BACKED_UP_ITEMS+=("database/youtarr.sql")
+    DB_SIZE=$(du -h "$BACKUP_DIR/database/youtarr.sql" | cut -f1)
+    yt_success "Database dumped ($DB_SIZE)"
+else
+    yt_error "Database dump failed"
+    # Clean up if we started the container
+    if [[ "$DB_STARTED_FOR_BACKUP" == "true" ]]; then
+        (cd "$PROJECT_DIR" && $COMPOSE_CMD $COMPOSE_ARGS down)
+    fi
+    rm -rf "$STAGING_DIR"
+    exit 1
+fi
+
+# Stop database if we started it
+if [[ "$DB_STARTED_FOR_BACKUP" == "true" ]]; then
+    yt_info "Stopping database container..."
+    (cd "$PROJECT_DIR" && $COMPOSE_CMD $COMPOSE_ARGS down)
+    yt_success "Database container stopped"
+fi
+
+# Copy metadata files (required - cannot be regenerated)
+yt_section "Metadata Backup"
+if [[ -d "$PROJECT_DIR/jobs/info" ]] && [[ -n "$(ls -A "$PROJECT_DIR/jobs/info" 2>/dev/null)" ]]; then
+    mkdir -p "$BACKUP_DIR/metadata/jobs"
+    if cp -r "$PROJECT_DIR/jobs/info" "$BACKUP_DIR/metadata/jobs/" 2>/dev/null; then
+        METADATA_COUNT=$(find "$BACKUP_DIR/metadata/jobs/info" -type f 2>/dev/null | wc -l)
+        METADATA_SIZE=$(du -sh "$BACKUP_DIR/metadata/jobs/info" 2>/dev/null | cut -f1)
+        BACKED_UP_ITEMS+=("metadata/jobs/info/")
+        yt_success "Backed up $METADATA_COUNT metadata files ($METADATA_SIZE)"
+    elif sudo cp -r "$PROJECT_DIR/jobs/info" "$BACKUP_DIR/metadata/jobs/" 2>/dev/null; then
+        # Fix ownership so we can read/archive the files
+        sudo chown -R "$(id -u):$(id -g)" "$BACKUP_DIR/metadata/jobs/info"
+        METADATA_COUNT=$(find "$BACKUP_DIR/metadata/jobs/info" -type f 2>/dev/null | wc -l)
+        METADATA_SIZE=$(du -sh "$BACKUP_DIR/metadata/jobs/info" 2>/dev/null | cut -f1)
+        BACKED_UP_ITEMS+=("metadata/jobs/info/")
+        yt_success "Backed up $METADATA_COUNT metadata files ($METADATA_SIZE) (with sudo)"
+    else
+        yt_warn "Could not backup jobs/info/ (permission denied)"
+    fi
+else
+    yt_info "No metadata files found in jobs/info/"
+fi
+
+# Optional: Copy image files
+if [[ "$SKIP_IMAGES" == "false" ]]; then
+    yt_section "Images Backup"
+    if [[ -d "$PROJECT_DIR/server/images" ]] && [[ -n "$(ls -A "$PROJECT_DIR/server/images" 2>/dev/null)" ]]; then
+        mkdir -p "$BACKUP_DIR/metadata/server"
+        if cp -r "$PROJECT_DIR/server/images" "$BACKUP_DIR/metadata/server/" 2>/dev/null; then
+            IMAGES_COUNT=$(find "$BACKUP_DIR/metadata/server/images" -type f 2>/dev/null | wc -l)
+            IMAGES_SIZE=$(du -sh "$BACKUP_DIR/metadata/server/images" 2>/dev/null | cut -f1)
+            BACKED_UP_ITEMS+=("metadata/server/images/")
+            yt_success "Backed up $IMAGES_COUNT image files ($IMAGES_SIZE)"
+        elif sudo cp -r "$PROJECT_DIR/server/images" "$BACKUP_DIR/metadata/server/" 2>/dev/null; then
+            # Fix ownership so we can read/archive the files
+            sudo chown -R "$(id -u):$(id -g)" "$BACKUP_DIR/metadata/server/images"
+            IMAGES_COUNT=$(find "$BACKUP_DIR/metadata/server/images" -type f 2>/dev/null | wc -l)
+            IMAGES_SIZE=$(du -sh "$BACKUP_DIR/metadata/server/images" 2>/dev/null | cut -f1)
+            BACKED_UP_ITEMS+=("metadata/server/images/")
+            yt_success "Backed up $IMAGES_COUNT image files ($IMAGES_SIZE) (with sudo)"
+        else
+            yt_warn "Could not backup server/images/ (permission denied)"
+        fi
+    else
+        yt_info "No image files found in server/images/"
+    fi
+else
+    yt_info "Skipping image files (--skip-images)"
+fi
+
+# Create manifest
+yt_section "Creating Archive"
+cat > "$BACKUP_DIR/manifest.json" <<EOF
+{
+  "version": "1.0",
+  "created": "$(date -Iseconds)",
+  "hostname": "$(hostname)",
+  "architecture": "$ARCH",
+  "is_arm": $IS_ARM,
+  "db_name": "$DB_NAME",
+  "items": $(printf '%s\n' "${BACKED_UP_ITEMS[@]}" | jq -R . | jq -s .),
+  "options": {
+    "skip_images": $SKIP_IMAGES
+  }
+}
+EOF
+yt_success "Created manifest.json"
+
+# Create tar.gz archive
+ARCHIVE_PATH="$OUTPUT_DIR/$BACKUP_NAME.tar.gz"
+yt_info "Creating archive..."
+if ! (cd "$STAGING_DIR" && tar -czf "$ARCHIVE_PATH" "$BACKUP_NAME"); then
+    yt_error "Failed to create archive"
+    rm -rf "$STAGING_DIR"
+    exit 1
+fi
+
+# Clean up staging directory (trap will handle this, but be explicit)
+rm -rf "$STAGING_DIR"
+
+# Get archive size
+ARCHIVE_SIZE=$(du -h "$ARCHIVE_PATH" | cut -f1)
+
+yt_section "Backup Complete"
+yt_success "Backup created successfully!"
+echo ""
+yt_info "Archive: $ARCHIVE_PATH"
+yt_info "Size: $ARCHIVE_SIZE"
+echo ""
+yt_detail "Contents:"
+for item in "${BACKED_UP_ITEMS[@]}"; do
+    yt_detail "  - $item"
+done
+echo ""
+yt_warn "Remember: Video files are NOT included in this backup."
+yt_detail "Ensure your YOUTUBE_OUTPUT_DIR is backed up separately."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=scripts/_console_output.sh
+source "$SCRIPT_DIR/_console_output.sh"
+
+# Default configuration
+FORCE=false
+SKIP_DB=false
+BACKUP_FILE=""
+
+# Cleanup function for interruptions
+cleanup() {
+    if [[ -n "${EXTRACT_DIR:-}" ]] && [[ -d "$EXTRACT_DIR" ]]; then
+        rm -rf "$EXTRACT_DIR" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+print_usage() {
+  cat <<EOF
+Usage: $(basename "$0") BACKUP_FILE [OPTIONS]
+
+Restores Youtarr configuration and database from a backup archive.
+
+Arguments:
+  BACKUP_FILE        Path to the backup archive (.tar.gz)
+
+Options:
+  --force            Skip confirmation prompts
+  --skip-db          Restore config files only, skip database restore
+  --help             Show this help message
+
+What gets restored:
+  - Environment config (.env)
+  - Application settings (config/config.json)
+  - YouTube cookies (config/cookies.user.txt if present)
+  - Download history (config/complete.list)
+  - Database (MariaDB) - unless --skip-db
+  - Video metadata (jobs/info/) - if present in backup
+  - Thumbnails (server/images/) - if present in backup
+
+IMPORTANT:
+  - Stop Youtarr before restoring: ./stop.sh
+  - Video files must be restored separately to YOUTUBE_OUTPUT_DIR
+  - After restore, start Youtarr with: ./start.sh
+
+Examples:
+  $(basename "$0") ./backups/youtarr-backup-20240115-120000.tar.gz
+  $(basename "$0") /mnt/backup/youtarr-backup.tar.gz --force
+  $(basename "$0") backup.tar.gz --skip-db  # Config only
+EOF
+}
+
+# Function to check if docker compose (v2) or docker-compose (v1) is available
+get_compose_command() {
+    if docker compose version &>/dev/null; then
+        echo "docker compose"
+    elif docker-compose version &>/dev/null; then
+        echo "docker-compose"
+    else
+        echo "Error: Neither 'docker compose' nor 'docker-compose' command found." >&2
+        echo "Please install Docker Compose." >&2
+        exit 1
+    fi
+}
+
+# Get environment variable value from .env file
+get_env_value() {
+    local env_file="$1"
+    local key="$2"
+    local default="${3:-}"
+    local value
+    value=$(grep -E "^${key}=" "$env_file" 2>/dev/null | head -n1 | cut -d'=' -f2- | sed 's/^"//;s/"$//' || true)
+    if [[ -n "$value" ]]; then
+        echo "$value"
+    else
+        echo "$default"
+    fi
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force)
+      FORCE=true
+      shift
+      ;;
+    --skip-db)
+      SKIP_DB=true
+      shift
+      ;;
+    --help)
+      print_usage
+      exit 0
+      ;;
+    -*)
+      yt_error "Unknown option: $1"
+      print_usage
+      exit 1
+      ;;
+    *)
+      if [[ -z "$BACKUP_FILE" ]]; then
+        BACKUP_FILE="$1"
+      else
+        yt_error "Unexpected argument: $1"
+        print_usage
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+yt_banner "Youtarr Restore"
+
+# Validate backup file is provided
+if [[ -z "$BACKUP_FILE" ]]; then
+    yt_error "No backup file specified."
+    print_usage
+    exit 1
+fi
+
+# Validate backup file exists
+if [[ ! -f "$BACKUP_FILE" ]]; then
+    yt_error "Backup file not found: $BACKUP_FILE"
+    exit 1
+fi
+
+# Get compose command
+COMPOSE_CMD=$(get_compose_command)
+yt_info "Docker compose command: $COMPOSE_CMD"
+
+# Detect ARM architecture
+ARCH=$(uname -m)
+IS_ARM=false
+if [[ "$ARCH" == "arm64" || "$ARCH" == "aarch64" ]]; then
+    IS_ARM=true
+    yt_info "Detected ARM architecture ($ARCH)"
+fi
+
+# Extract backup to temporary directory
+yt_section "Extracting Backup"
+EXTRACT_DIR=$(mktemp -d)
+yt_info "Extracting to temporary directory..."
+
+if ! tar -xzf "$BACKUP_FILE" -C "$EXTRACT_DIR"; then
+    yt_error "Failed to extract backup archive"
+    rm -rf "$EXTRACT_DIR"
+    exit 1
+fi
+
+# Find the backup directory (should be the only directory in extract)
+BACKUP_DIR=$(find "$EXTRACT_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+
+if [[ -z "$BACKUP_DIR" ]]; then
+    yt_error "Invalid backup archive structure - no directory found"
+    rm -rf "$EXTRACT_DIR"
+    exit 1
+fi
+
+yt_success "Backup extracted"
+
+# Validate backup contents
+yt_section "Validating Backup"
+
+# Check for manifest (newer backups) or env.backup (required)
+if [[ -f "$BACKUP_DIR/manifest.json" ]]; then
+    yt_info "Found manifest.json"
+    BACKUP_DATE=$(jq -r '.created // "unknown"' "$BACKUP_DIR/manifest.json" 2>/dev/null || echo "unknown")
+    BACKUP_HOSTNAME=$(jq -r '.hostname // "unknown"' "$BACKUP_DIR/manifest.json" 2>/dev/null || echo "unknown")
+    BACKUP_ARCH=$(jq -r '.architecture // "unknown"' "$BACKUP_DIR/manifest.json" 2>/dev/null || echo "unknown")
+    yt_detail "  Created: $BACKUP_DATE"
+    yt_detail "  Hostname: $BACKUP_HOSTNAME"
+    yt_detail "  Architecture: $BACKUP_ARCH"
+fi
+
+if [[ ! -f "$BACKUP_DIR/env.backup" ]]; then
+    yt_error "Invalid backup: missing env.backup file"
+    rm -rf "$EXTRACT_DIR"
+    exit 1
+fi
+
+# List backup contents
+yt_info "Backup contents:"
+[[ -f "$BACKUP_DIR/env.backup" ]] && yt_detail "  - Environment config (.env)"
+[[ -f "$BACKUP_DIR/config/config.json" ]] && yt_detail "  - Application settings (config/config.json)"
+[[ -f "$BACKUP_DIR/config/cookies.user.txt" ]] && yt_detail "  - YouTube cookies (config/cookies.user.txt)"
+[[ -f "$BACKUP_DIR/config/complete.list" ]] && yt_detail "  - Download history (config/complete.list)"
+[[ -f "$BACKUP_DIR/database/youtarr.sql" ]] && yt_detail "  - Database dump (youtarr.sql)"
+[[ -d "$BACKUP_DIR/metadata/jobs/info" ]] && yt_detail "  - Video metadata (jobs/info/)"
+[[ -d "$BACKUP_DIR/metadata/server/images" ]] && yt_detail "  - Thumbnails (server/images/)"
+
+# Check for existing data
+yt_section "Pre-restore Checks"
+
+HAS_EXISTING_DATA=false
+if [[ -f "$PROJECT_DIR/.env" ]]; then
+    HAS_EXISTING_DATA=true
+    yt_warn "Existing .env file found - will be overwritten"
+fi
+
+if [[ -f "$PROJECT_DIR/config/config.json" ]]; then
+    HAS_EXISTING_DATA=true
+    yt_warn "Existing config/config.json found - will be overwritten"
+fi
+
+if [[ -d "$PROJECT_DIR/database" ]] && [[ -n "$(ls -A "$PROJECT_DIR/database" 2>/dev/null)" ]]; then
+    HAS_EXISTING_DATA=true
+    yt_warn "Existing database directory found - database will be replaced"
+fi
+
+# Check if containers are running
+CONTAINERS_RUNNING=false
+if docker ps --format '{{.Names}}' | grep -qE '^youtarr(-db)?$'; then
+    CONTAINERS_RUNNING=true
+    yt_error "Youtarr containers are still running!"
+    yt_detail "Stop them first with: ./stop.sh"
+    if [[ "$FORCE" != "true" ]]; then
+        rm -rf "$EXTRACT_DIR"
+        exit 1
+    fi
+    yt_warn "Continuing anyway due to --force flag..."
+fi
+
+# Confirmation prompt
+if [[ "$FORCE" != "true" ]]; then
+    yt_section "Confirmation Required"
+
+    echo ""
+    cat <<'WARN'
+##########################################################################
+#  WARNING: This will overwrite existing Youtarr configuration!         #
+##########################################################################
+WARN
+    echo ""
+
+    if [[ "$HAS_EXISTING_DATA" == "true" ]]; then
+        yt_warn "Existing data will be overwritten!"
+    fi
+
+    if [[ "$SKIP_DB" == "true" ]]; then
+        yt_info "Database restore will be skipped (--skip-db)"
+    fi
+
+    echo ""
+    read -r -p "Type 'RESTORE' to proceed or anything else to abort: " confirmation
+
+    if [[ "${confirmation}" != "RESTORE" ]]; then
+        yt_info "Aborted. No data was restored."
+        rm -rf "$EXTRACT_DIR"
+        exit 0
+    fi
+fi
+
+# Stop containers if running (and we're forcing)
+if [[ "$CONTAINERS_RUNNING" == "true" ]]; then
+    yt_info "Stopping Youtarr containers..."
+    (cd "$PROJECT_DIR" && ./stop.sh)
+fi
+
+# Perform restore
+yt_section "Restoring Configuration"
+
+# Restore .env
+if [[ -f "$BACKUP_DIR/env.backup" ]]; then
+    cp "$BACKUP_DIR/env.backup" "$PROJECT_DIR/.env"
+    yt_success "Restored .env"
+fi
+
+# Restore config files
+mkdir -p "$PROJECT_DIR/config"
+
+if [[ -f "$BACKUP_DIR/config/config.json" ]]; then
+    cp "$BACKUP_DIR/config/config.json" "$PROJECT_DIR/config/"
+    yt_success "Restored config/config.json"
+fi
+
+if [[ -f "$BACKUP_DIR/config/cookies.user.txt" ]]; then
+    cp "$BACKUP_DIR/config/cookies.user.txt" "$PROJECT_DIR/config/"
+    yt_success "Restored config/cookies.user.txt"
+fi
+
+if [[ -f "$BACKUP_DIR/config/complete.list" ]]; then
+    cp "$BACKUP_DIR/config/complete.list" "$PROJECT_DIR/config/"
+    yt_success "Restored config/complete.list"
+fi
+
+# Restore metadata files if present
+if [[ -d "$BACKUP_DIR/metadata/jobs/info" ]]; then
+    mkdir -p "$PROJECT_DIR/jobs"
+    cp -r "$BACKUP_DIR/metadata/jobs/info" "$PROJECT_DIR/jobs/"
+    METADATA_COUNT=$(find "$PROJECT_DIR/jobs/info" -type f | wc -l)
+    yt_success "Restored $METADATA_COUNT metadata files to jobs/info/"
+fi
+
+if [[ -d "$BACKUP_DIR/metadata/server/images" ]]; then
+    mkdir -p "$PROJECT_DIR/server"
+    cp -r "$BACKUP_DIR/metadata/server/images" "$PROJECT_DIR/server/"
+    IMAGES_COUNT=$(find "$PROJECT_DIR/server/images" -type f | wc -l)
+    yt_success "Restored $IMAGES_COUNT image files to server/images/"
+fi
+
+# Database restore
+if [[ "$SKIP_DB" == "true" ]]; then
+    yt_section "Database Restore"
+    yt_info "Skipping database restore (--skip-db)"
+elif [[ -f "$BACKUP_DIR/database/youtarr.sql" ]]; then
+    yt_section "Database Restore"
+
+    # Read database credentials from the restored .env
+    DB_USER=$(get_env_value "$PROJECT_DIR/.env" "DB_USER" "root")
+    DB_PASSWORD=$(get_env_value "$PROJECT_DIR/.env" "DB_PASSWORD" "123qweasd")
+    DB_NAME=$(get_env_value "$PROJECT_DIR/.env" "DB_NAME" "youtarr")
+    DB_PORT=$(get_env_value "$PROJECT_DIR/.env" "DB_PORT" "3321")
+
+    # Need YOUTUBE_OUTPUT_DIR for compose to work
+    export YOUTUBE_OUTPUT_DIR=$(get_env_value "$PROJECT_DIR/.env" "YOUTUBE_OUTPUT_DIR" "/tmp")
+
+    # Determine compose args based on architecture
+    if [[ "$IS_ARM" == "true" ]]; then
+        COMPOSE_ARGS="-f $PROJECT_DIR/docker-compose.yml -f $PROJECT_DIR/docker-compose.arm.yml"
+    else
+        COMPOSE_ARGS="-f $PROJECT_DIR/docker-compose.yml"
+    fi
+
+    # Clear existing database directory for fresh import (only for bind mount, not named volume)
+    if [[ "$IS_ARM" != "true" ]] && [[ -d "$PROJECT_DIR/database" ]]; then
+        yt_info "Clearing existing database directory..."
+        sudo rm -rf "$PROJECT_DIR/database"
+        mkdir -p "$PROJECT_DIR/database"
+    fi
+
+    # Start database container
+    yt_info "Starting database container..."
+    (cd "$PROJECT_DIR" && $COMPOSE_CMD $COMPOSE_ARGS up -d youtarr-db)
+
+    # Wait for database to be healthy
+    yt_info "Waiting for database to be ready..."
+    MAX_WAIT=90
+    WAITED=0
+    while [[ $WAITED -lt $MAX_WAIT ]]; do
+        # First check if mysqladmin ping works
+        if docker exec youtarr-db mysqladmin ping -h localhost -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" &>/dev/null; then
+            # Then verify we can actually connect and run a query
+            if docker exec youtarr-db mysql -h 127.0.0.1 -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" -e "SELECT 1;" &>/dev/null; then
+                break
+            fi
+        fi
+        sleep 2
+        WAITED=$((WAITED + 2))
+    done
+
+    if [[ $WAITED -ge $MAX_WAIT ]]; then
+        yt_error "Database failed to become ready within ${MAX_WAIT}s"
+        yt_detail "Try starting Youtarr normally with ./start.sh"
+        (cd "$PROJECT_DIR" && $COMPOSE_CMD $COMPOSE_ARGS down)
+        rm -rf "$EXTRACT_DIR"
+        exit 1
+    fi
+
+    yt_success "Database is ready"
+
+    # Import database
+    yt_info "Importing database..."
+
+    # Drop and recreate database to ensure clean import
+    yt_info "Preparing database..."
+    DB_PREP_OUTPUT=$(docker exec youtarr-db mysql -h 127.0.0.1 -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" \
+        -e "DROP DATABASE IF EXISTS $DB_NAME; CREATE DATABASE $DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;" 2>&1) || true
+    if [[ -z "$DB_PREP_OUTPUT" ]] || [[ "$DB_PREP_OUTPUT" == *"Warning"* ]]; then
+        yt_success "Database prepared for import"
+    else
+        yt_warn "Database preparation output: $DB_PREP_OUTPUT"
+    fi
+
+    # Import the SQL dump
+    yt_info "Importing SQL dump (this may take a moment)..."
+    IMPORT_ERROR=$(docker exec -i youtarr-db mysql -h 127.0.0.1 -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" < "$BACKUP_DIR/database/youtarr.sql" 2>&1)
+    IMPORT_STATUS=$?
+    if [[ $IMPORT_STATUS -eq 0 ]]; then
+        yt_success "Database imported successfully"
+    else
+        yt_error "Database import failed"
+        yt_detail "Error: $IMPORT_ERROR"
+        (cd "$PROJECT_DIR" && $COMPOSE_CMD $COMPOSE_ARGS down)
+        rm -rf "$EXTRACT_DIR"
+        exit 1
+    fi
+
+    # Stop containers - let user start manually
+    yt_info "Stopping database container..."
+    (cd "$PROJECT_DIR" && $COMPOSE_CMD $COMPOSE_ARGS down)
+    yt_success "Database container stopped"
+else
+    yt_section "Database Restore"
+    yt_warn "No database dump found in backup - skipping database restore"
+fi
+
+# Clean up
+rm -rf "$EXTRACT_DIR"
+
+yt_section "Restore Complete"
+yt_success "Youtarr has been restored successfully!"
+echo ""
+yt_info "Next steps:"
+yt_detail "1. Verify YOUTUBE_OUTPUT_DIR in .env points to your video files"
+yt_detail "2. Ensure video files are present in that directory"
+yt_detail "3. Start Youtarr with: ./start.sh"
+echo ""
+
+# Read the restored YOUTUBE_OUTPUT_DIR for the reminder
+RESTORED_OUTPUT_DIR=$(get_env_value "$PROJECT_DIR/.env" "YOUTUBE_OUTPUT_DIR" "")
+if [[ -n "$RESTORED_OUTPUT_DIR" ]]; then
+    yt_warn "Backup was configured for: YOUTUBE_OUTPUT_DIR=$RESTORED_OUTPUT_DIR"
+    if [[ ! -d "$RESTORED_OUTPUT_DIR" ]]; then
+        yt_error "This directory does not exist! Update .env or create the directory."
+    fi
+fi


### PR DESCRIPTION
- Add scripts/backup.sh to create timestamped archives of config, database, and metadata
- Add scripts/restore.sh to restore from backups with confirmation prompt and ARM support
- Add docs/BACKUP_RESTORE.md with usage guide, migration scenarios, and troubleshooting
- Add backups/ to .gitignore and link documentation from README.md