### PR TITLE
feat(plex): add per-subfolder Plex library mappings

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4381,9 +4381,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -10340,9 +10340,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -244,6 +244,7 @@ function Configuration({ token }: ConfigurationProps) {
         onOpenLibrarySelector={openLibrarySelector}
         onOpenPlexAuthDialog={() => setOpenPlexAuthDialog(true)}
         onMobileTooltipClick={setMobileTooltip}
+        token={token}
       />
 
       <SponsorBlockSection

--- a/client/src/components/Configuration/sections/PlexIntegrationSection.tsx
+++ b/client/src/components/Configuration/sections/PlexIntegrationSection.tsx
@@ -15,6 +15,7 @@ import InfoIcon from '@mui/icons-material/Info';
 import { ConfigurationAccordion } from '../common/ConfigurationAccordion';
 import { InfoTooltip } from '../common/InfoTooltip';
 import { ConfigState, PlatformManagedState, PlexConnectionStatus } from '../types';
+import { PlexSubfolderMappings } from './PlexSubfolderMappings';
 
 interface PlexIntegrationSectionProps {
   config: ConfigState;
@@ -26,6 +27,7 @@ interface PlexIntegrationSectionProps {
   onOpenLibrarySelector: () => void;
   onOpenPlexAuthDialog: () => void;
   onMobileTooltipClick?: (text: string) => void;
+  token?: string | null;
 }
 
 export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
@@ -38,10 +40,11 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
   onOpenLibrarySelector,
   onOpenPlexAuthDialog,
   onMobileTooltipClick,
+  token = null,
 }) => {
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
-    let parsedValue: any = value;
+    let parsedValue: string = value;
 
     if (name === 'plexPort') {
       const digitsOnly = value.replace(/[^0-9]/g, '');
@@ -287,6 +290,15 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
               Selected Library ID: {config.plexYoutubeLibraryId}
             </Typography>
           )}
+        </Grid>
+
+        <Grid item xs={12}>
+          <PlexSubfolderMappings
+            mappings={config.plexSubfolderLibraryMappings ?? []}
+            onMappingsChange={(mappings) => onConfigChange({ plexSubfolderLibraryMappings: mappings })}
+            token={token}
+            plexConnectionStatus={plexConnectionStatus}
+          />
         </Grid>
       </Grid>
     </ConfigurationAccordion>

--- a/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
+++ b/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
@@ -87,19 +87,21 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
     setLoadingData(true);
     setFetchError(false);
 
-    Promise.all([
+    Promise.allSettled([
       axios.get<unknown>('/getplexlibraries', { headers, signal })
         .then((res) => (Array.isArray(res.data) ? (res.data as PlexLibrary[]) : [])),
       axios.get<unknown>('/api/channels/subfolders', { headers, signal })
         .then((res) => (Array.isArray(res.data) ? (res.data as string[]) : [])),
     ])
-      .then(([libs, folders]) => {
+      .then(([libsResult, foldersResult]) => {
         if (signal.aborted) return;
+        const libs = libsResult.status === 'fulfilled' ? libsResult.value : [];
+        const folders = foldersResult.status === 'fulfilled' ? foldersResult.value : [];
         setLibraries(libs);
         setSubfolders(folders);
-      })
-      .catch(() => {
-        if (!signal.aborted) setFetchError(true);
+        if (libsResult.status === 'rejected' || foldersResult.status === 'rejected') {
+          setFetchError(true);
+        }
       })
       .finally(() => {
         if (!signal.aborted) setLoadingData(false);
@@ -108,8 +110,11 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
     return () => controller.abort();
   }, [isConnected, token]);
 
-  const getLibraryTitle = (libraryId: string): string =>
-    libraries.find((lib) => lib.id === libraryId)?.title ?? libraryId;
+  const getLibraryTitle = (libraryId: string): string => {
+    const lib = libraries.find((l) => l.id === libraryId);
+    if (lib) return lib.title;
+    return libraries.length === 0 ? `Library ID: ${libraryId}` : libraryId;
+  };
 
   const isMappingDuplicate = (subfolder: string | null): boolean =>
     mappings.some((m) => m.subfolder === subfolder);

--- a/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
+++ b/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
@@ -1,0 +1,299 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Divider,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { PlexConnectionStatus } from '../types';
+
+export interface PlexSubfolderMapping {
+  subfolder: string | null;
+  libraryId: string;
+}
+
+interface PlexLibrary {
+  id: string;
+  title: string;
+}
+
+interface PlexSubfolderMappingsProps {
+  mappings: PlexSubfolderMapping[];
+  onMappingsChange: (mappings: PlexSubfolderMapping[]) => void;
+  token: string | null;
+  plexConnectionStatus: PlexConnectionStatus;
+}
+
+/**
+ * Internal sentinel for the "Root folder" Select option.
+ * Uses a long namespaced string that cannot collide with any real subfolder
+ * value: the API returns subfolders with the `__` prefix convention, so a
+ * channel would need sub_folder = 'ROOT_LIBRARY_MAPPING__' to collide here,
+ * which is effectively impossible in practice.
+ */
+const ROOT_SELECT_VALUE = '__YOUTARR_ROOT_LIBRARY_MAPPING__';
+
+/** Strip the __ filesystem prefix from a subfolder name returned by the API. */
+const stripPrefix = (folder: string): string => folder.replace(/^__/, '');
+
+/** Convert a Select value back to the stored mapping subfolder (null for root). */
+const selectValueToSubfolder = (value: string): string | null =>
+  value === ROOT_SELECT_VALUE ? null : stripPrefix(value);
+
+/** Format a mapping's subfolder for display in the table. */
+const formatMappingSubfolder = (subfolder: string | null): string =>
+  subfolder ? `__${subfolder}` : 'Root folder';
+
+export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
+  mappings,
+  onMappingsChange,
+  token,
+  plexConnectionStatus,
+}) => {
+  const [libraries, setLibraries] = useState<PlexLibrary[]>([]);
+  const [subfolders, setSubfolders] = useState<string[]>([]);
+  const [loadingData, setLoadingData] = useState(false);
+  const [fetchError, setFetchError] = useState(false);
+  const [newSubfolder, setNewSubfolder] = useState<string>('');
+  const [newLibraryId, setNewLibraryId] = useState<string>('');
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const isConnected = plexConnectionStatus === 'connected';
+
+  useEffect(() => {
+    if (!isConnected) return;
+
+    const controller = new AbortController();
+    const { signal } = controller;
+    const headers = { 'x-access-token': token || '' };
+
+    setLoadingData(true);
+    setFetchError(false);
+
+    Promise.all([
+      axios.get<unknown>('/getplexlibraries', { headers, signal })
+        .then((res) => (Array.isArray(res.data) ? (res.data as PlexLibrary[]) : [])),
+      axios.get<unknown>('/api/channels/subfolders', { headers, signal })
+        .then((res) => (Array.isArray(res.data) ? (res.data as string[]) : [])),
+    ])
+      .then(([libs, folders]) => {
+        if (signal.aborted) return;
+        setLibraries(libs);
+        setSubfolders(folders);
+      })
+      .catch(() => {
+        if (!signal.aborted) setFetchError(true);
+      })
+      .finally(() => {
+        if (!signal.aborted) setLoadingData(false);
+      });
+
+    return () => controller.abort();
+  }, [isConnected, token]);
+
+  const getLibraryTitle = (libraryId: string): string =>
+    libraries.find((lib) => lib.id === libraryId)?.title ?? libraryId;
+
+  const isMappingDuplicate = (subfolder: string | null): boolean =>
+    mappings.some((m) => m.subfolder === subfolder);
+
+  const handleAddMapping = () => {
+    if (!newSubfolder || !newLibraryId) return;
+
+    const subfolder = selectValueToSubfolder(newSubfolder);
+    if (isMappingDuplicate(subfolder)) return;
+
+    onMappingsChange([...mappings, { subfolder, libraryId: newLibraryId }]);
+    setNewSubfolder('');
+    setNewLibraryId('');
+    setShowAddForm(false);
+  };
+
+  const handleDeleteMapping = (subfolder: string | null) => {
+    onMappingsChange(mappings.filter((m) => m.subfolder !== subfolder));
+  };
+
+  const isAddDisabled =
+    !newSubfolder ||
+    !newLibraryId ||
+    isMappingDuplicate(selectValueToSubfolder(newSubfolder));
+
+  // When disconnected and no mappings exist yet, the whole section is unnecessary noise.
+  // When disconnected but mappings exist, keep the table visible so users can delete entries.
+  if (!isConnected && mappings.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Divider sx={{ mb: 2 }} />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        <Typography variant="subtitle2">
+          Per-Subfolder Library Mappings
+        </Typography>
+        {!showAddForm && (
+          <Tooltip title={!isConnected ? 'Connect to Plex to add new mappings' : ''}>
+            <span>
+              <Button
+                size="small"
+                startIcon={<AddIcon />}
+                onClick={() => setShowAddForm(true)}
+                data-testid="add-mapping-button"
+                disabled={loadingData || !isConnected}
+              >
+                Add Mapping
+              </Button>
+            </span>
+          </Tooltip>
+        )}
+      </Box>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+        Map each subfolder to a specific Plex library. Subfolders without a mapping use the
+        default library selected above.
+      </Typography>
+
+      {loadingData && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+          <CircularProgress size={16} />
+          <Typography variant="caption" color="text.secondary">
+            Loading libraries and subfolders…
+          </Typography>
+        </Box>
+      )}
+
+      {fetchError && (
+        <Alert severity="warning" sx={{ mb: 1.5 }}>
+          Could not load Plex libraries or subfolders. Check your connection and try refreshing.
+        </Alert>
+      )}
+
+      {mappings.length > 0 && (
+        <Table size="small" sx={{ mb: 2 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Subfolder</TableCell>
+              <TableCell>Plex Library</TableCell>
+              <TableCell padding="checkbox" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {mappings.map((mapping) => (
+              <TableRow key={`${mapping.subfolder === null ? '\x00root' : mapping.subfolder}-${mapping.libraryId}`}>
+                <TableCell>
+                  <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                    {formatMappingSubfolder(mapping.subfolder)}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2">
+                    {getLibraryTitle(mapping.libraryId)}
+                  </Typography>
+                </TableCell>
+                <TableCell padding="checkbox">
+                  <IconButton
+                    size="small"
+                    onClick={() => handleDeleteMapping(mapping.subfolder)}
+                    aria-label={`Remove mapping for ${formatMappingSubfolder(mapping.subfolder)}`}
+                    data-testid={`delete-mapping-${mapping.subfolder ?? 'root'}`}
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {mappings.length === 0 && !showAddForm && !loadingData && (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+          No per-subfolder mappings configured. All downloads will refresh the default library.
+        </Typography>
+      )}
+
+      {showAddForm && isConnected && (
+        <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'flex-start', flexWrap: 'wrap', mt: 1 }}>
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel id="new-mapping-subfolder-label">Subfolder</InputLabel>
+            <Select
+              labelId="new-mapping-subfolder-label"
+              label="Subfolder"
+              value={newSubfolder}
+              onChange={(e: SelectChangeEvent) => setNewSubfolder(e.target.value)}
+              data-testid="new-mapping-subfolder-select"
+              disabled={loadingData}
+            >
+              <MenuItem value={ROOT_SELECT_VALUE}>Root folder</MenuItem>
+              {subfolders.map((folder) => (
+                <MenuItem
+                  key={folder}
+                  value={folder}
+                  disabled={isMappingDuplicate(selectValueToSubfolder(folder))}
+                >
+                  {folder}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ minWidth: 180 }}>
+            <InputLabel id="new-mapping-library-label">Plex Library</InputLabel>
+            <Select
+              labelId="new-mapping-library-label"
+              label="Plex Library"
+              value={newLibraryId}
+              onChange={(e: SelectChangeEvent) => setNewLibraryId(e.target.value)}
+              data-testid="new-mapping-library-select"
+              disabled={loadingData}
+            >
+              {libraries.map((lib) => (
+                <MenuItem key={lib.id} value={lib.id}>
+                  {lib.title}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Button
+            variant="contained"
+            size="small"
+            onClick={handleAddMapping}
+            disabled={isAddDisabled}
+            data-testid="confirm-add-mapping-button"
+            sx={{ height: 40 }}
+          >
+            Add
+          </Button>
+          <Button
+            size="small"
+            onClick={() => {
+              setShowAddForm(false);
+              setNewSubfolder('');
+              setNewLibraryId('');
+            }}
+            sx={{ height: 40 }}
+          >
+            Cancel
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
@@ -65,6 +65,17 @@ describe('PlexSubfolderMappings', () => {
       expect(screen.getByTestId('delete-mapping-kids')).toBeInTheDocument();
     });
 
+    test('shows "Library ID:" fallback for library title when disconnected', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          plexConnectionStatus="not_connected"
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      expect(screen.getByText('Library ID: 2')).toBeInTheDocument();
+    });
+
     test('Add Mapping button is disabled when disconnected with existing mappings', () => {
       renderWithProviders(
         <PlexSubfolderMappings
@@ -129,6 +140,24 @@ describe('PlexSubfolderMappings', () => {
           screen.getByText(/Could not load Plex libraries or subfolders/)
         ).toBeInTheDocument();
       });
+    });
+
+    test('shows partial data and error alert when one endpoint fails', async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: MOCK_LIBRARIES })
+        .mockRejectedValueOnce(new Error('Subfolders failed'));
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Kids Shows')).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText(/Could not load Plex libraries or subfolders/)
+      ).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
@@ -1,0 +1,402 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { PlexSubfolderMappings, PlexSubfolderMapping } from '../PlexSubfolderMappings';
+import { renderWithProviders } from '../../../../test-utils';
+import { PlexConnectionStatus } from '../../types';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+const axios = require('axios');
+
+const MOCK_LIBRARIES = [
+  { id: '1', title: 'YouTube' },
+  { id: '2', title: 'Kids Shows' },
+];
+
+const MOCK_SUBFOLDERS = ['__kids', '__music'];
+
+function setupAxiosMocks() {
+  axios.get
+    .mockResolvedValueOnce({ data: MOCK_LIBRARIES })
+    .mockResolvedValueOnce({ data: MOCK_SUBFOLDERS });
+}
+
+const DEFAULT_PROPS = {
+  mappings: [] as PlexSubfolderMapping[],
+  onMappingsChange: jest.fn(),
+  token: 'test-token',
+  plexConnectionStatus: 'connected' as PlexConnectionStatus,
+};
+
+describe('PlexSubfolderMappings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when plexConnectionStatus is not connected', () => {
+    test('renders nothing when status is not_tested and no mappings exist', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} plexConnectionStatus="not_tested" />
+      );
+      expect(screen.queryByText('Per-Subfolder Library Mappings')).not.toBeInTheDocument();
+    });
+
+    test('renders nothing when status is not_connected and no mappings exist', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} plexConnectionStatus="not_connected" />
+      );
+      expect(screen.queryByText('Per-Subfolder Library Mappings')).not.toBeInTheDocument();
+    });
+
+    test('shows existing mappings with delete buttons when disconnected', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          plexConnectionStatus="not_connected"
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      expect(screen.getByText('Per-Subfolder Library Mappings')).toBeInTheDocument();
+      expect(screen.getByText('__kids')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-mapping-kids')).toBeInTheDocument();
+    });
+
+    test('Add Mapping button is disabled when disconnected with existing mappings', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          plexConnectionStatus="not_connected"
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      expect(screen.getByTestId('add-mapping-button')).toBeDisabled();
+    });
+  });
+
+  describe('when plexConnectionStatus is connected', () => {
+    beforeEach(() => {
+      setupAxiosMocks();
+    });
+
+    test('shows the section title "Per-Subfolder Library Mappings"', async () => {
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+      await waitFor(() => {
+        expect(screen.getByText('Per-Subfolder Library Mappings')).toBeInTheDocument();
+      });
+    });
+
+    test('shows "No per-subfolder mappings configured" when mappings array is empty', async () => {
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+      await waitFor(() => {
+        expect(
+          screen.getByText(/No per-subfolder mappings configured/)
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('shows the "Add Mapping" button', async () => {
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+    });
+
+    test('does NOT call axios when not connected', () => {
+      axios.get.mockReset();
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} plexConnectionStatus="not_connected" />
+      );
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loading and error states', () => {
+    test('shows loading indicator while fetches are in progress', () => {
+      axios.get.mockReturnValue(new Promise(() => {}));
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+      expect(screen.getByText(/Loading libraries and subfolders/)).toBeInTheDocument();
+    });
+
+    test('shows error alert when fetch fails', async () => {
+      axios.get.mockRejectedValue(new Error('Network error'));
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Could not load Plex libraries or subfolders/)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('existing mappings display', () => {
+    test('renders a table row for each mapping showing subfolder name with __ prefix', async () => {
+      setupAxiosMocks();
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText('__kids')).toBeInTheDocument();
+      });
+    });
+
+    test('renders "Root folder" label for a mapping with subfolder: null', async () => {
+      setupAxiosMocks();
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: null, libraryId: '1' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Root folder')).toBeInTheDocument();
+      });
+    });
+
+    test('renders the library title from the fetched libraries list', async () => {
+      setupAxiosMocks();
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Kids Shows')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('adding a mapping', () => {
+    beforeEach(() => {
+      setupAxiosMocks();
+    });
+
+    test('clicking "Add Mapping" shows the subfolder and library selects', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      expect(screen.getByRole('button', { name: 'Subfolder' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Plex Library' })).toBeInTheDocument();
+    });
+
+    test('clicking "Cancel" hides the form', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+      expect(screen.getByRole('button', { name: 'Subfolder' })).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(screen.queryByRole('button', { name: 'Subfolder' })).not.toBeInTheDocument();
+    });
+
+    test('"Add" button is disabled when no subfolder is selected', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      expect(screen.getByTestId('confirm-add-mapping-button')).toBeDisabled();
+    });
+
+    test('"Add" button is disabled when no library is selected', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      await user.click(screen.getByRole('button', { name: 'Subfolder' }));
+      await user.click(screen.getByRole('option', { name: '__kids' }));
+
+      expect(screen.getByTestId('confirm-add-mapping-button')).toBeDisabled();
+    });
+
+    test('"Add" button is disabled when the selected subfolder is already mapped (duplicate)', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: 'kids', libraryId: '1' }]}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      await user.click(screen.getByRole('button', { name: 'Subfolder' }));
+
+      const kidsOption = screen.getByRole('option', { name: '__kids' });
+      expect(kidsOption).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    test('selecting a subfolder and library and clicking "Add" calls onMappingsChange with the new mapping appended', async () => {
+      const user = userEvent.setup();
+      const onMappingsChange = jest.fn();
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} onMappingsChange={onMappingsChange} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      await user.click(screen.getByRole('button', { name: 'Subfolder' }));
+      await user.click(screen.getByRole('option', { name: '__kids' }));
+
+      await user.click(screen.getByRole('button', { name: 'Plex Library' }));
+      await user.click(screen.getByRole('option', { name: 'YouTube' }));
+
+      await user.click(screen.getByTestId('confirm-add-mapping-button'));
+
+      expect(onMappingsChange).toHaveBeenCalledWith([{ subfolder: 'kids', libraryId: '1' }]);
+    });
+
+    test('adding a root-folder mapping stores subfolder: null', async () => {
+      const user = userEvent.setup();
+      const onMappingsChange = jest.fn();
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} onMappingsChange={onMappingsChange} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      await user.click(screen.getByRole('button', { name: 'Subfolder' }));
+      await user.click(screen.getByRole('option', { name: 'Root folder' }));
+
+      await user.click(screen.getByRole('button', { name: 'Plex Library' }));
+      await user.click(screen.getByRole('option', { name: 'YouTube' }));
+
+      await user.click(screen.getByTestId('confirm-add-mapping-button'));
+
+      expect(onMappingsChange).toHaveBeenCalledWith([{ subfolder: null, libraryId: '1' }]);
+    });
+
+    test('the stored subfolder value has no __ prefix', async () => {
+      const user = userEvent.setup();
+      const onMappingsChange = jest.fn();
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} onMappingsChange={onMappingsChange} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      await user.click(screen.getByRole('button', { name: 'Subfolder' }));
+      await user.click(screen.getByRole('option', { name: '__music' }));
+
+      await user.click(screen.getByRole('button', { name: 'Plex Library' }));
+      await user.click(screen.getByRole('option', { name: 'Kids Shows' }));
+
+      await user.click(screen.getByTestId('confirm-add-mapping-button'));
+
+      const calledWith = onMappingsChange.mock.calls[0][0] as PlexSubfolderMapping[];
+      expect(calledWith[0].subfolder).toBe('music');
+    });
+  });
+
+  describe('deleting a mapping', () => {
+    beforeEach(() => {
+      setupAxiosMocks();
+    });
+
+    test('clicking the delete button for a mapping calls onMappingsChange with that mapping removed', async () => {
+      const user = userEvent.setup();
+      const onMappingsChange = jest.fn();
+      const mappings: PlexSubfolderMapping[] = [
+        { subfolder: 'kids', libraryId: '2' },
+        { subfolder: 'music', libraryId: '1' },
+      ];
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={mappings}
+          onMappingsChange={onMappingsChange}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('delete-mapping-kids')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('delete-mapping-kids'));
+
+      expect(onMappingsChange).toHaveBeenCalledWith([{ subfolder: 'music', libraryId: '1' }]);
+    });
+
+    test('the delete button data-testid is delete-mapping-kids for subfolder kids', async () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('delete-mapping-kids')).toBeInTheDocument();
+      });
+    });
+
+    test('the delete button data-testid is delete-mapping-root for null subfolder', async () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: null, libraryId: '1' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('delete-mapping-root')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/client/src/config/configSchema.ts
+++ b/client/src/config/configSchema.ts
@@ -32,6 +32,10 @@ export const CONFIG_FIELDS = {
   // Plex integration
   plexApiKey: { default: '', trackChanges: true },
   plexYoutubeLibraryId: { default: '', trackChanges: true },
+  plexSubfolderLibraryMappings: {
+    default: [] as Array<{ subfolder: string | null; libraryId: string }>,
+    trackChanges: true,
+  },
   plexIP: { default: '', trackChanges: true },
   plexPort: { default: '32400', trackChanges: true },
   plexViaHttps: { default: false, trackChanges: true },
@@ -124,6 +128,7 @@ export const DEFAULT_CONFIG: ConfigState = {
   defaultSubfolder: CONFIG_FIELDS.defaultSubfolder.default,
   plexApiKey: CONFIG_FIELDS.plexApiKey.default,
   plexYoutubeLibraryId: CONFIG_FIELDS.plexYoutubeLibraryId.default,
+  plexSubfolderLibraryMappings: CONFIG_FIELDS.plexSubfolderLibraryMappings.default,
   plexIP: CONFIG_FIELDS.plexIP.default,
   plexPort: CONFIG_FIELDS.plexPort.default,
   plexViaHttps: CONFIG_FIELDS.plexViaHttps.default,

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -11,6 +11,7 @@
   "plexViaHttps": false,
   "plexApiKey": "",
   "plexYoutubeLibraryId": "",
+  "plexSubfolderLibraryMappings": [],
   "plexUrl": "",
   "sponsorblockEnabled": false,
   "sponsorblockAction": "remove",

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -137,8 +137,25 @@ Configuration can be modified through:
 - **Config Key**: `plexYoutubeLibraryId`
 - **Type**: `string`
 - **Default**: `""` (empty)
-- **Description**: Plex library section ID for YouTube videos
+- **Description**: Default Plex library section ID for YouTube videos. Used for all downloads that do not match a per-subfolder mapping (see below).
 - **Note**: Library refresh is automatically triggered if configured when new videos are downloaded
+
+### Plex Subfolder Library Mappings
+- **Config Key**: `plexSubfolderLibraryMappings`
+- **Type**: `Array<{ subfolder: string | null, libraryId: string }>`
+- **Default**: `[]` (empty — all downloads use the default library above)
+- **Description**: Maps channel subfolders to specific Plex library IDs, enabling different subfolders to refresh different Plex libraries after a download.
+- **Usage**: Configured via the web UI under **Plex Media Server Integration → Per-Subfolder Library Mappings** once connected to Plex.
+- **Format**: Each entry specifies a `subfolder` (the clean name without the `__` filesystem prefix, or `null` for the root/no-subfolder case) and the target `libraryId`.
+- **Example**:
+  ```json
+  "plexSubfolderLibraryMappings": [
+    { "subfolder": "kids", "libraryId": "2" },
+    { "subfolder": "music", "libraryId": "3" },
+    { "subfolder": null, "libraryId": "1" }
+  ]
+  ```
+- **Fallback**: Any subfolder not listed here will fall back to `plexYoutubeLibraryId`.
 
 ### Plex IP
 - **Config Key**: `plexIP`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,9 +2301,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/server/modules/__tests__/channelSettingsModule.test.js
+++ b/server/modules/__tests__/channelSettingsModule.test.js
@@ -41,7 +41,9 @@ jest.mock('../jobModule', () => ({
 }));
 
 jest.mock('../plexModule', () => ({
-  refreshLibrary: jest.fn().mockResolvedValue(true)
+  refreshLibrary: jest.fn().mockResolvedValue(true),
+  refreshLibraryForSubfolder: jest.fn().mockResolvedValue(true),
+  refreshLibrariesForSubfolders: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe('ChannelSettingsModule', () => {
@@ -824,7 +826,7 @@ describe('ChannelSettingsModule', () => {
       });
     });
 
-    test('should trigger Plex library refresh asynchronously', async () => {
+    test('should trigger Plex library refresh for both old and new subfolders asynchronously', async () => {
       fs.existsSync
         .mockReturnValueOnce(true)
         .mockReturnValueOnce(false);
@@ -834,14 +836,14 @@ describe('ChannelSettingsModule', () => {
       // Plex refresh is called via setImmediate, so we need to flush the queue
       await new Promise(resolve => setImmediate(resolve));
 
-      expect(plexModule.refreshLibrary).toHaveBeenCalled();
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledWith([null, 'Music']);
     });
 
     test('should not fail if Plex refresh fails', async () => {
       fs.existsSync
         .mockReturnValueOnce(true)
         .mockReturnValueOnce(false);
-      plexModule.refreshLibrary.mockRejectedValue(new Error('Plex error'));
+      plexModule.refreshLibrariesForSubfolders.mockRejectedValue(new Error('Plex error'));
 
       const result = await channelSettingsModule.moveChannelFolder(channel, null, 'Music');
 
@@ -851,7 +853,7 @@ describe('ChannelSettingsModule', () => {
       await new Promise(resolve => setImmediate(resolve));
 
       expect(logger.error).toHaveBeenCalledWith(
-        expect.objectContaining({ err: 'Plex error' }),
+        expect.objectContaining({ err: expect.any(Error) }),
         'Could not refresh Plex library'
       );
     });

--- a/server/modules/__tests__/downloadModule.test.js
+++ b/server/modules/__tests__/downloadModule.test.js
@@ -323,7 +323,7 @@ describe('DownloadModule', () => {
 
       await downloadModule.doChannelDownloads();
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('Using grouped downloads: 2 group(s) with resolved settings');
+      expect(logger.info).toHaveBeenCalledWith({ groupCount: 2 }, 'Using grouped downloads with resolved settings');
       expect(spy).toHaveBeenCalledWith({}, groups, false);
     });
 
@@ -588,7 +588,7 @@ describe('DownloadModule', () => {
 
       await downloadModule.doGroupedChannelDownloads({}, groups);
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('Processing 2 channel download groups in a single job');
+      expect(logger.info).toHaveBeenCalledWith({ groupCount: 2 }, 'Processing channel download groups in a single job');
       expect(jobModuleMock.addOrUpdateJob).toHaveBeenCalledTimes(1);
       expect(jobModuleMock.addOrUpdateJob).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -666,17 +666,30 @@ describe('DownloadModule', () => {
       });
     });
 
-    it('should refresh Plex and start next job after all groups complete', async () => {
+    it('should refresh Plex libraries for each group subfolder after all groups complete', async () => {
       const groups = [
         { quality: '1080', subFolder: null, channels: [{ channel_id: 'UC1' }] }
       ];
       const plexModuleMock = require('../plexModule');
-      plexModuleMock.refreshLibrary = jest.fn().mockReturnValue(Promise.resolve());
+      plexModuleMock.refreshLibrariesForSubfolders = jest.fn().mockReturnValue(Promise.resolve());
 
       await downloadModule.doGroupedChannelDownloads({}, groups);
 
-      expect(plexModuleMock.refreshLibrary).toHaveBeenCalled();
+      expect(plexModuleMock.refreshLibrariesForSubfolders).toHaveBeenCalledWith([null]);
       expect(jobModuleMock.startNextJob).toHaveBeenCalled();
+    });
+
+    it('should pass all group subfolders to refreshLibrariesForSubfolders', async () => {
+      const groups = [
+        { quality: '1080', subFolder: 'kids', channels: [{ channel_id: 'UC1' }] },
+        { quality: '720', subFolder: 'music', channels: [{ channel_id: 'UC2' }] },
+      ];
+      const plexModuleMock = require('../plexModule');
+      plexModuleMock.refreshLibrariesForSubfolders = jest.fn().mockReturnValue(Promise.resolve());
+
+      await downloadModule.doGroupedChannelDownloads({}, groups);
+
+      expect(plexModuleMock.refreshLibrariesForSubfolders).toHaveBeenCalledWith(['kids', 'music']);
     });
 
     it('should stop processing groups if job is terminated', async () => {
@@ -686,7 +699,7 @@ describe('DownloadModule', () => {
         { quality: '480', subFolder: null, channels: [{ channel_id: 'UC3' }] }
       ];
       const plexModuleMock = require('../plexModule');
-      plexModuleMock.refreshLibrary = jest.fn().mockReturnValue(Promise.resolve());
+      plexModuleMock.refreshLibrariesForSubfolders = jest.fn().mockReturnValue(Promise.resolve());
 
       // Mock executeGroupDownload to simulate the first group completing
       const executeSpy = jest.spyOn(downloadModule, 'executeGroupDownload').mockResolvedValue();
@@ -701,7 +714,7 @@ describe('DownloadModule', () => {
 
       // Should only execute first group, then stop when it detects termination
       expect(executeSpy).toHaveBeenCalledTimes(1);
-      expect(plexModuleMock.refreshLibrary).not.toHaveBeenCalled();
+      expect(plexModuleMock.refreshLibrariesForSubfolders).not.toHaveBeenCalled();
       expect(jobModuleMock.startNextJob).not.toHaveBeenCalled();
     });
   });

--- a/server/modules/__tests__/plexModule.test.js
+++ b/server/modules/__tests__/plexModule.test.js
@@ -146,7 +146,7 @@ describe('plexModule', () => {
   });
 
   describe('refreshLibrary', () => {
-    test('successfully refreshes library', async () => {
+    test('successfully refreshes library using global config ID', async () => {
       const mockResponse = { status: 200, data: 'success' };
       axios.get.mockResolvedValue(mockResponse);
 
@@ -156,10 +156,23 @@ describe('plexModule', () => {
         'http://127.0.0.1:32400/library/sections/1/refresh?X-Plex-Token=existing-token'
       );
       expect(result).toBe(mockResponse);
-      expect(logger.info).toHaveBeenCalledWith('Refreshing Plex library');
+      expect(logger.info).toHaveBeenCalledWith(
+        { libraryId: '1' },
+        'Refreshing Plex library'
+      );
       expect(logger.info).toHaveBeenCalledWith(
         { libraryId: '1' },
         'Plex library refresh initiated successfully'
+      );
+    });
+
+    test('uses explicit libraryId argument when provided', async () => {
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibrary('5');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'http://127.0.0.1:32400/library/sections/5/refresh?X-Plex-Token=existing-token'
       );
     });
 
@@ -215,6 +228,34 @@ describe('plexModule', () => {
       expect(logger.error).toHaveBeenCalledWith({ err: error }, 'Failed to refresh Plex library');
     });
 
+    test('skips refresh when libraryId is non-numeric', async () => {
+      const result = await plexModule.refreshLibrary('../../admin');
+
+      expect(axios.get).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        { libraryId: '../../admin' },
+        'Skipping Plex refresh - invalid non-numeric library ID'
+      );
+    });
+
+    test('skips refresh when libraryId contains letters', async () => {
+      const result = await plexModule.refreshLibrary('abc');
+
+      expect(axios.get).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    test('allows valid numeric libraryId', async () => {
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibrary('42');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'http://127.0.0.1:32400/library/sections/42/refresh?X-Plex-Token=existing-token'
+      );
+    });
+
     test('uses PLEX_URL from environment when available', async () => {
       process.env.PLEX_URL = 'http://env-plex:8080';
       axios.get.mockResolvedValue({ status: 200 });
@@ -224,6 +265,157 @@ describe('plexModule', () => {
       expect(axios.get).toHaveBeenCalledWith(
         'http://env-plex:8080/library/sections/1/refresh?X-Plex-Token=existing-token'
       );
+    });
+  });
+
+  describe('getLibraryIdForSubfolder', () => {
+    test('returns matching libraryId when a mapping exists for the subfolder', () => {
+      config.plexSubfolderLibraryMappings = [
+        { subfolder: 'kids', libraryId: '2' },
+        { subfolder: 'music', libraryId: '3' },
+      ];
+
+      expect(plexModule.getLibraryIdForSubfolder('kids')).toBe('2');
+      expect(plexModule.getLibraryIdForSubfolder('music')).toBe('3');
+    });
+
+    test('returns global plexYoutubeLibraryId when no mapping matches', () => {
+      config.plexSubfolderLibraryMappings = [{ subfolder: 'kids', libraryId: '2' }];
+
+      expect(plexModule.getLibraryIdForSubfolder('unknown')).toBe('1');
+    });
+
+    test('returns mapping for root (null) subfolder', () => {
+      config.plexSubfolderLibraryMappings = [{ subfolder: null, libraryId: '4' }];
+
+      expect(plexModule.getLibraryIdForSubfolder(null)).toBe('4');
+    });
+
+    test('falls back to global ID when mappings array is empty', () => {
+      config.plexSubfolderLibraryMappings = [];
+
+      expect(plexModule.getLibraryIdForSubfolder('anything')).toBe('1');
+    });
+
+    test('falls back to global ID when plexSubfolderLibraryMappings is undefined', () => {
+      delete config.plexSubfolderLibraryMappings;
+
+      expect(plexModule.getLibraryIdForSubfolder('kids')).toBe('1');
+    });
+  });
+
+  describe('refreshLibraryForSubfolder', () => {
+    test('refreshes the library mapped to the given subfolder', async () => {
+      config.plexSubfolderLibraryMappings = [{ subfolder: 'kids', libraryId: '2' }];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibraryForSubfolder('kids');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/library/sections/2/refresh')
+      );
+    });
+
+    test('falls back to global library when no mapping for subfolder', async () => {
+      config.plexSubfolderLibraryMappings = [];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibraryForSubfolder('unknown');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/library/sections/1/refresh')
+      );
+    });
+
+    test('uses global library for null (root) subfolder when no root mapping', async () => {
+      config.plexSubfolderLibraryMappings = [];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibraryForSubfolder(null);
+
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/library/sections/1/refresh')
+      );
+    });
+  });
+
+  describe('refreshLibrariesForSubfolders', () => {
+    test('refreshes each distinct library once', async () => {
+      config.plexSubfolderLibraryMappings = [
+        { subfolder: 'kids', libraryId: '2' },
+        { subfolder: 'music', libraryId: '3' },
+      ];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibrariesForSubfolders(['kids', 'music', null]);
+
+      // kids -> 2, music -> 3, null -> 1 (fallback): 3 distinct IDs → 3 calls
+      expect(axios.get).toHaveBeenCalledTimes(3);
+    });
+
+    test('deduplicates when two different subfolders map to the same library ID', async () => {
+      config.plexSubfolderLibraryMappings = [
+        { subfolder: 'kids', libraryId: '2' },
+        { subfolder: 'cartoons', libraryId: '2' }, // same target library as kids
+      ];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibrariesForSubfolders(['kids', 'cartoons']);
+
+      // Both resolve to library '2' — only one HTTP call should be made
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/library/sections/2/refresh')
+      );
+    });
+
+    test('refreshes global fallback library when all subfolders are unmapped', async () => {
+      config.plexSubfolderLibraryMappings = [];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibrariesForSubfolders([null, 'foo', 'bar']);
+
+      // All three map to the global ID '1': deduplicated to one call
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/library/sections/1/refresh')
+      );
+    });
+
+    test('handles empty subfolders array without making any calls', async () => {
+      await plexModule.refreshLibrariesForSubfolders([]);
+
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    test('continues refreshing remaining libraries when one fails', async () => {
+      config.plexSubfolderLibraryMappings = [
+        { subfolder: 'kids', libraryId: '2' },
+        { subfolder: 'music', libraryId: '3' },
+      ];
+      // Library '2' fails; library '3' must still be called and the promise must resolve
+      axios.get
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({ status: 200 });
+
+      await expect(
+        plexModule.refreshLibrariesForSubfolders(['kids', 'music'])
+      ).resolves.toBeUndefined();
+
+      expect(axios.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('refreshLibraryForSubfolder - error handling', () => {
+    test('propagates rejection when refreshLibrary throws unexpectedly', async () => {
+      config.plexSubfolderLibraryMappings = [{ subfolder: 'kids', libraryId: '2' }];
+      // Force the axios call inside refreshLibrary to throw synchronously after try/catch
+      // by making getBaseUrl produce a value but axios.get throwing past the catch
+      // In practice refreshLibrary catches all errors and returns null, so this confirms
+      // that the method resolves (does not throw) even when the underlying call fails.
+      axios.get.mockRejectedValue(new Error('Unexpected'));
+
+      await expect(plexModule.refreshLibraryForSubfolder('kids')).resolves.toBeNull();
     });
   });
 

--- a/server/modules/__tests__/plexModule.test.js
+++ b/server/modules/__tests__/plexModule.test.js
@@ -302,6 +302,19 @@ describe('plexModule', () => {
 
       expect(plexModule.getLibraryIdForSubfolder('kids')).toBe('1');
     });
+
+    test('skips null and non-object entries in mappings array without throwing', () => {
+      config.plexSubfolderLibraryMappings = [
+        null,
+        undefined,
+        'bad-string',
+        42,
+        { subfolder: 'kids', libraryId: '2' },
+      ];
+
+      expect(plexModule.getLibraryIdForSubfolder('kids')).toBe('2');
+      expect(plexModule.getLibraryIdForSubfolder('unknown')).toBe('1');
+    });
   });
 
   describe('refreshLibraryForSubfolder', () => {
@@ -407,7 +420,7 @@ describe('plexModule', () => {
   });
 
   describe('refreshLibraryForSubfolder - error handling', () => {
-    test('propagates rejection when refreshLibrary throws unexpectedly', async () => {
+    test('resolves to null when the underlying refresh fails', async () => {
       config.plexSubfolderLibraryMappings = [{ subfolder: 'kids', libraryId: '2' }];
       // Force the axios call inside refreshLibrary to throw synchronously after try/catch
       // by making getBaseUrl produce a value but axios.get throwing past the catch

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const Channel = require('../models/channel');
 const configModule = require('./configModule');
+const plexModule = require('./plexModule');
 const { Op } = require('sequelize');
 const logger = require('../logger');
 const ratingMapper = require('./ratingMapper');
@@ -763,11 +764,13 @@ class ChannelSettingsModule {
       // Don't await this to prevent timeout issues from blocking the operation
       setImmediate(async () => {
         try {
-          const plexModule = require('./plexModule');
-          await plexModule.refreshLibrary();
-          logger.info('Plex library refresh completed after folder move');
+          await plexModule.refreshLibrariesForSubfolders([effectiveOldSubFolder, effectiveNewSubFolder]);
+          logger.info(
+            { oldSubfolder: effectiveOldSubFolder, newSubfolder: effectiveNewSubFolder },
+            'Plex library refresh completed after folder move (source and destination libraries notified)'
+          );
         } catch (plexError) {
-          logger.error({ err: plexError.message }, 'Could not refresh Plex library');
+          logger.error({ err: plexError }, 'Could not refresh Plex library');
           // Don't fail the whole operation if Plex refresh fails
         }
       });
@@ -780,7 +783,7 @@ class ChannelSettingsModule {
         newPath
       };
     } catch (error) {
-      logger.error({ err: error.message }, 'Error moving channel folder');
+      logger.error({ err: error }, 'Error moving channel folder');
       throw new Error(`Failed to move channel folder: ${error.message}`);
     }
   }

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -770,8 +770,8 @@ class ChannelSettingsModule {
             'Plex library refresh completed after folder move (source and destination libraries notified)'
           );
         } catch (plexError) {
+          // Defensive: refreshLibrary currently swallows errors internally
           logger.error({ err: plexError }, 'Could not refresh Plex library');
-          // Don't fail the whole operation if Plex refresh fails
         }
       });
       logger.info('Plex library refresh initiated asynchronously');

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -37,7 +37,8 @@ jest.mock('../../configModule', () => ({
 }));
 
 jest.mock('../../plexModule', () => ({
-  refreshLibrary: jest.fn().mockResolvedValue()
+  refreshLibrary: jest.fn().mockResolvedValue(),
+  refreshLibraryForSubfolder: jest.fn().mockResolvedValue(),
 }));
 
 jest.mock('../../jobModule', () => ({
@@ -796,14 +797,35 @@ describe('DownloadExecutor', () => {
       expect(archiveModule.addVideoToArchive).toHaveBeenCalledWith('abc123XYZ_d');
     });
 
-    it('should trigger Plex library refresh on completion', async () => {
+    it('should trigger Plex library refresh for the subfolder on completion', async () => {
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, 'kids');
+
+      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith('kids');
+    });
+
+    it('should trigger Plex library refresh with null subfolder when none provided', async () => {
       setTimeout(() => {
         mockProcess.emit('exit', 0, null);
       }, 10);
 
       await executor.doDownload(mockArgs, mockJobId, mockJobType);
 
-      expect(plexModule.refreshLibrary).toHaveBeenCalled();
+      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
+    });
+
+    it('should NOT trigger Plex refresh when skipJobTransition is true', async () => {
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      // skipJobTransition=true (7th positional arg)
+      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, true, 'kids');
+
+      expect(plexModule.refreshLibraryForSubfolder).not.toHaveBeenCalled();
     });
 
     it('should start next job after completion', async () => {

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -92,6 +92,7 @@ jest.mock('../../filesystem', () => ({
   ROOT_SENTINEL: '##ROOT##',
   GLOBAL_DEFAULT_SENTINEL: '##USE_GLOBAL_DEFAULT##',
   resolveEffectiveSubfolder: jest.fn((subfolder) => {
+    if (subfolder === '##ROOT##') return null;
     if (subfolder === '##USE_GLOBAL_DEFAULT##') return null;
     if (subfolder && subfolder.trim() !== '') return subfolder.trim();
     return null;

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -88,7 +88,14 @@ jest.mock('../../filesystem', () => ({
   isVideoDirectory: jest.fn(),
   isChannelDirectory: jest.fn(),
   isDirectoryEmpty: jest.fn(),
-  cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false)
+  cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false),
+  ROOT_SENTINEL: '##ROOT##',
+  GLOBAL_DEFAULT_SENTINEL: '##USE_GLOBAL_DEFAULT##',
+  resolveEffectiveSubfolder: jest.fn((subfolder) => {
+    if (subfolder === '##USE_GLOBAL_DEFAULT##') return null;
+    if (subfolder && subfolder.trim() !== '') return subfolder.trim();
+    return null;
+  }),
 }));
 
 const DownloadExecutor = require('../downloadExecutor');
@@ -826,6 +833,26 @@ describe('DownloadExecutor', () => {
       await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, true, 'kids');
 
       expect(plexModule.refreshLibraryForSubfolder).not.toHaveBeenCalled();
+    });
+
+    it('should normalize ##ROOT## sentinel to null before Plex refresh', async () => {
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, '##ROOT##');
+
+      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
+    });
+
+    it('should normalize ##USE_GLOBAL_DEFAULT## sentinel before Plex refresh', async () => {
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, '##USE_GLOBAL_DEFAULT##');
+
+      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
     });
 
     it('should start next job after completion', async () => {

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -1390,7 +1390,11 @@ class DownloadExecutor {
 
         // Only refresh Plex and start next job if not processing multiple groups
         if (!skipJobTransition) {
-          plexModule.refreshLibraryForSubfolder(subfolderOverride).catch(err => {
+          // Normalize sentinel values before Plex lookup: ##ROOT## → null, ##USE_GLOBAL_DEFAULT## → resolved default
+          const resolvedSubfolder = subfolderOverride === filesystem.ROOT_SENTINEL
+            ? null
+            : filesystem.resolveEffectiveSubfolder(subfolderOverride, configModule.getConfig().defaultSubfolder || null);
+          plexModule.refreshLibraryForSubfolder(resolvedSubfolder).catch(err => {
             logger.error({ err }, 'Failed to refresh Plex library');
           });
           jobModule.startNextJob().catch(err => {

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -1390,7 +1390,7 @@ class DownloadExecutor {
 
         // Only refresh Plex and start next job if not processing multiple groups
         if (!skipJobTransition) {
-          plexModule.refreshLibrary().catch(err => {
+          plexModule.refreshLibraryForSubfolder(subfolderOverride).catch(err => {
             logger.error({ err }, 'Failed to refresh Plex library');
           });
           jobModule.startNextJob().catch(err => {

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -1390,10 +1390,8 @@ class DownloadExecutor {
 
         // Only refresh Plex and start next job if not processing multiple groups
         if (!skipJobTransition) {
-          // Normalize sentinel values before Plex lookup: ##ROOT## → null, ##USE_GLOBAL_DEFAULT## → resolved default
-          const resolvedSubfolder = subfolderOverride === filesystem.ROOT_SENTINEL
-            ? null
-            : filesystem.resolveEffectiveSubfolder(subfolderOverride, configModule.getConfig().defaultSubfolder || null);
+          const resolvedSubfolder = filesystem.resolveEffectiveSubfolder(subfolderOverride, configModule.getConfig().defaultSubfolder || null);
+          // Defensive: refreshLibrary currently swallows errors internally
           plexModule.refreshLibraryForSubfolder(resolvedSubfolder).catch(err => {
             logger.error({ err }, 'Failed to refresh Plex library');
           });

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -1,5 +1,6 @@
 const configModule = require('./configModule');
 const jobModule = require('./jobModule');
+const plexModule = require('./plexModule');
 const DownloadExecutor = require('./download/downloadExecutor');
 const YtdlpCommandBuilder = require('./download/ytdlpCommandBuilder');
 const tempPathManager = require('./download/tempPathManager');
@@ -106,7 +107,7 @@ class DownloadModule {
         groups.some((g) => g.filterConfig && g.filterConfig.hasGroupingCriteria && g.filterConfig.hasGroupingCriteria());
 
       if (needsGrouping) {
-        console.log(`Using grouped downloads: ${groups.length} group(s) with resolved settings`);
+        logger.info({ groupCount: groups.length }, 'Using grouped downloads with resolved settings');
         return await this.doGroupedChannelDownloads(jobData, groups, isNextJob);
       }
 
@@ -187,7 +188,7 @@ class DownloadModule {
   }
 
   async doGroupedChannelDownloads(jobData, groups, isNextJob = false) {
-    console.log(`Processing ${groups.length} channel download groups in a single job`);
+    logger.info({ groupCount: groups.length }, 'Processing channel download groups in a single job');
 
     // Create ONE job for all groups
     const jobType = `Channel Downloads - ${groups.length} group(s)`;
@@ -227,7 +228,7 @@ class DownloadModule {
       const groupDesc = `Group ${i + 1}/${groups.length} (${group.quality}p${group.subFolder ? `, ${group.subFolder}` : ''})`;
       const groupJobType = `Channel Downloads - ${groupDesc}`;
 
-      console.log(`Processing ${groupJobType} with ${group.channels.length} channels`);
+      logger.info({ groupJobType, channelCount: group.channels.length }, 'Processing download group');
 
       // Update job type to show current group
       await jobModule.updateJob(jobId, {
@@ -237,7 +238,7 @@ class DownloadModule {
       try {
         // Execute this group's download (without starting next job)
         await this.executeGroupDownload(group, jobId, groupJobType, jobData, true);
-        console.log(`Completed ${groupJobType}`);
+        logger.info({ groupJobType }, 'Completed download group');
       } catch (err) {
         logger.error({ err, group: groupDesc }, 'Error processing download group');
         await jobModule.updateJob(jobId, {
@@ -319,10 +320,12 @@ class DownloadModule {
       }
     }
 
-    // Refresh Plex library once after all groups
-    const plexModule = require('./plexModule');
-    plexModule.refreshLibrary().catch(err => {
-      logger.error({ err }, 'Failed to refresh Plex library');
+    // Refresh each distinct Plex library mapped to the downloaded subfolders.
+    // Pre-condition: g.subFolder must already be a resolved effective subfolder
+    // (clean name, no __ prefix, no ##USE_GLOBAL_DEFAULT## sentinel) as produced
+    // by channelDownloadGrouper. null means root (no subfolder).
+    plexModule.refreshLibrariesForSubfolders(groups.map(g => g.subFolder ?? null)).catch(err => {
+      logger.error({ err }, 'Failed to refresh Plex libraries after grouped download');
     });
 
     // Now start the next job in the queue
@@ -376,7 +379,7 @@ class DownloadModule {
       // Check if we have any URLs to download
       if (urls.length === 0) {
         logger.warn({ jobType }, 'Skipping group - no enabled tabs for any channels in this group');
-        console.log(`Skipping ${jobType} - no enabled tabs for any channels`);
+        logger.info({ jobType }, 'Skipping group - no enabled tabs for any channels');
         return; // Skip this group, continue with next group in sequence
       }
 

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -324,6 +324,7 @@ class DownloadModule {
     // Pre-condition: g.subFolder must already be a resolved effective subfolder
     // (clean name, no __ prefix, no ##USE_GLOBAL_DEFAULT## sentinel) as produced
     // by channelDownloadGrouper. null means root (no subfolder).
+    // Defensive: refreshLibrary currently swallows errors internally
     plexModule.refreshLibrariesForSubfolders(groups.map(g => g.subFolder ?? null)).catch(err => {
       logger.error({ err }, 'Failed to refresh Plex libraries after grouped download');
     });

--- a/server/modules/filesystem/__tests__/pathBuilder.test.js
+++ b/server/modules/filesystem/__tests__/pathBuilder.test.js
@@ -12,7 +12,7 @@ const {
   isValidYoutubeId,
   calculateRelocatedPath
 } = require('../pathBuilder');
-const { GLOBAL_DEFAULT_SENTINEL } = require('../constants');
+const { GLOBAL_DEFAULT_SENTINEL, ROOT_SENTINEL } = require('../constants');
 
 describe('filesystem/pathBuilder', () => {
   describe('buildSubfolderSegment', () => {
@@ -69,6 +69,11 @@ describe('filesystem/pathBuilder', () => {
   });
 
   describe('resolveEffectiveSubfolder', () => {
+    it('should return null for ROOT_SENTINEL regardless of global default', () => {
+      expect(resolveEffectiveSubfolder(ROOT_SENTINEL, 'default')).toBeNull();
+      expect(resolveEffectiveSubfolder(ROOT_SENTINEL, null)).toBeNull();
+    });
+
     it('should return global default for GLOBAL_DEFAULT_SENTINEL', () => {
       expect(resolveEffectiveSubfolder(GLOBAL_DEFAULT_SENTINEL, 'default')).toBe('default');
     });

--- a/server/modules/filesystem/pathBuilder.js
+++ b/server/modules/filesystem/pathBuilder.js
@@ -7,6 +7,7 @@ const path = require('path');
 const {
   SUBFOLDER_PREFIX,
   GLOBAL_DEFAULT_SENTINEL,
+  ROOT_SENTINEL,
   CHANNEL_TEMPLATE,
   VIDEO_FOLDER_TEMPLATE,
   VIDEO_FILE_TEMPLATE,
@@ -53,7 +54,8 @@ function extractSubfolderName(dirName) {
 
 /**
  * Resolve the effective subfolder for a channel
- * Handles the three-state logic:
+ * Handles four-state logic:
+ * - ROOT_SENTINEL -> null (explicit root override, e.g. manual downloads)
  * - GLOBAL_DEFAULT_SENTINEL -> use global default
  * - non-empty string -> use that subfolder
  * - null/empty -> null (download to root, backwards compatible)
@@ -63,6 +65,11 @@ function extractSubfolderName(dirName) {
  * @returns {string|null} - The actual subfolder to use (without __ prefix), or null for root
  */
 function resolveEffectiveSubfolder(channelSubFolder, globalDefault = null) {
+  // Explicit "download to root" override
+  if (channelSubFolder === ROOT_SENTINEL) {
+    return null;
+  }
+
   // Explicit "use global default" setting
   if (channelSubFolder === GLOBAL_DEFAULT_SENTINEL) {
     return globalDefault || null;

--- a/server/modules/plexModule.js
+++ b/server/modules/plexModule.js
@@ -30,22 +30,72 @@ class PlexModule {
     return `${protocol}://${ip}:${port}`;
   }
 
-  async refreshLibrary() {
-    logger.info('Refreshing Plex library');
-    // Example GET http://[plexIP]:[plexPort]/library/sections/[plexYoutubeLibraryId]/refresh?X-Plex-Token=[plexApiKey]
+  /**
+   * Get the Plex library ID that should be refreshed for a given resolved subfolder.
+   * Falls back to the global plexYoutubeLibraryId when no specific mapping is found.
+   * @param {string|null} subfolder - Resolved subfolder name (no __ prefix, null = root)
+   * @returns {string} Library ID to refresh
+   */
+  getLibraryIdForSubfolder(subfolder) {
+    const config = configModule.getConfig();
+    const raw = config.plexSubfolderLibraryMappings;
+    const mappings = Array.isArray(raw) ? raw : [];
+
+    const normalizedSubfolder = subfolder || null;
+    const match = mappings.find((m) => (m.subfolder || null) === normalizedSubfolder);
+    return (match && match.libraryId) || config.plexYoutubeLibraryId || '';
+  }
+
+  /**
+   * Refresh the Plex library associated with the given resolved subfolder.
+   * Falls back to the global library when no specific mapping exists.
+   * @param {string|null} subfolder - Resolved subfolder name (no __ prefix, null = root)
+   * @returns {Promise<Object|null>}
+   */
+  async refreshLibraryForSubfolder(subfolder) {
+    const libraryId = this.getLibraryIdForSubfolder(subfolder);
+    return this.refreshLibrary(libraryId);
+  }
+
+  /**
+   * Refresh all distinct Plex libraries mapped to the provided subfolders.
+   * Deduplicates library IDs so each library is only refreshed once.
+   * @param {Array<string|null>} subfolders - Array of resolved subfolder names
+   * @returns {Promise<void>}
+   */
+  async refreshLibrariesForSubfolders(subfolders) {
+    const libraryIds = new Set(subfolders.map((sf) => this.getLibraryIdForSubfolder(sf)));
+    await Promise.all(
+      [...libraryIds].map((libraryId) =>
+        this.refreshLibrary(libraryId).catch((err) => {
+          logger.error({ err, libraryId }, 'Failed to refresh Plex library for subfolder');
+        })
+      )
+    );
+  }
+
+  async refreshLibrary(libraryId) {
+    const config = configModule.getConfig();
+    const resolvedLibraryId = libraryId || config.plexYoutubeLibraryId;
+    logger.info({ libraryId: resolvedLibraryId }, 'Refreshing Plex library');
     try {
-      const config = configModule.getConfig();
       const baseUrl = this.getBaseUrl(config.plexIP, config, config.plexPort, config.plexViaHttps);
 
-      if (!baseUrl || !config.plexYoutubeLibraryId || !config.plexApiKey) {
+      if (!baseUrl || !resolvedLibraryId || !config.plexApiKey) {
         logger.warn('Skipping Plex refresh - missing server details or credentials');
         return null;
       }
 
+      // Plex library IDs are always numeric; reject anything else to prevent path traversal
+      if (!/^\d+$/.test(String(resolvedLibraryId))) {
+        logger.warn({ libraryId: resolvedLibraryId }, 'Skipping Plex refresh - invalid non-numeric library ID');
+        return null;
+      }
+
       const response = await axios.get(
-        `${baseUrl}/library/sections/${config.plexYoutubeLibraryId}/refresh?X-Plex-Token=${config.plexApiKey}`
+        `${baseUrl}/library/sections/${encodeURIComponent(resolvedLibraryId)}/refresh?X-Plex-Token=${config.plexApiKey}`
       );
-      logger.info({ libraryId: config.plexYoutubeLibraryId }, 'Plex library refresh initiated successfully');
+      logger.info({ libraryId: resolvedLibraryId }, 'Plex library refresh initiated successfully');
       return response;
     } catch (error) {
       logger.error({ err: error }, 'Failed to refresh Plex library');

--- a/server/modules/plexModule.js
+++ b/server/modules/plexModule.js
@@ -67,7 +67,7 @@ class PlexModule {
    */
   async refreshLibrariesForSubfolders(subfolders) {
     const libraryIds = new Set(subfolders.map((sf) => this.getLibraryIdForSubfolder(sf)));
-    await Promise.all(
+    await Promise.allSettled(
       [...libraryIds].map((libraryId) =>
         this.refreshLibrary(libraryId)
       )

--- a/server/modules/plexModule.js
+++ b/server/modules/plexModule.js
@@ -42,7 +42,9 @@ class PlexModule {
     const mappings = Array.isArray(raw) ? raw : [];
 
     const normalizedSubfolder = subfolder || null;
-    const match = mappings.find((m) => (m.subfolder || null) === normalizedSubfolder);
+    const match = mappings
+      .filter((m) => m && typeof m === 'object')
+      .find((m) => (m.subfolder || null) === normalizedSubfolder);
     return (match && match.libraryId) || config.plexYoutubeLibraryId || '';
   }
 
@@ -67,9 +69,7 @@ class PlexModule {
     const libraryIds = new Set(subfolders.map((sf) => this.getLibraryIdForSubfolder(sf)));
     await Promise.all(
       [...libraryIds].map((libraryId) =>
-        this.refreshLibrary(libraryId).catch((err) => {
-          logger.error({ err, libraryId }, 'Failed to refresh Plex library for subfolder');
-        })
+        this.refreshLibrary(libraryId)
       )
     );
   }
@@ -77,7 +77,6 @@ class PlexModule {
   async refreshLibrary(libraryId) {
     const config = configModule.getConfig();
     const resolvedLibraryId = libraryId || config.plexYoutubeLibraryId;
-    logger.info({ libraryId: resolvedLibraryId }, 'Refreshing Plex library');
     try {
       const baseUrl = this.getBaseUrl(config.plexIP, config, config.plexPort, config.plexViaHttps);
 
@@ -86,12 +85,12 @@ class PlexModule {
         return null;
       }
 
-      // Plex library IDs are always numeric; reject anything else to prevent path traversal
       if (!/^\d+$/.test(String(resolvedLibraryId))) {
         logger.warn({ libraryId: resolvedLibraryId }, 'Skipping Plex refresh - invalid non-numeric library ID');
         return null;
       }
 
+      logger.info({ libraryId: resolvedLibraryId }, 'Refreshing Plex library');
       const response = await axios.get(
         `${baseUrl}/library/sections/${encodeURIComponent(resolvedLibraryId)}/refresh?X-Plex-Token=${config.plexApiKey}`
       );


### PR DESCRIPTION
## Summary

Adds support for mapping individual channel subfolders to specific Plex library IDs, so that after a download completes only the relevant library is refreshed instead of a single global one. Closes #310.

- **New config field** `plexSubfolderLibraryMappings` — array of `{ subfolder, libraryId }` entries stored in `config.json`, managed via the Configuration UI
- **Backend**: New `plexModule` methods (`getLibraryIdForSubfolder`, `refreshLibraryForSubfolder`, `refreshLibrariesForSubfolders`) with ID-level deduplication, numeric libraryId validation, and fallback to the global `plexYoutubeLibraryId`
- **Three refresh call sites updated**: `downloadExecutor` (single downloads), `downloadModule` (grouped downloads), `channelSettingsModule` (folder moves — refreshes both source and destination libraries)
- **Frontend**: New `PlexSubfolderMappings` component inside the Plex Integration accordion with add/delete flows, loading/error states, and disabled-with-tooltip when Plex is disconnected
- **Standards hardening**: Hoisted late-binding `require()` calls, replaced all `console.log` with structured `logger.info`, fixed `err: error.message` → `err: error`, added `AbortController` cleanup, migrated `fetch()` to Axios

<img width="1206" height="225" alt="Screenshot 2026-04-10 at 2 23 44 PM" src="https://github.com/user-attachments/assets/33aeadd5-f00d-43b0-a9c2-3d8b2497c717" />


## Changes

| Area | Files | What |
|------|-------|------|
| Backend core | `plexModule.js` | New mapping methods, numeric ID validation, `encodeURIComponent` |
| Backend wiring | `downloadExecutor.js`, `downloadModule.js`, `channelSettingsModule.js` | Subfolder-aware refresh at all three call sites |
| Frontend | `PlexSubfolderMappings.tsx`, `PlexIntegrationSection.tsx`, `Configuration.tsx` | New UI component + integration |
| Config | `config.example.json`, `configSchema.ts` | New `plexSubfolderLibraryMappings` field |
| Tests | 4 backend + 1 frontend test files | 270+ new test lines covering all new methods |
| Docs | `CONFIG.md` | New field documentation |

## Test plan

- [x] All 4,871 tests pass (2,840 frontend + 2,031 backend) — verified by pre-commit hook on every commit
- [ ] Manual: Navigate to Configuration → Plex Integration, connect to Plex, verify the Per-Subfolder Library Mappings section appears
- [ ] Manual: Add a mapping (select subfolder + library), verify it persists after save
- [ ] Manual: Delete a mapping, verify removal
- [ ] Manual: Disconnect Plex, verify existing mappings remain visible with disabled Add button
- [ ] Manual: Trigger a channel download with a mapped subfolder, verify only the correct Plex library is refreshed in logs
- [ ] Manual: Move a channel between subfolders, verify both source and destination libraries are refreshed

