### PR TITLE
feat: add bulk import video downloads (#327)

### DIFF
--- a/client/src/components/DownloadManager/ManualDownload/BulkImportDialog.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/BulkImportDialog.tsx
@@ -1,0 +1,292 @@
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Button,
+  Box,
+  Alert,
+  Typography,
+  Divider,
+  Collapse,
+  IconButton,
+} from '@mui/material';
+import {
+  UploadFile as UploadFileIcon,
+  ExpandMore as ExpandMoreIcon,
+  ExpandLess as ExpandLessIcon,
+  Close as CloseIcon,
+} from '@mui/icons-material';
+import { VideoInfo } from './types';
+import { parseYoutubeUrls, BulkParseResult } from './urlParser';
+
+interface BulkImportDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onImport: (videos: VideoInfo[]) => void;
+  existingVideoIds: Set<string>;
+}
+
+const BulkImportDialog: React.FC<BulkImportDialogProps> = ({
+  open,
+  onClose,
+  onImport,
+  existingVideoIds,
+}) => {
+  const [textValue, setTextValue] = useState('');
+  const [parseResult, setParseResult] = useState<BulkParseResult | null>(null);
+  const [showInvalid, setShowInvalid] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  const doParse = useCallback(
+    (text: string) => {
+      if (!text.trim()) {
+        setParseResult(null);
+        return;
+      }
+      const result = parseYoutubeUrls(text, existingVideoIds);
+      setParseResult(result);
+    },
+    [existingVideoIds]
+  );
+
+  const handleTextChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const value = e.target.value;
+      setTextValue(value);
+      setFileError(null);
+
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+      debounceRef.current = setTimeout(() => doParse(value), 300);
+    },
+    [doParse]
+  );
+
+  const handleFileUpload = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      if (!file.name.endsWith('.txt')) {
+        setFileError('Please select a .txt file.');
+        return;
+      }
+
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const content = event.target?.result;
+        if (typeof content === 'string') {
+          setTextValue(content);
+          setFileError(null);
+          doParse(content);
+        }
+      };
+      reader.onerror = () => {
+        setFileError('Failed to read file.');
+      };
+      reader.readAsText(file);
+
+      // Reset file input so the same file can be re-selected
+      e.target.value = '';
+    },
+    [doParse]
+  );
+
+  const handleImport = useCallback(() => {
+    if (!parseResult || parseResult.valid.length === 0) return;
+
+    const videos: VideoInfo[] = parseResult.valid.map((parsed) => ({
+      youtubeId: parsed.youtubeId,
+      url: parsed.url,
+      channelName: '',
+      videoTitle: '',
+      duration: 0,
+      publishedAt: 0,
+      isAlreadyDownloaded: false,
+      isMembersOnly: false,
+      isBulkImport: true,
+    }));
+
+    onImport(videos);
+  }, [parseResult, onImport]);
+
+  // Reset state when dialog opens/closes
+  useEffect(() => {
+    if (!open) {
+      setTextValue('');
+      setParseResult(null);
+      setShowInvalid(false);
+      setFileError(null);
+    }
+  }, [open]);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  const validCount = parseResult?.valid.length ?? 0;
+  const dupeCount = parseResult?.duplicates.length ?? 0;
+  const invalidCount = parseResult?.invalid.length ?? 0;
+  const playlistCount = parseResult?.playlistLines.length ?? 0;
+  const hasResults = parseResult !== null && (validCount > 0 || dupeCount > 0 || invalidCount > 0 || playlistCount > 0);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="sm"
+      fullWidth
+      data-testid="bulk-import-dialog"
+    >
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        Bulk Import URLs
+        <IconButton onClick={onClose} size="small" aria-label="close">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+          Paste YouTube video URLs, one per line:
+        </Typography>
+
+        <TextField
+          multiline
+          fullWidth
+          minRows={8}
+          maxRows={16}
+          value={textValue}
+          onChange={handleTextChange}
+          placeholder={
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ\nhttps://youtu.be/jNQXAC9IVRw\nhttps://www.youtube.com/shorts/9bZkp7q19f0'
+          }
+          variant="outlined"
+          inputProps={{ 'data-testid': 'bulk-import-textarea' }}
+        />
+
+        <Divider sx={{ my: 2 }}>
+          <Typography variant="caption" color="text.secondary">
+            or
+          </Typography>
+        </Divider>
+
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Button
+            variant="outlined"
+            startIcon={<UploadFileIcon />}
+            onClick={() => fileInputRef.current?.click()}
+            size="small"
+          >
+            Upload .txt file
+          </Button>
+          <input
+            type="file"
+            accept=".txt"
+            ref={fileInputRef}
+            onChange={handleFileUpload}
+            style={{ display: 'none' }}
+            data-testid="bulk-import-file-input"
+          />
+          {fileError && (
+            <Typography variant="caption" color="error">
+              {fileError}
+            </Typography>
+          )}
+        </Box>
+
+        {hasResults && (
+          <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {validCount > 0 && (
+              <Alert severity="success" variant="outlined">
+                {validCount} valid URL{validCount !== 1 ? 's' : ''} found
+              </Alert>
+            )}
+
+            {dupeCount > 0 && (
+              <Alert severity="warning" variant="outlined">
+                {dupeCount} duplicate{dupeCount !== 1 ? 's' : ''} skipped
+              </Alert>
+            )}
+
+            {playlistCount > 0 && (
+              <Alert severity="info" variant="outlined">
+                {playlistCount} playlist URL{playlistCount !== 1 ? 's' : ''} skipped
+                — paste individual video URLs instead
+              </Alert>
+            )}
+
+            {invalidCount > 0 && (
+              <Alert
+                severity="error"
+                variant="outlined"
+                action={
+                  <IconButton
+                    size="small"
+                    onClick={() => setShowInvalid(!showInvalid)}
+                    aria-label={showInvalid ? 'hide invalid lines' : 'show invalid lines'}
+                  >
+                    {showInvalid ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                  </IconButton>
+                }
+              >
+                {invalidCount} invalid line{invalidCount !== 1 ? 's' : ''} skipped
+              </Alert>
+            )}
+
+            <Collapse in={showInvalid}>
+              <Box
+                sx={{
+                  maxHeight: 120,
+                  overflowY: 'auto',
+                  bgcolor: 'action.hover',
+                  borderRadius: 1,
+                  p: 1,
+                }}
+              >
+                {parseResult?.invalid.map((line, i) => (
+                  <Typography
+                    key={i}
+                    variant="caption"
+                    display="block"
+                    sx={{ wordBreak: 'break-all' }}
+                  >
+                    {line}
+                  </Typography>
+                ))}
+              </Box>
+            </Collapse>
+          </Box>
+        )}
+
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 2 }}>
+          Previously downloaded videos will be skipped unless you enable re-download in the settings dialog.
+        </Typography>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleImport}
+          disabled={validCount === 0}
+          data-testid="bulk-import-confirm"
+        >
+          Add {validCount > 0 ? validCount : ''} to Queue
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default BulkImportDialog;

--- a/client/src/components/DownloadManager/ManualDownload/ManualDownload.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/ManualDownload.tsx
@@ -21,6 +21,7 @@ import axios from 'axios';
 import UrlInput from './UrlInput';
 import VideoChip from './VideoChip';
 import DownloadSettingsDialog from './DownloadSettingsDialog';
+import BulkImportDialog from './BulkImportDialog';
 import { VideoInfo, ValidationResponse, DownloadSettings } from './types';
 
 interface ManualDownloadProps {
@@ -37,6 +38,13 @@ const ManualDownload: React.FC<ManualDownloadProps> = ({ onStartDownload, token,
   const [isDownloading, setIsDownloading] = useState(false);
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
   const [previouslyDownloadedCount, setPreviouslyDownloadedCount] = useState(0);
+  const [showBulkImport, setShowBulkImport] = useState(false);
+
+  const handleBulkImport = useCallback((videos: VideoInfo[]) => {
+    setValidatedVideos(prev => [...prev, ...videos]);
+    setShowBulkImport(false);
+    setSuccessMessage(`Added ${videos.length} URL${videos.length !== 1 ? 's' : ''} to download queue.`);
+  }, []);
 
   const validateUrl = useCallback(async (url: string): Promise<boolean> => {
     setIsValidating(true);
@@ -163,11 +171,24 @@ const ManualDownload: React.FC<ManualDownloadProps> = ({ onStartDownload, token,
         <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
           Paste YouTube video URLs to add to queue
         </Typography>
-        <UrlInput
-          onValidate={validateUrl}
-          isValidating={isValidating}
-          disabled={isDownloading}
-        />
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start' }}>
+          <Box sx={{ flex: 1 }}>
+            <UrlInput
+              onValidate={validateUrl}
+              isValidating={isValidating}
+              disabled={isDownloading}
+            />
+          </Box>
+          <Button
+            variant="outlined"
+            onClick={() => setShowBulkImport(true)}
+            startIcon={<PlaylistAddIcon />}
+            disabled={isDownloading}
+            sx={{ whiteSpace: 'nowrap', minHeight: 56 }}
+          >
+            Bulk Import
+          </Button>
+        </Box>
       </Paper>
 
       {validatedVideos.length > 0 && (
@@ -273,6 +294,13 @@ const ManualDownload: React.FC<ManualDownloadProps> = ({ onStartDownload, token,
         mode="manual"
         defaultResolutionSource="global"
         token={token}
+      />
+
+      <BulkImportDialog
+        open={showBulkImport}
+        onClose={() => setShowBulkImport(false)}
+        onImport={handleBulkImport}
+        existingVideoIds={new Set(validatedVideos.map(v => v.youtubeId))}
       />
     </Box>
   );

--- a/client/src/components/DownloadManager/ManualDownload/VideoChip.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/VideoChip.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Chip, Tooltip, Box, Grow, Popover, Typography, IconButton } from '@mui/material';
-import { Close as CloseIcon, History as HistoryIcon, Lock } from '@mui/icons-material';
+import { Close as CloseIcon, History as HistoryIcon, Lock, Link as LinkIcon } from '@mui/icons-material';
 import { VideoInfo } from './types';
 
 interface VideoChipProps {
@@ -33,6 +33,50 @@ const getMediaTypeInfo = (mediaType?: string) => {
 
 const VideoChip: React.FC<VideoChipProps> = ({ video, onDelete }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  if (video.isBulkImport) {
+    const bulkLabel = (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <LinkIcon sx={{ fontSize: '0.9rem', color: 'text.secondary', flexShrink: 0 }} />
+        <Box>
+          <Box sx={{ fontWeight: 'bold', fontSize: '0.75rem' }}>
+            {video.youtubeId}
+          </Box>
+          <Box sx={{ fontSize: '0.7rem', color: 'text.secondary' }}>
+            URL-only import
+          </Box>
+        </Box>
+      </Box>
+    );
+
+    return (
+      <Grow in timeout={300}>
+        <Tooltip title={video.url}>
+          <Chip
+            label={bulkLabel}
+            onDelete={() => onDelete(video.youtubeId)}
+            deleteIcon={<CloseIcon />}
+            color="info"
+            variant="filled"
+            sx={{
+              height: 'auto',
+              py: 1,
+              '& .MuiChip-label': {
+                display: 'block',
+                whiteSpace: 'normal'
+              },
+              width: '100%',
+              transition: 'all 0.2s ease',
+              '&:hover': {
+                transform: 'scale(1.02)',
+                boxShadow: 2
+              }
+            }}
+          />
+        </Tooltip>
+      </Grow>
+    );
+  }
 
   const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/BulkImportDialog.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/BulkImportDialog.test.tsx
@@ -1,0 +1,344 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import BulkImportDialog from '../BulkImportDialog';
+
+describe('BulkImportDialog', () => {
+  const mockOnClose = jest.fn();
+  const mockOnImport = jest.fn();
+  const emptySet = new Set<string>();
+
+  const defaultProps = {
+    open: true,
+    onClose: mockOnClose,
+    onImport: mockOnImport,
+    existingVideoIds: emptySet,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  describe('Rendering', () => {
+    test('renders dialog when open', () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      expect(screen.getByText('Bulk Import URLs')).toBeInTheDocument();
+      expect(
+        screen.getByText('Paste YouTube video URLs, one per line:')
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('bulk-import-textarea')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /upload .txt file/i })
+      ).toBeInTheDocument();
+    });
+
+    test('does not render dialog when closed', () => {
+      render(<BulkImportDialog {...defaultProps} open={false} />);
+
+      expect(screen.queryByText('Bulk Import URLs')).not.toBeInTheDocument();
+    });
+
+    test('shows re-download guidance text', () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      expect(
+        screen.getByText(/previously downloaded videos will be skipped/i)
+      ).toBeInTheDocument();
+    });
+
+    test('Add to Queue button is disabled when no valid URLs', () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      const addButton = screen.getByTestId('bulk-import-confirm');
+      expect(addButton).toBeDisabled();
+    });
+  });
+
+  describe('URL Parsing', () => {
+    test('shows valid URL count after typing', async () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      const textarea = screen.getByTestId('bulk-import-textarea');
+      fireEvent.change(textarea, {
+        target: {
+          value:
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ\nhttps://youtu.be/jNQXAC9IVRw',
+        },
+      });
+
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.getByText(/2 valid URLs found/i)).toBeInTheDocument();
+      });
+    });
+
+    test('shows duplicate count', async () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      const textarea = screen.getByTestId('bulk-import-textarea');
+      fireEvent.change(textarea, {
+        target: {
+          value:
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ\nhttps://youtu.be/dQw4w9WgXcQ',
+        },
+      });
+
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 valid URL found/i)).toBeInTheDocument();
+      });
+      expect(screen.getByText(/1 duplicate skipped/i)).toBeInTheDocument();
+    });
+
+    test('shows invalid line count', async () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      const textarea = screen.getByTestId('bulk-import-textarea');
+      fireEvent.change(textarea, {
+        target: {
+          value:
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ\nnot a url\nalso invalid',
+        },
+      });
+
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 valid URL found/i)).toBeInTheDocument();
+      });
+      expect(screen.getByText(/2 invalid lines skipped/i)).toBeInTheDocument();
+    });
+
+    test('shows playlist URL message', async () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      const textarea = screen.getByTestId('bulk-import-textarea');
+      fireEvent.change(textarea, {
+        target: {
+          value:
+            'https://www.youtube.com/playlist?list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf',
+        },
+      });
+
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/playlist URL.*skipped/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('detects duplicates against existing queue', async () => {
+      const existingIds = new Set(['dQw4w9WgXcQ']);
+
+      render(
+        <BulkImportDialog {...defaultProps} existingVideoIds={existingIds} />
+      );
+
+      const textarea = screen.getByTestId('bulk-import-textarea');
+      fireEvent.change(textarea, {
+        target: {
+          value: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        },
+      });
+
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 duplicate skipped/i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('bulk-import-confirm')).toBeDisabled();
+    });
+
+    test('clears results when textarea is emptied', async () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      const textarea = screen.getByTestId('bulk-import-textarea');
+
+      fireEvent.change(textarea, {
+        target: { value: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+      });
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 valid URL found/i)).toBeInTheDocument();
+      });
+
+      fireEvent.change(textarea, { target: { value: '' } });
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/valid URL/i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Import action', () => {
+    test('calls onImport with valid videos', async () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      const textarea = screen.getByTestId('bulk-import-textarea');
+      fireEvent.change(textarea, {
+        target: {
+          value:
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ\nhttps://youtu.be/jNQXAC9IVRw',
+        },
+      });
+
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('bulk-import-confirm')).not.toBeDisabled();
+      });
+
+      fireEvent.click(screen.getByTestId('bulk-import-confirm'));
+
+      expect(mockOnImport).toHaveBeenCalledTimes(1);
+      const importedVideos = mockOnImport.mock.calls[0][0];
+      expect(importedVideos).toHaveLength(2);
+      expect(importedVideos[0]).toMatchObject({
+        youtubeId: 'dQw4w9WgXcQ',
+        url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        isBulkImport: true,
+        channelName: '',
+        videoTitle: '',
+        duration: 0,
+      });
+      expect(importedVideos[1]).toMatchObject({
+        youtubeId: 'jNQXAC9IVRw',
+        isBulkImport: true,
+      });
+    });
+
+    test('shows correct count in button text', async () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      const textarea = screen.getByTestId('bulk-import-textarea');
+      fireEvent.change(textarea, {
+        target: {
+          value:
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ\nhttps://youtu.be/jNQXAC9IVRw\nhttps://www.youtube.com/watch?v=9bZkp7q19f0',
+        },
+      });
+
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('bulk-import-confirm')).toHaveTextContent(
+          'Add 3 to Queue'
+        );
+      });
+    });
+  });
+
+  describe('Close and reset', () => {
+    test('calls onClose when Cancel is clicked', () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('calls onClose when X button is clicked', () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /close/i }));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('resets state when dialog is reopened', async () => {
+      const { rerender } = render(<BulkImportDialog {...defaultProps} />);
+
+      const textarea = screen.getByTestId('bulk-import-textarea');
+      fireEvent.change(textarea, {
+        target: { value: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+      });
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.getByText(/1 valid URL found/i)).toBeInTheDocument();
+      });
+
+      // Close dialog
+      rerender(<BulkImportDialog {...defaultProps} open={false} />);
+
+      // Reopen dialog
+      rerender(<BulkImportDialog {...defaultProps} open={true} />);
+
+      expect(screen.getByTestId('bulk-import-textarea')).toHaveValue('');
+      expect(screen.queryByText(/valid URL/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('File upload', () => {
+    test('renders file upload button', () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      expect(
+        screen.getByRole('button', { name: /upload .txt file/i })
+      ).toBeInTheDocument();
+    });
+
+    test('shows error for non-.txt files', async () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      const fileInput = screen.getByTestId('bulk-import-file-input');
+      const file = new File(['content'], 'test.csv', { type: 'text/csv' });
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/please select a .txt file/i)).toBeInTheDocument();
+      });
+    });
+
+    test('populates textarea with .txt file content', async () => {
+      render(<BulkImportDialog {...defaultProps} />);
+
+      const fileContent =
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ\nhttps://youtu.be/jNQXAC9IVRw';
+      const file = new File([fileContent], 'urls.txt', {
+        type: 'text/plain',
+      });
+
+      const fileInput = screen.getByTestId('bulk-import-file-input');
+
+      // Mock FileReader
+      const originalFileReader = global.FileReader;
+      const mockFileReader = {
+        readAsText: jest.fn(),
+        onload: null as any,
+        onerror: null as any,
+        result: fileContent,
+      };
+      (global as any).FileReader = jest.fn(() => mockFileReader);
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      // Trigger the onload callback
+      mockFileReader.onload({ target: { result: fileContent } });
+
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('bulk-import-textarea')).toHaveValue(
+          fileContent
+        );
+      });
+
+      // Restore original FileReader
+      global.FileReader = originalFileReader;
+    });
+  });
+});

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/ManualDownload.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/ManualDownload.test.tsx
@@ -48,6 +48,50 @@ jest.mock('../VideoChip', () => {
   };
 });
 
+jest.mock('../BulkImportDialog', () => {
+  return function MockBulkImportDialog({ open, onClose, onImport, existingVideoIds }: any) {
+    if (!open) return null;
+    return (
+      <div data-testid="bulk-import-dialog">
+        <button
+          onClick={() =>
+            onImport([
+              {
+                youtubeId: 'bulk1',
+                url: 'https://www.youtube.com/watch?v=bulk1aaaaaa',
+                channelName: '',
+                videoTitle: '',
+                duration: 0,
+                publishedAt: 0,
+                isAlreadyDownloaded: false,
+                isMembersOnly: false,
+                isBulkImport: true,
+              },
+              {
+                youtubeId: 'bulk2',
+                url: 'https://www.youtube.com/watch?v=bulk2aaaaaa',
+                channelName: '',
+                videoTitle: '',
+                duration: 0,
+                publishedAt: 0,
+                isAlreadyDownloaded: false,
+                isMembersOnly: false,
+                isBulkImport: true,
+              },
+            ])
+          }
+          data-testid="bulk-import-confirm"
+        >
+          Add to Queue
+        </button>
+        <button onClick={onClose} data-testid="bulk-import-cancel">
+          Cancel
+        </button>
+      </div>
+    );
+  };
+});
+
 jest.mock('../DownloadSettingsDialog', () => {
   return function MockDownloadSettingsDialog({ open, onClose, onConfirm }: any) {
     if (!open) return null;
@@ -510,6 +554,70 @@ describe('ManualDownload', () => {
         '/api/checkYoutubeVideoURL',
         { url: 'https://youtube.com/watch?v=test123' },
         { headers: { 'x-access-token': '' } }
+      );
+    });
+  });
+
+  test('renders Bulk Import button', () => {
+    render(<ManualDownload onStartDownload={mockOnStartDownload} token={mockToken} />);
+
+    expect(screen.getByRole('button', { name: /bulk import/i })).toBeInTheDocument();
+  });
+
+  test('opens bulk import dialog when button is clicked', () => {
+    render(<ManualDownload onStartDownload={mockOnStartDownload} token={mockToken} />);
+
+    const bulkButton = screen.getByRole('button', { name: /bulk import/i });
+    fireEvent.click(bulkButton);
+
+    expect(screen.getByTestId('bulk-import-dialog')).toBeInTheDocument();
+  });
+
+  test('adds bulk-imported videos to queue', async () => {
+    render(<ManualDownload onStartDownload={mockOnStartDownload} token={mockToken} />);
+
+    const bulkButton = screen.getByRole('button', { name: /bulk import/i });
+    fireEvent.click(bulkButton);
+
+    const confirmButton = screen.getByTestId('bulk-import-confirm');
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('video-chip-bulk1')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('video-chip-bulk2')).toBeInTheDocument();
+    expect(screen.getByText('Added 2 URLs to download queue.')).toBeInTheDocument();
+    expect(screen.getByText('2 videos to download')).toBeInTheDocument();
+  });
+
+  test('downloads bulk-imported videos', async () => {
+    mockOnStartDownload.mockResolvedValueOnce(undefined);
+
+    render(<ManualDownload onStartDownload={mockOnStartDownload} token={mockToken} />);
+
+    // Open bulk import and add videos
+    const bulkButton = screen.getByRole('button', { name: /bulk import/i });
+    fireEvent.click(bulkButton);
+    fireEvent.click(screen.getByTestId('bulk-import-confirm'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('video-chip-bulk1')).toBeInTheDocument();
+    });
+
+    // Start download
+    const downloadButton = screen.getByRole('button', { name: /download videos/i });
+    fireEvent.click(downloadButton);
+
+    await screen.findByTestId('download-settings-dialog');
+    fireEvent.click(screen.getByTestId('confirm-download'));
+
+    await waitFor(() => {
+      expect(mockOnStartDownload).toHaveBeenCalledWith(
+        [
+          'https://www.youtube.com/watch?v=bulk1aaaaaa',
+          'https://www.youtube.com/watch?v=bulk2aaaaaa',
+        ],
+        null
       );
     });
   });

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/VideoChip.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/VideoChip.test.tsx
@@ -309,4 +309,70 @@ describe('VideoChip', () => {
       expect(chip).toHaveStyle({ width: '100%' });
     });
   });
+
+  describe('Bulk Import Rendering', () => {
+    const bulkVideo: VideoInfo = {
+      youtubeId: 'dQw4w9WgXcQ',
+      url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      channelName: '',
+      videoTitle: '',
+      duration: 0,
+      publishedAt: 0,
+      isAlreadyDownloaded: false,
+      isMembersOnly: false,
+      isBulkImport: true,
+    };
+
+    test('renders video ID for bulk import chip', () => {
+      render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} />);
+
+      expect(screen.getByText('dQw4w9WgXcQ')).toBeInTheDocument();
+    });
+
+    test('renders URL-only import label', () => {
+      render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} />);
+
+      expect(screen.getByText('URL-only import')).toBeInTheDocument();
+    });
+
+    test('applies info color for bulk import chip', () => {
+      render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} />);
+
+      const chip = screen.getByRole('button');
+      expect(chip).toHaveClass('MuiChip-colorInfo');
+    });
+
+    test('shows full URL in tooltip for bulk import', async () => {
+      render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} />);
+
+      const chip = screen.getByRole('button');
+      fireEvent.mouseOver(chip);
+
+      expect(await screen.findByRole('tooltip')).toHaveTextContent(
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+      );
+    });
+
+    test('calls onDelete with youtubeId for bulk import chip', () => {
+      render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} />);
+
+      const deleteIcon = screen.getByTestId('CloseIcon');
+      fireEvent.click(deleteIcon);
+
+      expect(mockOnDelete).toHaveBeenCalledWith('dQw4w9WgXcQ');
+    });
+
+    test('does not show duration, media type, or history icon for bulk import', () => {
+      render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} />);
+
+      expect(screen.queryByText('0:00')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('HistoryIcon')).not.toBeInTheDocument();
+    });
+
+    test('renders link icon for bulk import chip', () => {
+      render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} />);
+
+      expect(screen.getByTestId('LinkIcon')).toBeInTheDocument();
+    });
+  });
 });

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/urlParser.test.ts
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/urlParser.test.ts
@@ -1,0 +1,301 @@
+import { parseYoutubeUrls } from '../urlParser';
+
+describe('parseYoutubeUrls', () => {
+  const emptySet = new Set<string>();
+
+  describe('valid URL formats', () => {
+    test('parses standard youtube.com/watch URLs', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0]).toEqual({
+        url: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        youtubeId: 'dQw4w9WgXcQ',
+      });
+    });
+
+    test('parses youtu.be short URLs', () => {
+      const result = parseYoutubeUrls(
+        'https://youtu.be/dQw4w9WgXcQ',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('dQw4w9WgXcQ');
+      expect(result.valid[0].url).toBe(
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+      );
+    });
+
+    test('parses youtube.com/shorts URLs', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('dQw4w9WgXcQ');
+    });
+
+    test('parses youtube.com/embed URLs', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/embed/dQw4w9WgXcQ',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('dQw4w9WgXcQ');
+    });
+
+    test('parses youtube.com/live URLs', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/live/dQw4w9WgXcQ',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('dQw4w9WgXcQ');
+    });
+
+    test('parses m.youtube.com URLs', () => {
+      const result = parseYoutubeUrls(
+        'https://m.youtube.com/watch?v=dQw4w9WgXcQ',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('dQw4w9WgXcQ');
+    });
+
+    test('parses music.youtube.com URLs', () => {
+      const result = parseYoutubeUrls(
+        'https://music.youtube.com/watch?v=dQw4w9WgXcQ',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('dQw4w9WgXcQ');
+    });
+
+    test('parses URLs without www prefix', () => {
+      const result = parseYoutubeUrls(
+        'https://youtube.com/watch?v=dQw4w9WgXcQ',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('dQw4w9WgXcQ');
+    });
+
+    test('parses URLs without https prefix', () => {
+      const result = parseYoutubeUrls(
+        'youtube.com/watch?v=dQw4w9WgXcQ',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('dQw4w9WgXcQ');
+    });
+
+    test('strips extra query params and canonicalizes URL', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf&t=42s',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].url).toBe(
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+      );
+    });
+
+    test('handles youtu.be URLs with tracking params', () => {
+      const result = parseYoutubeUrls(
+        'https://youtu.be/dQw4w9WgXcQ?si=abc123def456',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].url).toBe(
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+      );
+    });
+  });
+
+  describe('multiple URLs', () => {
+    test('parses multiple URLs separated by newlines', () => {
+      const input = [
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        'https://youtu.be/jNQXAC9IVRw',
+        'https://www.youtube.com/shorts/9bZkp7q19f0',
+      ].join('\n');
+
+      const result = parseYoutubeUrls(input, emptySet);
+      expect(result.valid).toHaveLength(3);
+      expect(result.valid.map((v) => v.youtubeId)).toEqual([
+        'dQw4w9WgXcQ',
+        'jNQXAC9IVRw',
+        '9bZkp7q19f0',
+      ]);
+    });
+
+    test('handles Windows-style line endings', () => {
+      const input =
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ\r\nhttps://youtu.be/jNQXAC9IVRw';
+
+      const result = parseYoutubeUrls(input, emptySet);
+      expect(result.valid).toHaveLength(2);
+    });
+
+    test('skips blank lines', () => {
+      const input =
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ\n\n\nhttps://youtu.be/jNQXAC9IVRw\n\n';
+
+      const result = parseYoutubeUrls(input, emptySet);
+      expect(result.valid).toHaveLength(2);
+      expect(result.invalid).toHaveLength(0);
+    });
+  });
+
+  describe('deduplication', () => {
+    test('deduplicates within batch', () => {
+      const input = [
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        'https://youtu.be/dQw4w9WgXcQ',
+      ].join('\n');
+
+      const result = parseYoutubeUrls(input, emptySet);
+      expect(result.valid).toHaveLength(1);
+      expect(result.duplicates).toHaveLength(1);
+    });
+
+    test('deduplicates against existing queue', () => {
+      const existingIds = new Set(['dQw4w9WgXcQ']);
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        existingIds
+      );
+      expect(result.valid).toHaveLength(0);
+      expect(result.duplicates).toHaveLength(1);
+    });
+
+    test('deduplicates same video in different URL formats', () => {
+      const input = [
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        'https://youtu.be/dQw4w9WgXcQ',
+        'https://www.youtube.com/shorts/dQw4w9WgXcQ',
+      ].join('\n');
+
+      const result = parseYoutubeUrls(input, emptySet);
+      expect(result.valid).toHaveLength(1);
+      expect(result.duplicates).toHaveLength(2);
+    });
+  });
+
+  describe('invalid lines', () => {
+    test('marks non-YouTube URLs as invalid', () => {
+      const result = parseYoutubeUrls('https://vimeo.com/12345', emptySet);
+      expect(result.valid).toHaveLength(0);
+      expect(result.invalid).toHaveLength(1);
+    });
+
+    test('marks random text as invalid', () => {
+      const result = parseYoutubeUrls('just some random text', emptySet);
+      expect(result.valid).toHaveLength(0);
+      expect(result.invalid).toHaveLength(1);
+    });
+
+    test('marks YouTube channel URLs as invalid', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/@SomeChannel',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(0);
+      expect(result.invalid).toHaveLength(1);
+    });
+  });
+
+  describe('playlist detection', () => {
+    test('detects playlist URLs without video ID', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/playlist?list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(0);
+      expect(result.playlistLines).toHaveLength(1);
+    });
+
+    test('still extracts video from URL with both video ID and list param', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('dQw4w9WgXcQ');
+      expect(result.playlistLines).toHaveLength(0);
+    });
+  });
+
+  describe('mixed input', () => {
+    test('correctly categorizes mixed valid/invalid/duplicate/playlist lines', () => {
+      const existingIds = new Set(['xXexist1ng_']);
+      const input = [
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        'https://www.youtube.com/watch?v=xXexist1ng_',
+        'https://www.youtube.com/playlist?list=PLrAXtmErZgOeiKm4',
+        'not a url at all',
+        'https://www.youtube.com/watch?v=jNQXAC9IVRw',
+        'https://youtu.be/dQw4w9WgXcQ',
+      ].join('\n');
+
+      const result = parseYoutubeUrls(input, existingIds);
+      expect(result.valid).toHaveLength(2);
+      expect(result.duplicates).toHaveLength(2); // xXexist1ng_ + dQw4w9WgXcQ duplicate
+      expect(result.invalid).toHaveLength(1);
+      expect(result.playlistLines).toHaveLength(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('returns empty results for empty string', () => {
+      const result = parseYoutubeUrls('', emptySet);
+      expect(result.valid).toHaveLength(0);
+      expect(result.duplicates).toHaveLength(0);
+      expect(result.invalid).toHaveLength(0);
+      expect(result.playlistLines).toHaveLength(0);
+    });
+
+    test('returns empty results for whitespace-only string', () => {
+      const result = parseYoutubeUrls('   \n\n   ', emptySet);
+      expect(result.valid).toHaveLength(0);
+    });
+
+    test('handles URLs with leading/trailing whitespace', () => {
+      const result = parseYoutubeUrls(
+        '   https://www.youtube.com/watch?v=dQw4w9WgXcQ   ',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('dQw4w9WgXcQ');
+    });
+
+    test('handles video IDs with hyphens and underscores', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/watch?v=a-b_c1D2E3F',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(1);
+      expect(result.valid[0].youtubeId).toBe('a-b_c1D2E3F');
+    });
+
+    test('rejects video IDs that are too short', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/watch?v=tooshort',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(0);
+      expect(result.invalid).toHaveLength(1);
+    });
+
+    test('rejects video IDs that are too long', () => {
+      const result = parseYoutubeUrls(
+        'https://www.youtube.com/watch?v=toolongvideoid',
+        emptySet
+      );
+      expect(result.valid).toHaveLength(0);
+      expect(result.invalid).toHaveLength(1);
+    });
+  });
+});

--- a/client/src/components/DownloadManager/ManualDownload/types.ts
+++ b/client/src/components/DownloadManager/ManualDownload/types.ts
@@ -9,6 +9,7 @@ export interface VideoInfo {
   isAlreadyDownloaded: boolean;
   isMembersOnly: boolean;
   media_type?: string;
+  isBulkImport?: boolean;
 }
 
 export interface DownloadSettings {

--- a/client/src/components/DownloadManager/ManualDownload/urlParser.ts
+++ b/client/src/components/DownloadManager/ManualDownload/urlParser.ts
@@ -1,0 +1,120 @@
+export interface ParsedUrl {
+  url: string;
+  youtubeId: string;
+}
+
+export interface BulkParseResult {
+  valid: ParsedUrl[];
+  duplicates: string[];
+  invalid: string[];
+  playlistLines: string[];
+}
+
+const VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{11}$/;
+
+function extractVideoId(raw: string): string | null {
+  let trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
+    trimmed = `https://${trimmed}`;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  const hostname = parsed.hostname.replace(/^www\./i, '').toLowerCase();
+  const pathSegments = parsed.pathname.split('/').filter(Boolean);
+
+  const isYoutubeDomain =
+    hostname === 'youtube.com' ||
+    hostname === 'm.youtube.com' ||
+    hostname === 'music.youtube.com';
+
+  if (hostname === 'youtu.be') {
+    const candidate = pathSegments[0];
+    if (candidate && VIDEO_ID_PATTERN.test(candidate)) {
+      return candidate;
+    }
+    return null;
+  }
+
+  if (!isYoutubeDomain) return null;
+
+  if (pathSegments[0] === 'watch') {
+    const candidate = parsed.searchParams.get('v');
+    if (candidate && VIDEO_ID_PATTERN.test(candidate)) {
+      return candidate;
+    }
+  } else if (
+    pathSegments[0] === 'shorts' ||
+    pathSegments[0] === 'embed' ||
+    pathSegments[0] === 'live'
+  ) {
+    const candidate = pathSegments[1];
+    if (candidate && VIDEO_ID_PATTERN.test(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function isPlaylistUrl(line: string): boolean {
+  return /[?&]list=|\/playlist\b/i.test(line);
+}
+
+function isLikelyUrl(line: string): boolean {
+  return /youtube\.com|youtu\.be/i.test(line);
+}
+
+export function parseYoutubeUrls(
+  text: string,
+  existingIds: Set<string>
+): BulkParseResult {
+  const lines = text
+    .split(/[\n\r]+/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  const valid: ParsedUrl[] = [];
+  const duplicates: string[] = [];
+  const invalid: string[] = [];
+  const playlistLines: string[] = [];
+  const seenIds = new Set<string>();
+
+  for (const line of lines) {
+    if (isPlaylistUrl(line) && !extractVideoId(line)) {
+      playlistLines.push(line);
+      continue;
+    }
+
+    const videoId = extractVideoId(line);
+
+    if (!videoId) {
+      if (isLikelyUrl(line)) {
+        invalid.push(line);
+      } else if (line.length > 0) {
+        invalid.push(line);
+      }
+      continue;
+    }
+
+    if (existingIds.has(videoId) || seenIds.has(videoId)) {
+      duplicates.push(line);
+      continue;
+    }
+
+    seenIds.add(videoId);
+    valid.push({
+      url: `https://www.youtube.com/watch?v=${videoId}`,
+      youtubeId: videoId,
+    });
+  }
+
+  return { valid, duplicates, invalid, playlistLines };
+}


### PR DESCRIPTION
- Add BulkImportDialog with textarea and .txt file upload for pasting multiple YouTube URLs at once
- Add urlParser utility that extracts video IDs from youtube.com, youtu.be, m.youtube.com, music.youtube.com, /shorts/, /embed/, /live/
- Deduplicate URLs within the batch and against the existing queue
- Detect and surface playlist-only URLs with guidance to use individual video URLs instead
- Extend VideoChip with a distinct "URL-only import" rendering for bulk-imported videos
- Add and update tests