### PR TITLE
feat: auto-clean empty channel directories (#443)

### DIFF
--- a/server/modules/__tests__/videoDeletionModule.test.js
+++ b/server/modules/__tests__/videoDeletionModule.test.js
@@ -39,10 +39,17 @@ describe('VideoDeletionModule', () => {
       promises: mockFs
     }));
 
-    // Mock the filesystem module (isVideoDirectory)
+    // Mock the filesystem module (isVideoDirectory, cleanupEmptyChannelDirectory, cleanupEmptyParents)
     // Default to true (nested structure) for backwards compatibility with existing tests
     jest.doMock('../filesystem', () => ({
-      isVideoDirectory: jest.fn(() => true)
+      isVideoDirectory: jest.fn(() => true),
+      cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false),
+      cleanupEmptyParents: jest.fn().mockResolvedValue()
+    }));
+
+    // Mock configModule for _tryCleanupChannelDirectory
+    jest.doMock('../configModule', () => ({
+      directoryPath: '/test/output'
     }));
 
     // Require the module after mocks are in place
@@ -267,6 +274,158 @@ describe('VideoDeletionModule', () => {
         videoId: 1,
         error: 'Unknown error occurred'
       });
+    });
+  });
+
+  describe('_tryCleanupChannelDirectory', () => {
+    let mockFilesystem;
+
+    beforeEach(() => {
+      mockFilesystem = require('../filesystem');
+    });
+
+    test('should call cleanupEmptyChannelDirectory with grandparent path for nested deletion', async () => {
+      const mockVideoRecord = {
+        id: 1,
+        youtubeId: 'abc123',
+        filePath: '/test/output/Channel Name/Channel Name - Video Title - abc123/video.mp4',
+        removed: false,
+        update: jest.fn().mockResolvedValue()
+      };
+
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+      mockFs.rm.mockResolvedValue();
+
+      await VideoDeletionModule.deleteVideoById(1);
+
+      expect(mockFilesystem.cleanupEmptyChannelDirectory).toHaveBeenCalledWith(
+        '/test/output/Channel Name',
+        '/test/output',
+        { includeIgnorableFiles: true }
+      );
+    });
+
+    test('should call cleanupEmptyChannelDirectory with parent path for flat deletion', async () => {
+      // Override isVideoDirectory to return false for flat mode
+      mockFilesystem.isVideoDirectory.mockReturnValue(false);
+
+      const mockVideoRecord = {
+        id: 1,
+        youtubeId: 'abc123',
+        filePath: '/test/output/Channel Name/Channel Name - Video Title [abc123].mp4',
+        removed: false,
+        update: jest.fn().mockResolvedValue()
+      };
+
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+      mockFs.readdir.mockResolvedValue([]);
+
+      await VideoDeletionModule.deleteVideoById(1);
+
+      expect(mockFilesystem.cleanupEmptyChannelDirectory).toHaveBeenCalledWith(
+        '/test/output/Channel Name',
+        '/test/output',
+        { includeIgnorableFiles: true }
+      );
+    });
+
+    test('should NOT call cleanup when video has no filePath', async () => {
+      const mockVideoRecord = {
+        id: 1,
+        youtubeId: 'abc123',
+        filePath: null,
+        removed: false,
+        update: jest.fn().mockResolvedValue()
+      };
+
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+
+      await VideoDeletionModule.deleteVideoById(1);
+
+      expect(mockFilesystem.cleanupEmptyChannelDirectory).not.toHaveBeenCalled();
+    });
+
+    test('should NOT call cleanup when file deletion fails', async () => {
+      const mockVideoRecord = {
+        id: 1,
+        youtubeId: 'abc123',
+        filePath: '/test/output/Channel/Channel - Video - abc123/video.mp4',
+        removed: false
+      };
+
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+
+      const permissionError = new Error('EACCES');
+      permissionError.code = 'EACCES';
+      mockFs.rm.mockRejectedValue(permissionError);
+
+      await VideoDeletionModule.deleteVideoById(1);
+
+      expect(mockFilesystem.cleanupEmptyChannelDirectory).not.toHaveBeenCalled();
+    });
+
+    test('should not affect success response when cleanup throws', async () => {
+      mockFilesystem.cleanupEmptyChannelDirectory.mockRejectedValueOnce(new Error('cleanup failed'));
+
+      const mockVideoRecord = {
+        id: 1,
+        youtubeId: 'abc123',
+        filePath: '/test/output/Channel Name/Channel Name - Video Title - abc123/video.mp4',
+        removed: false,
+        update: jest.fn().mockResolvedValue()
+      };
+
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+      mockFs.rm.mockResolvedValue();
+
+      const result = await VideoDeletionModule.deleteVideoById(1);
+
+      expect(result.success).toBe(true);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ err: expect.any(Error) }),
+        expect.stringContaining('non-fatal')
+      );
+    });
+
+    test('should call cleanupEmptyParents when channel dir was removed', async () => {
+      mockFilesystem.cleanupEmptyChannelDirectory.mockResolvedValueOnce(true);
+
+      const mockVideoRecord = {
+        id: 1,
+        youtubeId: 'abc123',
+        filePath: '/test/output/__subfolder/Channel Name/Channel Name - Video Title - abc123/video.mp4',
+        removed: false,
+        update: jest.fn().mockResolvedValue()
+      };
+
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+      mockFs.rm.mockResolvedValue();
+
+      await VideoDeletionModule.deleteVideoById(1);
+
+      expect(mockFilesystem.cleanupEmptyParents).toHaveBeenCalledWith(
+        '/test/output/__subfolder',
+        '/test/output'
+      );
+    });
+
+    test('should NOT call cleanupEmptyParents when channel dir was not removed', async () => {
+      mockFilesystem.cleanupEmptyChannelDirectory.mockResolvedValueOnce(false);
+
+      const mockVideoRecord = {
+        id: 1,
+        youtubeId: 'abc123',
+        filePath: '/test/output/Channel Name/Channel Name - Video Title - abc123/video.mp4',
+        removed: false,
+        update: jest.fn().mockResolvedValue()
+      };
+
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+      mockFs.rm.mockResolvedValue();
+
+      await VideoDeletionModule.deleteVideoById(1);
+
+      expect(mockFilesystem.cleanupEmptyParents).not.toHaveBeenCalled();
     });
   });
 

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -86,7 +86,8 @@ jest.mock('../../filesystem', () => ({
   isMainVideoFile: jest.fn(),
   isVideoDirectory: jest.fn(),
   isChannelDirectory: jest.fn(),
-  isDirectoryEmpty: jest.fn()
+  isDirectoryEmpty: jest.fn(),
+  cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false)
 }));
 
 const DownloadExecutor = require('../downloadExecutor');

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -69,38 +69,9 @@ class DownloadExecutor {
   }
 
   // Helper function to remove a channel directory if it's empty
-  // This is called after removing a video directory to clean up empty channel folders
+  // Delegates to the shared directoryManager implementation
   async cleanupEmptyChannelDirectory(channelDir) {
-    const fsPromises = require('fs').promises;
-
-    try {
-      // Verify this is actually a channel directory (not root or subfolder)
-      if (!filesystem.isChannelDirectory(channelDir, configModule.directoryPath)) {
-        logger.debug({ channelDir }, 'Not a channel directory, skipping cleanup');
-        return;
-      }
-
-      // Check if directory exists
-      const exists = await fsPromises.access(channelDir).then(() => true).catch(() => false);
-      if (!exists) {
-        logger.debug({ channelDir }, 'Channel directory does not exist');
-        return;
-      }
-
-      // Check if directory is empty
-      const isEmpty = await filesystem.isDirectoryEmpty(channelDir);
-      if (!isEmpty) {
-        logger.debug({ channelDir }, 'Channel directory not empty, keeping it');
-        return;
-      }
-
-      // Remove empty channel directory
-      await fsPromises.rmdir(channelDir);
-      logger.info({ channelDir }, 'Removed empty channel directory');
-    } catch (error) {
-      logger.error({ err: error, channelDir }, 'Error cleaning up empty channel directory');
-      // Don't throw - this is a best-effort cleanup
-    }
+    await filesystem.cleanupEmptyChannelDirectory(channelDir, configModule.directoryPath);
   }
 
   // Cleanup function for in-progress videos based on database tracking

--- a/server/modules/filesystem/__tests__/constants.test.js
+++ b/server/modules/filesystem/__tests__/constants.test.js
@@ -9,7 +9,8 @@ const {
   YOUTUBE_ID_DASH_PATTERN,
   YOUTUBE_ID_PATTERN,
   MAIN_VIDEO_FILE_PATTERN,
-  FRAGMENT_FILE_PATTERN
+  FRAGMENT_FILE_PATTERN,
+  CHANNEL_CLEANUP_IGNORABLE_FILES
 } = require('../constants');
 
 describe('filesystem/constants', () => {
@@ -134,6 +135,16 @@ describe('filesystem/constants', () => {
 
     it('should not match main video files', () => {
       expect(FRAGMENT_FILE_PATTERN.test('Channel - Title [dQw4w9WgXcQ].mp4')).toBe(false);
+    });
+  });
+
+  describe('CHANNEL_CLEANUP_IGNORABLE_FILES', () => {
+    it('should exist and be an array', () => {
+      expect(Array.isArray(CHANNEL_CLEANUP_IGNORABLE_FILES)).toBe(true);
+    });
+
+    it('should contain poster.jpg', () => {
+      expect(CHANNEL_CLEANUP_IGNORABLE_FILES).toContain('poster.jpg');
     });
   });
 });

--- a/server/modules/filesystem/__tests__/directoryManager.test.js
+++ b/server/modules/filesystem/__tests__/directoryManager.test.js
@@ -8,7 +8,8 @@ jest.mock('fs', () => ({
   promises: {
     readdir: jest.fn(),
     rmdir: jest.fn(),
-    access: jest.fn()
+    access: jest.fn(),
+    unlink: jest.fn()
   }
 }));
 
@@ -25,6 +26,7 @@ const {
   ensureDirSync,
   ensureDirWithRetries,
   isDirectoryEmpty,
+  isDirectoryEffectivelyEmpty,
   removeIfEmpty,
   isVideoDirectory,
   isChannelDirectory,
@@ -149,6 +151,56 @@ describe('filesystem/directoryManager', () => {
     });
   });
 
+  describe('isDirectoryEffectivelyEmpty', () => {
+    it('should return true for truly empty directory', async () => {
+      fsPromises.readdir.mockResolvedValueOnce([]);
+
+      const result = await isDirectoryEffectivelyEmpty('/path/empty');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for directory containing only poster.jpg', async () => {
+      fsPromises.readdir.mockResolvedValueOnce(['poster.jpg']);
+
+      const result = await isDirectoryEffectivelyEmpty('/path/channel');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true with case-insensitive match (Poster.JPG)', async () => {
+      fsPromises.readdir.mockResolvedValueOnce(['Poster.JPG']);
+
+      const result = await isDirectoryEffectivelyEmpty('/path/channel');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when directory contains video files', async () => {
+      fsPromises.readdir.mockResolvedValueOnce(['poster.jpg', 'video.mp4']);
+
+      const result = await isDirectoryEffectivelyEmpty('/path/channel');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for non-existent directory', async () => {
+      fsPromises.readdir.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await isDirectoryEffectivelyEmpty('/path/missing');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when directory contains non-ignorable files only', async () => {
+      fsPromises.readdir.mockResolvedValueOnce(['Channel - Title - abc123']);
+
+      const result = await isDirectoryEffectivelyEmpty('/path/channel');
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe('removeIfEmpty', () => {
     it('should remove empty directory', async () => {
       fsPromises.readdir.mockResolvedValueOnce([]);
@@ -244,29 +296,100 @@ describe('filesystem/directoryManager', () => {
   describe('cleanupEmptyChannelDirectory', () => {
     const baseDir = '/videos';
 
-    it('should remove empty channel directory', async () => {
+    it('should remove empty channel directory and return true', async () => {
       fsPromises.access.mockResolvedValueOnce();
       fsPromises.readdir.mockResolvedValueOnce([]);
       fsPromises.rmdir.mockResolvedValueOnce();
 
-      await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir);
+      const result = await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir);
 
       expect(fsPromises.rmdir).toHaveBeenCalledWith('/videos/ChannelName');
+      expect(result).toBe(true);
     });
 
-    it('should not remove non-channel directory', async () => {
-      await cleanupEmptyChannelDirectory('/videos', baseDir);
+    it('should not remove non-channel directory and return false', async () => {
+      const result = await cleanupEmptyChannelDirectory('/videos', baseDir);
 
       expect(fsPromises.rmdir).not.toHaveBeenCalled();
+      expect(result).toBe(false);
     });
 
-    it('should not remove non-empty channel directory', async () => {
+    it('should not remove non-empty channel directory and return false', async () => {
       fsPromises.access.mockResolvedValueOnce();
       fsPromises.readdir.mockResolvedValueOnce(['video-folder']);
 
-      await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir);
+      const result = await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir);
 
       expect(fsPromises.rmdir).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('should return false when directory does not exist', async () => {
+      fsPromises.access.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir);
+
+      expect(fsPromises.rmdir).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    describe('with includeIgnorableFiles: true', () => {
+      it('should remove directory with only poster.jpg', async () => {
+        fsPromises.access.mockResolvedValueOnce();
+        // First readdir for isDirectoryEffectivelyEmpty
+        fsPromises.readdir.mockResolvedValueOnce(['poster.jpg']);
+        fsPromises.unlink.mockResolvedValueOnce();
+        // Second readdir for deleting ignorable files
+        fsPromises.readdir.mockResolvedValueOnce(['poster.jpg']);
+        fsPromises.rmdir.mockResolvedValueOnce();
+
+        const result = await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir, {
+          includeIgnorableFiles: true
+        });
+
+        expect(fsPromises.unlink).toHaveBeenCalledWith('/videos/ChannelName/poster.jpg');
+        expect(fsPromises.rmdir).toHaveBeenCalledWith('/videos/ChannelName');
+        expect(result).toBe(true);
+      });
+
+      it('should not remove directory with video files present', async () => {
+        fsPromises.access.mockResolvedValueOnce();
+        fsPromises.readdir.mockResolvedValueOnce(['poster.jpg', 'video.mp4']);
+
+        const result = await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir, {
+          includeIgnorableFiles: true
+        });
+
+        expect(fsPromises.rmdir).not.toHaveBeenCalled();
+        expect(result).toBe(false);
+      });
+
+      it('should remove truly empty directory', async () => {
+        fsPromises.access.mockResolvedValueOnce();
+        fsPromises.readdir.mockResolvedValueOnce([]);
+        // Second readdir for deleting ignorable files (empty, so no unlinking)
+        fsPromises.readdir.mockResolvedValueOnce([]);
+        fsPromises.rmdir.mockResolvedValueOnce();
+
+        const result = await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir, {
+          includeIgnorableFiles: true
+        });
+
+        expect(fsPromises.unlink).not.toHaveBeenCalled();
+        expect(fsPromises.rmdir).toHaveBeenCalledWith('/videos/ChannelName');
+        expect(result).toBe(true);
+      });
+    });
+
+    it('should default includeIgnorableFiles to false (backward compat)', async () => {
+      fsPromises.access.mockResolvedValueOnce();
+      // Directory contains only poster.jpg — should NOT be removed with default options
+      fsPromises.readdir.mockResolvedValueOnce(['poster.jpg']);
+
+      const result = await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir);
+
+      expect(fsPromises.rmdir).not.toHaveBeenCalled();
+      expect(result).toBe(false);
     });
   });
 

--- a/server/modules/filesystem/constants.js
+++ b/server/modules/filesystem/constants.js
@@ -104,6 +104,13 @@ const MAIN_MEDIA_FILE_PATTERN = /\[[a-zA-Z0-9_-]{10,12}\]\.(mp4|mkv|webm|mp3)$/;
  */
 const FRAGMENT_FILE_PATTERN = /\.f[\d-]+\.(mp4|m4a|webm|mkv)$/;
 
+/**
+ * Files that can be ignored when deciding whether a channel directory is empty
+ * If a channel directory contains ONLY these files (and no actual video content),
+ * it is considered "effectively empty" and eligible for cleanup
+ */
+const CHANNEL_CLEANUP_IGNORABLE_FILES = ['poster.jpg'];
+
 module.exports = {
   SUBFOLDER_PREFIX,
   GLOBAL_DEFAULT_SENTINEL,
@@ -120,5 +127,6 @@ module.exports = {
   MAIN_VIDEO_FILE_PATTERN,
   MAIN_AUDIO_FILE_PATTERN,
   MAIN_MEDIA_FILE_PATTERN,
-  FRAGMENT_FILE_PATTERN
+  FRAGMENT_FILE_PATTERN,
+  CHANNEL_CLEANUP_IGNORABLE_FILES
 };

--- a/server/modules/filesystem/directoryManager.js
+++ b/server/modules/filesystem/directoryManager.js
@@ -7,7 +7,7 @@ const fs = require('fs-extra');
 const fsPromises = require('fs').promises;
 const path = require('path');
 const logger = require('../../logger');
-const { YOUTUBE_ID_PATTERN, SUBFOLDER_PREFIX, MAIN_VIDEO_FILE_PATTERN, FRAGMENT_FILE_PATTERN } = require('./constants');
+const { YOUTUBE_ID_PATTERN, SUBFOLDER_PREFIX, MAIN_VIDEO_FILE_PATTERN, FRAGMENT_FILE_PATTERN, CHANNEL_CLEANUP_IGNORABLE_FILES } = require('./constants');
 const { sleep } = require('./fileOperations');
 
 /**
@@ -68,6 +68,26 @@ async function isDirectoryEmpty(dirPath) {
     return entries.length === 0;
   } catch (error) {
     // Directory doesn't exist or can't be read - treat as "empty" for cleanup purposes
+    logger.debug({ err: error, dirPath }, 'Cannot read directory (may not exist)');
+    return false;
+  }
+}
+
+/**
+ * Check if a directory is "effectively empty" — either truly empty
+ * or contains only ignorable files (e.g., poster.jpg)
+ *
+ * @param {string} dirPath - Directory path to check
+ * @returns {Promise<boolean>} - True if directory is effectively empty
+ */
+async function isDirectoryEffectivelyEmpty(dirPath) {
+  try {
+    const entries = await fsPromises.readdir(dirPath);
+    if (entries.length === 0) return true;
+    return entries.every(entry =>
+      CHANNEL_CLEANUP_IGNORABLE_FILES.includes(entry.toLowerCase())
+    );
+  } catch (error) {
     logger.debug({ err: error, dirPath }, 'Cannot read directory (may not exist)');
     return false;
   }
@@ -186,14 +206,18 @@ function isSubfolderDir(dirName) {
  *
  * @param {string} channelDir - Channel directory path
  * @param {string} baseDir - The base output directory
- * @returns {Promise<void>}
+ * @param {Object} [options] - Options
+ * @param {boolean} [options.includeIgnorableFiles=false] - When true, also removes directories containing only ignorable files (e.g., poster.jpg)
+ * @returns {Promise<boolean>} - True if directory was removed
  */
-async function cleanupEmptyChannelDirectory(channelDir, baseDir) {
+async function cleanupEmptyChannelDirectory(channelDir, baseDir, options = {}) {
+  const { includeIgnorableFiles = false } = options;
+
   try {
     // Verify this is actually a channel directory (not root or subfolder)
     if (!isChannelDirectory(channelDir, baseDir)) {
       logger.debug({ channelDir }, 'Not a channel directory, skipping cleanup');
-      return;
+      return false;
     }
 
     // Check if directory exists
@@ -201,22 +225,42 @@ async function cleanupEmptyChannelDirectory(channelDir, baseDir) {
       await fsPromises.access(channelDir);
     } catch {
       logger.debug({ channelDir }, 'Channel directory does not exist');
-      return;
+      return false;
     }
 
-    // Check if directory is empty
-    const isEmpty = await isDirectoryEmpty(channelDir);
+    // Check if directory is empty (or effectively empty)
+    const isEmpty = includeIgnorableFiles
+      ? await isDirectoryEffectivelyEmpty(channelDir)
+      : await isDirectoryEmpty(channelDir);
     if (!isEmpty) {
       logger.debug({ channelDir }, 'Channel directory not empty, keeping it');
-      return;
+      return false;
+    }
+
+    // When includeIgnorableFiles is true, delete ignorable files before rmdir
+    if (includeIgnorableFiles) {
+      const entries = await fsPromises.readdir(channelDir);
+      for (const entry of entries) {
+        const filePath = path.join(channelDir, entry);
+        try {
+          await fsPromises.unlink(filePath);
+          logger.debug({ filePath }, 'Removed ignorable file from channel directory');
+        } catch (unlinkErr) {
+          if (unlinkErr.code !== 'ENOENT') {
+            logger.warn({ err: unlinkErr, filePath }, 'Failed to remove ignorable file');
+          }
+        }
+      }
     }
 
     // Remove empty channel directory
     await fsPromises.rmdir(channelDir);
     logger.info({ channelDir }, 'Removed empty channel directory');
+    return true;
   } catch (error) {
     logger.error({ err: error, channelDir }, 'Error cleaning up empty channel directory');
     // Don't throw - this is a best-effort cleanup
+    return false;
   }
 }
 
@@ -303,6 +347,7 @@ module.exports = {
   ensureDirSync,
   ensureDirWithRetries,
   isDirectoryEmpty,
+  isDirectoryEffectivelyEmpty,
   removeIfEmpty,
   isVideoDirectory,
   isChannelDirectory,

--- a/server/modules/videoDeletionModule.js
+++ b/server/modules/videoDeletionModule.js
@@ -2,7 +2,7 @@ const { Video } = require('../models');
 const fs = require('fs').promises;
 const path = require('path');
 const logger = require('../logger');
-const { isVideoDirectory } = require('./filesystem');
+const { isVideoDirectory, cleanupEmptyChannelDirectory, cleanupEmptyParents } = require('./filesystem');
 
 class VideoDeletionModule {
   constructor() {}
@@ -35,6 +35,38 @@ class VideoDeletionModule {
       fileSize: parseInt(video.fileSize) || 0,
       timeCreated: video.timeCreated
     };
+  }
+
+  /**
+   * Attempt to clean up an empty channel directory after video deletion
+   * Best-effort: errors are logged as warnings and do not propagate
+   * @param {string} filePath - The deleted video's file path
+   * @param {boolean} flat - Whether the video used flat directory structure
+   * @private
+   */
+  async _tryCleanupChannelDirectory(filePath, flat) {
+    try {
+      const configModule = require('./configModule');
+      const baseDir = configModule.directoryPath;
+
+      // Derive channel directory:
+      //   Nested: grandparent of filePath (filePath -> videoDir -> channelDir)
+      //   Flat: parent of filePath (filePath -> channelDir)
+      const channelDir = flat
+        ? path.dirname(filePath)
+        : path.dirname(path.dirname(filePath));
+
+      const removed = await cleanupEmptyChannelDirectory(channelDir, baseDir, {
+        includeIgnorableFiles: true
+      });
+
+      if (removed) {
+        // Clean up empty subfolder parent (e.g., /base/__subfolder/ now empty)
+        await cleanupEmptyParents(path.dirname(channelDir), baseDir);
+      }
+    } catch (error) {
+      logger.warn({ err: error, filePath }, 'Error during channel directory cleanup (non-fatal)');
+    }
   }
 
   /**
@@ -136,6 +168,9 @@ class VideoDeletionModule {
 
       // Mark video as removed in database
       await video.update({ removed: true });
+
+      // Best-effort cleanup of empty channel directory
+      await this._tryCleanupChannelDirectory(video.filePath, flat);
 
       return {
         success: true,


### PR DESCRIPTION
- Add CHANNEL_CLEANUP_IGNORABLE_FILES constant for files (poster.jpg) that don't count as real content when deciding if a directory is empty
- Add isDirectoryEffectivelyEmpty() with case-insensitive matching for ignorable files
- Enhance cleanupEmptyChannelDirectory() with includeIgnorableFiles option that deletes ignorable files before rmdir; returns boolean; defaults to false for backward compatibility
- Add _tryCleanupChannelDirectory() to videoDeletionModule that runs best-effort after every successful deletion (nested and flat modes), with parent subfolder cleanup when channel dir is removed
- Replace duplicate 30-line cleanup implementation in downloadExecutor with delegation to shared directoryManager function