### PR TITLE
dev review followup: plex fixes, display refactor, and docs cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,644 +10,254 @@ Youtarr is a Dockerized application that automatically downloads videos from You
 - **Frontend**: React/TypeScript application with Material-UI components
 - **Infrastructure**: Docker Compose setup with separate containers for app and database
 
-## Architecture
+## Scope Discipline
 
-### Backend Structure (server/)
-- `server.js`: Main Express server entry point
-- `db.js`: Database connection and Sequelize setup
-- `logger.js`: Pino-based structured logging with request correlation
-- `models/`: Sequelize models (channel, video, job, jobvideo, jobvideodownload, channelvideo, session, apikey)
-- `routes/`: API route handlers
-  - `auth.js`: Authentication and session management
-  - `channels.js`: Channel subscription and refresh
-  - `videos.js`: Video browsing and download triggers
-  - `config.js`: Application configuration
-  - `jobs.js`: Download job status
-  - `plex.js`: Plex integration
-  - `setup.js`: Initial setup wizard
-  - `subscriptions.js`: Subscription import (Takeout CSV, cookies upload, import jobs)
-  - `apikeys.js`: API key management
-  - `health.js`: Health check endpoints
-- `modules/`: Core business logic modules
-  - `channelModule.js`: YouTube channel management
-  - `downloadModule.js`: Video download handling via yt-dlp
-  - `plexModule.js`: Plex Media Server integration
-  - `jobModule.js`: Background job processing
-  - `configModule.js`: Configuration management
-  - `videosModule.js`: Video metadata and processing
-  - `webSocketServer.js`: WebSocket communication for real-time updates
-  - `databaseHealthModule.js`: Database connection validation and schema health checks
-  - `notificationModule.js`: Multi-service notifications via Apprise (Discord, Slack, Telegram, Email, Pushover, Gotify, Ntfy, Matrix, etc.)
-  - `channelSettingsModule.js`: Per-channel settings (subfolders, quality overrides)
-  - `videoDeletionModule.js`: Video file and database deletion with dry-run support
-  - `nfoGenerator.js`: NFO metadata file generation for Jellyfin/Kodi/Emby
-  - Additional modules: `cronJobs.js` (scheduled tasks), `apiKeyModule.js` (API key auth), `ytdlpModule.js` (yt-dlp updates), `messageEmitter.js` (WebSocket broadcasting)
-- `modules/download/`: Download orchestration
-  - `downloadExecutor.js`: Main download orchestration
-  - `ytdlpCommandBuilder.js`: yt-dlp command construction
-  - `DownloadProgressMonitor.js`: Real-time progress tracking
-  - `tempPathManager.js`: Temporary file management
-  - `videoMetadataProcessor.js`: Metadata extraction
-- `modules/filesystem/`: File system abstraction layer
-  - `pathBuilder.js`: Download path construction
-  - `directoryManager.js`: Directory creation and management
-  - `fileOperations.js`: File move/copy operations
-  - `sanitizer.js`: Filename sanitization
-  - `constants.js`: Filesystem constants
-- `modules/notifications/`: Multi-service notification system
-  - `serviceRegistry.js`: Service detection (Discord, Slack, Telegram, Email, etc.)
-  - `formatters/`: Service-specific message formatters
-  - `senders/`: Delivery mechanisms (Discord webhooks, Apprise)
-- `modules/subscriptionImport/`: Bulk subscription import orchestration
-  - `index.js`: Aggregator entry point
-  - `importJobRunner.js`: Import job execution and channel resolution
-  - `takeoutParser.js`: Google Takeout CSV parsing
-  - `cookiesFetcher.js`: Cookie-based channel fetching
-  - `thumbnailEnricher.js`: Channel thumbnail resolution
-  - `concurrencyLimiter.js`: Parallel request throttling
-  - `errorClassifier.js`: Import error categorization
-  - `constants.js`: Import-related constants
+**IMPORTANT: Change only what the task requires.** This rule overrides every other rule in this file when they conflict.
+
+- **Bug fixes**: make the minimum change needed to fix the bug. Do not rewrite surrounding code for style, extract helpers you don't need for the fix, or clean up while you're there.
+- **Features**: touch only files the feature requires. Write new code to the standards below. Leave pre-existing code alone unless the feature forces you to change it.
+- **Refactors**: only when the user explicitly asks for a refactor, and only as wide as the user scopes it.
+- **Unrelated issues you notice** (oversized files, duplication, legacy patterns, missing tests, `console.log` calls, `any` types, drifted error-response shapes): list them in your final report so the user can decide whether to address them. **Do not fix them.**
+- **When in doubt**: ask. A small clarifying question is cheaper than an unwanted refactor.
+
+The size and quality rules in this file apply to code you are **creating or substantially rewriting**. They are not a mandate to refactor existing code you pass through.
 
 ## Task Handling
 
-For multi-part requests (e.g., 'review this PR AND explain WebSocket handling'), explicitly acknowledge all parts and complete each one before considering the task done.
+For multi-part requests (e.g., "review this PR AND explain WebSocket handling"), explicitly acknowledge all parts and complete each one before considering the task done.
 
-### Frontend Structure (client/src/)
-- `App.tsx`: Main application component with routing
-- `components/`: React components organized by feature
-  - `ChannelManager/`: Channel subscription management (with `hooks/`, `components/`, and `components/chips/` subdirectories)
-  - `ChannelPage/`: Individual channel detail page (with `hooks/` and `components/` subdirectories)
-  - `DownloadManager/`: Download queue and history
-  - `VideosPage/`: Video browsing and filtering
-  - `Configuration/`: App settings with 10+ sections in `sections/` subdirectory, reusable UI in `common/`, and feature hooks in `hooks/`
-  - `InitialSetup.tsx`: First-time setup wizard
-  - `LocalLogin.tsx`: Local user authentication form
-  - `StorageStatus.tsx`: Real-time storage status display
-  - `SubscriptionImport/`: Bulk channel import from YouTube (with `hooks/`, `components/`, and `__tests__/` subdirectories)
-  - `shared/`: Shared/reusable components (e.g., DeleteVideosDialog) and hooks
-  - Additional pages: `ChangelogPage.tsx`, `PlexAuthDialog.tsx`, `DatabaseErrorOverlay.tsx`, `ErrorBoundary.tsx`
-- `hooks/`: Custom React hooks for data fetching and state management
-- `theme.ts`: Material-UI theme configuration (light/dark mode)
-- `config/`: Configuration schemas and validation (Zod schemas)
-- `types/`: TypeScript type definitions
-- `contexts/`: React Context definitions (e.g., WebSocketContext)
-- `providers/`: Context provider implementations (e.g., WebSocketProvider)
-- `utils/`: Utility functions and helpers
+## Architecture
 
-#### Frontend API Error Handling
-**Database Error Detection:** The global `fetch()` function is automatically overridden in `App.tsx` to detect database errors across all API calls. This means:
+### Backend (server/)
+- `server.js`: Express entry point. `db.js`: Sequelize setup. `logger.js`: Pino logger with request correlation.
+- `models/`: Sequelize models (channel, video, job, jobvideo, jobvideodownload, channelvideo, session, apikey). Associations: Channel hasMany Videos, Job hasMany JobVideos.
+- `routes/`: API handlers (auth, channels, videos, config, jobs, plex, setup, subscriptions, apikeys, health). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.
+- `modules/`: class-based singletons holding business logic. Top-level modules include `channelModule`, `downloadModule`, `plexModule`, `jobModule`, `configModule`, `videosModule`, `webSocketServer`, `databaseHealthModule`, `notificationModule`, `channelSettingsModule`, `videoDeletionModule`, `nfoGenerator`, `cronJobs`, `apiKeyModule`, `ytdlpModule`, `messageEmitter`.
+- `modules/download/`: download orchestration (`downloadExecutor`, `ytdlpCommandBuilder`, `DownloadProgressMonitor`, `tempPathManager`, `videoMetadataProcessor`).
+- `modules/filesystem/`: path/file abstraction (`pathBuilder`, `directoryManager`, `fileOperations`, `sanitizer`, `constants`). Good example of the sub-module aggregator pattern.
+- `modules/notifications/`: multi-service notifications via Apprise (`serviceRegistry`, `formatters/`, `senders/`). Good example of a pluggable service registry.
+- `modules/subscriptionImport/`: bulk channel import (`importJobRunner`, `takeoutParser`, `cookiesFetcher`, `thumbnailEnricher`, `concurrencyLimiter`, `errorClassifier`).
 
-- ✅ You can use normal `fetch()` syntax anywhere in the frontend
-- ✅ Database errors (503 responses with `requiresDbFix: true`) are automatically detected
-- ✅ The database error overlay appears automatically during outages
-- ✅ No special wrapper functions or imports needed
-
-**Implementation:** When the backend returns a 503 status with `requiresDbFix: true` in the JSON response, the overridden fetch automatically dispatches a custom event that triggers the database error overlay with appropriate messaging and polling for recovery.
+### Frontend (client/src/)
+- `App.tsx`: app routing plus a global `fetch()` override that detects 503 `requiresDbFix` responses and surfaces the database error overlay. You can use normal `fetch()` anywhere; database errors are handled automatically.
+- `components/`: feature directories and pages. Complex features pair a top-level `FeatureName.tsx` with a same-named `FeatureName/` directory holding `components/`, `hooks/`, and `__tests__/`. Examples of this sibling-file layout: `ChannelManager.tsx` + `ChannelManager/`, `Configuration.tsx` + `Configuration/`, `ChannelPage.tsx` + `ChannelPage/`. Newer features (e.g. `SubscriptionImport/`) put the main component at `FeatureName/index.tsx` instead; either layout is acceptable for new features.
+- `hooks/`: app-wide custom hooks for data fetching and state.
+- `contexts/` and `providers/`: React Context for cross-cutting concerns (auth token, WebSocket, theme).
+- `config/configSchema.ts`: the `CONFIG_FIELDS` registry. Use this pattern when adding new configuration fields; it auto-derives types, defaults, and change tracking.
+- `theme.ts`: Material-UI theme (light/dark mode). `types/`, `utils/`: shared types and helpers.
 
 ### Database
-- MariaDB 10.3 with utf8mb4 support for full Unicode
-- Sequelize migrations in `migrations/`
-- Models use associations: Channel hasMany Videos, Job hasMany JobVideos
+- MariaDB 10.3 with utf8mb4. Migrations in `migrations/` run automatically on container startup. Create new migrations with `./scripts/db-create-migration.sh migration-name`.
 
-## Code Quality Standards
+### Reference docs (consult these instead of re-deriving from code)
+- `docs/DEVELOPMENT.md`: dev environment setup, `./scripts/build-dev.sh` (flags: `--install-deps`, `--no-cache`) and `./scripts/start-dev.sh` (flags: `--no-auth`, `--debug`, `--headless-auth`, `--pull-latest`, `--dev`, `--arm`, `--external-db`), Vite HMR dev server option (`cd client && npm run dev` on port 3000), running tests, Swagger/OpenAPI docs at `/swagger` and `/swagger.json`.
+- `docs/DOCKER.md`: Docker architecture (two containers), Compose file variants (main, ARM override, external-db), volume layout, NAS configuration, backup/restore, platform deployment (`DATA_PATH`, `AUTH_ENABLED`, `PLEX_URL`).
+- `docs/DATABASE.md`: schema tables, internal vs external database, migration workflow, idempotent migration helpers, troubleshooting.
+- `docs/ENVIRONMENT_VARIABLES.md`: all env vars (`DB_*`, `YOUTUBE_OUTPUT_DIR`, `DATA_PATH`, `YOUTARR_UID/GID`, `AUTH_ENABLED`, `AUTH_PRESET_*`, `PLEX_URL`, `LOG_LEVEL`, `TZ`, `YOUTARR_IMAGE`).
+- `docs/CONFIG.md`: `config/config.json` schema. Real field names include `plexApiKey`, `plexYoutubeLibraryId`, `plexSubfolderLibraryMappings`, `plexIP`/`plexPort`/`plexViaHttps`/`plexUrl`, `channelAutoDownload`, `channelDownloadFrequency` (cron), `channelFilesToDownload`, `preferredResolution`, `videoCodec`, `defaultSubfolder`, plus groups for SponsorBlock, notifications (`appriseUrls`), download performance, and auto-removal. Legacy `cronSchedule` is auto-migrated to `channelDownloadFrequency` on startup.
+- `docs/AUTHENTICATION.md`: Plex OAuth, local auth (bcrypt, `username`/`passwordHash`), API keys (`x-api-key` header, rate-limited, download-only scope), session management (`x-access-token`, 7-day expiry), headless bootstrap via `AUTH_PRESET_*`.
+- `docs/API_INTEGRATION.md`: API key integration for external tools (bookmarklets, iOS Shortcuts, Android Tasker, Home Assistant, cURL/Python/JS). Documents the `/api/videos/download` endpoint, rate limits, and CORS/auth-proxy bypass for Cloudflare Zero Trust and Authelia.
+- `docs/TROUBLESHOOTING.md`: common runtime issues.
+
+### Implementation notes (non-obvious behaviors)
+- **Plex integration** uses OAuth; the user must be the Plex server admin. The target Plex library must be "Other Videos" with the "Personal Media" agent.
+- **Video downloads**: yt-dlp writes to a temp location, then post-processing finalizes files into the channel's target directory. Resume-on-partial-download is supported.
+- **WebSocket server** shares the HTTP server port (3011 in container, 3087 on host) via the `ws` library; there is no separate WS port.
+- **Deno** is installed in the container; yt-dlp uses it automatically for JS-heavy extractors.
+
+## Code Quality Standards (for new and rewritten code)
+
+These standards apply when you are authoring new code or doing an explicit rewrite. See **Scope Discipline** above.
 
 ### General Principles
-
-- **DRY (Don't Repeat Yourself)**: Extract duplicated logic into shared utilities or modules. If you see the same pattern 3+ times, it should be abstracted.
-- **Single Responsibility**: Each module, class, or function should have one clear purpose. If a function name requires "and" to describe it, split it.
-- **Keep files focused**: Backend modules should stay under ~500 lines. Frontend components should stay under ~300 lines. If a file grows beyond this, extract sub-modules or child components. (Several legacy files exceed these limits -- `channelModule.js` at 2356 lines, `downloadExecutor.js` at 1505 lines, `VideosPage.tsx` at 1047 lines -- these should not be used as examples to follow.)
-- **No magic numbers**: Use named constants. Timeouts, retry counts, limits, and default values should be defined as named constants at the top of the file or in a shared constants module, not embedded inline.
-- **Prefer early returns**: Reduce nesting by returning early for error/edge cases rather than wrapping the happy path in deep conditionals.
+- **DRY when writing the third copy**: if you find yourself writing the same logic a third time in your own new code, extract it.
+- **Single responsibility**: each module, class, or function should have one clear purpose. If a function name requires "and" to describe it, split it.
+- **Right-size your extractions**: do not create helpers, components, or hooks for one-time operations. Three similar lines of code is better than a premature abstraction. If a helper is used in exactly one place, inline it.
+- **File size targets for new files**: backend modules under ~500 lines, frontend components under ~300 lines. Several legacy files exceed these limits (notably `channelModule.js`, `jobModule.js`, `channelSettingsModule.js`, `videoDeletionModule.js`, `VideosPage.tsx`, `ChannelVideos.tsx`, `DownloadProgress.tsx`) - do not use them as examples. The codebase is migrating toward these targets over time.
+- **Named constants for magic values**: in new code, timeouts, retry counts, limits, and defaults should be named constants at the top of the file or in a shared constants module.
+- **Early returns** for error and edge cases, to keep happy-path nesting shallow.
+- **Comments**: only where the logic is not self-evident. Do not add docstrings, type comments, or explanatory prose to code you did not change.
 
 ### Backend Standards (Node.js/Express)
 
 #### Logging
-- **Always use the Pino logger** (`require('../logger')` or `require('../../logger')`), never `console.log` or `console.error`. The logger provides structured output, log levels, and automatic sensitive-data redaction.
-- **Use structured logging** with context objects: `logger.error({ err: error, videoId }, 'Download failed')` -- not string interpolation.
-- **Use appropriate log levels**: `error` for failures that need attention, `warn` for recoverable issues, `info` for significant operations, `debug` for diagnostic detail.
+- **Always use the Pino logger** (`require('../logger')`), never `console.log` or `console.error`.
+- **Structured logging** with context objects: `logger.error({ err: error, videoId }, 'Download failed')`, not string interpolation.
+- **Levels**: `error` for failures needing attention, `warn` for recoverable issues, `info` for significant operations, `debug` for diagnostic detail.
 
 #### Error Handling
-- **Standard API error response format**: All error responses from routes must use this structure:
-  ```javascript
-  res.status(statusCode).json({ error: 'Human-readable error message' });
-  ```
-- **Always catch async errors** in route handlers. Use try-catch and return proper HTTP status codes. Never let unhandled promise rejections escape.
-- **Log errors with context**: Include relevant IDs, operation names, and the error object using structured logging (see above).
-- **Use specific error codes** where applicable (e.g., 400 for bad input, 404 for not found, 409 for conflicts, 503 for service unavailable).
+- **Standard error response shape**: `res.status(statusCode).json({ error: 'Human-readable message' })`. The codebase has drift (`{ success: false, error }`, `{ status, message }`); new code must use `{ error }`.
+- **Always catch async errors** in route handlers with try-catch. Never let unhandled promise rejections escape.
+- **Specific status codes**: 400 for bad input, 401 for unauthenticated, 403 for forbidden, 404 for not found, 409 for conflicts, 503 for service unavailable.
+- **Log errors with context**: include relevant IDs, operation names, and the error object.
 
 #### Route Patterns
-- **Use the dependency injection factory pattern** for all route files. Routes export a factory function that receives dependencies:
+- **Dependency injection factory pattern** for all new route files:
   ```javascript
   function createMyRoutes({ verifyToken, myModule }) {
     const router = express.Router();
-    // ... route definitions
+    // ...
     return router;
   }
   module.exports = createMyRoutes;
   ```
-  This is the established pattern (see `server/routes/index.js`). Never import modules directly in route files.
-- **Keep routes thin**: Routes should validate input, call module methods, and format responses. Business logic belongs in modules.
+  Never import modules directly inside route files; receive them as factory arguments.
+- **Keep routes thin**: validate input, call module methods, format responses. Business logic belongs in modules.
 
 #### Module Patterns
-- **Class-based singletons**: Modules export a single instance (`module.exports = new MyModule()`). Follow this pattern for new modules.
-- **Avoid circular dependencies**: If module A and module B need each other, restructure the dependency (extract shared logic, use events, or pass dependencies at call time). Do not use late-binding `require()` inside methods as a workaround.
-- **Use the established sub-module pattern** for complex features. Good examples to follow:
-  - `server/modules/filesystem/` -- clean aggregator index with namespaced exports
-  - `server/modules/notifications/` -- service registry with pluggable formatters and senders
+- **Class-based singletons**: new modules export a single instance (`module.exports = new MyModule()`).
+- **Avoid circular dependencies**: restructure the dependency graph, extract shared logic, use events, or pass dependencies at call time. Do not use late-binding `require()` inside methods as a workaround. Some existing modules (e.g., `cronJobs.js`) use late-binding; do not copy the pattern.
+- **Sub-module aggregator pattern** for complex features: see `server/modules/filesystem/` and `server/modules/notifications/` as good examples.
 
 #### Database
-- **Use Sequelize model methods** for queries, not raw SQL, unless there's a specific performance reason.
-- **Create migrations using the script**: `./scripts/db-create-migration.sh migration-name`. Never manually create migration files.
-- **Use transactions** for multi-step database operations that must be atomic.
+- **Sequelize model methods** for queries, not raw SQL, unless there is a specific performance reason. Raw queries must use explicit parameter binding.
+- **Create migrations using the script**: `./scripts/db-create-migration.sh migration-name`. Never create migration files manually.
+- **Transactions** for multi-step operations that must be atomic.
 
 ### Frontend Standards (React/TypeScript)
 
 #### TypeScript
-- **No `any` types**: Use proper types for all variables, parameters, and return values. Especially:
-  - Error handlers: Use `unknown` and type-narrow instead of `catch (err: any)`
-  - API responses: Define interfaces for all response shapes
-  - WebSocket messages: Type the message payloads
-  - Event handlers: Use React's built-in event types
-- **Define interfaces** for component props, API responses, and shared data structures. Co-locate types with their feature when specific, or place in `client/src/types/` when shared.
-- **Use the CONFIG_FIELDS registry pattern** (`client/src/config/configSchema.ts`) when adding new configuration fields -- it auto-derives types, defaults, and change tracking.
+- **No `any` in new code**. Use proper types everywhere:
+  - Error handlers: `catch (err: unknown)` with type narrowing.
+  - API responses, WebSocket payloads: define interfaces.
+  - Event handlers: use React's built-in event types.
+- **Define interfaces** for props, API payloads, and shared data. Co-locate feature-specific types with the feature; put shared types in `client/src/types/`.
+- **CONFIG_FIELDS registry**: use `client/src/config/configSchema.ts` when adding new configuration fields.
+- The codebase has ~300 existing `any` occurrences; do not add more.
 
 #### Component Structure
-- **Decompose large components**: If a component has more than ~10 state variables or exceeds ~300 lines, extract logic into custom hooks and UI into child components.
-- **Feature directory structure**: For complex features, organize as:
+- **When authoring or rewriting a component**: aim for fewer than 10 `useState` calls and under 300 lines. If you cross that threshold while writing new code, extract logic into custom hooks and UI into child components.
+- **Feature directory layout** for new complex features, either of these is acceptable:
   ```
+  # Sibling-file layout (most common in this repo)
+  FeatureName.tsx              # the main component
   FeatureName/
-  ├── components/       # Child components
-  ├── hooks/           # Feature-specific hooks
-  ├── __tests__/       # Tests and stories
-  └── index.tsx        # Main component (or separate file)
+  ├── components/
+  ├── hooks/
+  └── __tests__/
+
+  # index.tsx layout
+  FeatureName/
+  ├── components/
+  ├── hooks/
+  ├── __tests__/
+  └── index.tsx
   ```
-  Good examples: `ChannelManager/`, `Configuration/`, `ChannelPage/`.
+  Sibling-file examples: `ChannelManager.tsx`, `Configuration.tsx`, `ChannelPage.tsx`. `index.tsx` example: `SubscriptionImport/`.
 
 #### Custom Hooks
-- **Extract data fetching and state logic** into custom hooks. Each hook should manage one concern (e.g., `useChannelList` for channel data, `useConfigSave` for save operations).
-- **Standard hook return pattern**: Return an object with `{ data, loading, error, ...actions }` for consistency across hooks.
-- **Clean up effects**: Always return cleanup functions from `useEffect` for subscriptions, timers, and event listeners.
-- **Memoize expensive computations**: Use `useMemo` for derived data and `useCallback` for callbacks passed to children, but don't over-memoize trivial values.
+- **Extract data fetching and multi-step state logic** into hooks. Each hook owns one concern.
+- **Return shape**: `{ data, loading, error, ...actions }` for consistency.
+- **Do not extract one-off state**: local component state read in exactly one place stays inline.
+- **Cleanup effects**: always return cleanup from `useEffect` for subscriptions, timers, and event listeners.
+- **Memoize deliberately**: `useMemo` for genuinely expensive derivations, `useCallback` for callbacks passed to memoized children. Do not over-memoize trivial values.
 
 #### Styling
-- **Use MUI's `sx` prop** for all styling. Do not use inline `style` attributes -- they bypass the theme system and don't support responsive breakpoints, hover states, or dark mode.
-  ```typescript
-  // Good
-  <Box sx={{ p: 2, display: 'flex', bgcolor: 'background.paper' }}>
-  
-  // Bad
-  <Box style={{ padding: '16px', display: 'flex' }}>
-  ```
-- **Use theme values** instead of hardcoded colors: `theme.palette.primary.main` not `'#1976d2'`.
-- **Use responsive breakpoints**: `useMediaQuery(theme.breakpoints.down('sm'))` for mobile-responsive behavior.
+- **Use MUI's `sx` prop** for styling, not inline `style`. `sx` is theme-aware, responsive, and supports hover states and dark mode.
+- **Theme values**: `theme.palette.primary.main`, not `'#1976d2'`.
+- **Responsive breakpoints**: `useMediaQuery(theme.breakpoints.down('sm'))`.
 
 #### API Calls
-- **Use Axios** for API calls (not `fetch`). This is the established pattern for data-fetching hooks.
-- **Include auth headers via the token prop**: `headers: { 'x-access-token': token }`. Hooks receive `token` from their calling component.
-- **Type API responses**: Define interfaces for request and response payloads.
-- **Handle errors with specific status codes** where applicable (403, 404, 503) rather than generic catch-all messages.
+- **Use Axios** in new hooks and components. A few legacy hooks use raw `fetch()` (`client/src/hooks/useConfig.ts` and `client/src/components/Configuration/hooks/usePlexConnection.ts`); do not copy them.
+- **Auth headers**: `headers: { 'x-access-token': token }`. Hooks receive `token` from the calling component.
+- **Type requests and responses** with interfaces.
+- **Handle specific status codes** (403, 404, 503) rather than generic catch-alls.
+- **Exception**: the global `fetch()` override in `App.tsx` is the one place `fetch` is intentional, for database error detection.
 
 #### State Management
-- Use React Context for cross-cutting concerns (auth token, WebSocket, theme).
-- Use local `useState` / `useReducer` for component-specific state.
-- Use custom events sparingly and only for decoupled communication (e.g., `CONFIG_UPDATED_EVENT`).
+- React Context for cross-cutting concerns (auth, WebSocket, theme).
+- Local `useState` / `useReducer` for component-specific state.
+- Custom events sparingly, only for decoupled communication (e.g., `CONFIG_UPDATED_EVENT`).
 
-## Important Tool Usage
+## Security
 
-### File Searching
-- **Always use `rg` (ripgrep) instead of `grep`** - it's faster and more powerful
-- ripgrep is pre-installed and should be your default search tool
-- Example: `rg "pattern" --type ts` instead of `grep -r "pattern" *.ts`
+Youtarr shells out to `yt-dlp` and writes files using user-influenced paths, so this section is not optional.
 
-## Common Development Commands
+- **Validate untrusted input at route boundaries**. Check types, lengths, and shape before passing anything to modules. Return 400 with `{ error }` for invalid input.
+- **Never interpolate user data into shell commands or filesystem paths directly.** Use the existing helpers: `modules/download/ytdlpCommandBuilder.js`, `modules/filesystem/pathBuilder.js`, `modules/filesystem/sanitizer.js`. If a new helper is needed, add it to those modules, not inline in a route.
+- **Auth by default**: new routes must wire `verifyToken` unless the user explicitly says the route is public. If you add a public route, call it out in your final report so the user can confirm.
+- **Never log secrets**. Pino redacts known keys, but do not bypass redaction by interpolating tokens, passwords, cookies, or API keys into log messages.
+- **Treat uploaded files as untrusted**: Takeout CSV and cookies uploads in the subscription import flow must be validated, size-limited, and parsed defensively.
+- **Sequelize protects against SQL injection only when using model methods**. Raw queries require explicit parameterization.
+- **Rate-limit endpoints that accept external identifiers or credentials** (follow the existing pattern in `server/routes/videos.js` and `server/routes/auth.js`).
 
-### Development with Docker
-For development, use the Docker-based "build-and-test" workflow. See [Development Guide](docs/DEVELOPMENT.md) for detailed instructions:
+## Testing
 
-```bash
-# Build development environment
-./scripts/build-dev.sh
-
-# Start development environment
-./scripts/start-dev.sh
-
-# Additional start-dev.sh options:
-# ./scripts/start-dev.sh --no-auth        # Disable authentication
-# ./scripts/start-dev.sh --headless-auth  # Bootstrap auth credentials for headless deployments
-# ./scripts/start-dev.sh --pull-latest    # Pull latest git commits and Docker images
-# ./scripts/start-dev.sh --debug          # Enable debug logging
-
-# Access the app at http://localhost:3087
-
-# After making code changes, rebuild and restart:
-./scripts/build-dev.sh
-./scripts/start-dev.sh  # Automatically stops and restarts
-
-# View logs
-docker compose logs -f
-
-# Stop development environment
-./scripts/stop-dev.sh
-```
-
-**Development Setup Characteristics:**
-- ❌ No hot reload - code changes require rebuild
-- ✅ Tests code in actual Docker environment
-- ✅ Consistent with production container
-- ✅ Includes all system dependencies (yt-dlp, ffmpeg)
-- ℹ️ For faster iteration during active development, consider running backend/frontend outside Docker, then test in Docker before committing
-
-### Production with Docker
-```bash
-# Start application (creates .env on first run, pulls latest, starts containers)
-./start.sh
-
-# Start script options:
-./start.sh --pull-latest    # Update before starting
-./start.sh --dev            # Use bleeding-edge dev image
-./start.sh --arm            # Force ARM compose file
-./start.sh --external-db    # Use external database
-./start.sh --no-auth        # Disable authentication
-./start.sh --headless-auth  # Bootstrap auth credentials
-./start.sh --debug          # Enable debug logging
-
-# Stop application
-./stop.sh
-
-# View logs
-docker compose logs -f
-```
-
-### Code Quality
-```bash
-# Run ESLint on both frontend and backend
-npm run lint
-
-# Additional lint commands
-npm run lint:frontend    # Frontend only
-npm run lint:backend     # Backend only
-npm run lint:ts          # TypeScript type checking
-npm run lint:fix         # Auto-fix linting issues
-
-# Run tests with coverage
-npm run test:coverage
-
-# Lint is also configured with Husky for pre-commit hooks
-```
-
-### Testing
-
-**Always run tests from the project root:**
+**Run tests from the project root.** See `docs/DEVELOPMENT.md` for the full workflow.
 
 ```bash
-# Run all frontend tests
-npm run test:frontend
-
-# Run specific frontend test
-npm run test:frontend -- client/src/hooks/__tests__/useStorageStatus.test.ts
-
-# Run all backend tests
-npm run test:backend
-
-# Run specific backend test
-npm run test:backend -- server/modules/__tests__/videosModule.test.js
+npm run test:frontend                                        # all frontend tests
+npm run test:frontend -- client/src/hooks/__tests__/foo.ts   # one frontend test
+npm run test:backend                                         # all backend tests
+npm run test:backend -- server/modules/__tests__/foo.test.js # one backend test
+npm run lint                                                  # lint front + back
+npm run lint:ts                                               # TypeScript typecheck
 ```
 
-#### Important Testing Guidelines
-When writing tests with React Testing Library, **always follow these rules to avoid linting errors**:
+### Test Execution Policy
+**NEVER skip tests.** No `test.skip()`, no `describe.skip()`, no commented-out failing tests. Fix failing tests or delete them if obsolete. If a test is written, it must run and pass in CI.
 
-1. **Never use direct DOM queries** like `querySelector`, `parentElement`, or other native DOM methods
-   - ❌ BAD: `button.querySelector('[data-testid="AddIcon"]')`
-   - ✅ GOOD: `screen.getByTestId('AddIcon')`
+### React Testing Library Rules
+- **No direct DOM queries**: no `querySelector`, `parentElement`, or other native DOM access. Use `getByRole`, `getByLabelText`, `getByText`, `getByTestId`, and `within()` for scoped queries. ESLint enforces this via `testing-library/no-node-access`.
+- **No conditional `expect`** calls.
+- **Assert behavior, not implementation**. Test what the code does, not how.
 
-2. **Use Testing Library queries exclusively**:
-   - Avoid direct Node access. Prefer using the methods from Testing Library!
-   - `getBy...` / `queryBy...` / `findBy...` for single elements
-   - `getAllBy...` / `queryAllBy...` / `findAllBy...` for multiple elements
-   - Common queries: `ByRole`, `ByLabelText`, `ByPlaceholderText`, `ByText`, `ByTestId`
+### Jest Mocking Gotchas (project-specific)
+These are real landmines that cost time, not general Jest advice. Full examples live in existing tests under `server/modules/__tests__/` and `client/src/**/__tests__/`; consult them before mocking a new dependency.
 
-3. **For parent element access**, restructure your tests:
-   - Instead of `.parentElement`, use more specific queries
-   - Consider using `within()` for scoped queries
-   - Use accessible roles and labels rather than DOM structure
+1. **Mocking React components**: do NOT use JSX inside `jest.mock()`. Jest hoists the mock and JSX fails with "Invalid variable access." Use `React.createElement` via `require('react')` inside the factory.
+2. **Mocking axios**: use a factory (`jest.mock('axios', () => ({ get: jest.fn(), post: jest.fn(), ... }))`) and `require('axios')` after the mock. Direct ES6 `import axios from 'axios'` fails with ESM errors.
+3. **Mocking `fetch` JSON**: mock `json` as `jest.fn().mockResolvedValueOnce(...)`, not an async arrow function; the latter returns the wrong shape.
+4. **Mock path resolution**: mock paths are relative to the test file, not the component under test. Double-check `../` vs `../../`.
 
-4. **ESLint will flag violations** with: `testing-library/no-node-access`
-   - This rule ensures tests remain maintainable and less brittle
-   - Tests should interact with components as users would
+### Backend Test Setup
+- Place `jest.mock()` calls before `require()` imports.
+- Use `jest.resetModules()` and `jest.clearAllMocks()` in `beforeEach`, then re-require the module under test.
+- Mock only external dependencies (db, fs, HTTP, logger). Over-mocking internal module methods usually indicates a design issue.
 
-5. **Avoid calling `expect` conditionally**
+### Hook Test Setup
+- Use `renderHook` with explicit type annotations for parameterized hooks (e.g., `renderHook(({ token }: { token: string | null }) => useMyHook(token), { initialProps: { token: null } })`).
+- Use `waitFor` for async state changes, not arbitrary timeouts.
+- For polling/interval tests, use fake timers (`jest.useFakeTimers()`) and clean up with `jest.runOnlyPendingTimers()` + `jest.useRealTimers()` in `afterEach`.
+- Test cleanup on unmount.
 
-#### Jest Mocking Best Practices
+### Test Quality
+- Each test asserts one thing. A test with 15 assertions is testing too much.
+- Meaningful names: `'returns empty array when no channels exist'`, not `'test case 1'`.
+- Minimal setup: only what the specific test needs; use `beforeEach` for genuinely shared setup.
+- Do not test private implementation details. If you need to expose internals to test them, the API design needs work.
 
-1. **Mocking React Components in Tests**
-   - Jest has hoisting issues when mocking components with JSX
-   - ❌ BAD: Using JSX directly in jest.mock() causes "Invalid variable access" errors
-   ```javascript
-   jest.mock('../Component', () => {
-     return function MockComponent() {
-       return <div>Mock</div>; // This will fail!
-     }
-   });
-   ```
-   - ✅ GOOD: Use React.createElement to avoid hoisting issues
-   ```javascript
-   jest.mock('../Component', () => ({
-     __esModule: true,
-     default: function MockComponent(props) {
-       const React = require('react');
-       return React.createElement('div', { 'data-testid': 'mock' }, 'Mock');
-     }
-   }));
-   ```
+## Documentation Sync
 
-2. **Mocking axios**
-   - Use a factory function with `jest.mock()` to mock only the HTTP methods you need
-   - Import axios using `require()` after the mock (not ES6 import)
-   - ❌ BAD: `import axios from 'axios'` (will fail with ESM import errors)
-   - ✅ GOOD: Use factory function and require
-   ```javascript
-   // Mock axios with only the methods you need
-   jest.mock('axios', () => ({
-     get: jest.fn(),
-     post: jest.fn(),
-     delete: jest.fn(),
-   }));
+When a code change creates or invalidates information in this file or in `docs/`, update the docs in the same PR. This is not optional; stale docs are how we got here.
 
-   const axios = require('axios');
-
-   // In your test
-   axios.get.mockResolvedValueOnce({ data: mockData });
-   ```
-
-3. **Mocking fetch() Calls**
-   - Always mock the json() method as a jest function that returns a promise
-   - ❌ BAD: `json: async () => ({ data })`
-   - ✅ GOOD: `json: jest.fn().mockResolvedValueOnce({ data })`
-   ```javascript
-   mockFetch.mockResolvedValueOnce({
-     ok: true,
-     status: 200,
-     json: jest.fn().mockResolvedValueOnce({ data: 'value' })
-   });
-   ```
-
-4. **Mock Path Resolution**
-   - Mock paths must be relative to the test file location, not the component
-   - Double-check parent directory references (../ vs ../../)
-
-#### Hook Testing Patterns
-
-When testing custom React hooks, follow these patterns:
-
-1. **Basic Hook Testing Setup**
-   ```typescript
-   import { renderHook, waitFor } from '@testing-library/react';
-   import { useMyHook } from '../useMyHook';
-
-   describe('useMyHook', () => {
-     const { result } = renderHook(() => useMyHook(params));
-
-     expect(result.current.data).toBe(expected);
-   });
-   ```
-
-2. **Testing Hooks with Parameters (TypeScript)**
-   - Always provide explicit type annotations for renderHook callbacks
-   ```typescript
-   const { result, rerender } = renderHook(
-     ({ token }: { token: string | null }) => useStorageStatus(token),
-     { initialProps: { token: null as string | null } }
-   );
-
-   // Change props to trigger re-render
-   rerender({ token: 'new-token' });
-   ```
-
-3. **Testing Async Hooks**
-   - Use `waitFor` to wait for async state updates
-   - Wait for specific state changes, not just arbitrary delays
-   ```typescript
-   await waitFor(() => {
-     expect(result.current.loading).toBe(false);
-   });
-
-   await waitFor(() => {
-     expect(result.current.data).toEqual(expectedData);
-   });
-   ```
-
-4. **Testing Hooks with Timers (Polling, Intervals)**
-   - Use fake timers to control time-based behavior
-   - Clean up properly to avoid test interference
-   ```typescript
-   beforeEach(() => {
-     jest.clearAllMocks();
-     jest.useFakeTimers();
-   });
-
-   afterEach(() => {
-     jest.runOnlyPendingTimers();
-     jest.useRealTimers();
-   });
-
-   test('polls at interval', async () => {
-     // Initial fetch
-     await waitFor(() => {
-       expect(mockFn).toHaveBeenCalledTimes(1);
-     });
-
-     // Advance timers
-     jest.advanceTimersByTime(60000);
-
-     await waitFor(() => {
-       expect(mockFn).toHaveBeenCalledTimes(2);
-     });
-   });
-   ```
-
-5. **Testing Hook Cleanup (useEffect cleanup)**
-   ```typescript
-   test('cleans up on unmount', async () => {
-     const { unmount } = renderHook(() => useMyHook());
-
-     unmount();
-
-     // Verify cleanup happened (e.g., intervals cleared)
-     jest.advanceTimersByTime(60000);
-     expect(mockFn).toHaveBeenCalledTimes(1); // No additional calls
-   });
-   ```
-
-#### Backend Test Patterns
-
-Backend tests use Jest with extensive mocking. Follow these patterns:
-
-1. **Mock setup order**: Place all `jest.mock()` calls before `require()` imports. Use `jest.resetModules()` in `beforeEach` to ensure clean state.
-2. **Module loading after mocks**: Re-require the module under test in `beforeEach` after resetting modules:
-   ```javascript
-   let myModule;
-   beforeEach(() => {
-     jest.resetModules();
-     jest.clearAllMocks();
-     myModule = require('../myModule');
-   });
-   ```
-3. **Test structure**: Use descriptive `describe` blocks organized by method, and `test`/`it` blocks that describe the expected behavior (not the implementation).
-4. **Avoid over-mocking**: Only mock external dependencies (database, file system, HTTP). If you need to mock internal module methods to test, the module likely has a design issue.
-
-#### Test Quality Standards
-- **Tests must assert behavior, not implementation**: Test what the code does (outputs, side effects, state changes), not how it does it internally.
-- **Each test should test one thing**: A test with 15 assertions is testing too many things. Split it up.
-- **Use meaningful test names**: `'returns empty array when no channels exist'` not `'test case 1'`.
-- **Keep test setup minimal**: Only set up what the specific test needs. Use `beforeEach` for truly shared setup only.
-- **Don't test private implementation details**: If you need to expose internals just for testing, the API design needs work.
-
-#### Test Execution Policy
-**NEVER skip tests** - All tests must either pass or be fixed:
-- ❌ Never use `test.skip()` or `describe.skip()`
-- ❌ Never comment out failing tests
-- ✅ Fix failing tests immediately or remove them if obsolete
-- ✅ Tests should be comprehensive and actually test functionality
-- If a test is created, it must run and pass in CI/CD
-
-#### Running Individual Tests
-
-**Run from project root** using the appropriate npm script:
-
-Frontend tests:
-```bash
-npm run test:frontend -- client/src/hooks/__tests__/useStorageStatus.test.ts
-```
-
-Backend tests:
-```bash
-npm run test:backend -- server/modules/__tests__/videosModule.test.js
-```
-
-## Key Configuration
-
-### Environment Variables (Docker)
-- `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`: Database connection
-- `YOUTUBE_OUTPUT_DIR`: Host directory for downloaded videos (set in .env file)
-- `DATA_PATH`: Optional override for video storage path (used in platform deployments like Elfhosted)
-- `YOUTARR_UID`, `YOUTARR_GID`: Container user/group IDs for file permissions
-- `AUTH_PRESET_USERNAME`, `AUTH_PRESET_PASSWORD`: Headless auth bootstrap credentials
-- `LOG_LEVEL`: Logging verbosity (warn/info/debug)
-- `TZ`: Timezone for scheduled jobs
-
-### Application Config (config/config.json)
-- `plexApiKey`: Plex authentication token
-- `youtubeOutputDirectory`: Where videos are saved
-- `plexLibrarySection`: Plex library ID for YouTube videos
-- `youtubeApiKey`: Optional, for browsing channel videos in-app
-- `cronSchedule`: Download schedule (default: every 6 hours)
-
-## Important Implementation Details
-
-### Plex Integration
-- Uses Plex OAuth for authentication - must use same account as Plex server admin
-- Automatically triggers library scan after downloads
-- Videos organized in channel-named subdirectories
-- Plex library must be "Other Videos" type with "Personal Media" agent
-
-### Video Downloads
-- Uses yt-dlp for downloading (included in Docker image)
-- Downloads video, thumbnail, and metadata (.info.json)
-- Post-processes files for Plex compatibility
-- Supports resume on partial downloads
-
-### WebSocket Communication
-- Real-time updates for download progress
-- Channel refresh status
-- Job status updates
-- Uses ws library, shares HTTP server port (3011 in container, 3087 on host)
-
-### API Documentation
-- Swagger/OpenAPI documentation available at `/swagger`
-- All endpoints annotated for automatic documentation generation
-
-### Database Migrations
-- Run automatically on container startup
-- **Create new migrations using the script**: `./scripts/db-create-migration.sh migration-name`
-  - This uses sequelize-cli with the correct config and generates a properly timestamped migration file
-  - Alternative command: `npm run db:create-migration -- --name migration-name`
-  - ❌ Never manually create migration files - always use the script
-- Migrations support utf8mb4 for emoji support
-
-## Docker Architecture
-- Two containers: `youtarr` (app) and `youtarr-db` (MariaDB)
-- Health checks ensure database is ready before app starts
-- Volumes persist database data and configuration
-- Network isolation with `youtarr-network`
-- Deno is installed in the container to enhance yt-dlp performance (yt-dlp automatically uses Deno when available in PATH)
-
-### Docker Compose Files
-- `docker-compose.yml`: Main production configuration
-- `docker-compose.dev.yml`: Development overrides (code mounting, debug logging)
-- `docker-compose.arm.yml`: ARM architecture support (Apple Silicon, Raspberry Pi)
-- `docker-compose.external-db.yml`: External database configuration
-
-## Port Mappings
-
-Both development and production use the same port configuration:
-- Application (backend + frontend): 3087 (host) → 3011 (container)
-- WebSocket: shares application port (3087/3011)
-- Database: 3321 (both host and container)
-
-**Note:** Access the app via http://localhost:3087. In development, the setup serves pre-built static React files (no webpack dev server).
+- **New top-level route file or module**: add a one-liner to the Architecture section above.
+- **New feature directory under `client/src/components/`**: add a one-liner to the Frontend section.
+- **New or changed env var**: update `docs/ENVIRONMENT_VARIABLES.md`.
+- **New or changed config field**: update `docs/CONFIG.md` and register the field in `client/src/config/configSchema.ts`.
+- **New dev command or flag**: update `docs/DEVELOPMENT.md`.
+- **Schema changes**: update `docs/DATABASE.md`.
+- **API changes**: Swagger annotations live with the routes; update them so `/swagger` stays accurate.
 
 ## Git Workflow
 
-### Branch Strategy
-- **`dev`** - Default branch for active development; all PRs target this branch
-- **`main`** - Stable release branch; merging `dev` → `main` triggers a production release
-- **Feature branches** - Create from `dev`, merge back to `dev` via PR
+### Branches
+- **`dev`**: default branch for active development; all contributor PRs target `dev`.
+- **`main`**: stable release branch; merging `dev` -> `main` triggers a production release.
+- **Feature branches**: create from `dev`, merge back to `dev` via PR.
 
-### Release Process
-- Merging to `dev` → Builds RC image (`dev-latest`, `dev-rc.<sha>`)
-- Merging `dev` to `main` → Triggers production release with semantic versioning
-- Commit prefixes: `feat:` (minor), `fix:` (patch), `BREAKING CHANGE:` (major)
-- Docker images auto-published to `dialmaster/youtarr` on release
+### Release
+- Merging to `dev` builds an RC image (`dev-latest`, `dev-rc.<sha>`).
+- Merging `dev` -> `main` triggers a production release with semantic versioning.
+- Commit prefixes: `feat:` (minor), `fix:` (patch), `BREAKING CHANGE:` (major).
+- Docker images auto-publish to `dialmaster/youtarr` on release.
 
-### PR Guidelines
-- All contributor PRs should target `dev` (not `main`)
-- PRs to `dev` get automatic Claude Code reviews
-- CI runs on PRs to both `dev` and `main`
-
-## Anti-Patterns to Avoid
-
-These are common mistakes found in the codebase that should not be repeated in new code:
-
-### Backend
-- **`console.log` / `console.error`**: Always use the Pino logger. Several legacy files still use console -- don't follow that pattern.
-- **God modules**: Modules over 500 lines with multiple responsibilities. Break them up by extracting focused sub-modules.
-- **Late-binding `require()` inside functions**: This is a workaround for circular dependencies. Instead, restructure the dependency graph, pass the dependency as a parameter, or use an event emitter. (Several existing modules use this pattern, including `cronJobs.js` and others — migrate over time but do NOT refactor these as part of unrelated feature work or bug fixes.)
-- **Inconsistent error response shapes**: Don't mix `{ error: '...' }`, `{ success: false, error: '...' }`, and `{ status: 'error', message: '...' }`. Use `{ error: '...' }` consistently.
-- **Fire-and-forget promises**: Don't call an async function without awaiting or attaching error handling. Unhandled rejections crash the process.
-- **Hardcoded paths and timeouts**: Define as named constants, not inline literals.
-
-### Frontend
-- **`any` type escape hatch**: Don't use `any` to silence TypeScript. Use `unknown` with type narrowing for genuinely unknown types, or define proper interfaces.
-- **Monolith components**: Components with 10+ `useState` calls and hundreds of lines. Extract custom hooks for logic and child components for UI.
-- **Inline `style` prop**: Use MUI's `sx` prop for theme-aware, responsive styling.
-- **Mixed fetch/axios**: Use Axios consistently for API calls. The only exception is the global fetch override in `App.tsx` for database error detection.
-- **Prop drilling through many layers**: Use React Context or restructure component hierarchy if a prop is passed through 3+ levels unchanged.
-
-## Code Review
-
-When reviewing PRs or analyzing code, always complete the full analysis before ending - don't stop after just reading files. Provide actionable findings even if the session might end soon.
-
-### What to Check
-- **Consistency**: Does the new code follow established patterns in the codebase (dependency injection in routes, class-based modules, typed hooks)?
-- **File size**: Are new/modified files staying within reasonable limits (~500 lines backend, ~300 lines frontend)?
-- **Error handling**: Are errors properly caught, logged (with context), and returned to the caller?
-- **Type safety**: No `any` types in TypeScript? Proper error typing?
-- **Test coverage**: Do tests cover the new behavior? Are they testing behavior, not implementation?
-- **DRY**: Is there duplicated logic that should be extracted?
-- **Naming**: Are functions, variables, and files named clearly and consistently?
+### PRs
+- Contributor PRs target `dev`, not `main`.
+- PRs to `dev` get automatic Claude Code reviews.
+- CI runs on PRs to both `dev` and `main`.
 
 ## Debugging
 
 ### CI/CD
-
-When debugging CI/CD or GitHub Actions issues, check both the permissions AND the actual command execution logs. A fix isn't complete until the underlying behavior is verified working.
+When debugging CI/CD or GitHub Actions issues, check both the permissions AND the actual command execution logs. A fix is not complete until the underlying behavior is verified working.

--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -103,6 +103,7 @@ function Configuration({ token }: ConfigurationProps) {
   const {
     plexConnectionStatus,
     setPlexConnectionStatus,
+    plexLibraries,
     openPlexLibrarySelector,
     openPlexAuthDialog,
     setOpenPlexAuthDialog,
@@ -238,6 +239,7 @@ function Configuration({ token }: ConfigurationProps) {
         config={config}
         isPlatformManaged={isPlatformManaged}
         plexConnectionStatus={plexConnectionStatus}
+        plexLibraries={plexLibraries}
         hasPlexServerConfigured={hasPlexServerConfigured}
         onConfigChange={handleConfigChange}
         onTestConnection={testPlexConnection}
@@ -332,7 +334,8 @@ function Configuration({ token }: ConfigurationProps) {
         open={openPlexLibrarySelector}
         handleClose={closeLibrarySelector}
         setLibraryId={setLibraryId}
-        token={token}
+        libraries={plexLibraries}
+        currentLibraryId={config.plexYoutubeLibraryId}
       />
 
       <Snackbar

--- a/client/src/components/Configuration/hooks/__tests__/usePlexConnection.test.ts
+++ b/client/src/components/Configuration/hooks/__tests__/usePlexConnection.test.ts
@@ -210,6 +210,48 @@ describe('usePlexConnection', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
+
+    test('flips plexConnectionStatus to testing while the initial check is in flight', async () => {
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      // Keep the fetch pending so we can observe the intermediate state
+      let resolveFetch: (value: Response) => void = () => {};
+      mockFetch.mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          })
+      );
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      // While the fetch is pending, the status should read "testing" rather
+      // than the default "not_tested"
+      await waitFor(() => {
+        expect(result.current.plexConnectionStatus).toBe('testing');
+      });
+
+      // Resolve the fetch with a successful payload and verify the final state
+      await act(async () => {
+        resolveFetch({
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValueOnce([{ id: '1', title: 'YouTube' }]),
+        } as unknown as Response);
+      });
+
+      await waitFor(() => {
+        expect(result.current.plexConnectionStatus).toBe('connected');
+      });
+    });
   });
 
   describe('checkPlexConnection Function', () => {
@@ -1478,6 +1520,173 @@ describe('usePlexConnection', () => {
       const url = callArgs[0] as string;
       const params = new URLSearchParams(url.split('?')[1]);
       expect(params.get('testIP')).toBe('10.0.0.1');
+    });
+  });
+
+  describe('plexLibraries state', () => {
+    test('starts as an empty array before any fetch', () => {
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: false,
+        })
+      );
+
+      expect(result.current.plexLibraries).toEqual([]);
+    });
+
+    test('populates plexLibraries after a successful initial check', async () => {
+      const libraries = [
+        { id: '1', title: 'YouTube' },
+        { id: '31', title: 'Adults Library' },
+      ];
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(libraries),
+      } as any);
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.plexLibraries).toEqual(libraries);
+      });
+    });
+
+    test('clears plexLibraries when the initial check returns an empty list', async () => {
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce([]),
+      } as any);
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.plexConnectionStatus).toBe('not_connected');
+      });
+      expect(result.current.plexLibraries).toEqual([]);
+    });
+
+    test('clears plexLibraries when the initial check fails', async () => {
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.plexConnectionStatus).toBe('not_connected');
+      });
+      expect(result.current.plexLibraries).toEqual([]);
+    });
+
+    test('populates plexLibraries after a successful testPlexConnection call', async () => {
+      const initialLibraries = [{ id: '1', title: 'YouTube' }];
+      const updatedLibraries = [
+        { id: '1', title: 'YouTube' },
+        { id: '42', title: 'Kids Shows' },
+      ];
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      // Initial mount check consumes the first response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(initialLibraries),
+      } as any);
+      // testPlexConnection consumes the second response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(updatedLibraries),
+      } as any);
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.plexLibraries).toEqual(initialLibraries);
+      });
+
+      await act(async () => {
+        await result.current.testPlexConnection();
+      });
+
+      expect(result.current.plexLibraries).toEqual(updatedLibraries);
+    });
+
+    test('clears plexLibraries when testPlexConnection fails', async () => {
+      const initialLibraries = [{ id: '1', title: 'YouTube' }];
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      // Initial mount check succeeds and populates libraries
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(initialLibraries),
+      } as any);
+      // testPlexConnection rejects
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.plexLibraries).toEqual(initialLibraries);
+      });
+
+      await act(async () => {
+        await result.current.testPlexConnection();
+      });
+
+      expect(result.current.plexLibraries).toEqual([]);
     });
   });
 });

--- a/client/src/components/Configuration/hooks/usePlexConnection.ts
+++ b/client/src/components/Configuration/hooks/usePlexConnection.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { ConfigState, PlexConnectionStatus, SnackbarState } from '../types';
+import { PlexLibrary } from '../../../utils/plexLibraries';
 
 interface UsePlexConnectionParams {
   token: string | null;
@@ -19,12 +20,18 @@ export const usePlexConnection = ({
   hasPlexServerConfigured,
 }: UsePlexConnectionParams) => {
   const [plexConnectionStatus, setPlexConnectionStatus] = useState<PlexConnectionStatus>('not_tested');
+  const [plexLibraries, setPlexLibraries] = useState<PlexLibrary[]>([]);
   const [openPlexLibrarySelector, setOpenPlexLibrarySelector] = useState(false);
   const [openPlexAuthDialog, setOpenPlexAuthDialog] = useState(false);
   const [didInitialPlexCheck, setDidInitialPlexCheck] = useState(false);
 
   const checkPlexConnection = useCallback(() => {
     if (hasPlexServerConfigured) {
+      // Flip to "testing" up front so the chip reads "Testing..." during the
+      // in-flight request. Without this, a slow failing fetch (e.g. Plex is
+      // unreachable) would leave the chip stuck on "Not Tested" for the whole
+      // fetch window, misleading the user into thinking nothing is happening.
+      setPlexConnectionStatus('testing');
       fetch('/getplexlibraries', {
         headers: {
           'x-access-token': token || '',
@@ -32,10 +39,17 @@ export const usePlexConnection = ({
       })
         .then((response) => response.json())
         .then((data) => {
-          setPlexConnectionStatus(Array.isArray(data) && data.length > 0 ? 'connected' : 'not_connected');
+          if (Array.isArray(data) && data.length > 0) {
+            setPlexConnectionStatus('connected');
+            setPlexLibraries(data as PlexLibrary[]);
+          } else {
+            setPlexConnectionStatus('not_connected');
+            setPlexLibraries([]);
+          }
         })
         .catch(() => {
           setPlexConnectionStatus('not_connected');
+          setPlexLibraries([]);
         });
     }
   }, [hasPlexServerConfigured, token]);
@@ -110,6 +124,7 @@ export const usePlexConnection = ({
 
       if (Array.isArray(data) && data.length > 0) {
         setPlexConnectionStatus('connected');
+        setPlexLibraries(data as PlexLibrary[]);
         // Plex credentials are auto-saved. Update initial snapshot for those fields.
         setInitialConfig((prev) => (
           prev
@@ -123,6 +138,7 @@ export const usePlexConnection = ({
         });
       } else {
         setPlexConnectionStatus('not_connected');
+        setPlexLibraries([]);
         setSnackbar({
           open: true,
           message: 'Could not retrieve Plex libraries. Check your settings.',
@@ -132,6 +148,7 @@ export const usePlexConnection = ({
     } catch (error) {
       console.error('Error testing Plex connection:', error);
       setPlexConnectionStatus('not_connected');
+      setPlexLibraries([]);
       setSnackbar({
         open: true,
         message: 'Failed to connect to Plex server. Check IP and API key.',
@@ -178,6 +195,7 @@ export const usePlexConnection = ({
   return {
     plexConnectionStatus,
     setPlexConnectionStatus,
+    plexLibraries,
     openPlexLibrarySelector,
     openPlexAuthDialog,
     setOpenPlexAuthDialog,

--- a/client/src/components/Configuration/sections/PlexIntegrationSection.tsx
+++ b/client/src/components/Configuration/sections/PlexIntegrationSection.tsx
@@ -16,11 +16,14 @@ import { ConfigurationAccordion } from '../common/ConfigurationAccordion';
 import { InfoTooltip } from '../common/InfoTooltip';
 import { ConfigState, PlatformManagedState, PlexConnectionStatus } from '../types';
 import { PlexSubfolderMappings } from './PlexSubfolderMappings';
+import { PlexLibrary } from '../../../utils/plexLibraries';
+import { DefaultPlexLibraryDisplay } from './components/DefaultPlexLibraryDisplay';
 
 interface PlexIntegrationSectionProps {
   config: ConfigState;
   isPlatformManaged: PlatformManagedState;
   plexConnectionStatus: PlexConnectionStatus;
+  plexLibraries: PlexLibrary[];
   hasPlexServerConfigured: boolean;
   onConfigChange: (updates: Partial<ConfigState>) => void;
   onTestConnection: () => void;
@@ -34,6 +37,7 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
   config,
   isPlatformManaged,
   plexConnectionStatus,
+  plexLibraries,
   hasPlexServerConfigured,
   onConfigChange,
   onTestConnection,
@@ -68,7 +72,7 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
       case 'connected':
         return 'Connected';
       case 'not_connected':
-        return 'Not Connected';
+        return 'Unreachable';
       case 'testing':
         return 'Testing...';
       default:
@@ -110,8 +114,8 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
 
       {plexConnectionStatus === 'not_connected' && (
         <Alert severity="warning" sx={{ mb: 2 }}>
-          Unable to connect to Plex server. Library refresh will not work.
-          Please check your IP and API key, then click "Test Connection".
+          Plex is currently unreachable. Verify your Plex server is running and
+          that the IP, port, and API key above are correct, then click "Test Connection".
         </Alert>
       )}
 
@@ -278,18 +282,21 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
               disabled={plexConnectionStatus !== 'connected'}
               data-testid="select-library-button"
             >
-              Select Plex Library
+              Select Default Library
             </Button>
             <InfoTooltip
               text="Test Connection will verify and auto-save your Plex credentials if successful."
               onMobileClick={onMobileTooltipClick}
             />
           </Box>
-          {config.plexYoutubeLibraryId && (
-            <Typography variant="body2" sx={{ mt: 1 }}>
-              Selected Library ID: {config.plexYoutubeLibraryId}
-            </Typography>
-          )}
+          <DefaultPlexLibraryDisplay
+            libraries={plexLibraries}
+            libraryId={config.plexYoutubeLibraryId}
+            plexConnectionStatus={plexConnectionStatus}
+            hasPlexServerConfigured={hasPlexServerConfigured}
+            hasPlexApiKey={Boolean(config.plexApiKey)}
+            onMobileTooltipClick={onMobileTooltipClick}
+          />
         </Grid>
 
         <Grid item xs={12}>
@@ -298,6 +305,7 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
             onMappingsChange={(mappings) => onConfigChange({ plexSubfolderLibraryMappings: mappings })}
             token={token}
             plexConnectionStatus={plexConnectionStatus}
+            plexLibraries={plexLibraries}
           />
         </Grid>
       </Grid>

--- a/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
+++ b/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
@@ -23,15 +23,12 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { PlexConnectionStatus } from '../types';
+import { PlexLibrary, resolveLibraryDisplay } from '../../../utils/plexLibraries';
+import { PlexLibraryLabel } from './components/PlexLibraryLabel';
 
 export interface PlexSubfolderMapping {
   subfolder: string | null;
   libraryId: string;
-}
-
-interface PlexLibrary {
-  id: string;
-  title: string;
 }
 
 interface PlexSubfolderMappingsProps {
@@ -39,6 +36,7 @@ interface PlexSubfolderMappingsProps {
   onMappingsChange: (mappings: PlexSubfolderMapping[]) => void;
   token: string | null;
   plexConnectionStatus: PlexConnectionStatus;
+  plexLibraries: PlexLibrary[];
 }
 
 /**
@@ -66,8 +64,8 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
   onMappingsChange,
   token,
   plexConnectionStatus,
+  plexLibraries,
 }) => {
-  const [libraries, setLibraries] = useState<PlexLibrary[]>([]);
   const [subfolders, setSubfolders] = useState<string[]>([]);
   const [loadingData, setLoadingData] = useState(false);
   const [fetchError, setFetchError] = useState(false);
@@ -87,21 +85,15 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
     setLoadingData(true);
     setFetchError(false);
 
-    Promise.allSettled([
-      axios.get<unknown>('/getplexlibraries', { headers, signal })
-        .then((res) => (Array.isArray(res.data) ? (res.data as PlexLibrary[]) : [])),
-      axios.get<unknown>('/api/channels/subfolders', { headers, signal })
-        .then((res) => (Array.isArray(res.data) ? (res.data as string[]) : [])),
-    ])
-      .then(([libsResult, foldersResult]) => {
+    axios
+      .get<unknown>('/api/channels/subfolders', { headers, signal })
+      .then((res) => {
         if (signal.aborted) return;
-        const libs = libsResult.status === 'fulfilled' ? libsResult.value : [];
-        const folders = foldersResult.status === 'fulfilled' ? foldersResult.value : [];
-        setLibraries(libs);
-        setSubfolders(folders);
-        if (libsResult.status === 'rejected' || foldersResult.status === 'rejected') {
-          setFetchError(true);
-        }
+        setSubfolders(Array.isArray(res.data) ? (res.data as string[]) : []);
+      })
+      .catch(() => {
+        if (signal.aborted) return;
+        setFetchError(true);
       })
       .finally(() => {
         if (!signal.aborted) setLoadingData(false);
@@ -109,12 +101,6 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
 
     return () => controller.abort();
   }, [isConnected, token]);
-
-  const getLibraryTitle = (libraryId: string): string => {
-    const lib = libraries.find((l) => l.id === libraryId);
-    if (lib) return lib.title;
-    return libraries.length === 0 ? `Library ID: ${libraryId}` : libraryId;
-  };
 
   const isMappingDuplicate = (subfolder: string | null): boolean =>
     mappings.some((m) => m.subfolder === subfolder);
@@ -178,14 +164,14 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
           <CircularProgress size={16} />
           <Typography variant="caption" color="text.secondary">
-            Loading libraries and subfolders…
+            Loading subfolders...
           </Typography>
         </Box>
       )}
 
       {fetchError && (
         <Alert severity="warning" sx={{ mb: 1.5 }}>
-          Could not load Plex libraries or subfolders. Check your connection and try refreshing.
+          Could not load channel subfolders. Check your connection and try refreshing.
         </Alert>
       )}
 
@@ -199,30 +185,31 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {mappings.map((mapping) => (
-              <TableRow key={`${mapping.subfolder === null ? '\x00root' : mapping.subfolder}-${mapping.libraryId}`}>
-                <TableCell>
-                  <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                    {formatMappingSubfolder(mapping.subfolder)}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2">
-                    {getLibraryTitle(mapping.libraryId)}
-                  </Typography>
-                </TableCell>
-                <TableCell padding="checkbox">
-                  <IconButton
-                    size="small"
-                    onClick={() => handleDeleteMapping(mapping.subfolder)}
-                    aria-label={`Remove mapping for ${formatMappingSubfolder(mapping.subfolder)}`}
-                    data-testid={`delete-mapping-${mapping.subfolder ?? 'root'}`}
-                  >
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))}
+            {mappings.map((mapping) => {
+              const display = resolveLibraryDisplay(plexLibraries, mapping.libraryId);
+              return (
+                <TableRow key={`${mapping.subfolder === null ? '\x00root' : mapping.subfolder}-${mapping.libraryId}`}>
+                  <TableCell>
+                    <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                      {formatMappingSubfolder(mapping.subfolder)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <PlexLibraryLabel display={display} />
+                  </TableCell>
+                  <TableCell padding="checkbox">
+                    <IconButton
+                      size="small"
+                      onClick={() => handleDeleteMapping(mapping.subfolder)}
+                      aria-label={`Remove mapping for ${formatMappingSubfolder(mapping.subfolder)}`}
+                      data-testid={`delete-mapping-${mapping.subfolder ?? 'root'}`}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       )}
@@ -268,7 +255,7 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
               data-testid="new-mapping-library-select"
               disabled={loadingData}
             >
-              {libraries.map((lib) => (
+              {plexLibraries.map((lib) => (
                 <MenuItem key={lib.id} value={lib.id}>
                   {lib.title}
                 </MenuItem>

--- a/client/src/components/Configuration/sections/__tests__/PlexIntegrationSection.story.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexIntegrationSection.story.tsx
@@ -25,6 +25,7 @@ const meta: Meta<typeof PlexIntegrationSection> = {
   },
   args: {
     plexConnectionStatus: 'not_tested',
+    plexLibraries: [],
     hasPlexServerConfigured: true,
     isPlatformManaged: { plexUrl: false, authEnabled: true, useTmpForDownloads: false } as PlatformManagedState,
     onTestConnection: fn(),

--- a/client/src/components/Configuration/sections/__tests__/PlexIntegrationSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexIntegrationSection.test.tsx
@@ -27,6 +27,7 @@ const createSectionProps = (
   config: createConfig(),
   isPlatformManaged: createPlatformManagedState(),
   plexConnectionStatus: 'not_tested',
+  plexLibraries: [],
   hasPlexServerConfigured: false,
   onConfigChange: jest.fn(),
   onTestConnection: jest.fn(),
@@ -85,10 +86,10 @@ describe('PlexIntegrationSection Component', () => {
       expect(screen.getByText('Connected')).toBeInTheDocument();
     });
 
-    test('displays "Not Connected" chip when status is not_connected', () => {
+    test('displays "Unreachable" chip when status is not_connected', () => {
       const props = createSectionProps({ plexConnectionStatus: 'not_connected' });
       renderWithProviders(<PlexIntegrationSection {...props} />);
-      expect(screen.getByText('Not Connected')).toBeInTheDocument();
+      expect(screen.getByText('Unreachable')).toBeInTheDocument();
     });
 
     test('displays "Testing..." chip when status is testing', () => {
@@ -104,8 +105,10 @@ describe('PlexIntegrationSection Component', () => {
     test('shows warning when connection status is not_connected', () => {
       const props = createSectionProps({ plexConnectionStatus: 'not_connected' });
       renderWithProviders(<PlexIntegrationSection {...props} />);
-      expect(screen.getByText(/Unable to connect to Plex server/i)).toBeInTheDocument();
-      expect(screen.getByText(/check your IP and API key/i)).toBeInTheDocument();
+      expect(screen.getByText(/Plex is currently unreachable/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Verify your Plex server is running and that the IP, port, and API key/i)
+      ).toBeInTheDocument();
     });
 
     test('shows info when status is not_tested but has config', () => {
@@ -564,11 +567,12 @@ describe('PlexIntegrationSection Component', () => {
     });
   });
 
-  describe('Select Plex Library Button', () => {
-    test('renders Select Plex Library button', () => {
+  describe('Select Default Library Button', () => {
+    test('renders Select Default Library button', () => {
       const props = createSectionProps();
       renderWithProviders(<PlexIntegrationSection {...props} />);
       expect(screen.getByTestId('select-library-button')).toBeInTheDocument();
+      expect(screen.getByText('Select Default Library')).toBeInTheDocument();
     });
 
     test('calls onOpenLibrarySelector when clicked', async () => {
@@ -623,29 +627,162 @@ describe('PlexIntegrationSection Component', () => {
     });
   });
 
-  describe('Selected Library Display', () => {
-    test('displays selected library ID when present', () => {
+  describe('Default Library Display', () => {
+    test('shows "Library ID:" fallback when libraries have not been fetched yet', () => {
       const props = createSectionProps({
         config: createConfig({ plexYoutubeLibraryId: '12345' }),
+        plexLibraries: [],
       });
       renderWithProviders(<PlexIntegrationSection {...props} />);
-      expect(screen.getByText(/Selected Library ID: 12345/i)).toBeInTheDocument();
+      expect(screen.getByText('Default Plex Library:')).toBeInTheDocument();
+      expect(screen.getByText('Library ID: 12345')).toBeInTheDocument();
+      // No duplicated "(id: 12345)" suffix when the id is already the primary display
+      expect(screen.queryByText('(id: 12345)')).not.toBeInTheDocument();
     });
 
-    test('does not display library ID text when not set', () => {
+    test('shows the resolved library title with an "(id: X)" suffix when the id matches an entry', () => {
+      const props = createSectionProps({
+        config: createConfig({ plexYoutubeLibraryId: '31' }),
+        plexConnectionStatus: 'connected',
+        plexLibraries: [
+          { id: '1', title: 'Movies' },
+          { id: '31', title: 'Adults Library' },
+        ],
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(screen.getByText('Default Plex Library:')).toBeInTheDocument();
+      expect(screen.getByText('Adults Library')).toBeInTheDocument();
+      expect(screen.getByText('(id: 31)')).toBeInTheDocument();
+    });
+
+    test('falls back to the raw id when libraries are loaded but no entry matches, without an "(id: X)" suffix', () => {
+      const props = createSectionProps({
+        config: createConfig({ plexYoutubeLibraryId: '999' }),
+        plexConnectionStatus: 'connected',
+        plexLibraries: [{ id: '1', title: 'Movies' }],
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(screen.getByText('Default Plex Library:')).toBeInTheDocument();
+      expect(screen.getByText('999')).toBeInTheDocument();
+      expect(screen.queryByText('(id: 999)')).not.toBeInTheDocument();
+    });
+
+    test('does not render the default library line when plexYoutubeLibraryId is empty', () => {
       const props = createSectionProps({
         config: createConfig({ plexYoutubeLibraryId: '' }),
       });
       renderWithProviders(<PlexIntegrationSection {...props} />);
-      expect(screen.queryByText(/Selected Library ID:/i)).not.toBeInTheDocument();
+      expect(screen.queryByText('Default Plex Library:')).not.toBeInTheDocument();
     });
 
-    test('displays correct library ID value', () => {
+    test('handles alphanumeric library ids in the resolved case', () => {
       const props = createSectionProps({
         config: createConfig({ plexYoutubeLibraryId: 'my-custom-lib-99' }),
+        plexConnectionStatus: 'connected',
+        plexLibraries: [{ id: 'my-custom-lib-99', title: 'My Custom Library' }],
       });
       renderWithProviders(<PlexIntegrationSection {...props} />);
-      expect(screen.getByText(/Selected Library ID: my-custom-lib-99/i)).toBeInTheDocument();
+      expect(screen.getByText('Default Plex Library:')).toBeInTheDocument();
+      expect(screen.getByText('My Custom Library')).toBeInTheDocument();
+      expect(screen.getByText('(id: my-custom-lib-99)')).toBeInTheDocument();
+    });
+
+    test('shows a warning caption when Plex is unreachable and a default library is set', () => {
+      const props = createSectionProps({
+        config: createConfig({ plexYoutubeLibraryId: '31' }),
+        plexConnectionStatus: 'not_connected',
+        plexLibraries: [],
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(screen.getByTestId('default-library-unreachable-warning')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Cannot reach Plex; showing saved library ID/i)
+      ).toBeInTheDocument();
+    });
+
+    test('does not show the unreachable warning when Plex is connected', () => {
+      const props = createSectionProps({
+        config: createConfig({ plexYoutubeLibraryId: '31' }),
+        plexConnectionStatus: 'connected',
+        plexLibraries: [{ id: '31', title: 'Adults Library' }],
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(
+        screen.queryByTestId('default-library-unreachable-warning')
+      ).not.toBeInTheDocument();
+    });
+
+    test('does not show the unreachable warning when no default library is configured', () => {
+      const props = createSectionProps({
+        config: createConfig({ plexYoutubeLibraryId: '' }),
+        plexConnectionStatus: 'not_connected',
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(
+        screen.queryByTestId('default-library-unreachable-warning')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('No Default Library Warning', () => {
+    test('shows a warning when Plex is configured but no default library is set', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          plexYoutubeLibraryId: '',
+          plexIP: '192.168.1.100',
+          plexApiKey: 'test-key',
+        }),
+        hasPlexServerConfigured: true,
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(screen.getByTestId('no-default-library-warning')).toBeInTheDocument();
+      expect(screen.getByText('No Default Plex Library Configured')).toBeInTheDocument();
+    });
+
+    test('hides the warning when a default library is configured', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          plexYoutubeLibraryId: '31',
+          plexIP: '192.168.1.100',
+          plexApiKey: 'test-key',
+        }),
+        hasPlexServerConfigured: true,
+        plexLibraries: [{ id: '31', title: 'Adults Library' }],
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(
+        screen.queryByTestId('no-default-library-warning')
+      ).not.toBeInTheDocument();
+    });
+
+    test('hides the warning when Plex server is not configured at all', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          plexYoutubeLibraryId: '',
+          plexIP: '',
+          plexApiKey: '',
+        }),
+        hasPlexServerConfigured: false,
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(
+        screen.queryByTestId('no-default-library-warning')
+      ).not.toBeInTheDocument();
+    });
+
+    test('hides the warning when server IP is set but API key is missing', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          plexYoutubeLibraryId: '',
+          plexIP: '192.168.1.100',
+          plexApiKey: '',
+        }),
+        hasPlexServerConfigured: true,
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(
+        screen.queryByTestId('no-default-library-warning')
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -716,7 +853,7 @@ describe('PlexIntegrationSection Component', () => {
       expect(screen.getByText('Connected')).toBeInTheDocument();
 
       rerender(<PlexIntegrationSection {...props} plexConnectionStatus="not_connected" />);
-      expect(screen.getByText('Not Connected')).toBeInTheDocument();
+      expect(screen.getByText('Unreachable')).toBeInTheDocument();
     });
 
     test('handles platform managed configuration changes', () => {
@@ -824,7 +961,7 @@ describe('PlexIntegrationSection Component', () => {
       renderWithProviders(<PlexIntegrationSection {...props} />);
       const button = screen.getByTestId('select-library-button');
       expect(button).not.toBeDisabled();
-      expect(screen.queryByText(/Selected Library ID:/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Default Plex Library:/i)).not.toBeInTheDocument();
     });
 
     test('handles various port input values', async () => {
@@ -870,7 +1007,7 @@ describe('PlexIntegrationSection Component', () => {
 
       expect(screen.getByText('Get Key')).toBeInTheDocument();
       expect(screen.getByText('Test Connection')).toBeInTheDocument();
-      expect(screen.getByText('Select Plex Library')).toBeInTheDocument();
+      expect(screen.getByText('Select Default Library')).toBeInTheDocument();
     });
 
     test('alerts are displayed when appropriate', () => {
@@ -880,7 +1017,7 @@ describe('PlexIntegrationSection Component', () => {
       renderWithProviders(<PlexIntegrationSection {...props} />);
 
       // Check for specific alert content instead of role
-      expect(screen.getByText(/Unable to connect to Plex server/i)).toBeInTheDocument();
+      expect(screen.getByText(/Plex is currently unreachable/i)).toBeInTheDocument();
     });
 
     test('link has proper attributes for external navigation', () => {

--- a/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
@@ -20,9 +20,7 @@ const MOCK_LIBRARIES = [
 const MOCK_SUBFOLDERS = ['__kids', '__music'];
 
 function setupAxiosMocks() {
-  axios.get
-    .mockResolvedValueOnce({ data: MOCK_LIBRARIES })
-    .mockResolvedValueOnce({ data: MOCK_SUBFOLDERS });
+  axios.get.mockResolvedValue({ data: MOCK_SUBFOLDERS });
 }
 
 const DEFAULT_PROPS = {
@@ -30,6 +28,7 @@ const DEFAULT_PROPS = {
   onMappingsChange: jest.fn(),
   token: 'test-token',
   plexConnectionStatus: 'connected' as PlexConnectionStatus,
+  plexLibraries: MOCK_LIBRARIES,
 };
 
 describe('PlexSubfolderMappings', () => {
@@ -65,7 +64,21 @@ describe('PlexSubfolderMappings', () => {
       expect(screen.getByTestId('delete-mapping-kids')).toBeInTheDocument();
     });
 
-    test('shows "Library ID:" fallback for library title when disconnected', () => {
+    test('shows "Library ID:" fallback for library title when disconnected and libraries are empty', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          plexConnectionStatus="not_connected"
+          plexLibraries={[]}
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      expect(screen.getByText('Library ID: 2')).toBeInTheDocument();
+      // No duplicated "(id: 2)" when id is already the primary display
+      expect(screen.queryByText('(id: 2)')).not.toBeInTheDocument();
+    });
+
+    test('still shows the resolved library title when disconnected if libraries prop was populated earlier', () => {
       renderWithProviders(
         <PlexSubfolderMappings
           {...DEFAULT_PROPS}
@@ -73,7 +86,8 @@ describe('PlexSubfolderMappings', () => {
           mappings={[{ subfolder: 'kids', libraryId: '2' }]}
         />
       );
-      expect(screen.getByText('Library ID: 2')).toBeInTheDocument();
+      expect(screen.getByText('Kids Shows')).toBeInTheDocument();
+      expect(screen.getByText('(id: 2)')).toBeInTheDocument();
     });
 
     test('Add Mapping button is disabled when disconnected with existing mappings', () => {
@@ -126,26 +140,24 @@ describe('PlexSubfolderMappings', () => {
   });
 
   describe('loading and error states', () => {
-    test('shows loading indicator while fetches are in progress', () => {
+    test('shows loading indicator while the subfolder fetch is in progress', () => {
       axios.get.mockReturnValue(new Promise(() => {}));
       renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
-      expect(screen.getByText(/Loading libraries and subfolders/)).toBeInTheDocument();
+      expect(screen.getByText(/Loading subfolders/)).toBeInTheDocument();
     });
 
-    test('shows error alert when fetch fails', async () => {
+    test('shows error alert when the subfolder fetch fails', async () => {
       axios.get.mockRejectedValue(new Error('Network error'));
       renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
       await waitFor(() => {
         expect(
-          screen.getByText(/Could not load Plex libraries or subfolders/)
+          screen.getByText(/Could not load channel subfolders/)
         ).toBeInTheDocument();
       });
     });
 
-    test('shows partial data and error alert when one endpoint fails', async () => {
-      axios.get
-        .mockResolvedValueOnce({ data: MOCK_LIBRARIES })
-        .mockRejectedValueOnce(new Error('Subfolders failed'));
+    test('still shows mapping rows with resolved library titles when the subfolder fetch fails', async () => {
+      axios.get.mockRejectedValue(new Error('Subfolders failed'));
       renderWithProviders(
         <PlexSubfolderMappings
           {...DEFAULT_PROPS}
@@ -153,11 +165,12 @@ describe('PlexSubfolderMappings', () => {
         />
       );
       await waitFor(() => {
-        expect(screen.getByText('Kids Shows')).toBeInTheDocument();
+        expect(
+          screen.getByText(/Could not load channel subfolders/)
+        ).toBeInTheDocument();
       });
-      expect(
-        screen.getByText(/Could not load Plex libraries or subfolders/)
-      ).toBeInTheDocument();
+      expect(screen.getByText('Kids Shows')).toBeInTheDocument();
+      expect(screen.getByText('(id: 2)')).toBeInTheDocument();
     });
   });
 
@@ -188,7 +201,7 @@ describe('PlexSubfolderMappings', () => {
       });
     });
 
-    test('renders the library title from the fetched libraries list', async () => {
+    test('renders the library title with an "(id: X)" suffix for resolved libraries', async () => {
       setupAxiosMocks();
       renderWithProviders(
         <PlexSubfolderMappings
@@ -199,6 +212,7 @@ describe('PlexSubfolderMappings', () => {
       await waitFor(() => {
         expect(screen.getByText('Kids Shows')).toBeInTheDocument();
       });
+      expect(screen.getByText('(id: 2)')).toBeInTheDocument();
     });
   });
 
@@ -257,7 +271,7 @@ describe('PlexSubfolderMappings', () => {
         expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
       });
       await waitFor(() => {
-        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Loading subfolders/)).not.toBeInTheDocument();
       });
 
       await user.click(screen.getByTestId('add-mapping-button'));
@@ -281,7 +295,7 @@ describe('PlexSubfolderMappings', () => {
         expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
       });
       await waitFor(() => {
-        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Loading subfolders/)).not.toBeInTheDocument();
       });
 
       await user.click(screen.getByTestId('add-mapping-button'));
@@ -303,7 +317,7 @@ describe('PlexSubfolderMappings', () => {
         expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
       });
       await waitFor(() => {
-        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Loading subfolders/)).not.toBeInTheDocument();
       });
 
       await user.click(screen.getByTestId('add-mapping-button'));
@@ -330,7 +344,7 @@ describe('PlexSubfolderMappings', () => {
         expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
       });
       await waitFor(() => {
-        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Loading subfolders/)).not.toBeInTheDocument();
       });
 
       await user.click(screen.getByTestId('add-mapping-button'));
@@ -357,7 +371,7 @@ describe('PlexSubfolderMappings', () => {
         expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
       });
       await waitFor(() => {
-        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Loading subfolders/)).not.toBeInTheDocument();
       });
 
       await user.click(screen.getByTestId('add-mapping-button'));

--- a/client/src/components/Configuration/sections/components/DefaultPlexLibraryDisplay.tsx
+++ b/client/src/components/Configuration/sections/components/DefaultPlexLibraryDisplay.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { InfoTooltip } from '../../common/InfoTooltip';
+import { PlexConnectionStatus } from '../../types';
+import {
+  PlexLibrary,
+  resolveLibraryDisplay,
+} from '../../../../utils/plexLibraries';
+import { PlexLibraryLabel } from './PlexLibraryLabel';
+
+const DEFAULT_LIBRARY_TOOLTIP =
+  'Youtarr refreshes this library after downloads to the root folder, or to any subfolder that does not have its own mapping below.';
+
+interface DefaultPlexLibraryDisplayProps {
+  libraries: PlexLibrary[];
+  libraryId: string | undefined;
+  plexConnectionStatus: PlexConnectionStatus;
+  hasPlexServerConfigured: boolean;
+  hasPlexApiKey: boolean;
+  onMobileTooltipClick?: (text: string) => void;
+}
+
+/**
+ * Renders the "Default Plex Library: ..." line below the Test Connection /
+ * Select Default Library buttons in PlexIntegrationSection.
+ *
+ * Three states:
+ *   1. libraryId set and connected   -> show resolved title + id
+ *   2. libraryId set but unreachable -> show id fallback + warning caption
+ *   3. libraryId unset but Plex is configured -> "No Default Plex Library Configured"
+ *   4. libraryId unset and Plex not configured -> render nothing
+ */
+export const DefaultPlexLibraryDisplay: React.FC<DefaultPlexLibraryDisplayProps> = ({
+  libraries,
+  libraryId,
+  plexConnectionStatus,
+  hasPlexServerConfigured,
+  hasPlexApiKey,
+  onMobileTooltipClick,
+}) => {
+  if (libraryId) {
+    const display = resolveLibraryDisplay(libraries, libraryId);
+    return (
+      <Box sx={{ mt: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 0.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            Default Plex Library:
+          </Typography>
+          <PlexLibraryLabel display={display} boldPrimary />
+          <InfoTooltip
+            text={DEFAULT_LIBRARY_TOOLTIP}
+            onMobileClick={onMobileTooltipClick}
+          />
+        </Box>
+        {plexConnectionStatus === 'not_connected' && (
+          <Typography
+            variant="caption"
+            color="warning.main"
+            sx={{ display: 'block', mt: 0.25 }}
+            data-testid="default-library-unreachable-warning"
+          >
+            Cannot reach Plex; showing saved library ID.
+          </Typography>
+        )}
+      </Box>
+    );
+  }
+
+  if (hasPlexServerConfigured && hasPlexApiKey) {
+    return (
+      <Box
+        sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 1 }}
+        data-testid="no-default-library-warning"
+      >
+        <WarningAmberIcon fontSize="small" sx={{ color: 'warning.main' }} />
+        <Typography variant="body2" color="warning.main">
+          No Default Plex Library Configured
+        </Typography>
+      </Box>
+    );
+  }
+
+  return null;
+};

--- a/client/src/components/Configuration/sections/components/PlexLibraryLabel.tsx
+++ b/client/src/components/Configuration/sections/components/PlexLibraryLabel.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { PlexLibraryDisplay } from '../../../../utils/plexLibraries';
+
+interface PlexLibraryLabelProps {
+  display: PlexLibraryDisplay;
+  /**
+   * When true, the primary text (title or id) renders with fontWeight 600.
+   * Used by DefaultPlexLibraryDisplay; PlexSubfolderMappings uses the default.
+   */
+  boldPrimary?: boolean;
+}
+
+/**
+ * Render a `PlexLibraryDisplay` discriminated union once. Both consumers
+ * (DefaultPlexLibraryDisplay in PlexIntegrationSection and the mapping table
+ * in PlexSubfolderMappings) use this. Adding a fourth display branch only
+ * requires editing this file, not every consumer.
+ */
+export const PlexLibraryLabel: React.FC<PlexLibraryLabelProps> = ({
+  display,
+  boldPrimary = false,
+}) => {
+  const primarySx = boldPrimary ? { fontWeight: 600 } : undefined;
+
+  const renderContent = () => {
+    switch (display.kind) {
+      case 'resolved':
+        return (
+          <>
+            <Typography variant="body2" sx={primarySx}>
+              {display.title}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              (id: {display.id})
+            </Typography>
+          </>
+        );
+      case 'id-fallback':
+        return (
+          <Typography variant="body2" sx={primarySx}>
+            Library ID: {display.id}
+          </Typography>
+        );
+      case 'id-only':
+        return (
+          <Typography variant="body2" sx={primarySx}>
+            {display.id}
+          </Typography>
+        );
+      default: {
+        const _exhaustive: never = display;
+        return _exhaustive;
+      }
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'inline-flex', alignItems: 'baseline', gap: 0.5, flexWrap: 'wrap' }}>
+      {renderContent()}
+    </Box>
+  );
+};

--- a/client/src/components/Configuration/sections/components/__tests__/DefaultPlexLibraryDisplay.test.tsx
+++ b/client/src/components/Configuration/sections/components/__tests__/DefaultPlexLibraryDisplay.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DefaultPlexLibraryDisplay } from '../DefaultPlexLibraryDisplay';
+import { PlexLibrary } from '../../../../../utils/plexLibraries';
+
+const LIBRARIES: PlexLibrary[] = [
+  { id: '1', title: 'Movies' },
+  { id: '7', title: 'YouTube' },
+];
+
+describe('DefaultPlexLibraryDisplay', () => {
+  test('renders resolved title with id when libraryId matches a library', () => {
+    render(
+      <DefaultPlexLibraryDisplay
+        libraries={LIBRARIES}
+        libraryId="7"
+        plexConnectionStatus="connected"
+        hasPlexServerConfigured
+        hasPlexApiKey
+      />
+    );
+    expect(screen.getByText('Default Plex Library:')).toBeInTheDocument();
+    expect(screen.getByText('YouTube')).toBeInTheDocument();
+    expect(screen.getByText('(id: 7)')).toBeInTheDocument();
+  });
+
+  test('renders id-fallback when libraries are empty (offline) and a libraryId is set', () => {
+    render(
+      <DefaultPlexLibraryDisplay
+        libraries={[]}
+        libraryId="7"
+        plexConnectionStatus="not_connected"
+        hasPlexServerConfigured
+        hasPlexApiKey
+      />
+    );
+    expect(screen.getByText('Library ID: 7')).toBeInTheDocument();
+    expect(screen.getByTestId('default-library-unreachable-warning')).toBeInTheDocument();
+    expect(
+      screen.getByText('Cannot reach Plex; showing saved library ID.')
+    ).toBeInTheDocument();
+  });
+
+  test('renders id-only (no warning) when libraries populated but id missing from list', () => {
+    render(
+      <DefaultPlexLibraryDisplay
+        libraries={LIBRARIES}
+        libraryId="999"
+        plexConnectionStatus="connected"
+        hasPlexServerConfigured
+        hasPlexApiKey
+      />
+    );
+    expect(screen.getByText('999')).toBeInTheDocument();
+    expect(screen.queryByText(/Library ID:/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('default-library-unreachable-warning')).not.toBeInTheDocument();
+  });
+
+  test('does NOT render the unreachable warning when status is connected', () => {
+    render(
+      <DefaultPlexLibraryDisplay
+        libraries={LIBRARIES}
+        libraryId="7"
+        plexConnectionStatus="connected"
+        hasPlexServerConfigured
+        hasPlexApiKey
+      />
+    );
+    expect(screen.queryByTestId('default-library-unreachable-warning')).not.toBeInTheDocument();
+  });
+
+  test('shows "No Default Plex Library Configured" when libraryId is missing and Plex is configured', () => {
+    render(
+      <DefaultPlexLibraryDisplay
+        libraries={[]}
+        libraryId={undefined}
+        plexConnectionStatus="not_tested"
+        hasPlexServerConfigured
+        hasPlexApiKey
+      />
+    );
+    expect(screen.getByTestId('no-default-library-warning')).toBeInTheDocument();
+    expect(screen.getByText('No Default Plex Library Configured')).toBeInTheDocument();
+  });
+
+  test('renders nothing when libraryId missing AND plex not yet configured', () => {
+    const { container } = render(
+      <DefaultPlexLibraryDisplay
+        libraries={[]}
+        libraryId={undefined}
+        plexConnectionStatus="not_tested"
+        hasPlexServerConfigured={false}
+        hasPlexApiKey={false}
+      />
+    );
+    expect(screen.queryByTestId('no-default-library-warning')).not.toBeInTheDocument();
+    expect(screen.queryByText('Default Plex Library:')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders nothing when libraryId missing AND plex configured but no api key', () => {
+    const { container } = render(
+      <DefaultPlexLibraryDisplay
+        libraries={[]}
+        libraryId={undefined}
+        plexConnectionStatus="not_tested"
+        hasPlexServerConfigured
+        hasPlexApiKey={false}
+      />
+    );
+    expect(screen.queryByTestId('no-default-library-warning')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/client/src/components/Configuration/sections/components/__tests__/PlexLibraryLabel.test.tsx
+++ b/client/src/components/Configuration/sections/components/__tests__/PlexLibraryLabel.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PlexLibraryLabel } from '../PlexLibraryLabel';
+
+describe('PlexLibraryLabel', () => {
+  test('resolved branch renders title and id pair', () => {
+    render(
+      <PlexLibraryLabel
+        display={{ kind: 'resolved', title: 'Movies', id: '7' }}
+      />
+    );
+    expect(screen.getByText('Movies')).toBeInTheDocument();
+    expect(screen.getByText('(id: 7)')).toBeInTheDocument();
+  });
+
+  test('id-fallback branch renders "Library ID: <id>"', () => {
+    render(
+      <PlexLibraryLabel display={{ kind: 'id-fallback', id: '42' }} />
+    );
+    expect(screen.getByText('Library ID: 42')).toBeInTheDocument();
+  });
+
+  test('id-only branch renders just the raw id', () => {
+    render(<PlexLibraryLabel display={{ kind: 'id-only', id: '99' }} />);
+    expect(screen.getByText('99')).toBeInTheDocument();
+    expect(screen.queryByText(/Library ID/)).not.toBeInTheDocument();
+  });
+
+  test('boldPrimary applies fontWeight 600 to the primary text on resolved', () => {
+    render(
+      <PlexLibraryLabel
+        display={{ kind: 'resolved', title: 'Movies', id: '7' }}
+        boldPrimary
+      />
+    );
+    const title = screen.getByText('Movies');
+    expect(title).toHaveStyle({ fontWeight: '600' });
+  });
+
+  test('boldPrimary applies fontWeight 600 on id-fallback', () => {
+    render(
+      <PlexLibraryLabel
+        display={{ kind: 'id-fallback', id: '42' }}
+        boldPrimary
+      />
+    );
+    expect(screen.getByText('Library ID: 42')).toHaveStyle({ fontWeight: '600' });
+  });
+
+  test('boldPrimary applies fontWeight 600 on id-only', () => {
+    render(
+      <PlexLibraryLabel
+        display={{ kind: 'id-only', id: '99' }}
+        boldPrimary
+      />
+    );
+    expect(screen.getByText('99')).toHaveStyle({ fontWeight: '600' });
+  });
+
+  test('without boldPrimary, primary text is not bold', () => {
+    render(
+      <PlexLibraryLabel
+        display={{ kind: 'id-fallback', id: '42' }}
+      />
+    );
+    expect(screen.getByText('Library ID: 42')).not.toHaveStyle({ fontWeight: '600' });
+  });
+});

--- a/client/src/components/PlexLibrarySelector.tsx
+++ b/client/src/components/PlexLibrarySelector.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import {
   SelectChangeEvent,
+  FormControl,
   InputLabel,
   Modal,
   Select,
@@ -13,6 +14,7 @@ import {
 import CloseIcon from "@mui/icons-material/Close";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
+import { PlexLibrary } from "../utils/plexLibraries";
 
 interface PlexLibrarySelectorProps {
   open: boolean;
@@ -21,65 +23,40 @@ interface PlexLibrarySelectorProps {
     libraryId: string;
     libraryTitle: string;
   }) => void;
-  token: string | null;
-}
-
-interface PlexLibrary {
-  id: string;
-  title: string;
+  libraries: PlexLibrary[];
+  currentLibraryId?: string;
 }
 
 function PlexLibrarySelector({
   open,
   handleClose,
   setLibraryId,
-  token,
+  libraries,
+  currentLibraryId,
 }: PlexLibrarySelectorProps) {
-  const [libraries, setLibraries] = useState<PlexLibrary[]>([]);
   const [selectedLibrary, setSelectedLibrary] = useState<string>("");
-  const [plexError, setPlexError] = useState<boolean>(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
-  useEffect(() => {
-    if (!open) return;
+  const plexError = libraries.length === 0;
 
-    setPlexError(false);
-    fetch(`/getplexlibraries`, {
-      headers: {
-        "x-access-token": token || "",
-      },
-    })
-      .then((response) => {
-        if (!response.ok) {
-          console.error("Failed to fetch Plex libraries");
-          setLibraries([]);
-          setPlexError(true);
-          return [];
-        }
-        return response.json();
-      })
-      .then((data) => {
-        if (Array.isArray(data)) {
-          setLibraries(data);
-          setPlexError(false);
-        } else {
-          setLibraries([]);
-          setPlexError(true);
-        }
-      })
-      .catch((error) => {
-        console.error("Error fetching Plex libraries:", error);
-        setLibraries([]);
-        setPlexError(true);
-      });
-  }, [open, token]);
-
+  // Reset selection when the modal closes so the next open starts clean.
   useEffect(() => {
     if (!open) {
       setSelectedLibrary("");
     }
   }, [open]);
+
+  // Pre-select the currently configured library once libraries are available.
+  // The `prev || currentLibraryId` guard ensures we do not clobber a user's
+  // manual pick if this effect re-fires (e.g. libraries reference changes)
+  // while the modal is still open.
+  useEffect(() => {
+    if (!open || !currentLibraryId) return;
+    if (libraries.some((lib) => lib.id === currentLibraryId)) {
+      setSelectedLibrary((prev) => prev || currentLibraryId);
+    }
+  }, [open, currentLibraryId, libraries]);
 
   const handleLibraryChange = (event: SelectChangeEvent<string>) => {
     const libraryId = event.target.value as string;
@@ -94,6 +71,9 @@ function PlexLibrarySelector({
     });
     setSelectedLibrary("");
   };
+
+  const isSaveDisabled =
+    selectedLibrary === "" || selectedLibrary === currentLibraryId;
 
   return (
     <Modal open={open} onClose={handleClose} onBackdropClick={handleClose}>
@@ -133,44 +113,33 @@ function PlexLibrarySelector({
               <p>Note: Without connecting to Plex, downloading videos will still work, but you will not be able to refresh the library in Plex.</p>
             </Box>
           ) : (
-            <>
-              <InputLabel id="select-plex-library">
-                Select a Plex Library
-              </InputLabel>
+            <FormControl fullWidth>
+              <InputLabel id="select-plex-library">Plex Library</InputLabel>
               <Select
-                fullWidth
                 value={selectedLibrary}
                 onChange={handleLibraryChange}
-                label="Select a Plex Library"
+                label="Plex Library"
                 labelId="select-plex-library"
               >
-                {libraries.length === 0 ? (
-                  <MenuItem value="" disabled>
-                    No libraries available
+                {libraries.map((library) => (
+                  <MenuItem value={library.id} key={library.id}>
+                    {library.title}
                   </MenuItem>
-                ) : (
-                  libraries.map((library) => (
-                    <MenuItem value={library.id} key={library.id}>
-                      {library.title}
-                    </MenuItem>
-                  ))
-                )}
+                ))}
               </Select>
-            </>
+            </FormControl>
           )}
           {!plexError && (
-            <>
-              <Box style={{ marginTop: "16px" }}>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={handleSaveSelection}
-                  disabled={selectedLibrary === ""}
-                >
-                  Save Selection
-                </Button>
-              </Box>
-            </>
+            <Box sx={{ mt: 2 }}>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleSaveSelection}
+                disabled={isSaveDisabled}
+              >
+                Save Selection
+              </Button>
+            </Box>
           )}
         </Card>
       </Box>

--- a/client/src/components/__tests__/PlexLibrarySelector.story.tsx
+++ b/client/src/components/__tests__/PlexLibrarySelector.story.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
-import { http, HttpResponse } from 'msw';
 import PlexLibrarySelector from '../PlexLibrarySelector';
 
 const meta: Meta<typeof PlexLibrarySelector> = {
@@ -10,19 +9,10 @@ const meta: Meta<typeof PlexLibrarySelector> = {
     open: true,
     handleClose: fn(),
     setLibraryId: fn(),
-    token: 'storybook-token',
-  },
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('/getplexlibraries', () =>
-          HttpResponse.json([
-            { id: '1', title: 'Movies' },
-            { id: '2', title: 'TV Shows' },
-          ])
-        ),
-      ],
-    },
+    libraries: [
+      { id: '1', title: 'Movies' },
+      { id: '2', title: 'TV Shows' },
+    ],
   },
 };
 
@@ -32,7 +22,7 @@ type Story = StoryObj<typeof PlexLibrarySelector>;
 export const SelectLibrary: Story = {
   play: async ({ canvasElement, args }) => {
     const body = within(canvasElement.ownerDocument.body);
-    await userEvent.click(body.getByLabelText('Select a Plex Library'));
+    await userEvent.click(body.getByLabelText('Plex Library'));
     await userEvent.click(await body.findByText('Movies'));
 
     await userEvent.click(body.getByRole('button', { name: 'Save Selection' }));

--- a/client/src/components/__tests__/PlexLibrarySelector.test.tsx
+++ b/client/src/components/__tests__/PlexLibrarySelector.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import PlexLibrarySelector from '../PlexLibrarySelector';
+import { PlexLibrary } from '../../utils/plexLibraries';
+
+const LIBRARIES: PlexLibrary[] = [
+  { id: '1', title: 'Movies' },
+  { id: '2', title: 'TV Shows' },
+  { id: '31', title: 'Adults Library' },
+];
+
+describe('PlexLibrarySelector', () => {
+  const handleClose = jest.fn();
+  const setLibraryId = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('pre-selects the currently configured library when it matches a provided library', async () => {
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+        currentLibraryId="31"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Adults Library')).toBeInTheDocument();
+    });
+  });
+
+  test('does not pre-select when currentLibraryId is not in the provided libraries', async () => {
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+        currentLibraryId="999"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Selection' })).toBeDisabled();
+    });
+    expect(screen.queryByText('Movies')).not.toBeInTheDocument();
+    expect(screen.queryByText('Adults Library')).not.toBeInTheDocument();
+  });
+
+  test('does not pre-select when no currentLibraryId is provided', async () => {
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Selection' })).toBeDisabled();
+    });
+  });
+
+  test('disables Save Selection when the pre-selected library equals currentLibraryId', async () => {
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+        currentLibraryId="1"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Movies')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Save Selection' })).toBeDisabled();
+  });
+
+  test('enables Save Selection after the user picks a different library', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+        currentLibraryId="1"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Movies')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText('Plex Library'));
+    await user.click(await screen.findByRole('option', { name: 'TV Shows' }));
+
+    expect(screen.getByRole('button', { name: 'Save Selection' })).toBeEnabled();
+  });
+
+  test('calls setLibraryId with the chosen library and title on save', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Selection' })).toBeDisabled();
+    });
+
+    await user.click(screen.getByLabelText('Plex Library'));
+    await user.click(await screen.findByRole('option', { name: 'TV Shows' }));
+    await user.click(screen.getByRole('button', { name: 'Save Selection' }));
+
+    expect(setLibraryId).toHaveBeenCalledWith({
+      libraryId: '2',
+      libraryTitle: 'TV Shows',
+    });
+  });
+
+  test('shows the "Unable to connect" error block when libraries is empty', () => {
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={[]}
+      />
+    );
+
+    expect(
+      screen.getByText('Unable to connect to Plex server. Please check:')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save Selection' })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/utils/__tests__/plexLibraries.test.ts
+++ b/client/src/utils/__tests__/plexLibraries.test.ts
@@ -1,0 +1,40 @@
+import { resolveLibraryDisplay, PlexLibrary } from '../plexLibraries';
+
+describe('resolveLibraryDisplay', () => {
+  const LIBRARIES: PlexLibrary[] = [
+    { id: '1', title: 'YouTube' },
+    { id: '31', title: 'Adults Library' },
+    { id: '42', title: 'Kids Shows' },
+  ];
+
+  test('returns "resolved" with title and id when the id matches an entry', () => {
+    expect(resolveLibraryDisplay(LIBRARIES, '31')).toEqual({
+      kind: 'resolved',
+      title: 'Adults Library',
+      id: '31',
+    });
+  });
+
+  test('returns "id-fallback" when the libraries list is empty', () => {
+    expect(resolveLibraryDisplay([], '31')).toEqual({
+      kind: 'id-fallback',
+      id: '31',
+    });
+  });
+
+  test('returns "id-only" when the libraries list is populated but no entry matches', () => {
+    expect(resolveLibraryDisplay(LIBRARIES, '999')).toEqual({
+      kind: 'id-only',
+      id: '999',
+    });
+  });
+
+  test('handles alphanumeric library ids in the "resolved" path', () => {
+    const libs: PlexLibrary[] = [{ id: 'my-lib-99', title: 'My Lib' }];
+    expect(resolveLibraryDisplay(libs, 'my-lib-99')).toEqual({
+      kind: 'resolved',
+      title: 'My Lib',
+      id: 'my-lib-99',
+    });
+  });
+});

--- a/client/src/utils/plexLibraries.ts
+++ b/client/src/utils/plexLibraries.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared types and helpers for working with the Plex library list
+ * returned from GET /getplexlibraries.
+ */
+
+export interface PlexLibrary {
+  id: string;
+  title: string;
+}
+
+/**
+ * Discriminated display shape for rendering a Plex library id in the UI.
+ *
+ * - `resolved`: the id matched an entry in the library list, so callers can
+ *   show the title prominently and optionally append `(id: X)` without fear
+ *   of duplicating the id.
+ * - `id-fallback`: the library list is empty (disconnected, or not yet
+ *   fetched) so the raw id is the primary display and must not be decorated
+ *   with an additional "(id: X)" suffix.
+ * - `id-only`: the list is populated but no entry matches, meaning the saved
+ *   id refers to a library Plex no longer exposes. Same guidance: raw id is
+ *   the only thing to show.
+ */
+export type PlexLibraryDisplay =
+  | { kind: 'resolved'; title: string; id: string }
+  | { kind: 'id-fallback'; id: string }
+  | { kind: 'id-only'; id: string };
+
+/**
+ * Classify how a library id should be rendered given the current list.
+ */
+export function resolveLibraryDisplay(
+  libraries: PlexLibrary[],
+  libraryId: string
+): PlexLibraryDisplay {
+  const lib = libraries.find((l) => l.id === libraryId);
+  if (lib) {
+    return { kind: 'resolved', title: lib.title, id: libraryId };
+  }
+  if (libraries.length === 0) {
+    return { kind: 'id-fallback', id: libraryId };
+  }
+  return { kind: 'id-only', id: libraryId };
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,8 @@ services:
       dockerfile: Dockerfile
     image: ${YOUTARR_IMAGE:-youtarr-dev:latest}
     container_name: youtarr-dev
-    # Map 3011:3011 in dev so Vite proxy can reach backend at localhost:3011
+    # Expose backend on host port 3087 (container still listens on 3011).
+    # The Vite dev server proxies to http://127.0.0.1:3087 by default.
     ports:
       - "3087:3011"
     volumes:

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -94,6 +94,19 @@ Using the start script:
 
 For deployments behind external authentication or not exposed to the internet:
 
+1. Set in `.env`:
+   ```bash
+   AUTH_ENABLED=false
+   ```
+
+2. Youtarr bypasses internal authentication, no auth will be required to access Youtarr.
+
+**Warning**: Only disable when using:
+- VPN access
+- Reverse proxy with authentication
+- Platform auth (Cloudflare Access, Authelia, etc.)
+- Never expose to internet without protection!
+
 ## API Keys
 
 API Keys provide persistent authentication for external integrations like bookmarklets, mobile shortcuts, and automation tools.
@@ -159,19 +172,6 @@ UPDATE ApiKeys SET is_active = 0 WHERE id = 1;
 ```
 
 For detailed API documentation and examples (bookmarklets, mobile shortcuts, Python, cURL, etc.), see [API Integration Guide](API_INTEGRATION.md).
-
-1. Set in `.env`:
-   ```bash
-   AUTH_ENABLED=false
-   ```
-
-2. Youtarr bypasses internal authentication, no auth will be required to access Youtarr.
-
-**Warning**: Only disable when using:
-- VPN access
-- Reverse proxy with authentication
-- Platform auth (Cloudflare Access, Authelia, etc.)
-- Never expose to internet without protection!
 
 ## Session Management
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -36,12 +36,12 @@ Configuration can be modified through:
 
 ## Core Settings
 
-### Youtube Output Directory
-- **Config Key**: *This can only be set via .env and is view only in the web UI*
+### Youtube Output Directory (env-only, not a config.json field)
+- **Set via**: `YOUTUBE_OUTPUT_DIR` environment variable in `.env` (see [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md))
 - **Type**: `string`
 - **Default**: `"./downloads"`
-- **Description**: Directory path for downloaded videos
-- **Note**: Set during initial setup or via YOUTUBE_OUTPUT_DIR environment variable
+- **Description**: Directory path on the host where downloaded videos are stored
+- **Note**: This setting is **not** stored in `config/config.json`. It is displayed read-only in the web UI and can only be changed by editing `.env` and restarting. Legacy installs that had `youtubeOutputDirectory` in `config.json` are automatically migrated to `.env` during first-run `.env` bootstrap by `scripts/_create-env.sh` (i.e. the first time the start script runs with no existing `.env`).
 
 ### Enable Automatic Downloads
 - **Config Key**: `channelAutoDownload`

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -28,6 +28,7 @@ Youtarr uses MariaDB/MySQL for storing:
 | `JobVideos`        | `JobVideo`        | Job <-> video associations        |
 | `JobVideoDownloads`| `JobVideoDownload`| Download progress tracking        |
 | `Sessions`         | `Session`         | User authentication sessions      |
+| `ApiKeys`          | `ApiKey`          | API key credentials for external integrations (bookmarklets, shortcuts, automation) |
 | `SequelizeMeta`    | NA                | Sequelize ORM migration tracking  |
 
 ## Internal Database (Default)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -165,35 +165,46 @@ The development setup is a "build-and-test-in-Docker" workflow that ensures your
 3. Builds a Docker image with the pre-built static files
 
 **Runtime Phase** (`./scripts/start-dev.sh`):
-- Runs the Node.js Express server with `node server/server.js` (no hot reload)
-- Serves the pre-built React static files from `/app/client/build`
+- Runs the Node.js Express server with `node --watch server/server.js` - backend code changes auto-restart the server without a rebuild
+- Serves the pre-built React static files from `/app/client/build` (frontend changes require a rebuild unless you are running the Vite dev server)
 - Application accessible at http://localhost:3087
 
 ### Volume Mounts
 
-The development setup mounts these directories only:
+The development setup (`docker-compose.dev.yml`) mounts these directories into the container:
 
 ```yaml
 volumes:
-  - ./server/images:/app/server/images          # Generated thumbnails
-  - ./config:/app/config                        # Configuration files
-  -  ./jobs:/app/jobs                           # Job state
+  - ${YOUTUBE_OUTPUT_DIR:-./downloads}:/usr/src/app/data  # Downloaded videos
+  - ./server/images:/app/server/images                     # Generated thumbnails
+  - ./config:/app/config                                   # Configuration files
+  - ./jobs:/app/jobs                                       # Job state
+  # Backend source and migrations for hot reload with --watch
+  - ./server:/app/server
+  - ./migrations:/app/migrations
+  - ./package.json:/app/package.json
+  - ./package-lock.json:/app/package-lock.json
 ```
 
-**Important:** Source code (client/src/, server/*.js) is NOT mounted. This means:
-- ❌ No hot reload or live reload
-- ❌ Code changes are NOT automatically reflected
-- ✅ You must rebuild after every code change
+**Backend hot reload:** `./server/` is mounted and the container runs `node --watch server/server.js`, so backend code changes auto-restart the server without a rebuild. Check the container logs to confirm the restart.
+
+**Frontend:** `client/src/` is NOT mounted. Frontend changes reach the running app one of two ways:
+- **Full rebuild**: `./scripts/build-dev.sh` rebuilds the static bundle that the app container serves at http://localhost:3087.
+- **Vite dev server (recommended)**: run `cd client && npm run dev` in a second terminal. Vite serves the frontend on http://localhost:3000 with HMR and proxies API/WebSocket calls to the backend on host port 3087 (which `docker-compose.dev.yml` forwards to container port 3011). Override with `VITE_BACKEND_PORT` if you have remapped the host port.
 
 ### When to Rebuild
 
 You **must** rebuild (`./scripts/build-dev.sh`) for:
-- **Any** frontend code changes (React components, styles, etc.)
-- **Any** backend code changes (server.js, modules, etc.)
-- Installing new npm dependencies (use `--install-deps` flag)
-- Updating system dependencies (yt-dlp, ffmpeg - use `--no-cache` flag)
-- Changing Dockerfile
-- First time setup
+- Frontend code changes when you are using the static-bundle workflow (not needed if you are using the Vite dev server).
+- Installing new npm dependencies (use `--install-deps` flag).
+- Updating system dependencies (yt-dlp, ffmpeg - use `--no-cache` flag).
+- Changing the Dockerfile.
+- First time setup.
+
+You **do not** need to rebuild for:
+- Backend code changes (server/*.js, modules, routes) - `node --watch` picks them up automatically.
+- New migration files - `./migrations/` is mounted, though you still need to restart the container for them to run.
+- Frontend changes while the Vite dev server is running - Vite HMR updates the browser.
 
 ### Benefits of This Approach
 
@@ -385,12 +396,17 @@ ports:
 command: node --inspect=0.0.0.0:9229 server/server.js
 ```
 
-**Option 2: Console Debugging**
+**Option 2: Logger Debugging**
+
+Use the project's Pino logger (not `console.log`) so output stays structured and log levels work:
 
 ```javascript
-console.log('Debug info:', variable);
+const logger = require('../logger'); // adjust relative path as needed
+logger.debug({ variable }, 'Debug info');
 debugger; // Breakpoint
 ```
+
+Set `LOG_LEVEL=debug` in your `.env` to surface `logger.debug(...)` output.
 
 **Option 3: Exec into Container**
 
@@ -408,13 +424,16 @@ docker compose exec youtarr bash
 
 ### Database Debugging
 
-Enable Sequelize logging in `db.js`:
+Enable Sequelize SQL logging in `db.js` by routing it through the Pino logger:
 ```javascript
+const logger = require('./logger');
 const sequelize = new Sequelize({
   // ... other config
-  logging: console.log  // Enable SQL logging
+  logging: (sql) => logger.debug({ sql }, 'sequelize query')
 });
 ```
+
+Then set `LOG_LEVEL=debug` in your `.env` to see the queries.
 
 ## API Development
 
@@ -645,15 +664,24 @@ docker compose down
 
 ### Code Changes Not Reflected
 
-Code changes **always** require a rebuild since source code is not mounted in the container:
+Backend and frontend reload differently in the dev setup.
+
+**Backend code changes** (`server/*.js`, `server/modules/`, `server/routes/`, `migrations/`):
+- `./server/` and `./migrations/` are volume-mounted into the container and the container runs `node --watch`.
+- Saves auto-restart the server within a few seconds; check the container logs to confirm the restart fired.
+- No rebuild required. (New migration files still require a container restart to actually run.)
+
+**Frontend code changes** (`client/src/`):
+- `client/src/` is NOT mounted into the app container; the static bundle is baked into the image at build time.
+- If you are running the Vite dev server (`cd client && npm run dev`), HMR updates the browser automatically on http://localhost:3000 - no rebuild.
+- Otherwise, rebuild the static bundle:
 
 ```bash
-# Rebuild and restart (start-dev.sh automatically stops first)
 ./scripts/build-dev.sh
-./scripts/start-dev.sh
+./scripts/start-dev.sh  # automatically stops and restarts containers
 ```
 
-**Note:** This is expected behavior - the development setup builds the code into the image, it doesn't use live file mounting for source code.
+If a backend change is not being picked up, verify the container is actually running `node --watch` (`docker compose -f docker-compose.dev.yml logs youtarr` should show restart messages when you save) and that you edited a file under `./server/`.
 
 ### Module Not Found Errors
 
@@ -690,12 +718,13 @@ cd client && npm audit
 
 ### Backend Profiling
 
-Add to `server.js` for request timing:
+Add to `server.js` for request timing (use the Pino logger, not `console.log`):
 ```javascript
+const logger = require('./logger');
 app.use((req, res, next) => {
   const start = Date.now();
   res.on('finish', () => {
-    console.log(`${req.method} ${req.path} - ${Date.now() - start}ms`);
+    logger.info({ method: req.method, path: req.path, durationMs: Date.now() - start }, 'request');
   });
   next();
 });

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -6,6 +6,17 @@ Youtarr uses Docker Compose with two containers:
 - **youtarr**: Main application container (Node.js/React)
 - **youtarr-db**: MariaDB database container
 
+### Compose Files
+
+Youtarr ships four Compose files so each supported runtime can layer the right overrides:
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.yml` | Production defaults with the bundled MariaDB container. Used by `./start.sh`. |
+| `docker-compose.dev.yml` | Development mode: mounts `./server/` and migrations into the container, runs the backend with `node --watch` for hot reload, and uses a separate `youtarr-db-dev` database with its own named volume. Used by `./scripts/start-dev.sh`. See [DEVELOPMENT.md](DEVELOPMENT.md). |
+| `docker-compose.arm.yml` | ARM override (Apple Silicon, Raspberry Pi) that switches the MariaDB data directory to a named volume to avoid virtiofs issues. Layered on top of `docker-compose.yml` via `-f`. |
+| `docker-compose.external-db.yml` | Runs Youtarr against an external MariaDB/MySQL instance instead of the bundled database. Used by `./start-with-external-db.sh`. |
+
 ## Container Details
 
 ### Application Container (youtarr)
@@ -150,6 +161,8 @@ This section covers setting up Youtarr when you cannot (or prefer not to) clone 
 
 **We strongly recommend cloning the repository if possible.** If you must proceed, follow these steps carefully.
 
+> **Critical - read this first if you use automation**: If you are templating `docker-compose.yml` via Ansible, Terraform, Kubernetes, Helm, or any tool that auto-creates empty directories for every listed volume, read [Do Not Mount the Migrations Directory](#-important-do-not-mount-the-migrations-directory) at the top of this document before continuing. Auto-creating an empty `./migrations` directory will overwrite the packaged migrations and break the database bootstrap in a way that is hard to diagnose.
+
 ### Prerequisites
 
 - Docker and Docker Compose installed
@@ -178,6 +191,14 @@ wget https://raw.githubusercontent.com/DialmasterOrg/Youtarr/main/.env.example -
 - Manually copy `docker-compose.yml` from [GitHub](https://github.com/DialmasterOrg/Youtarr/blob/main/docker-compose.yml)
 - Manually copy `.env.example` from [GitHub](https://github.com/DialmasterOrg/Youtarr/blob/main/.env.example)
 
+**Using an external MariaDB/MySQL instance?** Download [`docker-compose.external-db.yml`](https://raw.githubusercontent.com/DialmasterOrg/Youtarr/main/docker-compose.external-db.yml) instead of `docker-compose.yml` and rename it to `docker-compose.yml` locally so the rest of this guide works unchanged:
+
+```bash
+wget https://raw.githubusercontent.com/DialmasterOrg/Youtarr/main/docker-compose.external-db.yml -O docker-compose.yml
+```
+
+You will also need to set `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME` in your `.env` (see [External Database Setup](#using-an-external-database) earlier in this document). Skip the bundled-database permission steps below if you go this route.
+
 #### 3. Configure Environment
 
 ```bash
@@ -190,44 +211,72 @@ vim .env  # or nano, or your preferred editor
 
 **Required settings:**
 - `YOUTUBE_OUTPUT_DIR` - Must be set to your video storage path
-- `TZ` - Your timezone (e.g., `America/New_York`, `Europe/London`)
 
 **Optional settings:**
-- `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` - For headless setups
-- See [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md) for full reference
+- `TZ` - Your timezone (e.g., `America/New_York`, `Europe/London`). Defaults to `UTC`. Set this if scheduled downloads and nightly cleanup should run in your local time.
+- `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` - For headless setups where you cannot reach the initial-setup wizard via localhost.
+- `YOUTARR_UID` / `YOUTARR_GID` - Run the container as a non-root user (recommended for security, see step 5 below).
+- **Changing bundled-database credentials?** If you want to customize the MariaDB password, set BOTH `DB_PASSWORD` **and** `DB_ROOT_PASSWORD` to the same value. Setting only one of them will cause the app to fail to connect because the app uses `DB_PASSWORD` while MariaDB's root account is initialized from `DB_ROOT_PASSWORD`. This only applies to the bundled database; external-DB users set `DB_PASSWORD` to match their existing database.
+- See [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md) for the full reference.
 
 #### 4. Create Required Directories
 
 Youtarr needs these directories to exist before first start:
 
 ```bash
-# Create all required directories
+# Youtarr app directories (always required)
 mkdir -p config jobs server/images
 
-# Create your download directory (adjust path to match YOUTUBE_OUTPUT_DIR in .env)
+# Your download directory (adjust path to match YOUTUBE_OUTPUT_DIR in .env)
 mkdir -p downloads  # If using default ./downloads
 # OR
 mkdir -p /path/to/your/custom/location  # If using custom path
 ```
 
+**Bundled database only** (skip if you are using an external database):
+
+```bash
+# MariaDB data directory for the bundled youtarr-db container
+mkdir -p database
+```
+
+On most Linux hosts, Docker will auto-create `./database` on first run and MariaDB's entrypoint will chown it to UID 999 (the `mysql` user inside the `mariadb:10.3` image). On Synology, QNAP, and some other NAS platforms with strict UID enforcement you may need to pre-create and chown the directory yourself:
+
+```bash
+sudo chown -R 999:999 database
+```
+
+If you hit `InnoDB: Operating system error number 13` at startup, you have hit this case - see [Switching to Named Volume](DATABASE.md#switching-to-named-volume) in the database docs for an alternative that sidesteps bind-mount permission issues entirely.
+
 #### 5. Set Permissions
 
-**If using UID/GID (1000:1000):**
-```bash
-sudo chown -R 1000:1000 config jobs server/images downloads
-```
+**By default, the container runs as root (UID 0).** If you leave `YOUTARR_UID` and `YOUTARR_GID` unset in `.env`, you can skip this entire step: the container manages file ownership itself.
 
-**If you configured custom YOUTARR_UID and YOUTARR_GID in .env:**
-```bash
-# Replace 1001:1001 with your configured UID:GID
-sudo chown -R 1001:1001 config jobs server/images downloads
-```
+**Recommended (non-root)**: run the container as a non-root user so files on the host are owned by a regular account. This requires both an `.env` change and a `chown` on the host, in this order:
 
-**Permission verification:**
-```bash
-ls -la config jobs server/images downloads
-# All directories should show ownership matching your configured UID:GID
-```
+1. Add your target UID/GID to `.env` (1000:1000 is the typical first user on Linux, but use whatever matches your host account):
+
+   ```bash
+   YOUTARR_UID=1000
+   YOUTARR_GID=1000
+   ```
+
+2. Change ownership of the Youtarr directories on the host to match:
+
+   ```bash
+   sudo chown -R 1000:1000 config jobs server/images downloads
+   ```
+
+   Replace `1000:1000` with whatever you put in `.env`. If you use a custom download path, `chown` that path instead of `downloads`.
+
+3. Verify:
+
+   ```bash
+   ls -la config jobs server/images downloads
+   # All directories should show ownership matching YOUTARR_UID:YOUTARR_GID
+   ```
+
+> **Important**: The `chown` must run **after** setting `YOUTARR_UID/GID` in `.env`, and the numeric IDs must match. Running `chown 1000:1000` without setting `YOUTARR_UID=1000` leaves the container running as root, which will then either overwrite your host-side ownership or fail to write into the chown'd directories depending on your filesystem. If you are already running as root and want to switch to non-root, stop the container first, chown everything (including your `YOUTUBE_OUTPUT_DIR`), then update `.env` and start again.
 
 #### 6. Start Containers
 
@@ -271,7 +320,7 @@ docker compose down
 # 2. Backup your configuration (recommended)
 tar -czf backup-$(date +%Y%m%d).tar.gz config jobs
 
-# 3. Download updated docker-compose.yml
+# 3. Download updated compose file
 wget https://raw.githubusercontent.com/DialmasterOrg/Youtarr/main/docker-compose.yml -O docker-compose.yml
 
 # 4. Pull latest images
@@ -284,7 +333,9 @@ docker compose up -d
 docker compose logs -f
 ```
 
-**Note**: Check [.env.example](https://github.com/DialmasterOrg/Youtarr/blob/main/.env.example) for new variables after major updates.
+**Notes**:
+- Check [.env.example](https://github.com/DialmasterOrg/Youtarr/blob/main/.env.example) for new variables after major updates.
+- If you originally downloaded `docker-compose.external-db.yml` for an external database setup, swap step 3 above for `wget https://raw.githubusercontent.com/DialmasterOrg/Youtarr/main/docker-compose.external-db.yml -O docker-compose.yml`. Mixing compose files across updates will silently switch you between bundled and external database modes.
 
 ### Platform-Specific Notes
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -40,9 +40,9 @@ When using the bundled MariaDB container, these variables typically use their de
 
 ### DB_PORT
 **Required**: No
-**Default**: `3321`
+**Default**: `3321` for the internal database (docker-compose.yml), `3306` for external databases (docker-compose.external-db.yml)
 **Description**: Database port number
-**Note**: Both internal and external databases use port 3321 as the default for Youtarr
+**Note**: The bundled MariaDB container listens on 3321 (both inside the container and on the host). When pointing Youtarr at an external MariaDB/MySQL instance, the default drops to the standard 3306; override it in `.env` if your external database listens elsewhere.
 
 ### DB_USER
 **Required**: No

--- a/scripts/reset-server-data.sh
+++ b/scripts/reset-server-data.sh
@@ -8,12 +8,20 @@ cat <<'WARN'
 ##########################################################################
 
 This script will permanently remove all Youtarr server state, including:
-  • MariaDB data volume (./database/)
+  • MariaDB data (bind mount ./database/ AND Docker named volumes)
   • Download archive list (config/complete.list)
   • Job metadata caches (jobs/info/*)
   • Downloaded thumbnails and posters (server/images/*)
 
-Actual media files stored in your Plex/YouTube output directory are NOT touched.
+Docker named volumes removed if present:
+  - youtarr_youtarr-db-data-dev  (used by docker-compose.dev.yml)
+  - youtarr_youtarr-db-data      (used by docker-compose.arm.yml)
+
+Works whether Youtarr is running or stopped. Any running Youtarr
+containers will be force-stopped so their volumes can be removed.
+
+Actual media files in your Plex/YouTube output directory are NOT touched.
+External databases (docker-compose.external-db.yml) are NOT touched.
 
 ##########################################################################
 WARN
@@ -28,9 +36,38 @@ fi
 
 echo "Resetting Youtarr server data..."
 
+# Known Youtarr container and volume names across compose flows
+# (production, dev, and ARM). We operate on names directly instead of via
+# `docker compose down` so the script works even when required env vars
+# (e.g. YOUTUBE_OUTPUT_DIR) or compose files are missing.
+YOUTARR_CONTAINERS=(youtarr-dev youtarr youtarr-db-dev youtarr-db)
+YOUTARR_VOLUMES=(youtarr_youtarr-db-data-dev youtarr_youtarr-db-data)
+
+if command -v docker &>/dev/null && docker info &>/dev/null; then
+  # Named volumes can't be removed while a container is using them, so
+  # force-remove any known Youtarr containers first. `docker rm -f` works
+  # on both running and stopped containers.
+  for container in "${YOUTARR_CONTAINERS[@]}"; do
+    if docker ps -a --format '{{.Names}}' | grep -qx "$container"; then
+      echo "  Removing container: $container"
+      docker rm -f "$container" >/dev/null 2>&1 || true
+    fi
+  done
+
+  for vol in "${YOUTARR_VOLUMES[@]}"; do
+    if docker volume inspect "$vol" &>/dev/null; then
+      echo "  Removing Docker volume: $vol"
+      docker volume rm "$vol" >/dev/null
+    fi
+  done
+else
+  echo "  Docker not available - skipping container/volume cleanup."
+fi
+
 # Ensure glob patterns that match nothing simply expand to nothing
 shopt -s nullglob
 
+# Bind-mounted MariaDB data directory (used by the default docker-compose.yml flow)
 sudo rm -rf ./database/
 sudo rm -f ./config/complete.list
 sudo rm -f ./jobs/info/*

--- a/server/modules/__tests__/channelSettingsModule.test.js
+++ b/server/modules/__tests__/channelSettingsModule.test.js
@@ -446,6 +446,54 @@ describe('ChannelSettingsModule', () => {
       const result = await channelSettingsModule.getAllSubFolders();
       expect(result).toEqual(['__Alpha', '__Beta', '__Zulu']);
     });
+
+    test('should include the configured global default subfolder when no channels exist', async () => {
+      Channel.findAll.mockResolvedValue([]);
+      const configModule = require('../configModule');
+      configModule.getDefaultSubfolder.mockReturnValue('Adults');
+
+      const result = await channelSettingsModule.getAllSubFolders();
+
+      expect(result).toEqual(['__Adults']);
+    });
+
+    test('should include the global default subfolder alongside explicit channel subfolders', async () => {
+      Channel.findAll.mockResolvedValue([
+        { sub_folder: 'Kids' },
+        { sub_folder: 'Music' }
+      ]);
+      const configModule = require('../configModule');
+      configModule.getDefaultSubfolder.mockReturnValue('Adults');
+
+      const result = await channelSettingsModule.getAllSubFolders();
+
+      expect(result).toEqual(['__Adults', '__Kids', '__Music']);
+    });
+
+    test('should deduplicate when the global default matches an explicit channel subfolder', async () => {
+      Channel.findAll.mockResolvedValue([
+        { sub_folder: 'Music' },
+        { sub_folder: 'Adults' }
+      ]);
+      const configModule = require('../configModule');
+      configModule.getDefaultSubfolder.mockReturnValue('Adults');
+
+      const result = await channelSettingsModule.getAllSubFolders();
+
+      expect(result).toEqual(['__Adults', '__Music']);
+    });
+
+    test('should not add anything when the global default subfolder is null', async () => {
+      Channel.findAll.mockResolvedValue([
+        { sub_folder: 'Music' }
+      ]);
+      const configModule = require('../configModule');
+      configModule.getDefaultSubfolder.mockReturnValue(null);
+
+      const result = await channelSettingsModule.getAllSubFolders();
+
+      expect(result).toEqual(['__Music']);
+    });
   });
 
   describe('previewTitleFilter', () => {

--- a/server/modules/__tests__/plexModule.test.js
+++ b/server/modules/__tests__/plexModule.test.js
@@ -153,7 +153,8 @@ describe('plexModule', () => {
       const result = await plexModule.refreshLibrary();
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://127.0.0.1:32400/library/sections/1/refresh?X-Plex-Token=existing-token'
+        'http://127.0.0.1:32400/library/sections/1/refresh?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
       expect(result).toBe(mockResponse);
       expect(logger.info).toHaveBeenCalledWith(
@@ -172,7 +173,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibrary('5');
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://127.0.0.1:32400/library/sections/5/refresh?X-Plex-Token=existing-token'
+        'http://127.0.0.1:32400/library/sections/5/refresh?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
     });
 
@@ -252,7 +254,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibrary('42');
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://127.0.0.1:32400/library/sections/42/refresh?X-Plex-Token=existing-token'
+        'http://127.0.0.1:32400/library/sections/42/refresh?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
     });
 
@@ -263,7 +266,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibrary();
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://env-plex:8080/library/sections/1/refresh?X-Plex-Token=existing-token'
+        'http://env-plex:8080/library/sections/1/refresh?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
     });
   });
@@ -325,7 +329,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibraryForSubfolder('kids');
 
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/library/sections/2/refresh')
+        expect.stringContaining('/library/sections/2/refresh'),
+        { timeout: 10000 }
       );
     });
 
@@ -336,7 +341,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibraryForSubfolder('unknown');
 
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/library/sections/1/refresh')
+        expect.stringContaining('/library/sections/1/refresh'),
+        { timeout: 10000 }
       );
     });
 
@@ -347,7 +353,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibraryForSubfolder(null);
 
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/library/sections/1/refresh')
+        expect.stringContaining('/library/sections/1/refresh'),
+        { timeout: 10000 }
       );
     });
   });
@@ -375,10 +382,11 @@ describe('plexModule', () => {
 
       await plexModule.refreshLibrariesForSubfolders(['kids', 'cartoons']);
 
-      // Both resolve to library '2' — only one HTTP call should be made
+      // Both resolve to library '2' - only one HTTP call should be made
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/library/sections/2/refresh')
+        expect.stringContaining('/library/sections/2/refresh'),
+        { timeout: 10000 }
       );
     });
 
@@ -391,7 +399,8 @@ describe('plexModule', () => {
       // All three map to the global ID '1': deduplicated to one call
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/library/sections/1/refresh')
+        expect.stringContaining('/library/sections/1/refresh'),
+        { timeout: 10000 }
       );
     });
 
@@ -451,7 +460,8 @@ describe('plexModule', () => {
       const result = await plexModule.getLibraries();
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://127.0.0.1:32400/library/sections?X-Plex-Token=existing-token'
+        'http://127.0.0.1:32400/library/sections?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
       expect(result).toEqual([
         {
@@ -481,7 +491,8 @@ describe('plexModule', () => {
       const result = await plexModule.getLibraries();
 
       expect(axios.get).toHaveBeenCalledWith(
-        'https://127.0.0.1:32400/library/sections?X-Plex-Token=existing-token'
+        'https://127.0.0.1:32400/library/sections?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
       expect(result).toEqual([
         {
@@ -541,7 +552,8 @@ describe('plexModule', () => {
         'Attempting to fetch Plex libraries via URL: http://192.168.1.10:8080'
       );
       expect(axios.get).toHaveBeenCalledWith(
-        'http://192.168.1.10:8080/library/sections?X-Plex-Token=token'
+        'http://192.168.1.10:8080/library/sections?X-Plex-Token=token',
+        { timeout: 10000 }
       );
       expect(result).toEqual([
         {
@@ -595,7 +607,8 @@ describe('plexModule', () => {
       await plexModule.getLibrariesWithParams(null, 'token', null);
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://env-plex:9999/library/sections?X-Plex-Token=token'
+        'http://env-plex:9999/library/sections?X-Plex-Token=token',
+        { timeout: 10000 }
       );
     });
 
@@ -634,7 +647,8 @@ describe('plexModule', () => {
         'Attempting to fetch Plex libraries via URL: https://192.168.1.10:8080'
       );
       expect(axios.get).toHaveBeenCalledWith(
-        'https://192.168.1.10:8080/library/sections?X-Plex-Token=token'
+        'https://192.168.1.10:8080/library/sections?X-Plex-Token=token',
+        { timeout: 10000 }
       );
       expect(result).toHaveLength(1);
     });
@@ -660,7 +674,8 @@ describe('plexModule', () => {
         'Attempting to fetch Plex libraries via URL: http://192.168.1.10:8080'
       );
       expect(axios.get).toHaveBeenCalledWith(
-        'http://192.168.1.10:8080/library/sections?X-Plex-Token=token'
+        'http://192.168.1.10:8080/library/sections?X-Plex-Token=token',
+        { timeout: 10000 }
       );
       expect(result).toHaveLength(1);
     });
@@ -687,7 +702,8 @@ describe('plexModule', () => {
         'Attempting to fetch Plex libraries via URL: https://192.168.1.10:8080'
       );
       expect(axios.get).toHaveBeenCalledWith(
-        'https://192.168.1.10:8080/library/sections?X-Plex-Token=token'
+        'https://192.168.1.10:8080/library/sections?X-Plex-Token=token',
+        { timeout: 10000 }
       );
       expect(result).toHaveLength(1);
     });

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -373,7 +373,16 @@ class ChannelSettingsModule {
 
   /**
    * Get all unique subfolders currently in use
-   * @returns {Promise<Array<string>>} - Array of unique subfolder names
+   *
+   * Includes:
+   * - Every explicit sub_folder value set on a channel (excluding the
+   *   ##USE_GLOBAL_DEFAULT## sentinel which is not a real folder name)
+   * - The configured global defaultSubfolder, if set. Channels on
+   *   ##USE_GLOBAL_DEFAULT## (and fresh installs with no channels at all)
+   *   still produce files under __{defaultSubfolder}/..., so the caller
+   *   must be able to see and map that folder.
+   *
+   * @returns {Promise<Array<string>>} - Array of unique subfolder names (with __ prefix)
    */
   async getAllSubFolders() {
     const channels = await Channel.findAll({
@@ -388,14 +397,22 @@ class ChannelSettingsModule {
       }
     });
 
-    const uniqueSubFolders = [...new Set(
+    const uniqueSubFolders = new Set(
       channels
         .map(ch => ch.sub_folder ? ch.sub_folder.trim() : null)
         .filter(folder => folder && folder !== GLOBAL_DEFAULT_SENTINEL)
-    )];
+    );
+
+    // Include the configured global default subfolder so the UI can map it
+    // even when no channels reference it explicitly. configModule already
+    // normalizes whitespace and returns null for empty values.
+    const globalDefault = configModule.getDefaultSubfolder();
+    if (globalDefault) {
+      uniqueSubFolders.add(globalDefault);
+    }
 
     // Add __ prefix for display (matches filesystem names)
-    return uniqueSubFolders.map(folder => buildSubfolderSegment(folder)).sort();
+    return [...uniqueSubFolders].map(folder => buildSubfolderSegment(folder)).sort();
   }
 
   /**

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -38,7 +38,7 @@ jest.mock('../../configModule', () => ({
 
 jest.mock('../../plexModule', () => ({
   refreshLibrary: jest.fn().mockResolvedValue(),
-  refreshLibraryForSubfolder: jest.fn().mockResolvedValue(),
+  refreshLibrariesForSubfolders: jest.fn().mockResolvedValue(),
 }));
 
 jest.mock('../../jobModule', () => ({
@@ -83,21 +83,25 @@ jest.mock('../../../models/channel', () => ({
 }));
 
 // Mock filesystem module
-jest.mock('../../filesystem', () => ({
-  isMainVideoFile: jest.fn(),
-  isVideoDirectory: jest.fn(),
-  isChannelDirectory: jest.fn(),
-  isDirectoryEmpty: jest.fn(),
-  cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false),
-  ROOT_SENTINEL: '##ROOT##',
-  GLOBAL_DEFAULT_SENTINEL: '##USE_GLOBAL_DEFAULT##',
-  resolveEffectiveSubfolder: jest.fn((subfolder) => {
-    if (subfolder === '##ROOT##') return null;
-    if (subfolder === '##USE_GLOBAL_DEFAULT##') return null;
-    if (subfolder && subfolder.trim() !== '') return subfolder.trim();
-    return null;
-  }),
-}));
+jest.mock('../../filesystem', () => {
+  const actualPathBuilder = jest.requireActual('../../filesystem/pathBuilder');
+  return {
+    isMainVideoFile: jest.fn(),
+    isVideoDirectory: jest.fn(),
+    isChannelDirectory: jest.fn(),
+    isDirectoryEmpty: jest.fn(),
+    cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false),
+    ROOT_SENTINEL: '##ROOT##',
+    GLOBAL_DEFAULT_SENTINEL: '##USE_GLOBAL_DEFAULT##',
+    resolveEffectiveSubfolder: jest.fn((subfolder) => {
+      if (subfolder === '##ROOT##') return null;
+      if (subfolder === '##USE_GLOBAL_DEFAULT##') return null;
+      if (subfolder && subfolder.trim() !== '') return subfolder.trim();
+      return null;
+    }),
+    extractSubfolderFromAbsPath: jest.fn(actualPathBuilder.extractSubfolderFromAbsPath),
+  };
+});
 
 const DownloadExecutor = require('../downloadExecutor');
 const filesystem = require('../../filesystem');
@@ -805,27 +809,114 @@ describe('DownloadExecutor', () => {
       expect(archiveModule.addVideoToArchive).toHaveBeenCalledWith('abc123XYZ_d');
     });
 
-    it('should trigger Plex library refresh for the subfolder on completion', async () => {
-      setTimeout(() => {
-        mockProcess.emit('exit', 0, null);
-      }, 10);
+    it('should refresh the Plex library for the subfolder extracted from the downloaded video path', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'abc123XYZ_d',
+          filePath: '/mock/output/__Adults/The Daily Show/The Daily Show - Video - abc123XYZ_d/The Daily Show - Video [abc123XYZ_d].mp4',
+          fileSize: '1024'
+        }
+      ]);
 
-      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, 'kids');
-
-      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith('kids');
-    });
-
-    it('should trigger Plex library refresh with null subfolder when none provided', async () => {
       setTimeout(() => {
         mockProcess.emit('exit', 0, null);
       }, 10);
 
       await executor.doDownload(mockArgs, mockJobId, mockJobType);
 
-      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledTimes(1);
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledWith(['Adults']);
+    });
+
+    it('should refresh with null when the downloaded video is in the root directory', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'abc123XYZ_d',
+          filePath: '/mock/output/ChannelName/ChannelName - Video - abc123XYZ_d/ChannelName - Video [abc123XYZ_d].mp4',
+          fileSize: '1024'
+        }
+      ]);
+
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledTimes(1);
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledWith([null]);
+    });
+
+    it('should refresh every distinct library once when videos span multiple subfolders', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'adults_vid1',
+          filePath: '/mock/output/__Adults/The Daily Show/vid1 - adults_vid1/vid1 [adults_vid1].mp4',
+          fileSize: '1024'
+        },
+        {
+          youtubeId: 'adults_vid2',
+          filePath: '/mock/output/__Adults/The Daily Show/vid2 - adults_vid2/vid2 [adults_vid2].mp4',
+          fileSize: '1024'
+        },
+        {
+          youtubeId: 'kids_vid1',
+          filePath: '/mock/output/__Kids/Sesame Street/vid3 - kids_vid1/vid3 [kids_vid1].mp4',
+          fileSize: '1024'
+        }
+      ]);
+
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledTimes(1);
+      const call = plexModule.refreshLibrariesForSubfolders.mock.calls[0][0];
+      expect(call).toHaveLength(2);
+      expect(new Set(call)).toEqual(new Set(['Adults', 'Kids']));
+    });
+
+    it('should fall back to audioFilePath when filePath is not set (audio-only download)', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'abc123XYZ_d',
+          filePath: null,
+          audioFilePath: '/mock/output/__Podcasts/Podcast Channel/Podcast - abc123XYZ_d/Podcast [abc123XYZ_d].mp3',
+          audioFileSize: '512'
+        }
+      ]);
+
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledWith(['Podcasts']);
+    });
+
+    it('should NOT trigger Plex refresh when no videos were downloaded', async () => {
+      // Default mock returns [] - no videos
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(plexModule.refreshLibrariesForSubfolders).not.toHaveBeenCalled();
     });
 
     it('should NOT trigger Plex refresh when skipJobTransition is true', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'abc123XYZ_d',
+          filePath: '/mock/output/__Adults/Channel/video - abc123XYZ_d/video [abc123XYZ_d].mp4',
+          fileSize: '1024'
+        }
+      ]);
+
       setTimeout(() => {
         mockProcess.emit('exit', 0, null);
       }, 10);
@@ -833,27 +924,7 @@ describe('DownloadExecutor', () => {
       // skipJobTransition=true (7th positional arg)
       await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, true, 'kids');
 
-      expect(plexModule.refreshLibraryForSubfolder).not.toHaveBeenCalled();
-    });
-
-    it('should normalize ##ROOT## sentinel to null before Plex refresh', async () => {
-      setTimeout(() => {
-        mockProcess.emit('exit', 0, null);
-      }, 10);
-
-      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, '##ROOT##');
-
-      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
-    });
-
-    it('should normalize ##USE_GLOBAL_DEFAULT## sentinel before Plex refresh', async () => {
-      setTimeout(() => {
-        mockProcess.emit('exit', 0, null);
-      }, 10);
-
-      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, '##USE_GLOBAL_DEFAULT##');
-
-      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
+      expect(plexModule.refreshLibrariesForSubfolders).not.toHaveBeenCalled();
     });
 
     it('should start next job after completion', async () => {

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -1390,11 +1390,26 @@ class DownloadExecutor {
 
         // Only refresh Plex and start next job if not processing multiple groups
         if (!skipJobTransition) {
-          const resolvedSubfolder = filesystem.resolveEffectiveSubfolder(subfolderOverride, configModule.getConfig().defaultSubfolder || null);
-          // Defensive: refreshLibrary currently swallows errors internally
-          plexModule.refreshLibraryForSubfolder(resolvedSubfolder).catch(err => {
-            logger.error({ err }, 'Failed to refresh Plex library');
-          });
+          // Derive the set of subfolders from where each video actually ended up
+          // on disk. This mirrors reality (the post-processor may have placed
+          // each video under its channel-specific sub_folder) instead of relying
+          // on the job-level subfolderOverride, which is null for typical
+          // manual URL and non-grouped channel downloads.
+          const baseDir = configModule.directoryPath;
+          const subfoldersInUse = new Set();
+          for (const video of (videoData || [])) {
+            const mediaPath = video.filePath || video.audioFilePath;
+            if (!mediaPath) continue;
+            subfoldersInUse.add(filesystem.extractSubfolderFromAbsPath(mediaPath, baseDir));
+          }
+
+          if (subfoldersInUse.size > 0) {
+            // Defensive: refreshLibrary currently swallows errors internally
+            plexModule.refreshLibrariesForSubfolders([...subfoldersInUse]).catch(err => {
+              logger.error({ err }, 'Failed to refresh Plex libraries');
+            });
+          }
+
           jobModule.startNextJob().catch(err => {
             logger.error({ err }, 'Failed to start next job');
           });

--- a/server/modules/filesystem/__tests__/pathBuilder.test.js
+++ b/server/modules/filesystem/__tests__/pathBuilder.test.js
@@ -10,7 +10,8 @@ const {
   buildThumbnailTemplate,
   extractYoutubeIdFromPath,
   isValidYoutubeId,
-  calculateRelocatedPath
+  calculateRelocatedPath,
+  extractSubfolderFromAbsPath
 } = require('../pathBuilder');
 const { GLOBAL_DEFAULT_SENTINEL, ROOT_SENTINEL } = require('../constants');
 
@@ -240,6 +241,72 @@ describe('filesystem/pathBuilder', () => {
 
     it('should return null for null original', () => {
       expect(calculateRelocatedPath('/a', '/b', null)).toBeNull();
+    });
+  });
+
+  describe('extractSubfolderFromAbsPath', () => {
+    const baseDir = '/usr/src/app/data';
+
+    it('should return the subfolder name for a path inside a subfolder directory', () => {
+      const filePath = '/usr/src/app/data/__Adults/The Daily Show/The Daily Show - Video - abc12345678/The Daily Show - Video [abc12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBe('Adults');
+    });
+
+    it('should return null for a path directly under the base directory (root)', () => {
+      const filePath = '/usr/src/app/data/ChannelName/ChannelName - Video - abc12345678/ChannelName - Video [abc12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBeNull();
+    });
+
+    it('should handle subfolder names with spaces and special characters', () => {
+      const filePath = '/usr/src/app/data/__Kids Shows/Channel/Video - id12345678/Video [id12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBe('Kids Shows');
+    });
+
+    it('should work with audio (mp3) file paths', () => {
+      const filePath = '/usr/src/app/data/__Podcasts/Channel/Video - id12345678/Video [id12345678].mp3';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBe('Podcasts');
+    });
+
+    it('should tolerate a trailing slash on the base directory', () => {
+      const filePath = '/usr/src/app/data/__Adults/Channel/Video - id12345678/Video [id12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, '/usr/src/app/data/')).toBe('Adults');
+    });
+
+    it('should return the subfolder for a flat-mode (skip_video_folder) layout with subfolder', () => {
+      // Flat mode: no per-video directory - video file lives directly in the channel dir
+      const filePath = '/usr/src/app/data/__Adults/Channel/Channel - Video [id12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBe('Adults');
+    });
+
+    it('should return null for a flat-mode (skip_video_folder) layout without subfolder', () => {
+      // Flat mode at root: channel dir directly under baseDir, file directly in channel dir
+      const filePath = '/usr/src/app/data/Channel/Channel - Video [id12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBeNull();
+    });
+
+    it('should return null when filePath is not under baseDir', () => {
+      expect(extractSubfolderFromAbsPath('/other/path/video.mp4', baseDir)).toBeNull();
+    });
+
+    it('should return null for null filePath', () => {
+      expect(extractSubfolderFromAbsPath(null, baseDir)).toBeNull();
+    });
+
+    it('should return null for undefined filePath', () => {
+      expect(extractSubfolderFromAbsPath(undefined, baseDir)).toBeNull();
+    });
+
+    it('should return null for empty filePath', () => {
+      expect(extractSubfolderFromAbsPath('', baseDir)).toBeNull();
+    });
+
+    it('should return null when baseDir is missing', () => {
+      expect(extractSubfolderFromAbsPath('/usr/src/app/data/__Adults/Channel/file.mp4', null)).toBeNull();
+    });
+
+    it('should return empty string for a bare __ subfolder segment', () => {
+      const filePath = '/usr/src/app/data/__/Channel/Video/Video [abc12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBe('');
     });
   });
 });

--- a/server/modules/filesystem/pathBuilder.js
+++ b/server/modules/filesystem/pathBuilder.js
@@ -204,6 +204,45 @@ function calculateRelocatedPath(oldBasePath, newBasePath, originalPath) {
   return newBasePath + relativePath;
 }
 
+/**
+ * Extract the effective subfolder from an absolute media file path
+ * Given a video or audio file path produced by the post-processor, return the
+ * subfolder name (without the __ prefix) that contains it, or null if the file
+ * is directly under the base directory (root, no subfolder).
+ *
+ * This is used to determine which Plex library to refresh for a downloaded
+ * video, based on where the file actually ended up on disk rather than
+ * re-running subfolder resolution logic.
+ *
+ * @param {string} filePath - Absolute path to the downloaded media file
+ * @param {string} baseDir - The base output directory (configModule.directoryPath)
+ * @returns {string|null} - The subfolder name (without __ prefix), or null for root
+ */
+function extractSubfolderFromAbsPath(filePath, baseDir) {
+  if (!filePath || !baseDir) {
+    return null;
+  }
+
+  const relativePath = path.relative(baseDir, filePath);
+
+  // path.relative returns a path starting with '..' when filePath is not under baseDir
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  const firstSegment = relativePath.split(path.sep)[0];
+  if (!firstSegment) {
+    return null;
+  }
+
+  if (isSubfolderDirectory(firstSegment)) {
+    return extractSubfolderName(firstSegment);
+  }
+
+  // First segment is the channel directory, meaning the file is in root (no subfolder)
+  return null;
+}
+
 module.exports = {
   buildSubfolderSegment,
   isSubfolderDirectory,
@@ -216,5 +255,6 @@ module.exports = {
   buildThumbnailTemplate,
   extractYoutubeIdFromPath,
   isValidYoutubeId,
-  calculateRelocatedPath
+  calculateRelocatedPath,
+  extractSubfolderFromAbsPath
 };

--- a/server/modules/plexModule.js
+++ b/server/modules/plexModule.js
@@ -2,6 +2,14 @@ const axios = require('axios');
 const configModule = require('./configModule');
 const logger = require('../logger');
 
+// Plex HTTP request timeout in milliseconds.
+// Any call to the local Plex server should complete within a few seconds on
+// a healthy LAN; anything longer almost certainly means Plex is unreachable.
+// Without this timeout, axios inherits the OS-level TCP retry timeouts which
+// can hang for 60+ seconds, leaving the Configuration UI stuck on "Testing..."
+// while the user waits for the initial connectivity check to resolve.
+const PLEX_REQUEST_TIMEOUT_MS = 10000;
+
 class PlexModule {
   constructor() {}
 
@@ -92,7 +100,8 @@ class PlexModule {
 
       logger.info({ libraryId: resolvedLibraryId }, 'Refreshing Plex library');
       const response = await axios.get(
-        `${baseUrl}/library/sections/${encodeURIComponent(resolvedLibraryId)}/refresh?X-Plex-Token=${config.plexApiKey}`
+        `${baseUrl}/library/sections/${encodeURIComponent(resolvedLibraryId)}/refresh?X-Plex-Token=${config.plexApiKey}`,
+        { timeout: PLEX_REQUEST_TIMEOUT_MS }
       );
       logger.info({ libraryId: resolvedLibraryId }, 'Plex library refresh initiated successfully');
       return response;
@@ -100,6 +109,8 @@ class PlexModule {
       logger.error({ err: error }, 'Failed to refresh Plex library');
       if (error.code === 'ECONNREFUSED') {
         logger.warn('Could not connect to Plex server - continuing without refresh');
+      } else if (error.code === 'ECONNABORTED') {
+        logger.warn('Plex request timed out - continuing without refresh');
       }
       // Return null or empty response to indicate failure, but don't throw
       return null;
@@ -129,7 +140,8 @@ class PlexModule {
       logger.info(`Attempting to fetch Plex libraries via URL: ${baseUrl}`);
 
       const response = await axios.get(
-        `${baseUrl}/library/sections?X-Plex-Token=${plexApiKey}`
+        `${baseUrl}/library/sections?X-Plex-Token=${plexApiKey}`,
+        { timeout: PLEX_REQUEST_TIMEOUT_MS }
       );
 
       const libraries = response.data.MediaContainer.Directory.map(
@@ -149,6 +161,8 @@ class PlexModule {
       logger.error({ err: error }, 'Failed to get Plex libraries');
       if (error.code === 'ECONNREFUSED') {
         logger.warn('Could not connect to Plex server - returning empty library list');
+      } else if (error.code === 'ECONNABORTED') {
+        logger.warn('Plex request timed out - returning empty library list');
       }
       // Return empty array instead of throwing to prevent frontend crashes
       return [];


### PR DESCRIPTION
Followup cleanup from the dev branch review. Four chunks of work:

- **Plex subfolder refresh fix**: the library refresh was using the job-level `subfolderOverride` instead of each video's actual file path, so manual URL and non-grouped channel downloads refreshed the wrong library when a channel had a per-channel `sub_folder`. Also made the default subfolder show up in the per-subfolder mappings dropdown when there are no channels or all channels use the global default.
- **Plex library display refactor**: cached the Plex library list in `usePlexConnection` so the selector opens without a refetch, added a request timeout so Plex calls don't hang, and pulled shared rendering into `plexLibraries.ts`, `PlexLibraryLabel`, and `DefaultPlexLibraryDisplay`. `PlexLibrarySelector` is a presentational component now, and `PlexIntegrationSection` is back under the 300-line budget. Tests added for all the new pieces.
- **Reset script**: `reset-server-data.sh` wasn't clearing the dev and arm db volume mounts, so "full reset" wasn't actually full.
- **Docs**: rewrote `CLAUDE.md` to add Scope Discipline, Security, and Documentation Sync sections and pushed architecture detail into the reference docs. Smaller updates to `DEVELOPMENT.md` (backend `node --watch` + Vite HMR), `DOCKER.md` (Compose comparison table, UID ordering), and drift fixes in `CONFIG.md`, `ENVIRONMENT_VARIABLES.md`, `AUTHENTICATION.md`, and `DATABASE.md`.