### PR TITLE
fix: yt-dlp update failure when run as non-root user (#451)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Download the latest yt-dlp release directly from GitHub
-RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp && \
-    chmod +x /usr/local/bin/yt-dlp
+# Download the latest yt-dlp release to a dedicated writable directory
+# so non-root users (YOUTARR_UID/YOUTARR_GID) can self-update at runtime
+RUN mkdir -p /opt/yt-dlp && \
+    curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /opt/yt-dlp/yt-dlp && \
+    chmod 0777 /opt/yt-dlp /opt/yt-dlp/yt-dlp
+ENV PATH="/opt/yt-dlp:${PATH}"
 
 # Install Deno
 ENV DENO_INSTALL="/usr/local"

--- a/server/modules/__tests__/ytdlpModule.test.js
+++ b/server/modules/__tests__/ytdlpModule.test.js
@@ -307,6 +307,20 @@ describe('ytdlpModule', () => {
       expect(result.message).toContain('Permission denied');
     });
 
+    it('handles "Unable to write to" permission error', async () => {
+      const mockProcess = createMockProcess();
+      spawn.mockReturnValue(mockProcess);
+
+      const updatePromise = ytdlpModule.performUpdate();
+
+      mockProcess.stderr.emit('data', 'Unable to write to /usr/local/bin/yt-dlp; try running as administrator');
+      mockProcess.emit('close', 100);
+
+      const result = await updatePromise;
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Permission denied');
+    });
+
     it('handles non-zero exit code', async () => {
       const mockProcess = createMockProcess();
       spawn.mockReturnValue(mockProcess);

--- a/server/modules/ytdlpModule.js
+++ b/server/modules/ytdlpModule.js
@@ -196,7 +196,7 @@ function performUpdate() {
       const output = stdout + stderr;
 
       if (code !== 0) {
-        if (output.includes('Permission denied')) {
+        if (output.includes('Permission denied') || output.includes('Unable to write to')) {
           logger.warn({ output }, 'yt-dlp update failed: permission denied');
           resolve({
             success: false,


### PR DESCRIPTION
- Move yt-dlp binary from /usr/local/bin/ to /opt/yt-dlp/ with world-writable permissions so non-root containers (YOUTARR_UID/GID) can perform self-updates
- Detect yt-dlp's "Unable to write to" error message in addition to "Permission denied" so users see the helpful platform-specific message instead of a generic exit code error
- Add test coverage