### PR TITLE
Fix issues raised in PR #440 review

### DIFF
--- a/server/modules/filesystem/directoryManager.js
+++ b/server/modules/filesystem/directoryManager.js
@@ -32,26 +32,19 @@ async function ensureDir(dirPath) {
  * @throws {Error} If all retries fail
  */
 async function ensureDirWithRetries(dirPath, { retries = 5, delayMs = 200 } = {}) {
-  let attempt = 0;
-  let lastError;
-
-  while (attempt <= retries) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
     try {
       await fs.ensureDir(dirPath);
       return;
     } catch (err) {
-      lastError = err;
       if (attempt === retries) {
         throw err;
       }
       const backoff = delayMs * Math.pow(2, attempt);
       logger.debug({ dirPath, attempt, backoff }, 'ensureDir failed, retrying after backoff');
       await sleep(backoff);
-      attempt += 1;
     }
   }
-
-  throw lastError;
 }
 
 /**

--- a/server/modules/filesystem/fileOperations.js
+++ b/server/modules/filesystem/fileOperations.js
@@ -30,26 +30,19 @@ function sleep(ms) {
  * @throws {Error} If all retries fail
  */
 async function moveWithRetries(src, dest, { retries = 5, delayMs = 200, overwrite = true } = {}) {
-  let attempt = 0;
-  let lastError;
-
-  while (attempt <= retries) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
     try {
       await fs.move(src, dest, { overwrite });
       return;
     } catch (err) {
-      lastError = err;
       if (attempt === retries) {
         throw err;
       }
       const backoff = delayMs * Math.pow(2, attempt);
       logger.debug({ src, dest, attempt, backoff }, 'Move failed, retrying after backoff');
       await sleep(backoff);
-      attempt += 1;
     }
   }
-
-  throw lastError;
 }
 
 /**


### PR DESCRIPTION
- Health check: add best-effort cleanup for orphaned test files when unlink fails after writeFile succeeds (e.g. NFS timeout between the two operations). Use crypto.randomUUID() instead of Date.now() to avoid filename collisions.
- Health check: add guard for undefined outputDir to throw a clear error instead of a cryptic TypeError from path.join(undefined, ...).
- Retry loops: replace while+lastError pattern with for-loop in both ensureDirWithRetries and moveWithRetries to eliminate unreachable dead code (throw lastError after exhaustive loop).
- Archive cleanup: only remove videos from the yt-dlp archive when they were explicitly marked as failed during download, not when they merely lack file size (stat/waitForFile failure). Prevents spurious re-downloads when NFS lag causes stat to fail on files that actually exist on disk.