### PR TITLE
feat: channel flat file structure option (#258)

### DIFF
--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -6,9 +6,11 @@ import {
   DialogActions,
   Button,
   FormControl,
+  FormControlLabel,
   InputLabel,
   Select,
   MenuItem,
+  Switch,
   TextField,
   CircularProgress,
   Alert,
@@ -39,6 +41,7 @@ interface ChannelSettings {
   title_filter_regex: string | null;
   audio_format: string | null;
   default_rating: string | null;
+  skip_video_folder: boolean | null;
 }
 
 interface FilterPreviewVideo {
@@ -96,7 +99,8 @@ function ChannelSettingsDialog({
     max_duration: null,
     title_filter_regex: null,
     audio_format: null,
-    default_rating: null
+    default_rating: null,
+    skip_video_folder: null
   });
   const [originalSettings, setOriginalSettings] = useState<ChannelSettings>({
     sub_folder: null,
@@ -105,7 +109,8 @@ function ChannelSettingsDialog({
     max_duration: null,
     title_filter_regex: null,
     audio_format: null,
-    default_rating: null
+    default_rating: null,
+    skip_video_folder: null
   });
   const [subfolders, setSubfolders] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -186,6 +191,7 @@ function ChannelSettingsDialog({
           default_rating: Object.prototype.hasOwnProperty.call(settingsData, 'default_rating')
             ? settingsData.default_rating
             : null,
+          skip_video_folder: settingsData.skip_video_folder ?? null,
         };
         setSettings(loadedSettings);
         setOriginalSettings(loadedSettings);
@@ -242,7 +248,8 @@ function ChannelSettingsDialog({
           max_duration: settings.max_duration,
           title_filter_regex: settings.title_filter_regex || null,
           audio_format: settings.audio_format || null,
-          default_rating: settings.default_rating || null
+          default_rating: settings.default_rating || null,
+          skip_video_folder: settings.skip_video_folder
         })
       });
 
@@ -274,6 +281,7 @@ function ChannelSettingsDialog({
         default_rating: result?.settings && Object.prototype.hasOwnProperty.call(result.settings, 'default_rating')
           ? result.settings.default_rating
           : settings.default_rating ?? null,
+        skip_video_folder: result?.settings?.skip_video_folder ?? settings.skip_video_folder ?? null,
       };
 
       setSettings(updatedSettings);
@@ -313,7 +321,8 @@ function ChannelSettingsDialog({
            settings.max_duration !== originalSettings.max_duration ||
            settings.title_filter_regex !== originalSettings.title_filter_regex ||
           settings.audio_format !== originalSettings.audio_format ||
-          settings.default_rating !== originalSettings.default_rating;
+          settings.default_rating !== originalSettings.default_rating ||
+          settings.skip_video_folder !== originalSettings.skip_video_folder;
   };
 
   const handlePreviewFilter = async () => {
@@ -460,6 +469,24 @@ function ChannelSettingsDialog({
                 MP3 files are saved at 192kbps in the same folder as videos.
               </Typography>
             )}
+
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={!!settings.skip_video_folder}
+                  onChange={(e) => setSettings({
+                    ...settings,
+                    skip_video_folder: e.target.checked ? true : null
+                  })}
+                  color="primary"
+                />
+              }
+              label="Flat file structure (no video subfolders)"
+              sx={{ mt: 1 }}
+            />
+            <Typography variant="caption" color="text.secondary" sx={{ mt: -1, mb: 1 }}>
+              When enabled, video files are saved directly in the channel folder instead of individual video subfolders. Only affects new downloads.
+            </Typography>
 
             <Alert severity="info" sx={{ mb: 2 }}>
               <Typography variant="body2" sx={{ fontWeight: 'bold', mb: 1 }}>

--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -192,7 +192,8 @@ function ChannelSettingsDialog({
             ? settingsData.default_rating
             : null,
           skip_video_folder: Object.prototype.hasOwnProperty.call(settingsData, 'skip_video_folder')
-            ? settingsData.skip_video_folder : null,
+            ? settingsData.skip_video_folder
+            : null,
         };
         setSettings(loadedSettings);
         setOriginalSettings(loadedSettings);

--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -191,7 +191,8 @@ function ChannelSettingsDialog({
           default_rating: Object.prototype.hasOwnProperty.call(settingsData, 'default_rating')
             ? settingsData.default_rating
             : null,
-          skip_video_folder: settingsData.skip_video_folder ?? null,
+          skip_video_folder: Object.prototype.hasOwnProperty.call(settingsData, 'skip_video_folder')
+            ? settingsData.skip_video_folder : null,
         };
         setSettings(loadedSettings);
         setOriginalSettings(loadedSettings);
@@ -281,7 +282,9 @@ function ChannelSettingsDialog({
         default_rating: result?.settings && Object.prototype.hasOwnProperty.call(result.settings, 'default_rating')
           ? result.settings.default_rating
           : settings.default_rating ?? null,
-        skip_video_folder: result?.settings?.skip_video_folder ?? settings.skip_video_folder ?? null,
+        skip_video_folder: result?.settings && Object.prototype.hasOwnProperty.call(result.settings, 'skip_video_folder')
+          ? result.settings.skip_video_folder
+          : settings.skip_video_folder ?? null,
       };
 
       setSettings(updatedSettings);

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -390,6 +390,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
           subfolder: settings.subfolder,
           audioFormat: settings.audioFormat,
           rating: settings.rating,
+          skipVideoFolder: settings.skipVideoFolder,
         }
       : undefined;
 

--- a/client/src/components/ChannelPage/__tests__/ChannelSettingsDialog.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelSettingsDialog.test.tsx
@@ -1413,14 +1413,15 @@ describe('ChannelSettingsDialog', () => {
       await user.click(saveButton);
 
       // Verify the PUT call includes skip_video_folder: true
+      let putCall: any[];
       await waitFor(() => {
-        const putCall = mockFetch.mock.calls.find(
+        putCall = mockFetch.mock.calls.find(
           (call: any[]) => call[0] === '/api/channels/channel123/settings' && call[1]?.method === 'PUT'
         );
         expect(putCall).toBeDefined();
-        const body = JSON.parse(putCall![1].body);
-        expect(body.skip_video_folder).toBe(true);
       });
+      const body = JSON.parse(putCall![1].body);
+      expect(body.skip_video_folder).toBe(true);
     });
 
     test('loads skip_video_folder true from server and shows toggle checked', async () => {

--- a/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
@@ -80,6 +80,7 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
   const [hasUserInteracted, setHasUserInteracted] = useState(false);
   const [subfolderOverride, setSubfolderOverride] = useState<string | null>(null);
   const [audioFormat, setAudioFormat] = useState<string | null>(defaultAudioFormat);
+  const [skipVideoFolder, setSkipVideoFolder] = useState(false);
 
   // Fetch available subfolders
   const { subfolders, loading: subfoldersLoading } = useSubfolders(token);
@@ -123,6 +124,7 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
       setSubfolderOverride(null);
       setAudioFormat(defaultAudioFormat);
       setRating(defaultRating ?? null);
+      setSkipVideoFolder(false);
     }
   }, [open, defaultAudioFormat]);
 
@@ -196,7 +198,8 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
     // Include subfolder override if set (only for manual mode)
     const hasOverride = useCustomSettings || allowRedownload ||
       (mode === 'manual' && subfolderOverride !== null) ||
-      (mode === 'manual' && audioFormat !== null);
+      (mode === 'manual' && audioFormat !== null) ||
+      (mode === 'manual' && skipVideoFolder);
 
     if (hasOverride) {
       onConfirm({
@@ -207,7 +210,8 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
         audioFormat: mode === 'manual' ? audioFormat : undefined,
         // Include rating only if custom settings are enabled (user explicitly selected it)
         // Use an explicit sentinel 'NR' when the user selected "No Rating" (null)
-        rating: useCustomSettings ? (rating === null ? 'NR' : (rating ?? undefined)) : undefined
+        rating: useCustomSettings ? (rating === null ? 'NR' : (rating ?? undefined)) : undefined,
+        skipVideoFolder: mode === 'manual' ? skipVideoFolder : undefined
       });
     } else {
       onConfirm(null); // Use defaults - post-processor will apply channel default rating
@@ -507,6 +511,24 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
                       <MenuItem value="TV-MA"><RatingBadge rating="TV-MA" size="small" sx={{ mr: 1 }} /> TV-MA</MenuItem>
                     </Select>
                   </FormControl>
+
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={skipVideoFolder}
+                        onChange={(e) => {
+                          setSkipVideoFolder(e.target.checked);
+                          setHasUserInteracted(true);
+                        }}
+                        color="primary"
+                      />
+                    }
+                    label="Flat file structure (no video subfolders)"
+                    sx={{ mb: 1 }}
+                  />
+                  <Typography variant="caption" color="text.secondary" sx={{ mb: 2, display: 'block' }}>
+                    Save files directly in the channel folder instead of individual video subfolders.
+                  </Typography>
                 </>
               )}
             </Box>

--- a/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
@@ -132,12 +132,14 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
     const checked = event.target.checked;
     setUseCustomSettings(checked);
     setHasUserInteracted(true);
-    // When enabling custom settings, if rating is not set, initialize to channel/defaultRating
-    if (checked && (rating === null || rating === undefined)) {
-      // defaultRating prop may be undefined in some usages
-      // prefer to leave null if no defaultRating available
-      if (typeof defaultRating !== 'undefined' && defaultRating !== null) {
-        setRating(defaultRating);
+    if (checked) {
+      // When enabling custom settings, if rating is not set, initialize to channel/defaultRating
+      if (rating === null || rating === undefined) {
+        // defaultRating prop may be undefined in some usages
+        // prefer to leave null if no defaultRating available
+        if (typeof defaultRating !== 'undefined' && defaultRating !== null) {
+          setRating(defaultRating);
+        }
       }
     }
   };
@@ -198,8 +200,7 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
     // Include subfolder override if set (only for manual mode)
     const hasOverride = useCustomSettings || allowRedownload ||
       (mode === 'manual' && subfolderOverride !== null) ||
-      (mode === 'manual' && audioFormat !== null) ||
-      (mode === 'manual' && skipVideoFolder);
+      (mode === 'manual' && audioFormat !== null);
 
     if (hasOverride) {
       onConfirm({
@@ -211,7 +212,7 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
         // Include rating only if custom settings are enabled (user explicitly selected it)
         // Use an explicit sentinel 'NR' when the user selected "No Rating" (null)
         rating: useCustomSettings ? (rating === null ? 'NR' : (rating ?? undefined)) : undefined,
-        skipVideoFolder: mode === 'manual' ? skipVideoFolder : undefined
+        skipVideoFolder: mode === 'manual' ? (useCustomSettings ? skipVideoFolder : false) : undefined
       });
     } else {
       onConfirm(null); // Use defaults - post-processor will apply channel default rating

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/DownloadSettingsDialog.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/DownloadSettingsDialog.test.tsx
@@ -826,27 +826,32 @@ describe('DownloadSettingsDialog', () => {
       );
     });
 
-    test('triggers override when only skipVideoFolder is toggled (no custom settings)', () => {
+    test('sends skipVideoFolder false when custom settings are disabled', () => {
       render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
 
       // Enable custom settings to access toggle
       const customToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
       fireEvent.click(customToggle);
 
-      // Toggle skipVideoFolder
+      // Toggle skipVideoFolder on
       const skipToggle = screen.getByRole('checkbox', { name: /Flat file structure/i });
       fireEvent.click(skipToggle);
+      expect(skipToggle).toBeChecked();
 
-      // Disable custom settings - skipVideoFolder should still trigger override
+      // Also enable re-download so hasOverride is true even with custom off
+      const redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
+      fireEvent.click(redownloadToggle);
+
+      // Disable custom settings
       fireEvent.click(customToggle);
 
       const confirmButton = screen.getByRole('button', { name: /Start Download/i });
       fireEvent.click(confirmButton);
 
-      // With skipVideoFolder true and mode manual, hasOverride should be true
+      // Payload should have skipVideoFolder: false when custom settings are off
       expect(mockOnConfirm).toHaveBeenCalledWith(
         expect.objectContaining({
-          skipVideoFolder: true,
+          skipVideoFolder: false,
         })
       );
     });

--- a/client/src/components/DownloadManager/ManualDownload/types.ts
+++ b/client/src/components/DownloadManager/ManualDownload/types.ts
@@ -18,6 +18,7 @@ export interface DownloadSettings {
   subfolder?: string | null;
   audioFormat?: string | null;
   rating?: string | null;
+  skipVideoFolder?: boolean;
 }
 
 export interface ValidationResponse {

--- a/client/src/hooks/useTriggerDownloads.ts
+++ b/client/src/hooks/useTriggerDownloads.ts
@@ -6,6 +6,7 @@ interface DownloadOverrideSettings {
   subfolder?: string | null;
   audioFormat?: string | null;
   rating?: string | null;
+  skipVideoFolder?: boolean;
 }
 
 interface TriggerDownloadsParams {
@@ -43,7 +44,8 @@ export function useTriggerDownloads(token: string | null): UseTriggerDownloadsRe
             allowRedownload: overrideSettings.allowRedownload,
             subfolder: overrideSettings.subfolder,
             audioFormat: overrideSettings.audioFormat,
-            rating: overrideSettings.rating
+            rating: overrideSettings.rating,
+            skipVideoFolder: overrideSettings.skipVideoFolder
           };
         }
 

--- a/docs/API_INTEGRATION.md
+++ b/docs/API_INTEGRATION.md
@@ -81,7 +81,8 @@ Add a single YouTube video to the download queue.
 {
   "url": "https://www.youtube.com/watch?v=VIDEO_ID",
   "resolution": "1080",
-  "subfolder": "Movies"
+  "subfolder": "Movies",
+  "skipVideoFolder": true
 }
 ```
 
@@ -90,6 +91,7 @@ Add a single YouTube video to the download queue.
 | `url` | Yes | string | YouTube video URL |
 | `resolution` | No | string | Override resolution (360, 480, 720, 1080, 1440, 2160) |
 | `subfolder` | No | string | Override download subfolder |
+| `skipVideoFolder` | No | boolean | When `true`, download files directly into the channel folder without creating a video subfolder |
 
 **Success Response (200):**
 ```json

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -27,9 +27,9 @@ Download specific YouTube videos manually without subscribing to channels.
    - Repeat for each video you want to queue
    - Every URL is validated and previewed with video metadata before it is added
 
-3. **Customize resolution settings** (optional)
-   - Choose a specific resolution for this download
-   - Or leave it at the default to use your global quality setting
+3. **Customize download settings** (optional)
+   - Choose a specific resolution for this download, or leave it at the default to use your global quality setting
+   - Enable **Flat file structure (no video subfolders)** to download files directly into the channel folder without creating individual video subfolders
 
 4. **Click "Start Download"**
    - The download will begin immediately
@@ -61,6 +61,7 @@ Subscribe to YouTube channels to automatically download new videos as they're pu
    - Click the settings icon (gear) to access channel settings:
      - **Custom subfolder**: Organize channels into separate media libraries (e.g., `__kids`, `__music`)
      - **Quality override**: Set a channel-specific resolution preference that overrides the global setting
+     - **Flat file structure**: Download videos directly into the channel folder without individual video subfolders (see [Folder Structure](YOUTARR_DOWNLOADS_FOLDER_STRUCTURE.md))
      - **Auto-download controls**: Enable/disable automatic downloads separately for:
        - `Videos`
        - `Shorts`

--- a/docs/YOUTARR_DOWNLOADS_FOLDER_STRUCTURE.md
+++ b/docs/YOUTARR_DOWNLOADS_FOLDER_STRUCTURE.md
@@ -2,7 +2,7 @@
 
 Youtarr downloads videos into folders named for the channel they came from.
 Channels can be configured in the web UI to place the channel folder into a subfolder, which will be prefixed with `__` to allow grouping channels together. This allows you to setup different libraries in your media server of choice for different channel groups.
-In each channel folder videos will be placed into their own subfolders with associated metadata files.
+By default, videos in each channel folder are placed into their own subfolders with associated metadata files. This can be changed to a flat file structure on a per-channel basis (see below).
 
 ### Expected Default Layout
 
@@ -38,4 +38,37 @@ YouTube Downloads/
 │       └── [videos]
 └── Regular Channel/                               # Channel with no subfolder setting
     └── [videos]
+```
+
+## Layout For Channels with Flat File Structure (No Video Subfolders)
+
+Channels can be configured to use a flat file structure, where video files are placed directly in the channel folder instead of individual video subfolders. This is a per-channel setting configured in the channel settings dialog ("Flat file structure (no video subfolders)") and only affects new downloads.
+
+The same option is available as a one-time override in the manual download settings dialog.
+
+```
+<YOUTUBE_OUTPUT_DIR>/
+├── Channel Name/
+│   ├── poster.jpg                             # Channel poster
+│   ├── Channel - Video [id].mp4              # Video file
+│   ├── Channel - Video [id].nfo              # Video metadata
+│   ├── Channel - Video [id].[lang].srt       # Subtitle file(s)
+│   ├── Channel - Video [id].jpg              # Video thumbnail
+│   ├── Channel - Another Video [id].mp4
+│   ├── Channel - Another Video [id].nfo
+│   ├── Channel - Another Video [id].[lang].srt
+│   └── Channel - Another Video [id].jpg
+```
+
+This also works in combination with subfolder settings:
+
+```
+YouTube Downloads/
+├── __Kids/
+│   └── Channel Name/                              # Flat structure + subfolder
+│       ├── poster.jpg
+│       ├── Channel - Video [id].mp4
+│       ├── Channel - Video [id].nfo
+│       ├── Channel - Video [id].[lang].srt
+│       └── Channel - Video [id].jpg
 ```

--- a/migrations/20260222034147-add-skip-video-folder-to-channels.js
+++ b/migrations/20260222034147-add-skip-video-folder-to-channels.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('channels', 'skip_video_folder', {
+      type: Sequelize.BOOLEAN,
+      allowNull: true,
+      defaultValue: null,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('channels', 'skip_video_folder');
+  }
+};

--- a/migrations/20260222034147-add-skip-video-folder-to-channels.js
+++ b/migrations/20260222034147-add-skip-video-folder-to-channels.js
@@ -7,6 +7,7 @@ module.exports = {
       type: Sequelize.BOOLEAN,
       allowNull: true,
       defaultValue: null,
+      comment: 'When true, videos are stored directly in the channel folder without per-video subfolders',
     });
   },
 

--- a/server/models/channel.js
+++ b/server/models/channel.js
@@ -92,6 +92,11 @@ Channel.init(
       defaultValue: null,
       comment: 'Default rating to apply to unrated videos in this channel',
     },
+    skip_video_folder: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     sequelize,

--- a/server/models/channel.js
+++ b/server/models/channel.js
@@ -96,6 +96,7 @@ Channel.init(
       type: DataTypes.BOOLEAN,
       allowNull: true,
       defaultValue: null,
+      comment: 'When true, videos are stored directly in the channel folder without per-video subfolders',
     },
   },
   {

--- a/server/modules/__tests__/channelDownloadGrouper.test.js
+++ b/server/modules/__tests__/channelDownloadGrouper.test.js
@@ -61,14 +61,14 @@ describe('ChannelDownloadGrouper', () => {
         const filterConfig = new ChannelFilterConfig(300, 3600, 'test.*regex');
         const key = filterConfig.buildFilterKey();
 
-        expect(key).toBe('{"min":300,"max":3600,"regex":"test.*regex","audio":null}');
+        expect(key).toBe('{"min":300,"max":3600,"regex":"test.*regex","audio":null,"skipVF":false}');
       });
 
       it('should build unique key with null values', () => {
         const filterConfig = new ChannelFilterConfig(null, null, null);
         const key = filterConfig.buildFilterKey();
 
-        expect(key).toBe('{"min":null,"max":null,"regex":null,"audio":null}');
+        expect(key).toBe('{"min":null,"max":null,"regex":null,"audio":null,"skipVF":false}');
       });
 
       it('should build different keys for different filters', () => {
@@ -194,7 +194,8 @@ describe('ChannelDownloadGrouper', () => {
           'min_duration',
           'max_duration',
           'title_filter_regex',
-          'audio_format'
+          'audio_format',
+          'skip_video_folder'
         ]
       });
       expect(result).toEqual(mockChannels);

--- a/server/modules/__tests__/channelDownloadGrouper.test.js
+++ b/server/modules/__tests__/channelDownloadGrouper.test.js
@@ -86,35 +86,35 @@ describe('ChannelDownloadGrouper', () => {
       });
     });
 
-    describe('hasFilters', () => {
+    describe('hasGroupingCriteria', () => {
       it('should return true when minDuration is set', () => {
         const filterConfig = new ChannelFilterConfig(300, null, null);
-        expect(filterConfig.hasFilters()).toBe(true);
+        expect(filterConfig.hasGroupingCriteria()).toBe(true);
       });
 
       it('should return true when maxDuration is set', () => {
         const filterConfig = new ChannelFilterConfig(null, 3600, null);
-        expect(filterConfig.hasFilters()).toBe(true);
+        expect(filterConfig.hasGroupingCriteria()).toBe(true);
       });
 
       it('should return true when titleFilterRegex is set', () => {
         const filterConfig = new ChannelFilterConfig(null, null, 'test');
-        expect(filterConfig.hasFilters()).toBe(true);
+        expect(filterConfig.hasGroupingCriteria()).toBe(true);
       });
 
       it('should return true when all filters are set', () => {
         const filterConfig = new ChannelFilterConfig(300, 3600, 'test');
-        expect(filterConfig.hasFilters()).toBe(true);
+        expect(filterConfig.hasGroupingCriteria()).toBe(true);
       });
 
       it('should return false when no filters are set', () => {
         const filterConfig = new ChannelFilterConfig(null, null, null);
-        expect(filterConfig.hasFilters()).toBe(false);
+        expect(filterConfig.hasGroupingCriteria()).toBe(false);
       });
 
       it('should return false for default constructor', () => {
         const filterConfig = new ChannelFilterConfig();
-        expect(filterConfig.hasFilters()).toBe(false);
+        expect(filterConfig.hasGroupingCriteria()).toBe(false);
       });
     });
 

--- a/server/modules/__tests__/downloadModule.test.js
+++ b/server/modules/__tests__/downloadModule.test.js
@@ -360,7 +360,7 @@ describe('DownloadModule', () => {
             minDuration: 300,
             maxDuration: 3600,
             titleFilterRegex: null,
-            hasFilters: jest.fn().mockReturnValue(true)
+            hasGroupingCriteria: jest.fn().mockReturnValue(true)
           },
           channels: [{ channel_id: 'UC1' }]
         }
@@ -370,7 +370,7 @@ describe('DownloadModule', () => {
 
       await downloadModule.doChannelDownloads();
 
-      expect(groups[0].filterConfig.hasFilters).toHaveBeenCalled();
+      expect(groups[0].filterConfig.hasGroupingCriteria).toHaveBeenCalled();
       expect(spy).toHaveBeenCalledWith({}, groups, false);
     });
 
@@ -795,7 +795,7 @@ describe('DownloadModule', () => {
         minDuration: 300,
         maxDuration: 3600,
         titleFilterRegex: 'test.*',
-        hasFilters: jest.fn().mockReturnValue(true)
+        hasGroupingCriteria: jest.fn().mockReturnValue(true)
       };
       const group = {
         quality: '1080',

--- a/server/modules/__tests__/videoDeletionModule.test.js
+++ b/server/modules/__tests__/videoDeletionModule.test.js
@@ -24,7 +24,9 @@ describe('VideoDeletionModule', () => {
 
     // Mock fs.promises
     mockFs = {
-      rm: jest.fn()
+      rm: jest.fn(),
+      readdir: jest.fn().mockResolvedValue([]),
+      unlink: jest.fn()
     };
 
     // Mock the models
@@ -35,6 +37,12 @@ describe('VideoDeletionModule', () => {
     // Mock fs
     jest.doMock('fs', () => ({
       promises: mockFs
+    }));
+
+    // Mock the filesystem module (isVideoDirectory)
+    // Default to true (nested structure) for backwards compatibility with existing tests
+    jest.doMock('../filesystem', () => ({
+      isVideoDirectory: jest.fn(() => true)
     }));
 
     // Require the module after mocks are in place
@@ -147,7 +155,7 @@ describe('VideoDeletionModule', () => {
       expect(result).toEqual({
         success: false,
         videoId: 1,
-        error: 'Safety check failed: invalid directory path'
+        error: 'Safety check failed: invalid file path'
       });
       expect(mockFs.rm).not.toHaveBeenCalled();
     });
@@ -171,7 +179,7 @@ describe('VideoDeletionModule', () => {
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({ videoId: 1 }),
-        'Directory already removed'
+        'Files already removed'
       );
       expect(mockVideoRecord.update).toHaveBeenCalledWith({ removed: true });
       expect(result).toEqual({
@@ -199,7 +207,7 @@ describe('VideoDeletionModule', () => {
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({ videoId: 1, err: permissionError }),
-        'Failed to delete directory'
+        'Failed to delete video files'
       );
       expect(result).toEqual({
         success: false,
@@ -402,7 +410,7 @@ describe('VideoDeletionModule', () => {
 
       expect(result.failed[0]).toEqual({
         videoId: 1,
-        error: 'Safety check failed: invalid directory path'
+        error: 'Safety check failed: invalid file path'
       });
     });
   });
@@ -537,7 +545,7 @@ describe('VideoDeletionModule', () => {
         failed: [
           {
             youtubeId: 'abc123',
-            error: 'Safety check failed: invalid directory path'
+            error: 'Safety check failed: invalid file path'
           }
         ]
       });

--- a/server/modules/channelDownloadGrouper.js
+++ b/server/modules/channelDownloadGrouper.js
@@ -7,11 +7,12 @@ const { buildOutputTemplate, buildThumbnailTemplate } = require('./filesystem');
  * Encapsulates channel filter settings for download filtering
  */
 class ChannelFilterConfig {
-  constructor(minDuration = null, maxDuration = null, titleFilterRegex = null, audioFormat = null) {
+  constructor(minDuration = null, maxDuration = null, titleFilterRegex = null, audioFormat = null, skipVideoFolder = false) {
     this.minDuration = minDuration;
     this.maxDuration = maxDuration;
     this.titleFilterRegex = titleFilterRegex;
     this.audioFormat = audioFormat;
+    this.skipVideoFolder = !!skipVideoFolder;
   }
 
   /**
@@ -25,7 +26,8 @@ class ChannelFilterConfig {
       min: this.minDuration,
       max: this.maxDuration,
       regex: this.titleFilterRegex,
-      audio: this.audioFormat
+      audio: this.audioFormat,
+      skipVF: this.skipVideoFolder
     });
   }
 
@@ -37,7 +39,8 @@ class ChannelFilterConfig {
     return this.minDuration !== null ||
            this.maxDuration !== null ||
            this.titleFilterRegex !== null ||
-           this.audioFormat !== null;
+           this.audioFormat !== null ||
+           this.skipVideoFolder;
   }
 
   /**
@@ -50,7 +53,8 @@ class ChannelFilterConfig {
       channel.min_duration,
       channel.max_duration,
       channel.title_filter_regex,
-      channel.audio_format
+      channel.audio_format,
+      channel.skip_video_folder
     );
   }
 }
@@ -76,7 +80,8 @@ class ChannelDownloadGrouper {
         'min_duration',
         'max_duration',
         'title_filter_regex',
-        'audio_format'
+        'audio_format',
+        'skip_video_folder'
       ]
     });
 

--- a/server/modules/channelDownloadGrouper.js
+++ b/server/modules/channelDownloadGrouper.js
@@ -40,6 +40,8 @@ class ChannelFilterConfig {
            this.maxDuration !== null ||
            this.titleFilterRegex !== null ||
            this.audioFormat !== null ||
+           // skipVideoFolder affects download path structure, so channels with
+           // different settings must be in separate download groups
            this.skipVideoFolder;
   }
 

--- a/server/modules/channelDownloadGrouper.js
+++ b/server/modules/channelDownloadGrouper.js
@@ -32,10 +32,12 @@ class ChannelFilterConfig {
   }
 
   /**
-   * Check if any filters are set
-   * @returns {boolean} - True if at least one filter is configured
+   * Check if any grouping criteria (filters or structural settings) are set.
+   * Includes duration/title filters and structural options like skipVideoFolder
+   * that affect how downloads are organized on disk.
+   * @returns {boolean} - True if at least one criterion is configured
    */
-  hasFilters() {
+  hasGroupingCriteria() {
     return this.minDuration !== null ||
            this.maxDuration !== null ||
            this.titleFilterRegex !== null ||

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -274,6 +274,18 @@ class ChannelSettingsModule {
   }
 
   /**
+   * Validate skip_video_folder setting
+   * @param {boolean|null} value - Skip video folder setting to validate
+   * @returns {Object} - { valid: boolean, error?: string }
+   */
+  validateSkipVideoFolder(value) {
+    if (value === null || value === undefined || value === true || value === false) {
+      return { valid: true };
+    }
+    return { valid: false, error: 'skip_video_folder must be true, false, or null' };
+  }
+
+  /**
    * Get the full directory path for a channel, including subfolder if set
    * @param {Object} channel - Channel database record
    * @returns {string} - Full directory path
@@ -497,6 +509,7 @@ class ChannelSettingsModule {
       title_filter_regex: channel.title_filter_regex,
       audio_format: channel.audio_format,
       default_rating: channel.default_rating,
+      skip_video_folder: channel.skip_video_folder,
     };
   }
 
@@ -585,6 +598,14 @@ class ChannelSettingsModule {
       }
     }
 
+    // Validate skip_video_folder if provided
+    if (settings.skip_video_folder !== undefined) {
+      const validation = this.validateSkipVideoFolder(settings.skip_video_folder);
+      if (!validation.valid) {
+        throw new Error(validation.error);
+      }
+    }
+
     // Store old subfolder for potential move
     const oldSubFolder = channel.sub_folder;
     const newSubFolder = settings.sub_folder !== undefined ?
@@ -620,6 +641,9 @@ class ChannelSettingsModule {
     }
     if (settings.audio_format !== undefined) {
       updateData.audio_format = settings.audio_format;
+    }
+    if (settings.skip_video_folder !== undefined) {
+      updateData.skip_video_folder = settings.skip_video_folder;
     }
 
     // Update database FIRST to ensure changes are persisted before slow file operations
@@ -667,6 +691,7 @@ class ChannelSettingsModule {
         title_filter_regex: updatedChannel.title_filter_regex,
         audio_format: updatedChannel.audio_format,
         default_rating: updatedChannel.default_rating,
+        skip_video_folder: updatedChannel.skip_video_folder,
       },
       folderMoved: subFolderChanged,
       moveResult

--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -383,21 +383,21 @@ describe('YtdlpCommandBuilder', () => {
       expect(result).toBe('availability!=subscriber_only & !is_live & live_status!=is_upcoming');
     });
 
-    it('should return base filters when filterConfig.hasFilters is false', () => {
-      const filterConfig = { hasFilters: false };
+    it('should return base filters when filterConfig.hasGroupingCriteria is false', () => {
+      const filterConfig = { hasGroupingCriteria: false };
       const result = YtdlpCommandBuilder.buildMatchFilters(filterConfig);
       expect(result).toBe('availability!=subscriber_only & !is_live & live_status!=is_upcoming');
     });
 
-    it('should return base filters when filterConfig.hasFilters() returns false', () => {
-      const filterConfig = { hasFilters: () => false };
+    it('should return base filters when filterConfig.hasGroupingCriteria() returns false', () => {
+      const filterConfig = { hasGroupingCriteria: () => false };
       const result = YtdlpCommandBuilder.buildMatchFilters(filterConfig);
       expect(result).toBe('availability!=subscriber_only & !is_live & live_status!=is_upcoming');
     });
 
     it('should add minimum duration filter when specified', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         minDuration: 300 // 5 minutes
       };
       const result = YtdlpCommandBuilder.buildMatchFilters(filterConfig);
@@ -406,7 +406,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should add maximum duration filter when specified', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         maxDuration: 600 // 10 minutes
       };
       const result = YtdlpCommandBuilder.buildMatchFilters(filterConfig);
@@ -416,7 +416,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should add both min and max duration filters when specified', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         minDuration: 60, // 1 minute
         maxDuration: 1800 // 30 minutes
       };
@@ -426,7 +426,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should add title regex filter when specified', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         titleFilterRegex: 'tutorial'
       };
       const result = YtdlpCommandBuilder.buildMatchFilters(filterConfig);
@@ -435,7 +435,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should escape backslashes in title regex', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         titleFilterRegex: '\\d+' // Match one or more digits
       };
       const result = YtdlpCommandBuilder.buildMatchFilters(filterConfig);
@@ -444,7 +444,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should escape single quotes in title regex', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         titleFilterRegex: 'Let\'s Go'
       };
       const result = YtdlpCommandBuilder.buildMatchFilters(filterConfig);
@@ -453,7 +453,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should escape both backslashes and quotes in complex regex', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         titleFilterRegex: 'Part \\d+: It\'s Here'
       };
       const result = YtdlpCommandBuilder.buildMatchFilters(filterConfig);
@@ -462,7 +462,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should combine all filters when specified', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         minDuration: 120,
         maxDuration: 900,
         titleFilterRegex: 'review'
@@ -473,7 +473,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should handle zero as minimum duration', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         minDuration: 0
       };
       const result = YtdlpCommandBuilder.buildMatchFilters(filterConfig);
@@ -482,7 +482,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should handle zero as maximum duration', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         maxDuration: 0
       };
       const result = YtdlpCommandBuilder.buildMatchFilters(filterConfig);
@@ -491,7 +491,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should ignore null minimum duration', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         minDuration: null,
         maxDuration: 600
       };
@@ -501,7 +501,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should ignore undefined maximum duration', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         minDuration: 180,
         maxDuration: undefined
       };
@@ -511,7 +511,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should handle empty string title regex as no filter', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         titleFilterRegex: '',
         minDuration: 60
       };
@@ -712,7 +712,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should apply filterConfig with minimum duration', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         minDuration: 300
       };
       const result = YtdlpCommandBuilder.getBaseCommandArgs('1080', false, null, filterConfig);
@@ -722,7 +722,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should apply filterConfig with maximum duration', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         maxDuration: 900
       };
       const result = YtdlpCommandBuilder.getBaseCommandArgs('1080', false, null, filterConfig);
@@ -732,7 +732,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should apply filterConfig with title regex', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         titleFilterRegex: 'gameplay'
       };
       const result = YtdlpCommandBuilder.getBaseCommandArgs('1080', false, null, filterConfig);
@@ -742,7 +742,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should apply filterConfig with all filters combined', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         minDuration: 60,
         maxDuration: 600,
         titleFilterRegex: 'tutorial'
@@ -754,7 +754,7 @@ describe('YtdlpCommandBuilder', () => {
 
     it('should work with subfolder and filterConfig together', () => {
       const filterConfig = {
-        hasFilters: true,
+        hasGroupingCriteria: true,
         minDuration: 120
       };
       const result = YtdlpCommandBuilder.getBaseCommandArgs('1080', false, 'MyChannel', filterConfig);

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -155,6 +155,8 @@ class DownloadExecutor {
 
               const dirFiles = await fsPromises.readdir(dirPath);
               for (const fileName of dirFiles) {
+                // Match files by YouTube ID: bracketed form [ID] is the yt-dlp default;
+                // dash form " - ID" is a fallback for non-standard naming patterns
                 if (fileName.includes(`[${youtubeId}]`) || fileName.includes(` - ${youtubeId}`)) {
                   const fullPath = path.join(dirPath, fileName);
                   try {

--- a/server/modules/download/ytdlpCommandBuilder.js
+++ b/server/modules/download/ytdlpCommandBuilder.js
@@ -328,9 +328,9 @@ class YtdlpCommandBuilder {
     // If no filter config provided or no filters set, return base filters only
     if (
       !filterConfig ||
-      !filterConfig.hasFilters ||
-      (typeof filterConfig.hasFilters === 'function' &&
-        !filterConfig.hasFilters())
+      !filterConfig.hasGroupingCriteria ||
+      (typeof filterConfig.hasGroupingCriteria === 'function' &&
+        !filterConfig.hasGroupingCriteria())
     ) {
       return baseFilters.join(' & ');
     }

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -103,7 +103,7 @@ class DownloadModule {
         groups.length > 1 ||
         groups.some((g) => g.subFolder !== null) ||
         groups.some((g) => g.quality !== effectiveGlobalQuality) ||
-        groups.some((g) => g.filterConfig && g.filterConfig.hasFilters && g.filterConfig.hasFilters());
+        groups.some((g) => g.filterConfig && g.filterConfig.hasGroupingCriteria && g.filterConfig.hasGroupingCriteria());
 
       if (needsGrouping) {
         console.log(`Using grouped downloads: ${groups.length} group(s) with resolved settings`);

--- a/server/modules/videoDeletionModule.js
+++ b/server/modules/videoDeletionModule.js
@@ -12,7 +12,6 @@ class VideoDeletionModule {
    * In nested mode, the parent directory name ends with " - <youtubeId>"
    * In flat mode, the video file sits directly in the channel folder
    * @param {string} filePath - Full path to the video file
-   * @param {string} youtubeId - YouTube video ID
    * @returns {boolean} - True if flat structure
    */
   isFlat(filePath) {
@@ -102,6 +101,8 @@ class VideoDeletionModule {
           logger.info({ videoId, videoDirectory, youtubeId: video.youtubeId }, 'Flat structure detected, deleting individual files');
           const files = await fs.readdir(videoDirectory);
           for (const file of files) {
+            // Match files by YouTube ID: bracketed form [ID] is the yt-dlp default;
+            // dash form " - ID" is a fallback for non-standard naming patterns
             if (file.includes(`[${video.youtubeId}]`) || file.includes(` - ${video.youtubeId}`)) {
               const fullPath = path.join(videoDirectory, file);
               try {

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -543,7 +543,11 @@ async function copyChannelPosterIfNeeded(channelId, channelFolderPath) {
 
         if (isFlatMode) {
           // Flat mode: move individual files from temp channel folder to final channel folder
-          const updatedFilesInDir = await fs.readdir(videoDirectory);
+          // Filter by video ID to avoid moving files belonging to other downloads
+          const allFilesInDir = await fs.readdir(videoDirectory);
+          const updatedFilesInDir = allFilesInDir.filter(
+            file => file.includes(`[${id}]`)
+          );
           for (const file of updatedFilesInDir) {
             const srcPath = path.join(videoDirectory, file);
             const destPath = path.join(targetVideoDirectory, file);

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -545,8 +545,9 @@ async function copyChannelPosterIfNeeded(channelId, channelFolderPath) {
           // Flat mode: move individual files from temp channel folder to final channel folder
           // Filter by video ID to avoid moving files belonging to other downloads
           const allFilesInDir = await fs.readdir(videoDirectory);
+          // Bracketed form [ID] is the yt-dlp default; dash form " - ID" is a fallback
           const updatedFilesInDir = allFilesInDir.filter(
-            file => file.includes(`[${id}]`)
+            file => file.includes(`[${id}]`) || file.includes(` - ${id}`)
           );
           for (const file of updatedFilesInDir) {
             const srcPath = path.join(videoDirectory, file);

--- a/server/routes/videos.js
+++ b/server/routes/videos.js
@@ -663,6 +663,13 @@ module.exports = function createVideoRoutes({ verifyToken, videosModule, downloa
           });
         }
       }
+
+      // Validate skipVideoFolder if provided
+      if (overrideSettings.skipVideoFolder !== undefined && typeof overrideSettings.skipVideoFolder !== 'boolean') {
+        return res.status(400).json({
+          error: 'skipVideoFolder must be a boolean'
+        });
+      }
     }
 
     downloadModule.doSpecificDownloads(req);


### PR DESCRIPTION
- Add "Flat file structure (no video subfolders)" toggle to channel settings dialog and manual download settings dialog
- Add skip_video_folder column to channels table via migration
- Update yt-dlp command builder to omit video subfolder level in output/thumbnail paths when enabled
- Update post-processor to move individual files instead of entire directories in flat mode
- Update video deletion to remove matching files individually instead of deleting the parent directory
- Update download executor cleanup to handle flat-mode in-progress files
- Plumb skipVideoFolder through channel download grouper, download module, and API route with validation
- Add skipVideoFolder to the manual download API override settings
- Document flat file structure in folder structure, usage guide, and API integration docs
- Add tests for channel settings toggle, download settings toggle, download module, and deletion module

<img width="723" height="151" alt="image" src="https://github.com/user-attachments/assets/7f03d97f-6b53-497f-b435-8a9ad88d5f99" />
