### PR TITLE
feat: protect videos from auto-deletion (#505)

### DIFF
--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -931,6 +931,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onHoverChange={setHoveredVideo}
                       onToggleDeletion={toggleDeletionSelection}
                       onToggleIgnore={toggleIgnore}
+                      onToggleProtection={() => {}}
                       onMobileTooltip={setMobileTooltip}
                     />
                   ))}

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -258,6 +258,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     maxDuration: filters.maxDuration,
     dateFrom: filters.dateFrom,
     dateTo: filters.dateTo,
+    protectedFilter,
   }), [
     channelId,
     page,
@@ -272,6 +273,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     filters.maxDuration,
     filters.dateFrom,
     filters.dateTo,
+    protectedFilter,
   ]);
 
   const {
@@ -361,11 +363,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     });
   }, [videos, localIgnoreStatus, localProtectedStatus]);
 
-  // Videos are already filtered, sorted, and paginated by the server
-  // Apply client-side protected filter (after optimistic overrides are applied)
-  const paginatedVideos = protectedFilter
-    ? videosWithOverrides.filter(v => v.protected)
-    : videosWithOverrides;
+  const paginatedVideos = videosWithOverrides;
 
   // Use server-provided total count for pagination
   const totalPages = Math.ceil(totalCount / pageSize) || 1;
@@ -1028,7 +1026,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                   onSortChange={handleSortChange}
                   onToggleDeletion={toggleDeletionSelection}
                   onToggleIgnore={toggleIgnore}
-                  onToggleProtection={() => {}}
+                  onToggleProtection={handleToggleProtection}
                   onMobileTooltip={setMobileTooltip}
                 />
               )}

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -949,6 +949,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onCheckChange={handleCheckChange}
                       onToggleDeletion={toggleDeletionSelection}
                       onToggleIgnore={toggleIgnore}
+                      onToggleProtection={() => {}}
                       onMobileTooltip={setMobileTooltip}
                     />
                   ))}
@@ -968,6 +969,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                   onSortChange={handleSortChange}
                   onToggleDeletion={toggleDeletionSelection}
                   onToggleIgnore={toggleIgnore}
+                  onToggleProtection={() => {}}
                   onMobileTooltip={setMobileTooltip}
                 />
               )}

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -963,7 +963,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                 ))}
               </Grid>
             </Box>
-          ) : videos.length === 0 || paginatedVideos.length === 0 ? (
+          ) : videos.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 4 }}>
               <Typography variant="body1" color="text.secondary">
                 {hasAnyActiveFilter || searchQuery

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -100,6 +100,9 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   // Local state to track protection status changes without refetching
   const [localProtectedStatus, setLocalProtectedStatus] = useState<Record<string, boolean>>({});
 
+  // Protected filter state
+  const [protectedFilter, setProtectedFilter] = useState(false);
+
   // Filter state
   const {
     filters,
@@ -111,8 +114,12 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     setDateTo,
     clearAllFilters,
     hasActiveFilters,
-    activeFilterCount,
+    activeFilterCount: baseActiveFilterCount,
   } = useChannelVideoFilters();
+
+  // Include protectedFilter in the active filter count and hasActiveFilters
+  const activeFilterCount = baseActiveFilterCount + (protectedFilter ? 1 : 0);
+  const hasAnyActiveFilter = hasActiveFilters || protectedFilter;
 
   const { deleteVideosByYoutubeIds, loading: deleteLoading } = useVideoDeletion();
   const { toggleProtection, successMessage: protectionSuccess, error: protectionError, clearMessages: clearProtectionMessages } = useVideoProtection(token);
@@ -355,7 +362,10 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   }, [videos, localIgnoreStatus, localProtectedStatus]);
 
   // Videos are already filtered, sorted, and paginated by the server
-  const paginatedVideos = videosWithOverrides;
+  // Apply client-side protected filter (after optimistic overrides are applied)
+  const paginatedVideos = protectedFilter
+    ? videosWithOverrides.filter(v => v.protected)
+    : videosWithOverrides;
 
   // Use server-provided total count for pagination
   const totalPages = Math.ceil(totalCount / pageSize) || 1;
@@ -617,7 +627,13 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     setCheckedBoxes([]); // Clear selections when changing tabs
     setSelectedForDeletion([]); // Clear deletion selections when changing tabs
     clearAllFilters(); // Clear filters when changing tabs
+    setProtectedFilter(false); // Clear protected filter when changing tabs
   };
+
+  const handleClearAllFilters = useCallback(() => {
+    clearAllFilters();
+    setProtectedFilter(false);
+  }, [clearAllFilters]);
 
   const handleAutoDownloadChange = async (enabled: boolean) => {
     if (!channelId || !token || !selectedTab) return;
@@ -888,11 +904,13 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
           onMaxDurationChange={setMaxDuration}
           onDateFromChange={setDateFrom}
           onDateToChange={setDateTo}
-          onClearAll={clearAllFilters}
-          hasActiveFilters={hasActiveFilters}
+          onClearAll={handleClearAllFilters}
+          hasActiveFilters={hasAnyActiveFilter}
           activeFilterCount={activeFilterCount}
           hideDateFilter={selectedTab === 'shorts'}
           filtersExpanded={filtersExpanded}
+          protectedFilter={protectedFilter}
+          onProtectedFilterChange={setProtectedFilter}
         />
 
         {/* Tabs */}
@@ -928,7 +946,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
 
         {/* Content area */}
         <Box sx={{ p: 2 }} {...(isMobile ? handlers : {})}>
-          {videoFailed && videos.length === 0 && !hasActiveFilters && !searchQuery ? (
+          {videoFailed && videos.length === 0 && !hasAnyActiveFilter && !searchQuery ? (
             <Alert severity="error">
               Failed to fetch channel videos. Please try again later.
             </Alert>
@@ -947,10 +965,10 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                 ))}
               </Grid>
             </Box>
-          ) : videos.length === 0 ? (
+          ) : videos.length === 0 || paginatedVideos.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 4 }}>
               <Typography variant="body1" color="text.secondary">
-                {hasActiveFilters || searchQuery
+                {hasAnyActiveFilter || searchQuery
                   ? 'No videos found matching your search and filter criteria'
                   : 'No videos found'}
               </Typography>

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -35,6 +35,7 @@ import { useNavigate } from 'react-router-dom';
 import { useSwipeable } from 'react-swipeable';
 import { DownloadSettings } from '../DownloadManager/ManualDownload/types';
 import { useVideoDeletion } from '../shared/useVideoDeletion';
+import { useVideoProtection } from '../shared/useVideoProtection';
 import { getVideoStatus } from '../../utils/videoStatus';
 import VideoCard from './VideoCard';
 import VideoListItem from './VideoListItem';
@@ -96,6 +97,9 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   // Local state to track ignore status changes without refetching
   const [localIgnoreStatus, setLocalIgnoreStatus] = useState<Record<string, boolean>>({});
 
+  // Local state to track protection status changes without refetching
+  const [localProtectedStatus, setLocalProtectedStatus] = useState<Record<string, boolean>>({});
+
   // Filter state
   const {
     filters,
@@ -111,6 +115,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   } = useChannelVideoFilters();
 
   const { deleteVideosByYoutubeIds, loading: deleteLoading } = useVideoDeletion();
+  const { toggleProtection, successMessage: protectionSuccess, error: protectionError, clearMessages: clearProtectionMessages } = useVideoProtection(token);
 
   const { channel_id: routeChannelId } = useParams();
   const channelId = propChannelId ?? routeChannelId ?? undefined;
@@ -280,9 +285,10 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     }
   }, [availableTabsFromVideos]);
 
-  // Clear local ignore status overrides when videos are refetched (page change, tab change, etc)
+  // Clear local status overrides when videos are refetched (page change, tab change, etc)
   useEffect(() => {
     setLocalIgnoreStatus({});
+    setLocalProtectedStatus({});
   }, [page, selectedTab, hideDownloaded, searchQuery, sortBy, sortOrder, filters]);
 
   // Reset page to 1 when filters change
@@ -327,20 +333,26 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
 
   const navigate = useNavigate();
 
-  // Apply local ignore status overrides to videos (for optimistic updates)
+  // Apply local ignore and protection status overrides to videos (for optimistic updates)
   const videosWithOverrides = useMemo(() => {
     return videos.map(video => {
-      // If we have a local override for this video, use it
-      if (video.youtube_id in localIgnoreStatus) {
-        return {
-          ...video,
+      const hasIgnoreOverride = video.youtube_id in localIgnoreStatus;
+      const hasProtectedOverride = video.youtube_id in localProtectedStatus;
+
+      if (!hasIgnoreOverride && !hasProtectedOverride) return video;
+
+      return {
+        ...video,
+        ...(hasIgnoreOverride ? {
           ignored: localIgnoreStatus[video.youtube_id],
           ignored_at: localIgnoreStatus[video.youtube_id] ? new Date().toISOString() : null,
-        };
-      }
-      return video;
+        } : {}),
+        ...(hasProtectedOverride ? {
+          protected: localProtectedStatus[video.youtube_id],
+        } : {}),
+      };
     });
-  }, [videos, localIgnoreStatus]);
+  }, [videos, localIgnoreStatus, localProtectedStatus]);
 
   // Videos are already filtered, sorted, and paginated by the server
   const paginatedVideos = videosWithOverrides;
@@ -416,6 +428,35 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
 
   const handleRefreshCancel = () => {
     setRefreshConfirmOpen(false);
+  };
+
+  // Forward protection hook messages to the shared success/error state
+  useEffect(() => {
+    if (protectionSuccess) {
+      setSuccessMessage(protectionSuccess);
+      clearProtectionMessages();
+    }
+  }, [protectionSuccess, clearProtectionMessages]);
+
+  useEffect(() => {
+    if (protectionError) {
+      setErrorMessage(protectionError);
+      clearProtectionMessages();
+    }
+  }, [protectionError, clearProtectionMessages]);
+
+  const handleToggleProtection = async (youtubeId: string) => {
+    const video = paginatedVideos.find(v => v.youtube_id === youtubeId);
+    if (!video || !video.id) return;
+
+    const currentState = video.protected || false;
+    const newState = await toggleProtection(video.id, currentState);
+    if (newState !== undefined) {
+      setLocalProtectedStatus(prev => ({
+        ...prev,
+        [youtubeId]: newState,
+      }));
+    }
   };
 
   const toggleDeletionSelection = (youtubeId: string) => {
@@ -931,7 +972,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onHoverChange={setHoveredVideo}
                       onToggleDeletion={toggleDeletionSelection}
                       onToggleIgnore={toggleIgnore}
-                      onToggleProtection={() => {}}
+                      onToggleProtection={handleToggleProtection}
                       onMobileTooltip={setMobileTooltip}
                     />
                   ))}
@@ -949,7 +990,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onCheckChange={handleCheckChange}
                       onToggleDeletion={toggleDeletionSelection}
                       onToggleIgnore={toggleIgnore}
-                      onToggleProtection={() => {}}
+                      onToggleProtection={handleToggleProtection}
                       onMobileTooltip={setMobileTooltip}
                     />
                   ))}

--- a/client/src/components/ChannelPage/VideoCard.tsx
+++ b/client/src/components/ChannelPage/VideoCard.tsx
@@ -13,8 +13,6 @@ import {
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
-import ShieldIcon from '@mui/icons-material/Shield';
-import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration } from '../../utils';
@@ -24,6 +22,7 @@ import { getVideoStatus, getStatusColor, getStatusIcon, getStatusLabel, getMedia
 import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
 import RatingBadge from '../shared/RatingBadge';
+import ProtectionShieldButton from '../shared/ProtectionShieldButton';
 
 interface VideoCardProps {
   video: ChannelVideo;
@@ -252,37 +251,14 @@ function VideoCard({
 
             {/* Protection shield for downloaded videos */}
             {video.added && !video.removed && (
-              <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
-                <IconButton
-                  aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onToggleProtection(video.youtube_id);
-                  }}
-                  sx={{
-                    position: 'absolute',
-                    bottom: 6,
-                    left: 6,
-                    bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
-                    color: video.protected ? 'white' : 'grey.500',
-                    padding: 0.5,
-                    opacity: video.protected ? 1 : 0.6,
-                    '&:hover': {
-                      bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
-                      opacity: 1,
-                    },
-                    transition: 'all 0.2s',
-                    boxShadow: video.protected ? '0 0 6px rgba(25,118,210,0.5)' : 'none',
-                    zIndex: 2,
-                  }}
-                  size="small"
-                >
-                  {video.protected
-                    ? <ShieldIcon sx={{ fontSize: 16 }} />
-                    : <ShieldOutlinedIcon sx={{ fontSize: 16 }} />
-                  }
-                </IconButton>
-              </Tooltip>
+              <ProtectionShieldButton
+                isProtected={video.protected || false}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleProtection(video.youtube_id);
+                }}
+                sx={{ position: 'absolute', bottom: 6, left: 6, zIndex: 2 }}
+              />
             )}
           </Box>
 

--- a/client/src/components/ChannelPage/VideoCard.tsx
+++ b/client/src/components/ChannelPage/VideoCard.tsx
@@ -13,6 +13,8 @@ import {
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration } from '../../utils';
@@ -33,6 +35,7 @@ interface VideoCardProps {
   onHoverChange: (videoId: string | null) => void;
   onToggleDeletion: (youtubeId: string) => void;
   onToggleIgnore: (youtubeId: string) => void;
+  onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
 }
 
@@ -46,6 +49,7 @@ function VideoCard({
   onHoverChange,
   onToggleDeletion,
   onToggleIgnore,
+  onToggleProtection,
   onMobileTooltip,
 }: VideoCardProps) {
   const theme = useTheme();
@@ -192,6 +196,7 @@ function VideoCard({
             {/* Delete icon for downloaded videos that exist on disk */}
             {video.added && !video.removed && (
               <IconButton
+                aria-label="Delete video"
                 onClick={(e) => {
                   e.stopPropagation();
                   onToggleDeletion(video.youtube_id);
@@ -241,6 +246,41 @@ function VideoCard({
                   size="small"
                 >
                   {isIgnored ? <CheckCircleOutlineIcon fontSize="small" /> : <BlockIcon fontSize="small" />}
+                </IconButton>
+              </Tooltip>
+            )}
+
+            {/* Protection shield for downloaded videos */}
+            {video.added && !video.removed && (
+              <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
+                <IconButton
+                  aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggleProtection(video.youtube_id);
+                  }}
+                  sx={{
+                    position: 'absolute',
+                    bottom: 6,
+                    left: 6,
+                    bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
+                    color: video.protected ? 'white' : 'grey.500',
+                    padding: 0.5,
+                    opacity: video.protected ? 1 : 0.6,
+                    '&:hover': {
+                      bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
+                      opacity: 1,
+                    },
+                    transition: 'all 0.2s',
+                    boxShadow: video.protected ? '0 0 6px rgba(25,118,210,0.5)' : 'none',
+                    zIndex: 2,
+                  }}
+                  size="small"
+                >
+                  {video.protected
+                    ? <ShieldIcon sx={{ fontSize: 16 }} />
+                    : <ShieldOutlinedIcon sx={{ fontSize: 16 }} />
+                  }
                 </IconButton>
               </Tooltip>
             )}

--- a/client/src/components/ChannelPage/VideoListItem.tsx
+++ b/client/src/components/ChannelPage/VideoListItem.tsx
@@ -14,8 +14,6 @@ import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import ShieldIcon from '@mui/icons-material/Shield';
-import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration } from '../../utils';
 import { ChannelVideo } from '../../types/ChannelVideo';
@@ -24,6 +22,7 @@ import { getVideoStatus, getStatusColor, getStatusIcon, getStatusLabel, getMedia
 import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
 import RatingBadge from '../shared/RatingBadge';
+import ProtectionShieldButton from '../shared/ProtectionShieldButton';
 
 interface VideoListItemProps {
   video: ChannelVideo;
@@ -228,36 +227,15 @@ function VideoListItem({
 
           {/* Protection shield for downloaded videos */}
           {video.added && !video.removed && (
-            <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
-              <IconButton
-                aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onToggleProtection(video.youtube_id);
-                }}
-                sx={{
-                  position: 'absolute',
-                  bottom: 3,
-                  left: 3,
-                  bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
-                  color: video.protected ? 'white' : 'grey.500',
-                  padding: 0.3,
-                  opacity: video.protected ? 1 : 0.6,
-                  '&:hover': {
-                    bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
-                    opacity: 1,
-                  },
-                  transition: 'all 0.2s',
-                  boxShadow: video.protected ? '0 0 4px rgba(25,118,210,0.5)' : 'none',
-                }}
-                size="small"
-              >
-                {video.protected
-                  ? <ShieldIcon sx={{ fontSize: 14 }} />
-                  : <ShieldOutlinedIcon sx={{ fontSize: 14 }} />
-                }
-              </IconButton>
-            </Tooltip>
+            <ProtectionShieldButton
+              isProtected={video.protected || false}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleProtection(video.youtube_id);
+              }}
+              size="small"
+              sx={{ position: 'absolute', bottom: 3, left: 3 }}
+            />
           )}
         </Box>
 

--- a/client/src/components/ChannelPage/VideoListItem.tsx
+++ b/client/src/components/ChannelPage/VideoListItem.tsx
@@ -14,6 +14,8 @@ import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration } from '../../utils';
 import { ChannelVideo } from '../../types/ChannelVideo';
@@ -30,6 +32,7 @@ interface VideoListItemProps {
   onCheckChange: (videoId: string, isChecked: boolean) => void;
   onToggleDeletion: (youtubeId: string) => void;
   onToggleIgnore: (youtubeId: string) => void;
+  onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
 }
 
@@ -40,6 +43,7 @@ function VideoListItem({
   onCheckChange,
   onToggleDeletion,
   onToggleIgnore,
+  onToggleProtection,
   onMobileTooltip,
 }: VideoListItemProps) {
   const theme = useTheme();
@@ -168,6 +172,7 @@ function VideoListItem({
           {/* Delete icon for downloaded videos that exist on disk */}
           {video.added && !video.removed && (
             <IconButton
+              aria-label="Delete video"
               onClick={(e) => {
                 e.stopPropagation();
                 onToggleDeletion(video.youtube_id);
@@ -217,6 +222,40 @@ function VideoListItem({
                 size="small"
               >
                 {isIgnored ? <CheckCircleOutlineIcon sx={{ fontSize: 18 }} /> : <BlockIcon sx={{ fontSize: 18 }} />}
+              </IconButton>
+            </Tooltip>
+          )}
+
+          {/* Protection shield for downloaded videos */}
+          {video.added && !video.removed && (
+            <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
+              <IconButton
+                aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleProtection(video.youtube_id);
+                }}
+                sx={{
+                  position: 'absolute',
+                  bottom: 3,
+                  left: 3,
+                  bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
+                  color: video.protected ? 'white' : 'grey.500',
+                  padding: 0.3,
+                  opacity: video.protected ? 1 : 0.6,
+                  '&:hover': {
+                    bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
+                    opacity: 1,
+                  },
+                  transition: 'all 0.2s',
+                  boxShadow: video.protected ? '0 0 4px rgba(25,118,210,0.5)' : 'none',
+                }}
+                size="small"
+              >
+                {video.protected
+                  ? <ShieldIcon sx={{ fontSize: 14 }} />
+                  : <ShieldOutlinedIcon sx={{ fontSize: 14 }} />
+                }
               </IconButton>
             </Tooltip>
           )}

--- a/client/src/components/ChannelPage/VideoTableView.tsx
+++ b/client/src/components/ChannelPage/VideoTableView.tsx
@@ -17,6 +17,9 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
+import Tooltip from '@mui/material/Tooltip';
 import RatingBadge from '../shared/RatingBadge';
 import { formatDuration } from '../../utils';
 import { ChannelVideo } from '../../types/ChannelVideo';
@@ -40,6 +43,7 @@ interface VideoTableViewProps {
   onSortChange: (newSortBy: SortBy) => void;
   onToggleDeletion: (youtubeId: string) => void;
   onToggleIgnore: (youtubeId: string) => void;
+  onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
 }
 
@@ -55,6 +59,7 @@ function VideoTableView({
   onSortChange,
   onToggleDeletion,
   onToggleIgnore,
+  onToggleProtection,
   onMobileTooltip,
 }: VideoTableViewProps) {
   return (
@@ -142,6 +147,7 @@ function VideoTableView({
                   {/* Delete icon for downloaded videos that exist on disk */}
                   {video.added && !video.removed && (
                     <IconButton
+                      aria-label="Delete video"
                       onClick={(e) => {
                         e.stopPropagation();
                         onToggleDeletion(video.youtube_id);
@@ -157,6 +163,31 @@ function VideoTableView({
                     >
                       <DeleteIcon fontSize="small" />
                     </IconButton>
+                  )}
+                  {/* Protection shield for downloaded videos */}
+                  {video.added && !video.removed && (
+                    <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
+                      <IconButton
+                        aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onToggleProtection(video.youtube_id);
+                        }}
+                        sx={{
+                          color: video.protected ? 'primary.main' : 'action.active',
+                          '&:hover': {
+                            color: 'primary.main',
+                            bgcolor: 'primary.light',
+                          },
+                        }}
+                        size="small"
+                      >
+                        {video.protected
+                          ? <ShieldIcon fontSize="small" />
+                          : <ShieldOutlinedIcon fontSize="small" />
+                        }
+                      </IconButton>
+                    </Tooltip>
                   )}
                   {/* Ignore/Unignore button - for videos not currently on disk (never downloaded or missing) */}
                   {!isStillLive && (!video.added || video.removed) && (

--- a/client/src/components/ChannelPage/VideoTableView.tsx
+++ b/client/src/components/ChannelPage/VideoTableView.tsx
@@ -17,10 +17,8 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import ShieldIcon from '@mui/icons-material/Shield';
-import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
-import Tooltip from '@mui/material/Tooltip';
 import RatingBadge from '../shared/RatingBadge';
+import ProtectionShieldButton from '../shared/ProtectionShieldButton';
 import { formatDuration } from '../../utils';
 import { ChannelVideo } from '../../types/ChannelVideo';
 import { decodeHtml } from '../../utils/formatters';
@@ -166,28 +164,14 @@ function VideoTableView({
                   )}
                   {/* Protection shield for downloaded videos */}
                   {video.added && !video.removed && (
-                    <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
-                      <IconButton
-                        aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onToggleProtection(video.youtube_id);
-                        }}
-                        sx={{
-                          color: video.protected ? 'primary.main' : 'action.active',
-                          '&:hover': {
-                            color: 'primary.main',
-                            bgcolor: 'primary.light',
-                          },
-                        }}
-                        size="small"
-                      >
-                        {video.protected
-                          ? <ShieldIcon fontSize="small" />
-                          : <ShieldOutlinedIcon fontSize="small" />
-                        }
-                      </IconButton>
-                    </Tooltip>
+                    <ProtectionShieldButton
+                      isProtected={video.protected || false}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onToggleProtection(video.youtube_id);
+                      }}
+                      variant="inline"
+                    />
                   )}
                   {/* Ignore/Unignore button - for videos not currently on disk (never downloaded or missing) */}
                   {!isStillLive && (!video.added || video.removed) && (

--- a/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
@@ -532,6 +532,7 @@ describe('ChannelVideos Component', () => {
         maxDuration: null,
         dateFrom: null,
         dateTo: null,
+        protectedFilter: false,
       });
     });
 

--- a/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
@@ -36,6 +36,7 @@ describe('VideoCard Component', () => {
     onHoverChange: jest.fn(),
     onToggleDeletion: jest.fn(),
     onToggleIgnore: jest.fn(),
+    onToggleProtection: jest.fn(),
   };
 
   beforeEach(() => {
@@ -391,7 +392,7 @@ describe('VideoCard Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -413,7 +414,7 @@ describe('VideoCard Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -717,6 +718,46 @@ describe('VideoCard Component', () => {
       renderWithProviders(<VideoCard {...defaultProps} />);
       const img = screen.getByAltText('Test Video Title');
       expect(img).toHaveAttribute('loading', 'lazy');
+    });
+  });
+
+  describe('Protection Shield', () => {
+    test('renders shield icon for downloaded video', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoCard {...defaultProps} video={downloadedVideo} />);
+      expect(screen.getByLabelText('Protect from auto-deletion')).toBeInTheDocument();
+    });
+
+    test('renders active shield icon for protected video', () => {
+      const protectedVideo = { ...mockVideo, added: true, removed: false, protected: true };
+      renderWithProviders(<VideoCard {...defaultProps} video={protectedVideo} />);
+      expect(screen.getByLabelText('Remove protection')).toBeInTheDocument();
+    });
+
+    test('does not render shield icon for non-downloaded video', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.queryByLabelText('Protect from auto-deletion')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Remove protection')).not.toBeInTheDocument();
+    });
+
+    test('calls onToggleProtection when shield icon is clicked', async () => {
+      const user = userEvent.setup();
+      const onToggleProtection = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoCard
+          {...defaultProps}
+          video={downloadedVideo}
+          onToggleProtection={onToggleProtection}
+        />
+      );
+
+      const shieldButton = screen.getByLabelText('Protect from auto-deletion');
+      await user.click(shieldButton);
+
+      expect(onToggleProtection).toHaveBeenCalledTimes(1);
+      expect(onToggleProtection).toHaveBeenCalledWith('test123');
     });
   });
 

--- a/client/src/components/ChannelPage/__tests__/VideoListItem.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoListItem.test.tsx
@@ -33,6 +33,7 @@ describe('VideoListItem Component', () => {
     onCheckChange: jest.fn(),
     onToggleDeletion: jest.fn(),
     onToggleIgnore: jest.fn(),
+    onToggleProtection: jest.fn(),
   };
 
   beforeEach(() => {
@@ -435,7 +436,7 @@ describe('VideoListItem Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -457,7 +458,7 @@ describe('VideoListItem Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -759,6 +760,46 @@ describe('VideoListItem Component', () => {
       const ignoredVideo = { ...mockVideo, ignored: true };
       renderWithProviders(<VideoListItem {...defaultProps} video={ignoredVideo} />);
       expect(screen.getByText('Ignored')).toBeInTheDocument();
+    });
+  });
+
+  describe('Protection Shield', () => {
+    test('renders shield icon for downloaded video', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoListItem {...defaultProps} video={downloadedVideo} />);
+      expect(screen.getByLabelText('Protect from auto-deletion')).toBeInTheDocument();
+    });
+
+    test('renders active shield icon for protected video', () => {
+      const protectedVideo = { ...mockVideo, added: true, removed: false, protected: true };
+      renderWithProviders(<VideoListItem {...defaultProps} video={protectedVideo} />);
+      expect(screen.getByLabelText('Remove protection')).toBeInTheDocument();
+    });
+
+    test('does not render shield icon for non-downloaded video', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.queryByLabelText('Protect from auto-deletion')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Remove protection')).not.toBeInTheDocument();
+    });
+
+    test('calls onToggleProtection when shield icon is clicked', async () => {
+      const user = userEvent.setup();
+      const onToggleProtection = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoListItem
+          {...defaultProps}
+          video={downloadedVideo}
+          onToggleProtection={onToggleProtection}
+        />
+      );
+
+      const shieldButton = screen.getByLabelText('Protect from auto-deletion');
+      await user.click(shieldButton);
+
+      expect(onToggleProtection).toHaveBeenCalledTimes(1);
+      expect(onToggleProtection).toHaveBeenCalledWith('test123');
     });
   });
 });

--- a/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
@@ -39,6 +39,7 @@ describe('VideoTableView Component', () => {
     onSortChange: jest.fn(),
     onToggleDeletion: jest.fn(),
     onToggleIgnore: jest.fn(),
+    onToggleProtection: jest.fn(),
   };
 
   beforeEach(() => {
@@ -462,7 +463,7 @@ describe('VideoTableView Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -484,7 +485,7 @@ describe('VideoTableView Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -950,6 +951,46 @@ describe('VideoTableView Component', () => {
       expect(checkboxes[0]).toBeChecked();
       expect(checkboxes[1]).toBeChecked();
       expect(checkboxes[2]).toBeChecked();
+    });
+  });
+
+  describe('Protection Shield', () => {
+    test('renders shield icon for downloaded video', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[downloadedVideo]} />);
+      expect(screen.getByLabelText('Protect from auto-deletion')).toBeInTheDocument();
+    });
+
+    test('renders active shield icon for protected video', () => {
+      const protectedVideo = { ...mockVideo, added: true, removed: false, protected: true };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[protectedVideo]} />);
+      expect(screen.getByLabelText('Remove protection')).toBeInTheDocument();
+    });
+
+    test('does not render shield icon for non-downloaded video', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.queryByLabelText('Protect from auto-deletion')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Remove protection')).not.toBeInTheDocument();
+    });
+
+    test('calls onToggleProtection when shield icon is clicked', async () => {
+      const user = userEvent.setup();
+      const onToggleProtection = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoTableView
+          {...defaultProps}
+          videos={[downloadedVideo]}
+          onToggleProtection={onToggleProtection}
+        />
+      );
+
+      const shieldButton = screen.getByLabelText('Protect from auto-deletion');
+      await user.click(shieldButton);
+
+      expect(onToggleProtection).toHaveBeenCalledTimes(1);
+      expect(onToggleProtection).toHaveBeenCalledWith('test123');
     });
   });
 });

--- a/client/src/components/ChannelPage/components/ChannelVideosFilters.tsx
+++ b/client/src/components/ChannelPage/components/ChannelVideosFilters.tsx
@@ -3,10 +3,12 @@ import {
   Box,
   Button,
   Badge,
+  Chip,
   Collapse,
   Typography,
 } from '@mui/material';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import ShieldIcon from '@mui/icons-material/Shield';
 import DurationFilterInput from './DurationFilterInput';
 import DateRangeFilterInput from './DateRangeFilterInput';
 import FilterChips from './FilterChips';
@@ -27,6 +29,8 @@ interface ChannelVideosFiltersProps {
   activeFilterCount: number;
   hideDateFilter?: boolean;
   filtersExpanded?: boolean; // For desktop, controlled by parent
+  protectedFilter?: boolean;
+  onProtectedFilterChange?: (value: boolean) => void;
 }
 
 function ChannelVideosFilters({
@@ -43,6 +47,8 @@ function ChannelVideosFilters({
   activeFilterCount,
   hideDateFilter = false,
   filtersExpanded = false,
+  protectedFilter = false,
+  onProtectedFilterChange,
 }: ChannelVideosFiltersProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
@@ -98,6 +104,8 @@ function ChannelVideosFilters({
           onClearAll={onClearAll}
           hasActiveFilters={hasActiveFilters}
           hideDateFilter={hideDateFilter}
+          protectedFilter={protectedFilter}
+          onProtectedFilterChange={onProtectedFilterChange}
         />
       </Box>
     );
@@ -125,6 +133,17 @@ function ChannelVideosFilters({
             <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
               Shorts do not have date information
             </Typography>
+          )}
+          {onProtectedFilterChange && (
+            <Chip
+              icon={<ShieldIcon />}
+              label="Protected"
+              variant={protectedFilter ? 'filled' : 'outlined'}
+              color={protectedFilter ? 'primary' : 'default'}
+              size="small"
+              onClick={() => onProtectedFilterChange(!protectedFilter)}
+              sx={{ cursor: 'pointer' }}
+            />
           )}
           {hasActiveFilters && (
             <Button

--- a/client/src/components/ChannelPage/components/MobileFilterDrawer.tsx
+++ b/client/src/components/ChannelPage/components/MobileFilterDrawer.tsx
@@ -5,9 +5,11 @@ import {
   Typography,
   IconButton,
   Button,
+  Chip,
   Divider,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import ShieldIcon from '@mui/icons-material/Shield';
 import DurationFilterInput from './DurationFilterInput';
 import DateRangeFilterInput from './DateRangeFilterInput';
 import { VideoFilters } from '../hooks/useChannelVideoFilters';
@@ -25,6 +27,8 @@ interface MobileFilterDrawerProps {
   onClearAll: () => void;
   hasActiveFilters: boolean;
   hideDateFilter?: boolean;
+  protectedFilter?: boolean;
+  onProtectedFilterChange?: (value: boolean) => void;
 }
 
 function MobileFilterDrawer({
@@ -40,6 +44,8 @@ function MobileFilterDrawer({
   onClearAll,
   hasActiveFilters,
   hideDateFilter = false,
+  protectedFilter = false,
+  onProtectedFilterChange,
 }: MobileFilterDrawerProps) {
   return (
     <Drawer
@@ -98,6 +104,24 @@ function MobileFilterDrawer({
             <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
               Shorts do not have date information
             </Typography>
+          </Box>
+        )}
+
+        {/* Protected Filter */}
+        {onProtectedFilterChange && (
+          <Box sx={{ mb: 3 }}>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              Status
+            </Typography>
+            <Chip
+              icon={<ShieldIcon />}
+              label="Protected"
+              variant={protectedFilter ? 'filled' : 'outlined'}
+              color={protectedFilter ? 'primary' : 'default'}
+              size="small"
+              onClick={() => onProtectedFilterChange(!protectedFilter)}
+              sx={{ cursor: 'pointer' }}
+            />
           </Box>
         )}
 

--- a/client/src/components/ChannelPage/hooks/useChannelVideos.ts
+++ b/client/src/components/ChannelPage/hooks/useChannelVideos.ts
@@ -15,6 +15,7 @@ interface UseChannelVideosParams {
   maxDuration?: number | null;
   dateFrom?: Date | null;
   dateTo?: Date | null;
+  protectedFilter?: boolean;
 }
 
 interface UseChannelVideosResult {
@@ -43,6 +44,7 @@ export function useChannelVideos({
   maxDuration,
   dateFrom,
   dateTo,
+  protectedFilter,
 }: UseChannelVideosParams): UseChannelVideosResult {
   const [videos, setVideos] = useState<ChannelVideo[]>([]);
   const [totalCount, setTotalCount] = useState<number>(0);
@@ -86,6 +88,9 @@ export function useChannelVideos({
       if (dateTo) {
         queryParams.append('dateTo', dateTo.toISOString().split('T')[0]);
       }
+      if (protectedFilter) {
+        queryParams.append('protectedFilter', 'true');
+      }
 
       const response = await fetch(`/getchannelvideos/${channelId}?${queryParams}`, {
         headers: {
@@ -114,7 +119,7 @@ export function useChannelVideos({
     } finally {
       setLoading(false);
     }
-  }, [channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, token, minDuration, maxDuration, dateFrom, dateTo]);
+  }, [channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, token, minDuration, maxDuration, dateFrom, dateTo, protectedFilter]);
 
   useEffect(() => {
     fetchVideos();

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -713,6 +713,7 @@ function VideosPage({ token }: VideosPageProps) {
                                 </IconButton>
                               )}
                               {/* Protection shield */}
+                              {!video.removed && (
                               <ProtectionShieldButton
                                 isProtected={video.protected || false}
                                 onClick={(e) => {
@@ -721,6 +722,7 @@ function VideosPage({ token }: VideosPageProps) {
                                 }}
                                 sx={{ position: 'absolute', bottom: 6, left: 6, zIndex: 3 }}
                               />
+                              )}
                             </Box>
                             <Typography variant='subtitle1' textAlign='center'>
                               {video.youTubeVideoName}
@@ -1010,11 +1012,13 @@ function VideosPage({ token }: VideosPageProps) {
                           </TableCell>
                           <TableCell>
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                              <ProtectionShieldButton
-                                isProtected={video.protected || false}
-                                onClick={() => handleToggleProtection(video.id)}
-                                variant="inline"
-                              />
+                              {!video.removed && (
+                                <ProtectionShieldButton
+                                  isProtected={video.protected || false}
+                                  onClick={() => handleToggleProtection(video.id)}
+                                  variant="inline"
+                                />
+                              )}
                               <Tooltip title="Delete video from disk">
                                 <span>
                                   <IconButton

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -32,6 +32,8 @@ import Pagination from '@mui/material/Pagination';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import DeleteIcon from '@mui/icons-material/Delete';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration, formatYTDate } from '../utils';
@@ -48,6 +50,7 @@ import ScheduleIcon from '@mui/icons-material/Schedule';
 import DeleteVideosDialog from './shared/DeleteVideosDialog';
 import { useVideoDeletion } from './shared/useVideoDeletion';
 import DownloadFormatIndicator from './shared/DownloadFormatIndicator';
+import { useVideoProtection } from './shared/useVideoProtection';
 import RatingBadge from './shared/RatingBadge';
 import ChangeRatingDialog from './shared/ChangeRatingDialog';
 import VideoActionsDropdown from './shared/VideoActionsDropdown';
@@ -86,6 +89,8 @@ function VideosPage({ token }: VideosPageProps) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const { deleteVideos, loading: deleteLoading } = useVideoDeletion();
+  const { toggleProtection, successMessage: protectionSuccess, error: protectionError, clearMessages: clearProtectionMessages } = useVideoProtection(token);
+  const [protectedFilter, setProtectedFilter] = useState(false);
 
   const videosPerPage = isMobile ? 6 : 12;
 
@@ -119,6 +124,7 @@ function VideosPage({ token }: VideosPageProps) {
     if (filter) params.append('channelFilter', filter);
     if (dateFrom) params.append('dateFrom', dateFrom.toISOString().split('T')[0]);
     if (dateTo) params.append('dateTo', dateTo.toISOString().split('T')[0]);
+    if (protectedFilter) params.append('protectedFilter', 'true');
 
     try {
       const response = await axios.get<PaginatedVideosResponse>(`/getVideos?${params.toString()}`, {
@@ -146,7 +152,7 @@ function VideosPage({ token }: VideosPageProps) {
     } finally {
       setLoading(false);
     }
-  }, [token, page, videosPerPage, orderBy, sortOrder, search, filter, dateFrom, dateTo]);
+  }, [token, page, videosPerPage, orderBy, sortOrder, search, filter, dateFrom, dateTo, protectedFilter]);
 
   useEffect(() => {
     fetchVideos();
@@ -315,6 +321,21 @@ function VideosPage({ token }: VideosPageProps) {
     setDeleteDialogOpen(true);
   };
 
+  const handleToggleProtection = async (videoId: number) => {
+    const video = videos.find((v: VideoData) => v.id === videoId);
+    if (!video) return;
+
+    const currentState = video.protected || false;
+    const newState = await toggleProtection(video.id, currentState);
+    if (newState !== undefined) {
+      setVideos((prev: VideoData[]) =>
+        prev.map((v: VideoData) =>
+          v.id === videoId ? { ...v, protected: newState } : v
+        )
+      );
+    }
+  };
+
   const handlers = useSwipeable({
     onSwipedLeft: () => {
       if (page < totalPages) {
@@ -362,6 +383,18 @@ function VideosPage({ token }: VideosPageProps) {
               ),
             }}
           />
+
+          <Box display="flex" gap={1} flexWrap="wrap">
+            <Chip
+              icon={<ShieldIcon />}
+              label="Protected"
+              variant={protectedFilter ? 'filled' : 'outlined'}
+              color={protectedFilter ? 'primary' : 'default'}
+              size="small"
+              onClick={() => setProtectedFilter(!protectedFilter)}
+              sx={{ cursor: 'pointer' }}
+            />
+          </Box>
 
           {!isMobile && (
             <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -673,6 +706,33 @@ function VideosPage({ token }: VideosPageProps) {
                                   <DeleteIcon fontSize="small" />
                                 </IconButton>
                               )}
+                              {/* Protection shield */}
+                              <IconButton
+                                aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleToggleProtection(video.id);
+                                }}
+                                sx={{
+                                  position: 'absolute',
+                                  bottom: 6,
+                                  left: 6,
+                                  bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
+                                  color: video.protected ? 'white' : 'grey.500',
+                                  padding: 0.5,
+                                  opacity: video.protected ? 1 : 0.6,
+                                  '&:hover': {
+                                    bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
+                                    opacity: 1,
+                                  },
+                                  transition: 'all 0.2s',
+                                  boxShadow: video.protected ? '0 0 4px rgba(25,118,210,0.5)' : 'none',
+                                  zIndex: 3,
+                                }}
+                                size="small"
+                              >
+                                {video.protected ? <ShieldIcon sx={{ fontSize: 16 }} /> : <ShieldOutlinedIcon sx={{ fontSize: 16 }} />}
+                              </IconButton>
                             </Box>
                             <Typography variant='subtitle1' textAlign='center'>
                               {video.youTubeVideoName}
@@ -961,18 +1021,32 @@ function VideosPage({ token }: VideosPageProps) {
                             </Stack>
                           </TableCell>
                           <TableCell>
-                            <Tooltip title="Delete video from disk">
-                              <span>
-                                <IconButton
-                                  color="error"
-                                  size="small"
-                                  onClick={() => handleDeleteSingleVideo(video.id)}
-                                  disabled={video.removed || deleteLoading}
-                                >
-                                  <DeleteIcon />
-                                </IconButton>
-                              </span>
-                            </Tooltip>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                              <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}>
+                                <span>
+                                  <IconButton
+                                    color={video.protected ? 'primary' : 'default'}
+                                    size="small"
+                                    onClick={() => handleToggleProtection(video.id)}
+                                    sx={{ opacity: video.protected ? 1 : 0.5 }}
+                                  >
+                                    {video.protected ? <ShieldIcon /> : <ShieldOutlinedIcon />}
+                                  </IconButton>
+                                </span>
+                              </Tooltip>
+                              <Tooltip title="Delete video from disk">
+                                <span>
+                                  <IconButton
+                                    color="error"
+                                    size="small"
+                                    onClick={() => handleDeleteSingleVideo(video.id)}
+                                    disabled={video.removed || deleteLoading}
+                                  >
+                                    <DeleteIcon />
+                                  </IconButton>
+                                </span>
+                              </Tooltip>
+                            </Box>
                           </TableCell>
                         </>
                       )}
@@ -1038,6 +1112,25 @@ function VideosPage({ token }: VideosPageProps) {
       >
         <Alert onClose={() => setErrorMessage(null)} severity="error">
           {errorMessage}
+        </Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={protectionSuccess !== null}
+        autoHideDuration={4000}
+        onClose={clearProtectionMessages}
+      >
+        <Alert onClose={clearProtectionMessages} severity="success">
+          {protectionSuccess}
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={protectionError !== null}
+        autoHideDuration={4000}
+        onClose={clearProtectionMessages}
+      >
+        <Alert onClose={clearProtectionMessages} severity="error">
+          {protectionError}
         </Alert>
       </Snackbar>
     </Card>

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -33,7 +33,6 @@ import FilterListIcon from '@mui/icons-material/FilterList';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ShieldIcon from '@mui/icons-material/Shield';
-import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration, formatYTDate } from '../utils';
@@ -54,6 +53,7 @@ import { useVideoProtection } from './shared/useVideoProtection';
 import RatingBadge from './shared/RatingBadge';
 import ChangeRatingDialog from './shared/ChangeRatingDialog';
 import VideoActionsDropdown from './shared/VideoActionsDropdown';
+import ProtectionShieldButton from './shared/ProtectionShieldButton';
 
 interface VideosPageProps {
   token: string | null;
@@ -707,32 +707,14 @@ function VideosPage({ token }: VideosPageProps) {
                                 </IconButton>
                               )}
                               {/* Protection shield */}
-                              <IconButton
-                                aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
+                              <ProtectionShieldButton
+                                isProtected={video.protected || false}
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   handleToggleProtection(video.id);
                                 }}
-                                sx={{
-                                  position: 'absolute',
-                                  bottom: 6,
-                                  left: 6,
-                                  bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
-                                  color: video.protected ? 'white' : 'grey.500',
-                                  padding: 0.5,
-                                  opacity: video.protected ? 1 : 0.6,
-                                  '&:hover': {
-                                    bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
-                                    opacity: 1,
-                                  },
-                                  transition: 'all 0.2s',
-                                  boxShadow: video.protected ? '0 0 4px rgba(25,118,210,0.5)' : 'none',
-                                  zIndex: 3,
-                                }}
-                                size="small"
-                              >
-                                {video.protected ? <ShieldIcon sx={{ fontSize: 16 }} /> : <ShieldOutlinedIcon sx={{ fontSize: 16 }} />}
-                              </IconButton>
+                                sx={{ position: 'absolute', bottom: 6, left: 6, zIndex: 3 }}
+                              />
                             </Box>
                             <Typography variant='subtitle1' textAlign='center'>
                               {video.youTubeVideoName}
@@ -1022,18 +1004,11 @@ function VideosPage({ token }: VideosPageProps) {
                           </TableCell>
                           <TableCell>
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                              <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}>
-                                <span>
-                                  <IconButton
-                                    color={video.protected ? 'primary' : 'default'}
-                                    size="small"
-                                    onClick={() => handleToggleProtection(video.id)}
-                                    sx={{ opacity: video.protected ? 1 : 0.5 }}
-                                  >
-                                    {video.protected ? <ShieldIcon /> : <ShieldOutlinedIcon />}
-                                  </IconButton>
-                                </span>
-                              </Tooltip>
+                              <ProtectionShieldButton
+                                isProtected={video.protected || false}
+                                onClick={() => handleToggleProtection(video.id)}
+                                variant="inline"
+                              />
                               <Tooltip title="Delete video from disk">
                                 <span>
                                   <IconButton

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -384,21 +384,9 @@ function VideosPage({ token }: VideosPageProps) {
             }}
           />
 
-          <Box display="flex" gap={1} flexWrap="wrap">
-            <Chip
-              icon={<ShieldIcon />}
-              label="Protected"
-              variant={protectedFilter ? 'filled' : 'outlined'}
-              color={protectedFilter ? 'primary' : 'default'}
-              size="small"
-              onClick={() => setProtectedFilter(!protectedFilter)}
-              sx={{ cursor: 'pointer' }}
-            />
-          </Box>
-
           {!isMobile && (
             <LocalizationProvider dateAdapter={AdapterDateFns}>
-              <Stack direction="row" spacing={2}>
+              <Stack direction="row" spacing={2} alignItems="center">
                 <DatePicker
                   label="From Date"
                   value={dateFrom}
@@ -416,6 +404,15 @@ function VideosPage({ token }: VideosPageProps) {
                     setPage(1);
                   }}
                   renderInput={(params) => <TextField {...params} variant="outlined" fullWidth />}
+                />
+                <Chip
+                  icon={<ShieldIcon />}
+                  label={protectedFilter ? 'Protected Only' : 'Protected'}
+                  variant={protectedFilter ? 'filled' : 'outlined'}
+                  color={protectedFilter ? 'primary' : 'default'}
+                  onClick={() => setProtectedFilter(!protectedFilter)}
+                  onDelete={protectedFilter ? () => setProtectedFilter(false) : undefined}
+                  sx={{ cursor: 'pointer', height: 36 }}
                 />
                 {(dateFrom || dateTo) && (
                   <Button
@@ -455,7 +452,7 @@ function VideosPage({ token }: VideosPageProps) {
         </Stack>
 
         {isMobile && (
-          <Box display='flex' justifyContent='center' mb={2}>
+          <Box display='flex' justifyContent='center' gap={1} mb={2}>
             <Button
               variant='outlined'
               startIcon={<FilterListIcon />}
@@ -463,6 +460,15 @@ function VideosPage({ token }: VideosPageProps) {
             >
               Filter by Channel
             </Button>
+            <Chip
+              icon={<ShieldIcon />}
+              label={protectedFilter ? 'Protected Only' : 'Protected'}
+              variant={protectedFilter ? 'filled' : 'outlined'}
+              color={protectedFilter ? 'primary' : 'default'}
+              onClick={() => setProtectedFilter(!protectedFilter)}
+              onDelete={protectedFilter ? () => setProtectedFilter(false) : undefined}
+              sx={{ cursor: 'pointer', height: 36 }}
+            />
             <FilterMenu
               anchorEl={anchorEl}
               handleClose={handleClose}

--- a/client/src/components/shared/ProtectionShieldButton.tsx
+++ b/client/src/components/shared/ProtectionShieldButton.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
+import { SxProps, Theme } from '@mui/material/styles';
+
+type ShieldVariant = 'overlay' | 'inline';
+type ShieldSize = 'small' | 'medium';
+
+interface ProtectionShieldButtonProps {
+  isProtected: boolean;
+  onClick: (e: React.MouseEvent) => void;
+  variant?: ShieldVariant;
+  size?: ShieldSize;
+  sx?: SxProps<Theme>;
+}
+
+function ProtectionShieldButton({
+  isProtected,
+  onClick,
+  variant = 'overlay',
+  size = 'medium',
+  sx,
+}: ProtectionShieldButtonProps) {
+  const tooltipText = isProtected ? 'Remove protection' : 'Protect from auto-deletion';
+
+  const overlayStyles: SxProps<Theme> = {
+    bgcolor: isProtected ? 'primary.main' : 'rgba(0,0,0,0.5)',
+    color: isProtected ? 'white' : 'grey.500',
+    padding: size === 'small' ? 0.3 : 0.5,
+    opacity: isProtected ? 1 : 0.6,
+    '&:hover': {
+      bgcolor: isProtected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
+      opacity: 1,
+    },
+    transition: 'all 0.2s',
+    boxShadow: isProtected ? '0 0 6px rgba(25,118,210,0.5)' : 'none',
+  };
+
+  const inlineStyles: SxProps<Theme> = {
+    color: isProtected ? 'primary.main' : 'action.active',
+    opacity: isProtected ? 1 : 0.5,
+    '&:hover': {
+      color: 'primary.main',
+      bgcolor: 'primary.light',
+    },
+  };
+
+  const baseStyles = variant === 'overlay' ? overlayStyles : inlineStyles;
+  const iconFontSize = size === 'small' ? 14 : 16;
+
+  return (
+    <Tooltip title={tooltipText} arrow>
+      <IconButton
+        aria-label={tooltipText}
+        onClick={onClick}
+        sx={[
+          baseStyles,
+          ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+        ]}
+        size="small"
+      >
+        {isProtected
+          ? (variant === 'inline'
+              ? <ShieldIcon fontSize="small" />
+              : <ShieldIcon sx={{ fontSize: iconFontSize }} />)
+          : (variant === 'inline'
+              ? <ShieldOutlinedIcon fontSize="small" />
+              : <ShieldOutlinedIcon sx={{ fontSize: iconFontSize }} />)
+        }
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+export default ProtectionShieldButton;

--- a/client/src/components/shared/__tests__/ProtectionShieldButton.test.tsx
+++ b/client/src/components/shared/__tests__/ProtectionShieldButton.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProtectionShieldButton from '../ProtectionShieldButton';
+
+describe('ProtectionShieldButton', () => {
+  test('renders unprotected state with correct tooltip', () => {
+    render(<ProtectionShieldButton isProtected={false} onClick={jest.fn()} />);
+    expect(screen.getByLabelText('Protect from auto-deletion')).toBeInTheDocument();
+  });
+
+  test('renders protected state with correct tooltip', () => {
+    render(<ProtectionShieldButton isProtected={true} onClick={jest.fn()} />);
+    expect(screen.getByLabelText('Remove protection')).toBeInTheDocument();
+  });
+
+  test('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    render(<ProtectionShieldButton isProtected={false} onClick={onClick} />);
+    fireEvent.click(screen.getByLabelText('Protect from auto-deletion'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders inline variant', () => {
+    render(<ProtectionShieldButton isProtected={false} onClick={jest.fn()} variant="inline" />);
+    expect(screen.getByLabelText('Protect from auto-deletion')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/shared/__tests__/useVideoProtection.test.ts
+++ b/client/src/components/shared/__tests__/useVideoProtection.test.ts
@@ -1,0 +1,108 @@
+import { renderHook, act } from '@testing-library/react';
+
+jest.mock('axios', () => ({
+  patch: jest.fn(),
+}));
+
+const axios = require('axios');
+
+import { useVideoProtection } from '../useVideoProtection';
+
+describe('useVideoProtection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('toggleProtection calls PATCH with correct params and returns new state', async () => {
+    axios.patch.mockResolvedValueOnce({ data: { id: 1, protected: true } });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    let returnedState: boolean | undefined;
+    await act(async () => {
+      returnedState = await result.current.toggleProtection(1, false);
+    });
+
+    expect(axios.patch).toHaveBeenCalledWith(
+      '/api/videos/1/protected',
+      { protected: true },
+      { headers: { 'x-access-token': 'test-token' } }
+    );
+    expect(returnedState).toBe(true);
+  });
+
+  test('toggleProtection sends false when current state is true', async () => {
+    axios.patch.mockResolvedValueOnce({ data: { id: 1, protected: false } });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    await act(async () => {
+      await result.current.toggleProtection(1, true);
+    });
+
+    expect(axios.patch).toHaveBeenCalledWith(
+      '/api/videos/1/protected',
+      { protected: false },
+      { headers: { 'x-access-token': 'test-token' } }
+    );
+  });
+
+  test('sets successMessage on successful toggle on', async () => {
+    axios.patch.mockResolvedValueOnce({ data: { id: 1, protected: true } });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    await act(async () => {
+      await result.current.toggleProtection(1, false);
+    });
+
+    expect(result.current.successMessage).toBe('Video protected from auto-deletion');
+  });
+
+  test('sets successMessage on successful toggle off', async () => {
+    axios.patch.mockResolvedValueOnce({ data: { id: 1, protected: false } });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    await act(async () => {
+      await result.current.toggleProtection(1, true);
+    });
+
+    expect(result.current.successMessage).toBe('Video protection removed');
+  });
+
+  test('sets error on failure', async () => {
+    axios.patch.mockRejectedValueOnce({
+      response: { data: { error: 'Video not found' } }
+    });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    let returnedState: boolean | undefined;
+    await act(async () => {
+      returnedState = await result.current.toggleProtection(999, false);
+    });
+
+    expect(result.current.error).toBe('Video not found');
+    expect(returnedState).toBeUndefined();
+  });
+
+  test('clearMessages resets successMessage and error', async () => {
+    axios.patch.mockResolvedValueOnce({ data: { id: 1, protected: true } });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    await act(async () => {
+      await result.current.toggleProtection(1, false);
+    });
+
+    expect(result.current.successMessage).toBe('Video protected from auto-deletion');
+
+    act(() => {
+      result.current.clearMessages();
+    });
+
+    expect(result.current.successMessage).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/client/src/components/shared/useVideoProtection.ts
+++ b/client/src/components/shared/useVideoProtection.ts
@@ -36,7 +36,6 @@ export const useVideoProtection = (token: string | null): UseVideoProtectionRetu
         { headers: { 'x-access-token': token || '' } }
       );
 
-      setLoading(false);
       setSuccessMessage(
         newState
           ? 'Video protected from auto-deletion'
@@ -48,8 +47,9 @@ export const useVideoProtection = (token: string | null): UseVideoProtectionRetu
         (err as { response?: { data?: { error?: string } } })?.response?.data?.error ||
         (err instanceof Error ? err.message : 'Failed to update protection status');
       setError(errorMessage);
-      setLoading(false);
       return undefined;
+    } finally {
+      setLoading(false);
     }
   }, [token]);
 

--- a/client/src/components/shared/useVideoProtection.ts
+++ b/client/src/components/shared/useVideoProtection.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback } from 'react';
+import axios from 'axios';
+
+interface UseVideoProtectionReturn {
+  toggleProtection: (videoId: number, currentState: boolean) => Promise<boolean | undefined>;
+  loading: boolean;
+  error: string | null;
+  successMessage: string | null;
+  clearMessages: () => void;
+}
+
+export const useVideoProtection = (token: string | null): UseVideoProtectionReturn => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const clearMessages = useCallback(() => {
+    setError(null);
+    setSuccessMessage(null);
+  }, []);
+
+  const toggleProtection = useCallback(async (
+    videoId: number,
+    currentState: boolean
+  ): Promise<boolean | undefined> => {
+    setLoading(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    const newState = !currentState;
+
+    try {
+      const response = await axios.patch(
+        `/api/videos/${videoId}/protected`,
+        { protected: newState },
+        { headers: { 'x-access-token': token || '' } }
+      );
+
+      setLoading(false);
+      setSuccessMessage(
+        newState
+          ? 'Video protected from auto-deletion'
+          : 'Video protection removed'
+      );
+      return response.data.protected;
+    } catch (err: unknown) {
+      const errorMessage =
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+        (err instanceof Error ? err.message : 'Failed to update protection status');
+      setError(errorMessage);
+      setLoading(false);
+      return undefined;
+    }
+  }, [token]);
+
+  return {
+    toggleProtection,
+    loading,
+    error,
+    successMessage,
+    clearMessages,
+  };
+};

--- a/client/src/types/ChannelVideo.ts
+++ b/client/src/types/ChannelVideo.ts
@@ -7,6 +7,7 @@
 },*/
 
 export interface ChannelVideo {
+  id?: number;
   title: string;
   youtube_id: string;
   publishedAt: string | null | undefined;
@@ -26,4 +27,5 @@ export interface ChannelVideo {
   ignored_at?: string | null;
   normalized_rating?: string | null;
   rating_source?: string | null;
+  protected?: boolean;
 }

--- a/client/src/types/VideoData.ts
+++ b/client/src/types/VideoData.ts
@@ -24,6 +24,7 @@ export interface VideoData {
   media_type?: string;
   normalized_rating?: string | null;
   rating_source?: string | null;
+  protected?: boolean;
 }
 
 export interface EnabledChannel {

--- a/migrations/20260408204301-add-video-protected-field.js
+++ b/migrations/20260408204301-add-video-protected-field.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { addColumnIfMissing, removeColumnIfExists } = require('../helpers');
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await addColumnIfMissing(queryInterface, 'Videos', 'protected', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  down: async (queryInterface) => {
+    await removeColumnIfExists(queryInterface, 'Videos', 'protected');
+  },
+};

--- a/migrations/20260408204301-add-video-protected-field.js
+++ b/migrations/20260408204301-add-video-protected-field.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { addColumnIfMissing, removeColumnIfExists } = require('../helpers');
+const { addColumnIfMissing, removeColumnIfExists } = require('./helpers');
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {

--- a/server/__tests__/server.core.test.js
+++ b/server/__tests__/server.core.test.js
@@ -479,7 +479,8 @@ describe('server initialization', () => {
       dateTo: '2024-12-31',
       sortBy: 'title',
       sortOrder: 'asc',
-      channelFilter: 'channel123'
+      channelFilter: 'channel123',
+      protectedFilter: false,
     });
 
     expect(res.statusCode).toBe(200);
@@ -573,7 +574,8 @@ describe('server initialization', () => {
       dateTo: null,
       sortBy: 'added',
       sortOrder: 'desc',
-      channelFilter: ''
+      channelFilter: '',
+      protectedFilter: false,
     });
 
     expect(res.statusCode).toBe(200);

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -831,7 +831,8 @@ describe('server routes - channels', () => {
         null, // default minDuration
         null, // default maxDuration
         null, // default dateFrom
-        null  // default dateTo
+        null, // default dateTo
+        false // default protectedFilter
       );
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
@@ -897,7 +898,8 @@ describe('server routes - channels', () => {
         null, // default minDuration
         null, // default maxDuration
         null, // default dateFrom
-        null  // default dateTo
+        null, // default dateTo
+        false // default protectedFilter
       );
       expect(res.statusCode).toBe(200);
     });
@@ -936,7 +938,8 @@ describe('server routes - channels', () => {
         null, // default minDuration
         null, // default maxDuration
         null, // default dateFrom
-        null  // default dateTo
+        null, // default dateTo
+        false // default protectedFilter
       );
       expect(res.statusCode).toBe(200);
     });

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -1215,7 +1215,8 @@ describe('server routes - videos', () => {
         dateTo: null,
         sortBy: 'added',
         sortOrder: 'desc',
-        channelFilter: ''
+        channelFilter: '',
+        protectedFilter: false,
       });
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
@@ -1262,7 +1263,8 @@ describe('server routes - videos', () => {
         dateTo: '2024-12-31',
         sortBy: 'title',
         sortOrder: 'asc',
-        channelFilter: 'channel123'
+        channelFilter: 'channel123',
+        protectedFilter: false,
       });
       expect(res.statusCode).toBe(200);
     });

--- a/server/models/video.js
+++ b/server/models/video.js
@@ -101,6 +101,11 @@ Video.init(
       allowNull: true,
       comment: 'Source of the rating',
     },
+    protected: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
   },
   {
     sequelize,

--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -956,7 +956,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: ['video1', 'video2', 'video3']
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
         expect(result[0].added).toBe(true);
         expect(result[0].removed).toBe(false);
@@ -985,7 +985,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: ['video1', 'video2']
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
         expect(result[0].added).toBe(true);
         expect(result[0].removed).toBe(false);
@@ -1042,7 +1042,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: ['video1', 'video2']
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
         expect(result[0].added).toBe(true);
         expect(result[0].removed).toBe(false);
@@ -1071,7 +1071,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: ['video1', 'video2', 'video3']
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
 
         // Video1 - not downloaded
@@ -1099,7 +1099,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: []
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
         expect(result).toEqual([]);
       });
@@ -1205,7 +1205,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: ['video1', 'video2']
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
         expect(result[0].added).toBe(true);
         expect(result[0].removed).toBe(false);

--- a/server/modules/__tests__/videoDeletionModule.test.js
+++ b/server/modules/__tests__/videoDeletionModule.test.js
@@ -871,6 +871,15 @@ describe('VideoDeletionModule', () => {
         'Error getting videos older than threshold'
       );
     });
+
+    test('should exclude protected videos from results', async () => {
+      mockSequelize.query.mockResolvedValue([]);
+
+      await VideoDeletionModule.getVideosOlderThanThreshold(30);
+
+      const queryString = mockSequelize.query.mock.calls[0][0];
+      expect(queryString).toContain('Videos.protected = 0');
+    });
   });
 
   describe('getOldestVideos', () => {
@@ -982,6 +991,15 @@ describe('VideoDeletionModule', () => {
         expect.objectContaining({ err: expect.any(Error) }),
         'Error getting oldest videos'
       );
+    });
+
+    test('should exclude protected videos from results', async () => {
+      mockSequelize.query.mockResolvedValue([]);
+
+      await VideoDeletionModule.getOldestVideos(10);
+
+      const queryString = mockSequelize.query.mock.calls[0][0];
+      expect(queryString).toContain('Videos.protected = 0');
     });
   });
 

--- a/server/modules/__tests__/videosModule.test.js
+++ b/server/modules/__tests__/videosModule.test.js
@@ -830,6 +830,43 @@ describe('VideosModule', () => {
     });
   });
 
+  describe('setVideoProtection', () => {
+    test('sets protected to true for existing video', async () => {
+      const mockVideoRecord = {
+        id: 1,
+        protected: false,
+        update: jest.fn().mockResolvedValue(),
+      };
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+
+      const result = await VideosModule.setVideoProtection(1, true);
+
+      expect(mockVideo.findByPk).toHaveBeenCalledWith(1);
+      expect(mockVideoRecord.update).toHaveBeenCalledWith({ protected: true });
+      expect(result).toEqual({ id: 1, protected: true });
+    });
+
+    test('sets protected to false for existing video', async () => {
+      const mockVideoRecord = {
+        id: 1,
+        protected: true,
+        update: jest.fn().mockResolvedValue(),
+      };
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+
+      const result = await VideosModule.setVideoProtection(1, false);
+
+      expect(mockVideoRecord.update).toHaveBeenCalledWith({ protected: false });
+      expect(result).toEqual({ id: 1, protected: false });
+    });
+
+    test('throws error when video not found', async () => {
+      mockVideo.findByPk.mockResolvedValue(null);
+
+      await expect(VideosModule.setVideoProtection(999, true)).rejects.toThrow('Video not found');
+    });
+  });
+
   describe('bulkUpdateVideoRatings', () => {
     test('clears metadata when null rating is applied and tracks missing videos', async () => {
       const existingId = 101;

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -1439,7 +1439,7 @@ class ChannelModule {
    * @param {string|null} dateTo - Filter videos to this date (ISO string, default null)
    * @returns {Promise<Array>} - Array of video objects with download status
    */
-  async fetchNewestVideosFromDb(channelId, limit = 50, offset = 0, excludeDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', checkFiles = false, mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null) {
+  async fetchNewestVideosFromDb(channelId, limit = 50, offset = 0, excludeDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', checkFiles = false, mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = false) {
     // First get all videos to enrich with download status
     const allChannelVideos = await ChannelVideo.findAll({
       where: {
@@ -1469,6 +1469,11 @@ class ChannelModule {
 
     // Apply duration and date filters
     filteredVideos = this._applyDurationAndDateFilters(filteredVideos, minDuration, maxDuration, dateFrom, dateTo);
+
+    // Apply protected filter
+    if (protectedFilter) {
+      filteredVideos = filteredVideos.filter(video => video.protected);
+    }
 
     // Apply sorting
     filteredVideos.sort((a, b) => {
@@ -1546,9 +1551,9 @@ class ChannelModule {
    * @param {string|null} dateTo - Filter videos to this date (ISO string, default null)
    * @returns {Promise<Object>} - Object with totalCount and oldestVideoDate
    */
-  async getChannelVideoStats(channelId, excludeDownloaded = false, searchQuery = '', mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null) {
+  async getChannelVideoStats(channelId, excludeDownloaded = false, searchQuery = '', mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = false) {
     // If we have search or filter, we need to get all videos
-    if (excludeDownloaded || searchQuery || minDuration !== null || maxDuration !== null || dateFrom || dateTo) {
+    if (excludeDownloaded || searchQuery || minDuration !== null || maxDuration !== null || dateFrom || dateTo || protectedFilter) {
       // Need to filter by download status and/or search
       const allChannelVideos = await ChannelVideo.findAll({
         where: {
@@ -1577,6 +1582,11 @@ class ChannelModule {
 
       // Apply duration and date filters
       filteredVideos = this._applyDurationAndDateFilters(filteredVideos, minDuration, maxDuration, dateFrom, dateTo);
+
+      // Apply protected filter
+      if (protectedFilter) {
+        filteredVideos = filteredVideos.filter(video => video.protected);
+      }
 
       return {
         totalCount: filteredVideos.length,
@@ -2085,7 +2095,7 @@ class ChannelModule {
    * @param {string|null} dateTo - Filter videos to this date (ISO string, default null)
    * @returns {Promise<Object>} - Response object with videos and metadata
    */
-  async getChannelVideos(channelId, page = 1, pageSize = 50, hideDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', tabType = TAB_TYPES.VIDEOS, minDuration = null, maxDuration = null, dateFrom = null, dateTo = null) {
+  async getChannelVideos(channelId, page = 1, pageSize = 50, hideDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', tabType = TAB_TYPES.VIDEOS, minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = false) {
     const channel = await Channel.findOne({
       where: { channel_id: channelId },
     });
@@ -2145,7 +2155,7 @@ class ChannelModule {
 
       // Now fetch the requested page of videos with file checking enabled
       const offset = (page - 1) * pageSize;
-      const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo);
+      const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter);
 
       // Check if videos still exist on YouTube and mark as removed if they don't
       const videoValidationModule = require('./videoValidationModule');
@@ -2215,15 +2225,15 @@ class ChannelModule {
       }
 
       // Get stats for the response
-      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo);
+      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter);
 
       return this.buildChannelVideosResponse(paginatedVideos, channel, 'cache', stats, autoDownloadsEnabled, mediaType);
 
     } catch (error) {
       logger.error({ err: error, channelId }, 'Error fetching channel videos');
       const offset = (page - 1) * pageSize;
-      const cachedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo);
-      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo);
+      const cachedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter);
+      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter);
       return this.buildChannelVideosResponse(cachedVideos, channel, 'cache', stats, autoDownloadsEnabled, mediaType);
     }
   }

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -1296,7 +1296,8 @@ class ChannelModule {
         'audioFilePath',
         'audioFileSize',
         'normalized_rating',
-        'rating_source'
+        'rating_source',
+        'protected'
       ]
     });
 
@@ -1313,7 +1314,8 @@ class ChannelModule {
         filePath: v.filePath,
         audioFilePath: v.audioFilePath,
         audioFileSize: v.audioFileSize,
-        normalized_rating: v.normalized_rating
+        normalized_rating: v.normalized_rating,
+        protected: v.protected
       });
 
       // Collect videos that need file checking (only if checkFiles is true and have any file path)
@@ -1358,6 +1360,8 @@ class ChannelModule {
         if (status.normalized_rating) {
           plainVideoObject.normalized_rating = status.normalized_rating;
         }
+        plainVideoObject.id = status.id;
+        plainVideoObject.protected = status.protected;
       } else {
         // Video never downloaded
         plainVideoObject.added = false;
@@ -1366,6 +1370,7 @@ class ChannelModule {
         plainVideoObject.filePath = null;
         plainVideoObject.audioFilePath = null;
         plainVideoObject.audioFileSize = null;
+        plainVideoObject.protected = false;
       }
 
       // Replace thumbnail with template format (unless video is removed from YouTube)

--- a/server/modules/videoDeletionModule.js
+++ b/server/modules/videoDeletionModule.js
@@ -290,6 +290,7 @@ class VideoDeletionModule {
         LEFT JOIN JobVideos ON Videos.id = JobVideos.video_id
         LEFT JOIN Jobs ON Jobs.id = JobVideos.job_id
         WHERE Videos.removed = 0
+          AND Videos.protected = 0
           AND COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, '%Y%m%d')) IS NOT NULL
           AND COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, '%Y%m%d')) < DATE_SUB(NOW(), INTERVAL :ageInDays DAY)
         ORDER BY timeCreated ASC
@@ -334,6 +335,7 @@ class VideoDeletionModule {
         LEFT JOIN JobVideos ON Videos.id = JobVideos.video_id
         LEFT JOIN Jobs ON Jobs.id = JobVideos.job_id
         WHERE Videos.removed = 0
+          AND Videos.protected = 0
           AND COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, '%Y%m%d')) IS NOT NULL
 ${excludeClause}        ORDER BY timeCreated ASC
         LIMIT :limit

--- a/server/modules/videosModule.js
+++ b/server/modules/videosModule.js
@@ -18,7 +18,8 @@ class VideosModule {
       dateTo = null,
       sortBy = 'added',
       sortOrder = 'desc',
-      channelFilter = ''
+      channelFilter = '',
+      protectedFilter = false,
     } = options;
 
     try {
@@ -46,6 +47,10 @@ class VideosModule {
       if (dateTo) {
         whereConditions.push('Videos.originalDate <= :dateTo');
         replacements.dateTo = dateTo.replace(/-/g, '');
+      }
+
+      if (protectedFilter) {
+        whereConditions.push('Videos.protected = 1');
       }
 
       const whereClause = whereConditions.length > 0 ? `WHERE ${whereConditions.join(' AND ')}` : '';
@@ -95,6 +100,7 @@ class VideosModule {
           Videos.media_type,
           Videos.normalized_rating,
           Videos.rating_source,
+          Videos.protected,
           COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, '%Y%m%d')) AS timeCreated
         FROM Videos
         LEFT JOIN JobVideos ON Videos.id = JobVideos.video_id

--- a/server/modules/videosModule.js
+++ b/server/modules/videosModule.js
@@ -631,6 +631,15 @@ class VideosModule {
       throw err;
     }
   }
+
+  async setVideoProtection(id, protectedState) {
+    const video = await Video.findByPk(id);
+    if (!video) {
+      throw new Error('Video not found');
+    }
+    await video.update({ protected: protectedState });
+    return { id: video.id, protected: protectedState };
+  }
 }
 
 module.exports = new VideosModule();

--- a/server/routes/__tests__/videos.routes.test.js
+++ b/server/routes/__tests__/videos.routes.test.js
@@ -74,3 +74,149 @@ describe('POST /api/videos/rating', () => {
     }));
   });
 });
+
+describe('PATCH /api/videos/:id/protected', () => {
+  const loggerMock = {
+    info: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const createResponse = () => {
+    const res = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    return res;
+  };
+
+  const getHandler = (videosModuleMock) => {
+    const router = createVideoRoutes({
+      verifyToken: (req, res, next) => next(),
+      videosModule: videosModuleMock,
+      downloadModule: {}
+    });
+
+    const app = express();
+    app.use(router);
+
+    return findRouteHandler(app, 'patch', '/api/videos/:id/protected');
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('toggles protection on for a video', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn().mockResolvedValue({ id: 1, protected: true })
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '1' },
+      body: { protected: true },
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(videosModuleMock.setVideoProtection).toHaveBeenCalledWith(1, true);
+    expect(res.json).toHaveBeenCalledWith({ id: 1, protected: true });
+  });
+
+  test('toggles protection off for a video', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn().mockResolvedValue({ id: 1, protected: false })
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '1' },
+      body: { protected: false },
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(videosModuleMock.setVideoProtection).toHaveBeenCalledWith(1, false);
+    expect(res.json).toHaveBeenCalledWith({ id: 1, protected: false });
+  });
+
+  test('returns 400 when protected field is missing', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn()
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '1' },
+      body: {},
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'protected field (boolean) is required' });
+    expect(videosModuleMock.setVideoProtection).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 when protected is not a boolean', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn()
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '1' },
+      body: { protected: 'yes' },
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'protected field (boolean) is required' });
+  });
+
+  test('returns 404 when video not found', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn().mockRejectedValue(new Error('Video not found'))
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '999' },
+      body: { protected: true },
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Video not found' });
+  });
+
+  test('returns 500 on unexpected error', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn().mockRejectedValue(new Error('Database connection lost'))
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '1' },
+      body: { protected: true },
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Database connection lost' });
+  });
+});

--- a/server/routes/__tests__/videos.routes.test.js
+++ b/server/routes/__tests__/videos.routes.test.js
@@ -217,6 +217,6 @@ describe('PATCH /api/videos/:id/protected', () => {
     await handler(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Database connection lost' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Failed to update protection status' });
   });
 });

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -638,7 +638,8 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
     const maxDuration = (parsedMaxDuration !== null && !isNaN(parsedMaxDuration)) ? parsedMaxDuration : null;
     const dateFrom = req.query.dateFrom || null;
     const dateTo = req.query.dateTo || null;
-    const result = await channelModule.getChannelVideos(channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, minDuration, maxDuration, dateFrom, dateTo);
+    const protectedFilter = req.query.protectedFilter === 'true';
+    const result = await channelModule.getChannelVideos(channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter);
 
     if (Array.isArray(result)) {
       res.status(200).json({

--- a/server/routes/videos.js
+++ b/server/routes/videos.js
@@ -111,7 +111,7 @@ module.exports = function createVideoRoutes({ verifyToken, videosModule, downloa
     req.log.info('Getting videos');
 
     try {
-      const { page, limit, search, dateFrom, dateTo, sortBy, sortOrder, channelFilter } = req.query;
+      const { page, limit, search, dateFrom, dateTo, sortBy, sortOrder, channelFilter, protectedFilter } = req.query;
 
       const options = {
         page: parseInt(page) || 1,
@@ -121,7 +121,8 @@ module.exports = function createVideoRoutes({ verifyToken, videosModule, downloa
         dateTo: dateTo || null,
         sortBy: sortBy || 'added',
         sortOrder: sortOrder || 'desc',
-        channelFilter: channelFilter || ''
+        channelFilter: channelFilter || '',
+        protectedFilter: protectedFilter === 'true',
       };
 
       const result = await videosModule.getVideosPaginated(options);

--- a/server/routes/videos.js
+++ b/server/routes/videos.js
@@ -265,7 +265,7 @@ module.exports = function createVideoRoutes({ verifyToken, videosModule, downloa
         return res.status(404).json({ error: 'Video not found' });
       }
       req.log.error({ err: error }, 'Failed to update video protection status');
-      res.status(500).json({ error: error.message });
+      res.status(500).json({ error: 'Failed to update protection status' });
     }
   });
 

--- a/server/routes/videos.js
+++ b/server/routes/videos.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const router = express.Router();
 const rateLimit = require('express-rate-limit');
 
 // Video validation rate limiter
@@ -44,6 +43,8 @@ const apiKeyDownloadLimiter = rateLimit({
  * @returns {express.Router}
  */
 module.exports = function createVideoRoutes({ verifyToken, videosModule, downloadModule }) {
+  const router = express.Router();
+
   /**
    * @swagger
    * /getVideos:
@@ -209,6 +210,61 @@ module.exports = function createVideoRoutes({ verifyToken, videosModule, downloa
         success: false,
         error: error.message
       });
+    }
+  });
+
+  /**
+   * @swagger
+   * /api/videos/{id}/protected:
+   *   patch:
+   *     summary: Toggle video protection
+   *     description: Set whether a video is protected from automatic deletion.
+   *     tags: [Videos]
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: integer
+   *         description: Video database ID
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - protected
+   *             properties:
+   *               protected:
+   *                 type: boolean
+   *     responses:
+   *       200:
+   *         description: Protection status updated
+   *       400:
+   *         description: Invalid request
+   *       404:
+   *         description: Video not found
+   *       500:
+   *         description: Failed to update protection status
+   */
+  router.patch('/api/videos/:id/protected', verifyToken, async (req, res) => {
+    try {
+      const { id } = req.params;
+      const { protected: protectedState } = req.body;
+
+      if (typeof protectedState !== 'boolean') {
+        return res.status(400).json({ error: 'protected field (boolean) is required' });
+      }
+
+      const result = await videosModule.setVideoProtection(parseInt(id, 10), protectedState);
+      res.json(result);
+    } catch (error) {
+      if (error.message === 'Video not found') {
+        return res.status(404).json({ error: 'Video not found' });
+      }
+      req.log.error({ err: error }, 'Failed to update video protection status');
+      res.status(500).json({ error: error.message });
     }
   });
 


### PR DESCRIPTION
## Summary

Adds the ability for users to mark downloaded videos as "protected" to prevent them from being removed by the automatic cleanup system. Protected videos can still be manually deleted.

- New `protected` column on the Videos table with idempotent migration
- `PATCH /api/videos/:id/protected` endpoint to toggle protection status
- Auto-deletion queries (age-based and space-based) exclude protected videos
- Shield icon on video thumbnails across all views (Card, List, Table, Downloaded Videos page)
- Shared `ProtectionShieldButton` component and `useVideoProtection` hook to keep things DRY
- "Protected" filter chip on both the Downloaded Videos page and Channel pages
- Toast notifications on toggle: "Video protected from auto-deletion" / "Video protection removed"

Closes #505

## Channel Videos Page
<img width="1623" height="785" alt="image" src="https://github.com/user-attachments/assets/dc4e9767-e9ef-4c4a-85c7-962820e61054" />

## Downloaded Videos Page
<img width="1461" height="668" alt="image" src="https://github.com/user-attachments/assets/29aaa219-b455-4876-abbf-f5ef38ba9e8b" />

