### PR TITLE
feat: add dateadded element to NFO output (#444)

### DIFF
--- a/server/modules/__tests__/nfoGenerator.test.js
+++ b/server/modules/__tests__/nfoGenerator.test.js
@@ -82,7 +82,7 @@ describe('NfoGenerator', () => {
   });
 
   describe('formatDateAdded', () => {
-    it('should format a Date object to YYYY-MM-DD HH:MM:SS', () => {
+    it('should format a Date object to YYYY-MM-DD HH:mm:ss', () => {
       const date = new Date('2026-04-04T14:30:45Z');
       const result = nfoGenerator.formatDateAdded(date);
       expect(result).toBe('2026-04-04 14:30:45');
@@ -230,6 +230,7 @@ describe('NfoGenerator', () => {
       expect(nfoContent).toContain('<studio>Unknown Channel</studio>');
       expect(nfoContent).not.toContain('<plot>');
       expect(nfoContent).not.toContain('<premiered>');
+      expect(nfoContent).toContain('<dateadded>');
       expect(nfoContent).not.toContain('<runtime>');
       expect(nfoContent).not.toContain('<genre>');
       expect(nfoContent).not.toContain('<tag>');
@@ -410,6 +411,35 @@ describe('NfoGenerator', () => {
       expect(nfoContent).toContain('</video>');
       expect(nfoContent).toContain('</streamdetails>');
       expect(nfoContent).toContain('</fileinfo>');
+    });
+
+    it('should include dateadded element in NFO output', () => {
+      const jsonData = {
+        id: 'video123',
+        title: 'Test Video',
+        upload_date: '20231225'
+      };
+
+      nfoGenerator.writeVideoNfoFile(mockVideoPath, jsonData);
+
+      const nfoContent = fs.writeFileSync.mock.calls[0][1];
+      expect(nfoContent).toContain('<dateadded>');
+      expect(nfoContent).toContain('</dateadded>');
+      // Verify format is YYYY-MM-DD HH:mm:ss
+      expect(nfoContent).toMatch(/<dateadded>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}<\/dateadded>/);
+    });
+
+    it('should include dateadded even when upload_date is missing', () => {
+      const jsonData = {
+        title: 'No Upload Date Video'
+      };
+
+      nfoGenerator.writeVideoNfoFile(mockVideoPath, jsonData);
+
+      const nfoContent = fs.writeFileSync.mock.calls[0][1];
+      expect(nfoContent).toContain('<!-- Dates -->');
+      expect(nfoContent).toContain('<dateadded>');
+      expect(nfoContent).not.toContain('<premiered>');
     });
   });
 });

--- a/server/modules/nfoGenerator.js
+++ b/server/modules/nfoGenerator.js
@@ -46,19 +46,18 @@ class NfoGenerator {
   }
 
   /**
-   * Formats a Date as YYYY-MM-DD HH:MM:SS for NFO <dateadded> element
+   * Formats a Date as YYYY-MM-DD HH:mm:ss for NFO <dateadded> element
    * @param {Date} [date=new Date()] - Date to format (defaults to now)
-   * @returns {string} Formatted date string
+   * @returns {string} Formatted date string in 'YYYY-MM-DD HH:mm:ss' format (UTC)
    */
   formatDateAdded(date = new Date()) {
-    const d = date instanceof Date ? date : new Date();
     const pad = (n) => String(n).padStart(2, '0');
-    const year = d.getUTCFullYear();
-    const month = pad(d.getUTCMonth() + 1);
-    const day = pad(d.getUTCDate());
-    const hours = pad(d.getUTCHours());
-    const minutes = pad(d.getUTCMinutes());
-    const seconds = pad(d.getUTCSeconds());
+    const year = date.getUTCFullYear();
+    const month = pad(date.getUTCMonth() + 1);
+    const day = pad(date.getUTCDate());
+    const hours = pad(date.getUTCHours());
+    const minutes = pad(date.getUTCMinutes());
+    const seconds = pad(date.getUTCSeconds());
     return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
   }
 
@@ -144,10 +143,11 @@ class NfoGenerator {
         xml += `  <youtubeid>${youtubeId}</youtubeid>\n`;
       }
 
+      xml += '\n  <!-- Dates -->\n';
       if (premiered) {
-        xml += '\n  <!-- Dates -->\n';
         xml += `  <premiered>${premiered}</premiered>\n`;
       }
+      xml += `  <dateadded>${this.formatDateAdded()}</dateadded>\n`;
 
       xml += '\n  <!-- People / orgs -->\n';
       xml += `  <studio>${studio}</studio>\n`;


### PR DESCRIPTION
Emits <dateadded> with the download timestamp in every generated NFO
file, giving Emby/Jellyfin/Kodi a standard field for when the video
was added to the library. The existing <premiered> field (YouTube
upload date) is unchanged.

Verified in Jellyfin and Emby with a video that was originally published in Youtube on 1/26/2026 and then downloaded by Youtarr on 4/4/2026

Jellyfin:
<img width="1061" height="166" alt="image" src="https://github.com/user-attachments/assets/e55ddba8-6760-4466-b404-473abc7f6aa2" />
<img width="1025" height="126" alt="image" src="https://github.com/user-attachments/assets/4a3b4ac3-4b59-4c77-ad22-7d3c37b281bd" />

Emby:
<img width="958" height="924" alt="image" src="https://github.com/user-attachments/assets/af9a5cf6-a384-4859-9740-53c73f3fdb2f" />


NOTES: 
1. This will NOT work with Plex since Plex does not read the .nfo files
2. This only adds the new `<dateadded>` element to .nfo files for NEW video downloads, I did not implement anything to parse through all your previously downloaded videos and retroactively try to add a `<dateadded>` element to those.

