### PR TITLE
feat(channels): add manual tab override with yt-dlp redetect

### DIFF
--- a/client/src/components/ChannelPage.tsx
+++ b/client/src/components/ChannelPage.tsx
@@ -34,12 +34,14 @@ function ChannelPage({ token }: ChannelPageProps) {
     min_duration: number | null;
     max_duration: number | null;
     title_filter_regex: string | null;
+    hidden_tabs?: string[];
+    availableTabs?: string[];
   }) => {
     setChannel((prev) => {
       if (!prev) {
         return prev;
       }
-      return {
+      const next: Channel = {
         ...prev,
         sub_folder: updated.sub_folder,
         video_quality: updated.video_quality,
@@ -48,6 +50,17 @@ function ChannelPage({ token }: ChannelPageProps) {
         max_duration: updated.max_duration,
         title_filter_regex: updated.title_filter_regex,
       };
+      if (updated.availableTabs !== undefined) {
+        next.available_tabs = updated.availableTabs.length > 0
+          ? updated.availableTabs.join(',')
+          : null;
+      }
+      if (updated.hidden_tabs !== undefined) {
+        next.hidden_tabs = updated.hidden_tabs.length > 0
+          ? updated.hidden_tabs.join(',')
+          : null;
+      }
+      return next;
     });
   };
 
@@ -349,6 +362,7 @@ function ChannelPage({ token }: ChannelPageProps) {
         channelId={channel_id || undefined}
         channelVideoQuality={channel?.video_quality || null}
         channelAudioFormat={channel?.audio_format || null}
+        channelAvailableTabs={channel?.available_tabs ?? null}
       />
 
       {channel && channel_id && (

--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -32,6 +32,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import RatingBadge from '../shared/RatingBadge';
 import { useConfig } from '../../hooks/useConfig';
 import { SubfolderAutocomplete } from '../shared/SubfolderAutocomplete';
+import TabsEditor, { TabsEditorRefreshResult } from './components/TabsEditor';
 
 interface ChannelSettings {
   sub_folder: string | null;
@@ -42,6 +43,12 @@ interface ChannelSettings {
   audio_format: string | null;
   default_rating: string | null;
   skip_video_folder: boolean | null;
+  hidden_tabs: string[];
+}
+
+interface ChannelTabsState {
+  detectedTabs: string[];
+  availableTabs: string[];
 }
 
 interface FilterPreviewVideo {
@@ -63,7 +70,7 @@ interface ChannelSettingsDialogProps {
   channelId: string;
   channelName: string;
   token: string | null;
-  onSettingsSaved?: (settings: ChannelSettings) => void;
+  onSettingsSaved?: (settings: ChannelSettings & ChannelTabsState) => void;
 }
 
 const regexExamples = [
@@ -100,7 +107,8 @@ function ChannelSettingsDialog({
     title_filter_regex: null,
     audio_format: null,
     default_rating: null,
-    skip_video_folder: null
+    skip_video_folder: null,
+    hidden_tabs: []
   });
   const [originalSettings, setOriginalSettings] = useState<ChannelSettings>({
     sub_folder: null,
@@ -110,8 +118,10 @@ function ChannelSettingsDialog({
     title_filter_regex: null,
     audio_format: null,
     default_rating: null,
-    skip_video_folder: null
+    skip_video_folder: null,
+    hidden_tabs: []
   });
+  const [detectedTabs, setDetectedTabs] = useState<string[]>([]);
   const [subfolders, setSubfolders] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -194,9 +204,11 @@ function ChannelSettingsDialog({
           skip_video_folder: Object.prototype.hasOwnProperty.call(settingsData, 'skip_video_folder')
             ? settingsData.skip_video_folder
             : null,
+          hidden_tabs: Array.isArray(settingsData.hidden_tabs) ? settingsData.hidden_tabs : [],
         };
         setSettings(loadedSettings);
         setOriginalSettings(loadedSettings);
+        setDetectedTabs(Array.isArray(settingsData.detected_tabs) ? settingsData.detected_tabs : []);
 
         // Convert seconds to minutes for UI
         if (settingsData.min_duration) {
@@ -251,7 +263,8 @@ function ChannelSettingsDialog({
           title_filter_regex: settings.title_filter_regex || null,
           audio_format: settings.audio_format || null,
           default_rating: settings.default_rating || null,
-          skip_video_folder: settings.skip_video_folder
+          skip_video_folder: settings.skip_video_folder,
+          hidden_tabs: settings.hidden_tabs
         })
       });
 
@@ -273,6 +286,16 @@ function ChannelSettingsDialog({
       }
 
       const result = await response.json();
+      const resultHiddenTabs: string[] = Array.isArray(result?.settings?.hidden_tabs)
+        ? result.settings.hidden_tabs
+        : settings.hidden_tabs;
+      const resultDetectedTabs: string[] = Array.isArray(result?.settings?.detected_tabs)
+        ? result.settings.detected_tabs
+        : detectedTabs;
+      const resultAvailableTabs: string[] = Array.isArray(result?.settings?.available_tabs)
+        ? result.settings.available_tabs
+        : resultDetectedTabs.filter((tab) => !resultHiddenTabs.includes(tab));
+
       const updatedSettings: ChannelSettings = {
         sub_folder: result?.settings?.sub_folder ?? settings.sub_folder ?? null,
         video_quality: result?.settings?.video_quality ?? settings.video_quality ?? null,
@@ -286,14 +309,20 @@ function ChannelSettingsDialog({
         skip_video_folder: result?.settings && Object.prototype.hasOwnProperty.call(result.settings, 'skip_video_folder')
           ? result.settings.skip_video_folder
           : settings.skip_video_folder ?? null,
+        hidden_tabs: resultHiddenTabs,
       };
 
       setSettings(updatedSettings);
       setOriginalSettings(updatedSettings);
+      setDetectedTabs(resultDetectedTabs);
       setSuccess(true);
 
       if (onSettingsSaved) {
-        onSettingsSaved(updatedSettings);
+        onSettingsSaved({
+          ...updatedSettings,
+          detectedTabs: resultDetectedTabs,
+          availableTabs: resultAvailableTabs,
+        });
       }
 
       // Show success message briefly then close
@@ -319,6 +348,9 @@ function ChannelSettingsDialog({
   };
 
   const hasChanges = () => {
+    const tabsChanged =
+      settings.hidden_tabs.length !== originalSettings.hidden_tabs.length ||
+      settings.hidden_tabs.some((tab) => !originalSettings.hidden_tabs.includes(tab));
     return settings.sub_folder !== originalSettings.sub_folder ||
            settings.video_quality !== originalSettings.video_quality ||
            settings.min_duration !== originalSettings.min_duration ||
@@ -326,7 +358,23 @@ function ChannelSettingsDialog({
            settings.title_filter_regex !== originalSettings.title_filter_regex ||
           settings.audio_format !== originalSettings.audio_format ||
           settings.default_rating !== originalSettings.default_rating ||
-          settings.skip_video_folder !== originalSettings.skip_video_folder;
+          settings.skip_video_folder !== originalSettings.skip_video_folder ||
+          tabsChanged;
+  };
+
+  const allTabsHidden = detectedTabs.length > 0 &&
+    detectedTabs.every((tab) => settings.hidden_tabs.includes(tab));
+
+  const handleHiddenTabsChange = (nextHidden: string[]) => {
+    setSettings((prev) => ({ ...prev, hidden_tabs: nextHidden }));
+  };
+
+  const handleTabsRefresh = (result: TabsEditorRefreshResult) => {
+    setDetectedTabs(result.detectedTabs);
+    setSettings((prev) => ({ ...prev, hidden_tabs: result.hiddenTabs }));
+    setOriginalSettings((prev) => ({ ...prev, hidden_tabs: result.hiddenTabs }));
+    // The backend also updates available_tabs/auto_download_enabled_tabs on refresh,
+    // but the dialog will reflect those the next time the parent reloads channel info.
   };
 
   const handlePreviewFilter = async () => {
@@ -418,6 +466,18 @@ function ChannelSettingsDialog({
                 Settings saved successfully!
               </Alert>
             )}
+
+            <TabsEditor
+              channelId={channelId}
+              token={token}
+              detectedTabs={detectedTabs}
+              hiddenTabs={settings.hidden_tabs}
+              onHiddenTabsChange={handleHiddenTabsChange}
+              onRefresh={handleTabsRefresh}
+              disabled={saving}
+            />
+
+            <Divider sx={{ my: 0 }} />
 
             <FormControl fullWidth>
               <InputLabel id="video-quality-label" shrink>Channel Video Quality Override</InputLabel>
@@ -752,7 +812,7 @@ function ChannelSettingsDialog({
         <Button
           onClick={handleSave}
           variant="contained"
-          disabled={saving || loading || !hasChanges()}
+          disabled={saving || loading || !hasChanges() || allTabsHidden}
         >
           {saving ? <CircularProgress size={24} /> : 'Save'}
         </Button>

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -56,13 +56,20 @@ interface ChannelVideosProps {
   channelId?: string;
   channelVideoQuality?: string | null;
   channelAudioFormat?: string | null;
+  /**
+   * Effective available_tabs for the channel (comma-separated, already
+   * filtered through hidden_tabs). When provided, takes precedence over
+   * the tabs fetched from /api/channels/:channelId/tabs so the strip
+   * updates immediately after the user changes hidden_tabs in settings.
+   */
+  channelAvailableTabs?: string | null;
 }
 
 type ViewMode = 'table' | 'grid' | 'list';
 type SortBy = 'date' | 'title' | 'duration' | 'size';
 type SortOrder = 'asc' | 'desc';
 
-function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelId, channelVideoQuality, channelAudioFormat }: ChannelVideosProps) {
+function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelId, channelVideoQuality, channelAudioFormat, channelAvailableTabs }: ChannelVideosProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -293,6 +300,24 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
       setAvailableTabs(availableTabsFromVideos);
     }
   }, [availableTabsFromVideos]);
+
+  // Sync from the parent-supplied channel.available_tabs when it changes
+  // (e.g. right after the user saves a hidden_tabs change in settings).
+  useEffect(() => {
+    if (channelAvailableTabs === undefined) return;
+
+    const nextTabs = channelAvailableTabs
+      ? channelAvailableTabs.split(',').map((tab) => tab.trim()).filter((tab) => tab.length > 0)
+      : [];
+
+    if (nextTabs.length === 0) return;
+
+    setAvailableTabs(nextTabs);
+    setSelectedTab((current) => {
+      if (current && nextTabs.includes(current)) return current;
+      return nextTabs.includes('videos') ? 'videos' : nextTabs[0];
+    });
+  }, [channelAvailableTabs]);
 
   // Clear local status overrides when videos are refetched (page change, tab change, etc)
   useEffect(() => {

--- a/client/src/components/ChannelPage/__tests__/ChannelSettingsDialog.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelSettingsDialog.test.tsx
@@ -13,6 +13,17 @@ jest.mock('../../../hooks/useConfig', () => ({
   useConfig: jest.fn(),
 }));
 
+// Mock axios because TabsEditor (rendered inside the dialog) uses axios.post
+// for the refresh button. Existing dialog tests do not click refresh so the
+// mock is passive for them; it's only exercised by the refresh-path test.
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  isAxiosError: jest.fn(() => false),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const mockAxios = require('axios');
+
 const mockUseConfig = useConfig as jest.MockedFunction<typeof useConfig>;
 
 describe('ChannelSettingsDialog', () => {
@@ -46,6 +57,8 @@ describe('ChannelSettingsDialog', () => {
     jest.clearAllMocks();
     mockFetch = jest.fn();
     global.fetch = mockFetch;
+    mockAxios.post.mockReset();
+    mockAxios.isAxiosError.mockReturnValue(false);
     mockRefetchConfig.mockResolvedValue(undefined);
     // Reset mockUseConfig to default
     mockUseConfig.mockReturnValue({
@@ -989,10 +1002,12 @@ describe('ChannelSettingsDialog', () => {
       await user.click(saveButton);
 
       await waitFor(() => {
-        expect(mockOnSettingsSaved).toHaveBeenCalledWith({
-          ...mockChannelSettings,
-          video_quality: '720',
-        });
+        expect(mockOnSettingsSaved).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ...mockChannelSettings,
+            video_quality: '720',
+          })
+        );
       });
     });
 
@@ -1572,6 +1587,186 @@ describe('ChannelSettingsDialog', () => {
       });
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Channel Tabs integration', () => {
+    test('loads detected_tabs and hidden_tabs from settings and reflects them in TabsEditor', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            ...mockChannelSettings,
+            detected_tabs: ['videos', 'shorts', 'streams'],
+            hidden_tabs: ['shorts'],
+            available_tabs: ['videos', 'streams'],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        });
+
+      render(<ChannelSettingsDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeChecked();
+      expect(screen.getByTestId('tabs-editor-checkbox-shorts')).not.toBeChecked();
+      expect(screen.getByTestId('tabs-editor-checkbox-streams')).toBeChecked();
+    });
+
+    test('save request includes hidden_tabs in the PUT body', async () => {
+      const user = userEvent.setup();
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            ...mockChannelSettings,
+            detected_tabs: ['videos', 'shorts', 'streams'],
+            hidden_tabs: [],
+            available_tabs: ['videos', 'shorts', 'streams'],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            settings: {
+              ...mockChannelSettings,
+              hidden_tabs: ['shorts'],
+              detected_tabs: ['videos', 'shorts', 'streams'],
+              available_tabs: ['videos', 'streams'],
+            },
+          }),
+        });
+
+      render(<ChannelSettingsDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('tabs-editor-checkbox-shorts'));
+
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        const saveCall = mockFetch.mock.calls.find(
+          ([url, init]) =>
+            url === '/api/channels/channel123/settings' && init?.method === 'PUT'
+        );
+        expect(saveCall).toBeDefined();
+      });
+
+      const saveCall = mockFetch.mock.calls.find(
+        ([url, init]) =>
+          url === '/api/channels/channel123/settings' && init?.method === 'PUT'
+      )!;
+      const body = JSON.parse(saveCall[1].body as string);
+      expect(body.hidden_tabs).toEqual(['shorts']);
+    });
+
+    test('save button is disabled when every detected tab is hidden', async () => {
+      const user = userEvent.setup();
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            ...mockChannelSettings,
+            detected_tabs: ['videos', 'shorts'],
+            hidden_tabs: [],
+            available_tabs: ['videos', 'shorts'],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        });
+
+      render(<ChannelSettingsDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('tabs-editor-checkbox-videos'));
+      await user.click(screen.getByTestId('tabs-editor-checkbox-shorts'));
+
+      expect(screen.getByText('At least one tab must remain visible.')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    });
+
+    test('refresh updates detected tabs and resets originalSettings so Save stays disabled', async () => {
+      const user = userEvent.setup();
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            ...mockChannelSettings,
+            detected_tabs: ['videos', 'shorts'],
+            hidden_tabs: ['shorts'],
+            available_tabs: ['videos'],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        });
+
+      // Backend's redetect probe now also finds 'streams' and keeps 'shorts' hidden
+      mockAxios.post.mockResolvedValueOnce({
+        data: {
+          availableTabs: ['videos', 'streams'],
+          detectedTabs: ['videos', 'shorts', 'streams'],
+          hiddenTabs: ['shorts'],
+        },
+      });
+
+      render(<ChannelSettingsDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      // Initial state: only videos + shorts detected, streams not yet present
+      expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeChecked();
+      expect(screen.getByTestId('tabs-editor-checkbox-shorts')).not.toBeChecked();
+      expect(screen.queryByTestId('tabs-editor-checkbox-streams')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+      // Click refresh; TabsEditor posts via axios and receives the new state
+      await user.click(screen.getByTestId('tabs-editor-refresh'));
+
+      await waitFor(() => {
+        expect(mockAxios.post).toHaveBeenCalledWith(
+          '/api/channels/channel123/tabs/redetect',
+          null,
+          { headers: { 'x-access-token': 'test-token' } }
+        );
+      });
+
+      // After refresh: streams now rendered; videos + streams checked, shorts still hidden
+      await waitFor(() => {
+        expect(screen.getByTestId('tabs-editor-checkbox-streams')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeChecked();
+      expect(screen.getByTestId('tabs-editor-checkbox-shorts')).not.toBeChecked();
+      expect(screen.getByTestId('tabs-editor-checkbox-streams')).toBeChecked();
+
+      // Critical invariant: handleTabsRefresh resets originalSettings.hidden_tabs
+      // to the refresh result, so hasChanges() is false and Save stays disabled.
+      // If that reset is broken, Save would be ENABLED here.
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
     });
   });
 });

--- a/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
@@ -1,4 +1,5 @@
-import { screen, waitFor } from '@testing-library/react';
+import React, { useState } from 'react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -953,6 +954,167 @@ describe('ChannelVideos Component', () => {
       expect(screen.getByTestId('video-card-video1')).toBeInTheDocument();
       expect(screen.getByTestId('video-card-ignored1')).toBeInTheDocument();
       expect(screen.getByTestId('video-card-video2')).toBeInTheDocument();
+    });
+  });
+
+  describe('channelAvailableTabs prop sync', () => {
+    // Controlled harness: holds channelAvailableTabs in state and exposes a
+    // setter that tests call to simulate the parent passing a new value.
+    // This avoids interactions with RTL's `rerender` + wrapper option.
+    //
+    // Both the sync effect AND the internal tabs-fetch effect write to
+    // availableTabs state. To make these tests deterministic regardless of
+    // unrelated prior tests' scheduling, we ALSO mock the tabs fetch to
+    // return the same data the sync effect would produce so whichever effect
+    // "wins" the race yields an equivalent result. For tests that need the
+    // sync-effect state to be visible after a prop change, we seed the
+    // initial prop and let the sync effect establish state on mount.
+    let setTabsProp: ((val: string | null | undefined) => void) | null = null;
+
+    const Harness = ({ initial }: { initial?: string | null }) => {
+      const [prop, setProp] = useState<string | null | undefined>(initial);
+      setTabsProp = setProp;
+      return <ChannelVideos token={mockToken} channelAvailableTabs={prop} />;
+    };
+
+    // Build a fetch mock that always returns the same availableTabs the
+    // sync effect would set, so the fetch effect never introduces a
+    // different state into the race.
+    const mockTabsFetch = (tabs: string[]) => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ availableTabs: tabs }),
+      });
+    };
+
+    beforeEach(() => {
+      setTabsProp = null;
+    });
+
+    test('updates the rendered tab strip when parent passes a new channelAvailableTabs value', async () => {
+      // Both the fetch effect and the sync effect would set 3 tabs on mount
+      mockTabsFetch(['videos', 'shorts', 'streams']);
+
+      renderWithProviders(<Harness initial="videos,shorts,streams" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      });
+      expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
+
+      // Parent now passes a filtered list down (shorts hidden)
+      act(() => {
+        setTabsProp?.('videos,streams');
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('tab', { name: /Shorts/i })).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Videos/i })).toBeInTheDocument();
+    });
+
+    test('preserves the current selected tab when it remains in the new list', async () => {
+      const user = userEvent.setup();
+      mockTabsFetch(['videos', 'shorts', 'streams']);
+
+      renderWithProviders(<Harness initial="videos,shorts,streams" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('tab', { name: /Shorts/i }));
+
+      await waitFor(() => {
+        expect(useChannelVideos).toHaveBeenLastCalledWith(
+          expect.objectContaining({ tabType: 'shorts' })
+        );
+      });
+
+      // Parent passes [videos, shorts] (streams hidden, shorts still present)
+      act(() => {
+        setTabsProp?.('videos,shorts');
+      });
+
+      // Selected tab should still be shorts
+      await waitFor(() => {
+        expect(useChannelVideos).toHaveBeenLastCalledWith(
+          expect.objectContaining({ tabType: 'shorts' })
+        );
+      });
+      expect(screen.queryByRole('tab', { name: /Live/i })).not.toBeInTheDocument();
+    });
+
+    test('falls back to videos when the current tab is dropped from the new list', async () => {
+      const user = userEvent.setup();
+      mockTabsFetch(['videos', 'shorts', 'streams']);
+
+      renderWithProviders(<Harness initial="videos,shorts,streams" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      });
+
+      // Select the shorts tab
+      await user.click(screen.getByRole('tab', { name: /Shorts/i }));
+
+      await waitFor(() => {
+        expect(useChannelVideos).toHaveBeenLastCalledWith(
+          expect.objectContaining({ tabType: 'shorts' })
+        );
+      });
+
+      // Parent hides shorts; new list = [videos, streams], current 'shorts' is gone
+      act(() => {
+        setTabsProp?.('videos,streams');
+      });
+
+      // Selected tab should fall back to 'videos' (preferred fallback)
+      await waitFor(() => {
+        expect(useChannelVideos).toHaveBeenLastCalledWith(
+          expect.objectContaining({ tabType: 'videos' })
+        );
+      });
+    });
+
+    test('leaves the tab strip alone when channelAvailableTabs is undefined', async () => {
+      // Fetch and sync effect agree on 3 tabs from mount
+      mockTabsFetch(['videos', 'shorts', 'streams']);
+
+      renderWithProviders(<Harness initial="videos,shorts,streams" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
+      });
+
+      // Explicit undefined: the sync effect must early-return and leave state alone
+      act(() => {
+        setTabsProp?.(undefined);
+      });
+
+      expect(screen.getByRole('tab', { name: /Videos/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
+    });
+
+    test('leaves the tab strip alone when channelAvailableTabs is an empty string', async () => {
+      mockTabsFetch(['videos', 'shorts', 'streams']);
+
+      renderWithProviders(<Harness initial="videos,shorts,streams" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
+      });
+
+      // Empty string parses to empty array, so the sync effect should early-return
+      act(() => {
+        setTabsProp?.('');
+      });
+
+      expect(screen.getByRole('tab', { name: /Videos/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/ChannelPage/components/TabsEditor.tsx
+++ b/client/src/components/ChannelPage/components/TabsEditor.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  FormControlLabel,
+  FormGroup,
+  Typography
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+
+const TAB_TYPE_ORDER: string[] = ['videos', 'shorts', 'streams'];
+const TAB_LABEL: Record<string, string> = {
+  videos: 'Videos',
+  shorts: 'Shorts',
+  streams: 'Live / Streams'
+};
+
+export interface TabsEditorRefreshResult {
+  availableTabs: string[];
+  detectedTabs: string[];
+  hiddenTabs: string[];
+}
+
+interface TabsEditorProps {
+  channelId: string;
+  token: string | null;
+  detectedTabs: string[];
+  hiddenTabs: string[];
+  onHiddenTabsChange: (nextHidden: string[]) => void;
+  onRefresh: (result: TabsEditorRefreshResult) => void;
+  disabled?: boolean;
+}
+
+function TabsEditor({
+  channelId,
+  token,
+  detectedTabs,
+  hiddenTabs,
+  onHiddenTabsChange,
+  onRefresh,
+  disabled = false
+}: TabsEditorProps) {
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+
+  const hiddenSet = new Set(hiddenTabs);
+  const effectiveTabs = detectedTabs.filter((tab) => !hiddenSet.has(tab));
+  const allHidden = detectedTabs.length > 0 && effectiveTabs.length === 0;
+
+  // Ensure tabs always render in a stable order, even if the backend returns them shuffled.
+  const orderedDetectedTabs = TAB_TYPE_ORDER.filter((tab) => detectedTabs.includes(tab));
+
+  const handleToggle = (tab: string, visible: boolean) => {
+    // `visible` true  = checkbox checked = tab NOT hidden
+    // `visible` false = checkbox unchecked = tab IS hidden
+    const next = new Set(hiddenSet);
+    if (visible) {
+      next.delete(tab);
+    } else {
+      next.add(tab);
+    }
+    onHiddenTabsChange(Array.from(next));
+  };
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    setRefreshError(null);
+    try {
+      const { data } = await axios.post<TabsEditorRefreshResult>(
+        `/api/channels/${channelId}/tabs/redetect`,
+        null,
+        { headers: { 'x-access-token': token || '' } }
+      );
+      onRefresh({
+        availableTabs: Array.isArray(data.availableTabs) ? data.availableTabs : [],
+        detectedTabs: Array.isArray(data.detectedTabs) ? data.detectedTabs : [],
+        hiddenTabs: Array.isArray(data.hiddenTabs) ? data.hiddenTabs : []
+      });
+    } catch (err) {
+      let message = 'Failed to refresh tabs';
+      if (axios.isAxiosError(err) && err.response?.data?.error) {
+        message = err.response.data.error;
+      } else if (err instanceof Error) {
+        message = err.message;
+      }
+      setRefreshError(message);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+        Channel Tabs
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        Choose which YouTube tabs to use for this channel. Unchecking a tab hides it from the
+        channel page and the channel list, and disables its auto-download. Use &quot;Refresh
+        from YouTube&quot; if the detected tabs look wrong (e.g. a channel only shows as having
+        Shorts).
+      </Typography>
+
+      {orderedDetectedTabs.length === 0 ? (
+        <Alert severity="info" sx={{ mt: 1 }}>
+          No tabs have been detected for this channel yet. Click &quot;Refresh from YouTube&quot;
+          to run detection now.
+        </Alert>
+      ) : (
+        <FormGroup row sx={{ mt: 0.5 }}>
+          {orderedDetectedTabs.map((tab) => (
+            <FormControlLabel
+              key={tab}
+              control={
+                <Checkbox
+                  inputProps={{ 'data-testid': `tabs-editor-checkbox-${tab}` } as React.InputHTMLAttributes<HTMLInputElement>}
+                  checked={!hiddenSet.has(tab)}
+                  onChange={(e) => handleToggle(tab, e.target.checked)}
+                  disabled={disabled || refreshing}
+                />
+              }
+              label={TAB_LABEL[tab] || tab}
+            />
+          ))}
+        </FormGroup>
+      )}
+
+      {allHidden && (
+        <Alert severity="error">
+          At least one tab must remain visible.
+        </Alert>
+      )}
+
+      {refreshError && (
+        <Alert severity="error" onClose={() => setRefreshError(null)}>
+          {refreshError}
+        </Alert>
+      )}
+
+      <Box sx={{ mt: 0.5 }}>
+        <Button
+          data-testid="tabs-editor-refresh"
+          variant="outlined"
+          size="small"
+          startIcon={refreshing ? <CircularProgress size={14} /> : <RefreshIcon />}
+          onClick={handleRefresh}
+          disabled={disabled || refreshing}
+        >
+          {refreshing ? 'Refreshing...' : 'Refresh from YouTube'}
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+export default TabsEditor;

--- a/client/src/components/ChannelPage/components/__tests__/TabsEditor.test.tsx
+++ b/client/src/components/ChannelPage/components/__tests__/TabsEditor.test.tsx
@@ -1,0 +1,147 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import TabsEditor from '../TabsEditor';
+import { renderWithProviders } from '../../../../test-utils';
+
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  isAxiosError: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const axios = require('axios');
+
+describe('TabsEditor', () => {
+  const defaultProps = {
+    channelId: 'UC123',
+    token: 'test-token',
+    detectedTabs: ['videos', 'shorts', 'streams'],
+    hiddenTabs: [] as string[],
+    onHiddenTabsChange: jest.fn(),
+    onRefresh: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axios.isAxiosError.mockReturnValue(false);
+  });
+
+  test('renders a checkbox for each detected tab and marks them checked', () => {
+    renderWithProviders(<TabsEditor {...defaultProps} />);
+
+    expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeChecked();
+    expect(screen.getByTestId('tabs-editor-checkbox-shorts')).toBeChecked();
+    expect(screen.getByTestId('tabs-editor-checkbox-streams')).toBeChecked();
+  });
+
+  test('reflects hidden tabs as unchecked', () => {
+    renderWithProviders(<TabsEditor {...defaultProps} hiddenTabs={['shorts']} />);
+
+    expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeChecked();
+    expect(screen.getByTestId('tabs-editor-checkbox-shorts')).not.toBeChecked();
+    expect(screen.getByTestId('tabs-editor-checkbox-streams')).toBeChecked();
+  });
+
+  test('calls onHiddenTabsChange when a checkbox is unchecked', async () => {
+    const user = userEvent.setup();
+    const onHiddenTabsChange = jest.fn();
+    renderWithProviders(
+      <TabsEditor {...defaultProps} onHiddenTabsChange={onHiddenTabsChange} />
+    );
+
+    await user.click(screen.getByTestId('tabs-editor-checkbox-shorts'));
+
+    expect(onHiddenTabsChange).toHaveBeenCalledWith(['shorts']);
+  });
+
+  test('calls onHiddenTabsChange with remaining tabs when re-enabling a hidden tab', async () => {
+    const user = userEvent.setup();
+    const onHiddenTabsChange = jest.fn();
+    renderWithProviders(
+      <TabsEditor
+        {...defaultProps}
+        hiddenTabs={['shorts', 'streams']}
+        onHiddenTabsChange={onHiddenTabsChange}
+      />
+    );
+
+    await user.click(screen.getByTestId('tabs-editor-checkbox-streams'));
+
+    expect(onHiddenTabsChange).toHaveBeenCalledWith(['shorts']);
+  });
+
+  test('shows all-hidden error when every tab is hidden', () => {
+    renderWithProviders(
+      <TabsEditor {...defaultProps} hiddenTabs={['videos', 'shorts', 'streams']} />
+    );
+
+    expect(screen.getByText('At least one tab must remain visible.')).toBeInTheDocument();
+  });
+
+  test('shows empty-state message when no tabs have been detected', () => {
+    renderWithProviders(<TabsEditor {...defaultProps} detectedTabs={[]} />);
+
+    expect(
+      screen.getByText(/No tabs have been detected for this channel yet/)
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('tabs-editor-checkbox-videos')).not.toBeInTheDocument();
+  });
+
+  test('refresh button posts to /tabs/redetect and forwards result to onRefresh', async () => {
+    const user = userEvent.setup();
+    const onRefresh = jest.fn();
+    axios.post.mockResolvedValueOnce({
+      data: {
+        availableTabs: ['videos', 'streams'],
+        detectedTabs: ['videos', 'shorts', 'streams'],
+        hiddenTabs: ['shorts'],
+      },
+    });
+
+    renderWithProviders(
+      <TabsEditor {...defaultProps} hiddenTabs={['shorts']} onRefresh={onRefresh} />
+    );
+
+    await user.click(screen.getByTestId('tabs-editor-refresh'));
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/channels/UC123/tabs/redetect',
+        null,
+        { headers: { 'x-access-token': 'test-token' } }
+      );
+    });
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledWith({
+        availableTabs: ['videos', 'streams'],
+        detectedTabs: ['videos', 'shorts', 'streams'],
+        hiddenTabs: ['shorts'],
+      });
+    });
+  });
+
+  test('shows an error message when refresh fails', async () => {
+    const user = userEvent.setup();
+    axios.isAxiosError.mockReturnValue(true);
+    axios.post.mockRejectedValueOnce({
+      response: { status: 500, data: { error: 'yt-dlp exploded' } },
+    });
+
+    renderWithProviders(<TabsEditor {...defaultProps} />);
+
+    await user.click(screen.getByTestId('tabs-editor-refresh'));
+
+    await waitFor(() => {
+      expect(screen.getByText('yt-dlp exploded')).toBeInTheDocument();
+    });
+  });
+
+  test('disables checkboxes and refresh button while disabled prop is true', () => {
+    renderWithProviders(<TabsEditor {...defaultProps} disabled />);
+
+    expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeDisabled();
+    expect(screen.getByTestId('tabs-editor-refresh')).toBeDisabled();
+  });
+});

--- a/client/src/types/Channel.ts
+++ b/client/src/types/Channel.ts
@@ -5,7 +5,10 @@ export interface Channel {
   description?: string;
   title?: string;
   auto_download_enabled_tabs?: string;
+  // Effective (detected minus user-hidden) tab list, comma-separated.
   available_tabs?: string | null;
+  // User-hidden tabs, comma-separated. Only present on the settings endpoint.
+  hidden_tabs?: string | null;
   sub_folder?: string | null;
   video_quality?: string | null;
   min_duration?: number | null;

--- a/migrations/20260411232445-add-hidden-tabs-to-channels.js
+++ b/migrations/20260411232445-add-hidden-tabs-to-channels.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { addColumnIfMissing, removeColumnIfExists } = require('./helpers');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add hidden_tabs column to store user-selected tabs that should be hidden
+    // from the UI even when YouTube reports them as available. Comma-separated
+    // list of tab types ('videos', 'shorts', 'streams'). Null means nothing hidden.
+    await addColumnIfMissing(queryInterface, 'channels', 'hidden_tabs', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+      defaultValue: null
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await removeColumnIfExists(queryInterface, 'channels', 'hidden_tabs');
+  }
+};

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -190,7 +190,13 @@ const createServerModule = ({
           }),
           deleteChannel: jest.fn().mockResolvedValue({ success: true }),
           getChannelAvailableTabs: jest.fn().mockResolvedValue({ availableTabs: ['videos', 'shorts', 'streams']}),
-          updateAutoDownloadForTab: jest.fn().mockResolvedValue()
+          updateAutoDownloadForTab: jest.fn().mockResolvedValue(),
+          redetectChannelTabs: jest.fn().mockResolvedValue({
+            availableTabs: ['videos', 'shorts', 'streams'],
+            detectedTabs: ['videos', 'shorts', 'streams'],
+            hiddenTabs: [],
+            autoDownloadEnabledTabs: 'video'
+          })
         };
 
         const plexModuleMock = {
@@ -801,6 +807,72 @@ describe('server routes - channels', () => {
         error: 'Failed to update auto download setting',
         message: 'Database error'
       });
+    });
+  });
+
+  describe('POST /api/channels/:channelId/tabs/redetect', () => {
+    test('forces re-detection and returns the refreshed tabs', async () => {
+      const { app, channelModuleMock } = await createServerModule();
+      channelModuleMock.redetectChannelTabs.mockResolvedValueOnce({
+        availableTabs: ['videos', 'streams'],
+        detectedTabs: ['videos', 'shorts', 'streams'],
+        hiddenTabs: ['shorts'],
+        autoDownloadEnabledTabs: 'video'
+      });
+
+      const handlers = findRouteHandlers(app, 'post', '/api/channels/:channelId/tabs/redetect');
+      expect(handlers.length).toBeGreaterThan(0);
+      const redetectHandler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({ params: { channelId: 'channel-1' } });
+      const res = createMockResponse();
+
+      await redetectHandler(req, res);
+
+      expect(channelModuleMock.redetectChannelTabs).toHaveBeenCalledWith('channel-1');
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({
+        availableTabs: ['videos', 'streams'],
+        detectedTabs: ['videos', 'shorts', 'streams'],
+        hiddenTabs: ['shorts'],
+        autoDownloadEnabledTabs: 'video'
+      });
+    });
+
+    test('returns 404 when channel is not found', async () => {
+      const { app, channelModuleMock } = await createServerModule();
+      channelModuleMock.redetectChannelTabs.mockRejectedValueOnce(
+        new Error('Channel not found in database')
+      );
+
+      const handlers = findRouteHandlers(app, 'post', '/api/channels/:channelId/tabs/redetect');
+      const redetectHandler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({ params: { channelId: 'missing' } });
+      const res = createMockResponse();
+
+      await redetectHandler(req, res);
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toEqual({ error: 'Channel not found in database' });
+    });
+
+    test('returns 500 on unexpected error', async () => {
+      const { app, channelModuleMock } = await createServerModule();
+      channelModuleMock.redetectChannelTabs.mockRejectedValueOnce(
+        new Error('yt-dlp crashed')
+      );
+
+      const handlers = findRouteHandlers(app, 'post', '/api/channels/:channelId/tabs/redetect');
+      const redetectHandler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({ params: { channelId: 'channel-1' } });
+      const res = createMockResponse();
+
+      await redetectHandler(req, res);
+
+      expect(res.statusCode).toBe(500);
+      expect(res.body).toEqual({ error: 'Failed to re-detect available tabs' });
     });
   });
 

--- a/server/models/channel.js
+++ b/server/models/channel.js
@@ -51,6 +51,11 @@ Channel.init(
       allowNull: true,
       defaultValue: null,
     },
+    hidden_tabs: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      defaultValue: null,
+    },
     auto_download_enabled_tabs: {
       type: DataTypes.TEXT,
       allowNull: false,

--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -2837,6 +2837,278 @@ describe('ChannelModule', () => {
         expect(mockChannel.save).toHaveBeenCalled();
       });
     });
+
+    describe('hidden_tabs filtering', () => {
+      describe('computeEffectiveTabs', () => {
+        test('returns detected tabs when nothing hidden', () => {
+          const result = ChannelModule.computeEffectiveTabs('videos,shorts,streams', null);
+          expect(result).toEqual(['videos', 'shorts', 'streams']);
+        });
+
+        test('filters out hidden tabs', () => {
+          const result = ChannelModule.computeEffectiveTabs('videos,shorts,streams', 'shorts');
+          expect(result).toEqual(['videos', 'streams']);
+        });
+
+        test('filters multiple hidden tabs', () => {
+          const result = ChannelModule.computeEffectiveTabs('videos,shorts,streams', 'shorts,streams');
+          expect(result).toEqual(['videos']);
+        });
+
+        test('returns empty array when all detected are hidden', () => {
+          const result = ChannelModule.computeEffectiveTabs('videos,shorts', 'videos,shorts');
+          expect(result).toEqual([]);
+        });
+
+        test('returns empty array when available_tabs is null', () => {
+          const result = ChannelModule.computeEffectiveTabs(null, null);
+          expect(result).toEqual([]);
+        });
+
+        test('ignores hidden entries that are not in detected set', () => {
+          const result = ChannelModule.computeEffectiveTabs('videos', 'shorts,streams');
+          expect(result).toEqual(['videos']);
+        });
+
+        test('trims whitespace in both lists', () => {
+          const result = ChannelModule.computeEffectiveTabs(' videos , shorts ', ' shorts ');
+          expect(result).toEqual(['videos']);
+        });
+      });
+
+      describe('mapChannelToResponse with hidden_tabs', () => {
+        test('returns effective available_tabs excluding hidden tabs', () => {
+          const channel = {
+            channel_id: 'UC123',
+            uploader: 'Test',
+            uploader_id: 'UC123',
+            title: 'Test',
+            description: 'Test',
+            url: 'https://youtube.com/@test',
+            auto_download_enabled_tabs: 'video',
+            available_tabs: 'videos,shorts,streams',
+            hidden_tabs: 'shorts'
+          };
+
+          const result = ChannelModule.mapChannelToResponse(channel);
+
+          expect(result.available_tabs).toBe('videos,streams');
+        });
+
+        test('leaves available_tabs unchanged when hidden_tabs is null', () => {
+          const channel = {
+            channel_id: 'UC123',
+            uploader: 'Test',
+            uploader_id: 'UC123',
+            title: 'Test',
+            description: 'Test',
+            url: 'https://youtube.com/@test',
+            auto_download_enabled_tabs: 'video',
+            available_tabs: 'videos,shorts',
+            hidden_tabs: null
+          };
+
+          const result = ChannelModule.mapChannelToResponse(channel);
+
+          expect(result.available_tabs).toBe('videos,shorts');
+        });
+
+        test('returns null available_tabs when all detected are hidden', () => {
+          const channel = {
+            channel_id: 'UC123',
+            uploader: 'Test',
+            uploader_id: 'UC123',
+            title: 'Test',
+            description: 'Test',
+            url: 'https://youtube.com/@test',
+            auto_download_enabled_tabs: 'video',
+            available_tabs: 'videos',
+            hidden_tabs: 'videos'
+          };
+
+          const result = ChannelModule.mapChannelToResponse(channel);
+
+          expect(result.available_tabs).toBeNull();
+        });
+      });
+
+      describe('mapChannelListEntry with hidden_tabs', () => {
+        test('returns effective available_tabs excluding hidden tabs', () => {
+          const channel = {
+            url: 'https://youtube.com/@test',
+            uploader: 'Test',
+            channel_id: 'UC123',
+            auto_download_enabled_tabs: 'video',
+            available_tabs: 'videos,shorts,streams',
+            hidden_tabs: 'shorts,streams'
+          };
+
+          const result = ChannelModule.mapChannelListEntry(channel);
+
+          expect(result.available_tabs).toBe('videos');
+        });
+      });
+
+      describe('buildChannelVideosResponse with hidden_tabs', () => {
+        test('returns effective availableTabs excluding hidden tabs', () => {
+          const channel = {
+            ...mockChannelData,
+            available_tabs: 'videos,shorts,streams',
+            hidden_tabs: 'shorts'
+          };
+
+          const result = ChannelModule.buildChannelVideosResponse([mockVideoData], channel, 'cache', null, false, 'video');
+
+          expect(result.availableTabs).toEqual(['videos', 'streams']);
+        });
+      });
+
+      describe('getChannelAvailableTabs with hidden_tabs', () => {
+        test('returns effective tabs (detected minus hidden)', async () => {
+          const mockChannel = {
+            ...mockChannelData,
+            available_tabs: 'videos,shorts,streams',
+            hidden_tabs: 'shorts'
+          };
+          Channel.findOne.mockResolvedValue(mockChannel);
+
+          const result = await ChannelModule.getChannelAvailableTabs('UC123');
+
+          expect(result).toEqual({ availableTabs: ['videos', 'streams'] });
+        });
+      });
+    });
+
+    describe('redetectChannelTabs', () => {
+      test('probes tabs via yt-dlp even when available_tabs is cached', async () => {
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: 'shorts', // Pretend RSS era gave us only shorts
+          hidden_tabs: null,
+          auto_download_enabled_tabs: 'short'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn()
+          .mockImplementation(async (chId, tabType) => {
+            if (tabType === 'videos') return true;
+            if (tabType === 'shorts') return true;
+            if (tabType === 'streams') return true;
+            return false;
+          });
+
+        const result = await ChannelModule.redetectChannelTabs('UC123');
+
+        expect(ChannelModule.checkTabExistsViaYtdlp).toHaveBeenCalledWith('UC123', 'videos');
+        expect(ChannelModule.checkTabExistsViaYtdlp).toHaveBeenCalledWith('UC123', 'shorts');
+        expect(ChannelModule.checkTabExistsViaYtdlp).toHaveBeenCalledWith('UC123', 'streams');
+        expect(Channel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            available_tabs: 'videos,shorts,streams'
+          }),
+          { where: { channel_id: 'UC123' } }
+        );
+        expect(result.availableTabs).toEqual(['videos', 'shorts', 'streams']);
+        expect(result.detectedTabs).toEqual(['videos', 'shorts', 'streams']);
+      });
+
+      test('preserves hidden_tabs when re-detecting', async () => {
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: 'videos',
+          hidden_tabs: 'shorts',
+          auto_download_enabled_tabs: 'video'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn()
+          .mockImplementation(async (chId, tabType) => {
+            return tabType === 'videos' || tabType === 'shorts';
+          });
+
+        const result = await ChannelModule.redetectChannelTabs('UC123');
+
+        // The update call should NOT overwrite hidden_tabs
+        const updateCall = Channel.update.mock.calls[0][0];
+        expect(updateCall).not.toHaveProperty('hidden_tabs');
+
+        // Effective available_tabs = detected - hidden = [videos, shorts] - [shorts] = [videos]
+        expect(result.availableTabs).toEqual(['videos']);
+        // detectedTabs shows the raw detection
+        expect(result.detectedTabs).toEqual(['videos', 'shorts']);
+        expect(result.hiddenTabs).toEqual(['shorts']);
+      });
+
+      test('drops auto_download_enabled_tabs entries that are no longer detected', async () => {
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: 'videos,shorts,streams',
+          hidden_tabs: null,
+          auto_download_enabled_tabs: 'video,short,livestream'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        // Shorts no longer exists
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn()
+          .mockImplementation(async (chId, tabType) => {
+            return tabType === 'videos' || tabType === 'streams';
+          });
+
+        await ChannelModule.redetectChannelTabs('UC123');
+
+        const updateCall = Channel.update.mock.calls[0][0];
+        expect(updateCall.auto_download_enabled_tabs.split(',').sort())
+          .toEqual(['livestream', 'video'].sort());
+      });
+
+      test('drops auto_download_enabled_tabs entries that are hidden', async () => {
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: 'videos',
+          hidden_tabs: 'shorts',
+          auto_download_enabled_tabs: 'video,short'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn()
+          .mockImplementation(async (chId, tabType) => {
+            return tabType === 'videos' || tabType === 'shorts';
+          });
+
+        await ChannelModule.redetectChannelTabs('UC123');
+
+        const updateCall = Channel.update.mock.calls[0][0];
+        // short should have been stripped because shorts is in hidden_tabs
+        expect(updateCall.auto_download_enabled_tabs.split(',')).toEqual(['video']);
+      });
+
+      test('throws error when channel not found', async () => {
+        Channel.findOne.mockResolvedValue(null);
+        await expect(ChannelModule.redetectChannelTabs('UC999'))
+          .rejects.toThrow('Channel not found in database');
+      });
+
+      test('falls back to videos tab when all yt-dlp probes fail', async () => {
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: 'shorts',
+          hidden_tabs: null,
+          auto_download_enabled_tabs: 'short'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn().mockResolvedValue(false);
+
+        const result = await ChannelModule.redetectChannelTabs('UC123');
+
+        expect(result.detectedTabs).toEqual(['videos']);
+      });
+    });
   });
 
   describe('resolveChannelFolderName', () => {

--- a/server/modules/__tests__/channelSettingsModule.test.js
+++ b/server/modules/__tests__/channelSettingsModule.test.js
@@ -588,7 +588,7 @@ describe('ChannelSettingsModule', () => {
       Channel.findOne.mockResolvedValue(channel);
 
       const result = await channelSettingsModule.getChannelSettings('UC123456');
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         channel_id: 'UC123456',
         uploader: 'Test Channel',
         sub_folder: 'Music',
@@ -604,6 +604,32 @@ describe('ChannelSettingsModule', () => {
       await expect(
         channelSettingsModule.getChannelSettings('UC999999')
       ).rejects.toThrow('Channel not found');
+    });
+
+    test('includes detected_tabs, hidden_tabs, and effective available_tabs', async () => {
+      const channel = {
+        ...mockChannel,
+        available_tabs: 'videos,shorts,streams',
+        hidden_tabs: 'shorts'
+      };
+      Channel.findOne.mockResolvedValue(channel);
+
+      const result = await channelSettingsModule.getChannelSettings('UC123456');
+
+      expect(result.detected_tabs).toEqual(['videos', 'shorts', 'streams']);
+      expect(result.hidden_tabs).toEqual(['shorts']);
+      expect(result.available_tabs).toEqual(['videos', 'streams']);
+    });
+
+    test('returns empty arrays for detected_tabs/hidden_tabs when channel has no tab data', async () => {
+      const channel = { ...mockChannel };
+      Channel.findOne.mockResolvedValue(channel);
+
+      const result = await channelSettingsModule.getChannelSettings('UC123456');
+
+      expect(result.detected_tabs).toEqual([]);
+      expect(result.hidden_tabs).toEqual([]);
+      expect(result.available_tabs).toEqual([]);
     });
   });
 
@@ -743,6 +769,108 @@ describe('ChannelSettingsModule', () => {
       ).rejects.toThrow('Failed to move channel folder');
 
       expect(channel.update).toHaveBeenCalledWith({ sub_folder: null });
+    });
+
+    describe('hidden_tabs', () => {
+      test('persists hidden_tabs as comma-separated string', async () => {
+        const channel = {
+          ...mockChannel,
+          available_tabs: 'videos,shorts,streams',
+          hidden_tabs: null,
+          auto_download_enabled_tabs: 'video',
+          update: jest.fn().mockImplementation(function (data) {
+            Object.assign(this, data);
+            return Promise.resolve(this);
+          })
+        };
+        Channel.findOne.mockResolvedValue(channel);
+
+        const result = await channelSettingsModule.updateChannelSettings('UC123456', {
+          hidden_tabs: ['shorts']
+        });
+
+        expect(channel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ hidden_tabs: 'shorts' })
+        );
+        expect(result.settings.hidden_tabs).toEqual(['shorts']);
+        expect(result.settings.available_tabs).toEqual(['videos', 'streams']);
+      });
+
+      test('clears hidden_tabs when passed an empty array', async () => {
+        const channel = {
+          ...mockChannel,
+          available_tabs: 'videos,shorts',
+          hidden_tabs: 'shorts',
+          auto_download_enabled_tabs: 'video',
+          update: jest.fn().mockImplementation(function (data) {
+            Object.assign(this, data);
+            return Promise.resolve(this);
+          })
+        };
+        Channel.findOne.mockResolvedValue(channel);
+
+        await channelSettingsModule.updateChannelSettings('UC123456', {
+          hidden_tabs: []
+        });
+
+        expect(channel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ hidden_tabs: null })
+        );
+      });
+
+      test('rejects invalid tab type values', async () => {
+        const channel = {
+          ...mockChannel,
+          available_tabs: 'videos,shorts',
+          update: jest.fn()
+        };
+        Channel.findOne.mockResolvedValue(channel);
+
+        await expect(
+          channelSettingsModule.updateChannelSettings('UC123456', {
+            hidden_tabs: ['bogus']
+          })
+        ).rejects.toThrow('Invalid hidden_tabs');
+      });
+
+      test('rejects hiding every detected tab', async () => {
+        const channel = {
+          ...mockChannel,
+          available_tabs: 'videos,shorts',
+          update: jest.fn()
+        };
+        Channel.findOne.mockResolvedValue(channel);
+
+        await expect(
+          channelSettingsModule.updateChannelSettings('UC123456', {
+            hidden_tabs: ['videos', 'shorts']
+          })
+        ).rejects.toThrow('At least one tab must remain visible');
+      });
+
+      test('strips auto_download_enabled_tabs entries that map to a hidden tab', async () => {
+        const channel = {
+          ...mockChannel,
+          available_tabs: 'videos,shorts',
+          hidden_tabs: null,
+          auto_download_enabled_tabs: 'video,short',
+          update: jest.fn().mockImplementation(function (data) {
+            Object.assign(this, data);
+            return Promise.resolve(this);
+          })
+        };
+        Channel.findOne.mockResolvedValue(channel);
+
+        await channelSettingsModule.updateChannelSettings('UC123456', {
+          hidden_tabs: ['shorts']
+        });
+
+        const updateCall = channel.update.mock.calls.find(
+          (call) => 'auto_download_enabled_tabs' in (call[0] || {})
+        );
+        expect(updateCall).toBeDefined();
+        expect(updateCall[0].auto_download_enabled_tabs).toBe('video');
+      });
     });
   });
 

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -20,17 +20,7 @@ const { spawn, execSync } = require('child_process');
 
 const SUB_FOLDER_DEFAULT_KEY = '__default__';
 
-const TAB_TYPES = {
-  VIDEOS: 'videos',
-  SHORTS: 'shorts',
-  LIVE: 'streams',
-};
-
-const MEDIA_TAB_TYPE_MAP = {
-  'videos': 'video',
-  'shorts': 'short',
-  'streams': 'livestream',
-};
+const { TAB_TYPES, MEDIA_TAB_TYPE_MAP, parseTabCsv } = require('./tabsUtils');
 
 // Maximum number of videos to load when user clicks "Load More"
 // Limit set here because some channels have tens or hundreds of thousands of videos...
@@ -68,6 +58,33 @@ class ChannelModule {
       logger.error({ err: error, channelId: channel?.channel_id, mediaType }, 'Error parsing lastFetchedByTab');
       return null;
     }
+  }
+
+  /**
+   * Compute the "effective" available tabs for a channel by removing any
+   * user-hidden tabs from the detected list.
+   * @param {string|null} availableTabsCsv - Comma-separated list of detected tab types
+   * @param {string|null} hiddenTabsCsv - Comma-separated list of user-hidden tab types
+   * @returns {string[]} - Effective (detected minus hidden) tab types
+   */
+  computeEffectiveTabs(availableTabsCsv, hiddenTabsCsv) {
+    if (!availableTabsCsv) return [];
+
+    const detected = availableTabsCsv
+      .split(',')
+      .map((tab) => tab.trim())
+      .filter((tab) => tab.length > 0);
+
+    if (!hiddenTabsCsv) return detected;
+
+    const hidden = new Set(
+      hiddenTabsCsv
+        .split(',')
+        .map((tab) => tab.trim())
+        .filter((tab) => tab.length > 0)
+    );
+
+    return detected.filter((tab) => !hidden.has(tab));
   }
 
   /**
@@ -286,6 +303,7 @@ class ChannelModule {
    * @returns {Object} - Formatted channel response
    */
   mapChannelToResponse(channel) {
+    const effectiveTabs = this.computeEffectiveTabs(channel.available_tabs, channel.hidden_tabs);
     const out = {
       id: channel.channel_id,
       uploader: channel.uploader,
@@ -294,7 +312,7 @@ class ChannelModule {
       description: channel.description,
       url: channel.url,
       auto_download_enabled_tabs: channel.auto_download_enabled_tabs ?? 'video',
-      available_tabs: channel.available_tabs || null,
+      available_tabs: effectiveTabs.length > 0 ? effectiveTabs.join(',') : null,
       sub_folder: channel.sub_folder || null,
       video_quality: channel.video_quality || null,
       audio_format: channel.audio_format || null,
@@ -316,12 +334,13 @@ class ChannelModule {
    * @returns {Object} - Simplified channel representation
    */
   mapChannelListEntry(channel) {
+    const effectiveTabs = this.computeEffectiveTabs(channel.available_tabs, channel.hidden_tabs);
     const out = {
       url: channel.url,
       uploader: channel.uploader || '',
       channel_id: channel.channel_id || '',
       auto_download_enabled_tabs: channel.auto_download_enabled_tabs ?? 'video',
-      available_tabs: channel.available_tabs || null,
+      available_tabs: effectiveTabs.length > 0 ? effectiveTabs.join(',') : null,
       sub_folder: channel.sub_folder || null,
       video_quality: channel.video_quality || null,
       min_duration: channel.min_duration || null,
@@ -1817,8 +1836,10 @@ class ChannelModule {
    * @returns {Object} - Formatted response
    */
   buildChannelVideosResponse(videos, channel, dataSource = 'cache', stats = null, autoDownloadsEnabled = false, mediaType = 'video') {
-    // Parse available tabs if present
-    const availableTabs = channel && channel.available_tabs ? channel.available_tabs.split(',') : [];
+    // Parse available tabs if present (filters out user-hidden tabs)
+    const availableTabs = channel
+      ? this.computeEffectiveTabs(channel.available_tabs, channel.hidden_tabs)
+      : [];
 
     // Get the last fetched timestamp for this specific tab
     const lastFetched = channel ? this.getLastFetchedForTab(channel, mediaType) : null;
@@ -1896,9 +1917,46 @@ class ChannelModule {
   }
 
   /**
+   * Probe yt-dlp for each known tab type in parallel and return the list
+   * of detected tabs. Falls back to [TAB_TYPES.VIDEOS] if all probes fail
+   * so the channel stays usable. Shared by detectAndSaveChannelTabs and
+   * redetectChannelTabs to avoid drift between the two probe paths.
+   * @param {string} channelId - Channel ID to probe
+   * @returns {Promise<string[]>} - Detected tab types
+   * @private
+   */
+  async _probeTabsViaYtdlp(channelId) {
+    const tabTypesToTest = [TAB_TYPES.VIDEOS, TAB_TYPES.SHORTS, TAB_TYPES.LIVE];
+    const tabChecks = await Promise.all(
+      tabTypesToTest.map(async (tabType) => {
+        const exists = await this.checkTabExistsViaYtdlp(channelId, tabType);
+        if (exists) {
+          logger.info({ channelId, tabType }, 'Tab exists for channel');
+        } else {
+          logger.debug({ channelId, tabType }, 'Tab not available for channel');
+        }
+        return { tabType, exists };
+      })
+    );
+
+    const detected = tabChecks
+      .filter((result) => result.exists)
+      .map((result) => result.tabType);
+
+    if (detected.length === 0) {
+      logger.warn({ channelId }, 'All tab probes failed, defaulting to videos tab');
+      return [TAB_TYPES.VIDEOS];
+    }
+
+    return detected;
+  }
+
+  /**
    * Detect and save available tabs for a channel.
-   * Uses RSS feed checks for fast detection instead of yt-dlp.
-   * Uses activeFetches map to prevent concurrent detection for the same channel.
+   * Probes each tab type in parallel via yt-dlp. Short-circuits if
+   * the channel already has cached tabs (use redetectChannelTabs to
+   * force a fresh probe). Uses activeFetches map to prevent
+   * concurrent detection for the same channel.
    * @param {string} channelId - Channel ID to detect tabs for
    * @returns {Promise<{availableTabs: string[], autoDownloadEnabledTabs: string}|null>} - Detected tabs or null if skipped/failed
    */
@@ -1929,30 +1987,9 @@ class ChannelModule {
 
       logger.info({ channelId, channelTitle: channel.title }, 'Starting tab detection for channel (via yt-dlp)');
 
-      // Check all tabs in parallel using yt-dlp probing
-      const tabTypesToTest = [TAB_TYPES.VIDEOS, TAB_TYPES.SHORTS, TAB_TYPES.LIVE];
-      const tabChecks = await Promise.all(
-        tabTypesToTest.map(async (tabType) => {
-          const exists = await this.checkTabExistsViaYtdlp(channelId, tabType);
-          if (exists) {
-            logger.info({ channelId, tabType }, 'Tab exists for channel');
-          } else {
-            logger.debug({ channelId, tabType }, 'Tab not available for channel');
-          }
-          return { tabType, exists };
-        })
-      );
-
-      let availableTabs = tabChecks
-        .filter(result => result.exists)
-        .map(result => result.tabType);
-
-      // Fallback: if all RSS checks failed (e.g., network timeout), assume "videos" tab exists
-      // This prevents channels from being added with no tabs, which would make them unusable
-      if (availableTabs.length === 0) {
-        logger.warn({ channelId }, 'All tab checks failed, defaulting to videos tab');
-        availableTabs = [TAB_TYPES.VIDEOS];
-      }
+      // Probe every tab type in parallel via yt-dlp. Helper handles the
+      // fallback-to-videos behavior if all probes fail.
+      const availableTabs = await this._probeTabsViaYtdlp(channelId);
 
       // Determine auto_download_enabled_tabs: preserve existing user choice if set,
       // otherwise pick a smart default based on available tabs
@@ -1999,10 +2036,107 @@ class ChannelModule {
   }
 
   /**
+   * Force a fresh yt-dlp probe of a channel's tabs, bypassing any cached
+   * available_tabs value. Preserves the user's hidden_tabs selection and
+   * rewrites auto_download_enabled_tabs to drop any tabs that are no
+   * longer detected or are currently hidden.
+   *
+   * Concurrent calls for the same channel collapse to a single yt-dlp
+   * burst via the activeFetches map: a second caller receives the
+   * existing in-flight promise instead of spawning its own probe. This
+   * bounds at most one probe burst per channel in flight at any time.
+   *
+   * Use this when a channel's cached available_tabs is known to be stale
+   * (e.g. the RSS-era detection wrote a wrong value) and the user wants
+   * to re-run detection from the UI.
+   *
+   * @param {string} channelId - Channel ID to re-detect
+   * @returns {Promise<{availableTabs: string[], detectedTabs: string[], hiddenTabs: string[], autoDownloadEnabledTabs: string}>}
+   */
+  async redetectChannelTabs(channelId) {
+    const fetchKey = `redetect-tabs-${channelId}`;
+    const existing = this.activeFetches.get(fetchKey);
+    if (existing && existing.promise) {
+      logger.debug({ channelId }, 'redetectChannelTabs already running, awaiting in-flight probe');
+      return existing.promise;
+    }
+
+    const promise = this._redetectChannelTabsInner(channelId);
+    this.activeFetches.set(fetchKey, {
+      startTime: new Date().toISOString(),
+      type: 'tabRedetection',
+      promise,
+    });
+
+    try {
+      return await promise;
+    } finally {
+      this.activeFetches.delete(fetchKey);
+    }
+  }
+
+  /**
+   * Inner implementation of the redetect flow. Always executes a yt-dlp
+   * probe and database update. Do not call directly; go through
+   * redetectChannelTabs so the concurrency guard applies.
+   * @param {string} channelId - Channel ID to re-detect
+   * @returns {Promise<{availableTabs: string[], detectedTabs: string[], hiddenTabs: string[], autoDownloadEnabledTabs: string}>}
+   * @private
+   */
+  async _redetectChannelTabsInner(channelId) {
+    const channel = await Channel.findOne({ where: { channel_id: channelId } });
+    if (!channel) {
+      throw new Error('Channel not found in database');
+    }
+
+    logger.info({ channelId, channelTitle: channel.title }, 'Forcing tab re-detection for channel (via yt-dlp)');
+
+    const detectedTabs = await this._probeTabsViaYtdlp(channelId);
+    const hiddenTabs = parseTabCsv(channel.hidden_tabs);
+
+    // Compute effective tabs (what the user actually sees)
+    const effectiveTabs = this.computeEffectiveTabs(detectedTabs.join(','), channel.hidden_tabs);
+
+    // Rewrite auto_download_enabled_tabs: keep only entries whose
+    // corresponding tabType is both detected AND not hidden.
+    const validMediaTypes = new Set(effectiveTabs.map((tabType) => MEDIA_TAB_TYPE_MAP[tabType]).filter(Boolean));
+    const existingAutoTabs = parseTabCsv(channel.auto_download_enabled_tabs);
+    const filteredAutoTabs = existingAutoTabs.filter((mt) => validMediaTypes.has(mt));
+    const newAutoDownloadEnabledTabs = filteredAutoTabs.join(',');
+
+    await Channel.update(
+      {
+        available_tabs: detectedTabs.join(','),
+        auto_download_enabled_tabs: newAutoDownloadEnabledTabs
+      },
+      { where: { channel_id: channelId } }
+    );
+
+    logger.info(
+      { channelId, detectedTabs, hiddenTabs, effectiveTabs, autoDownloadEnabledTabs: newAutoDownloadEnabledTabs },
+      'Tab re-detection completed'
+    );
+
+    MessageEmitter.emitMessage('broadcast', null, 'channel', 'channelTabsDetected', {
+      channelId,
+      availableTabs: effectiveTabs,
+      autoDownloadEnabledTabs: newAutoDownloadEnabledTabs
+    });
+
+    return {
+      availableTabs: effectiveTabs,
+      detectedTabs,
+      hiddenTabs,
+      autoDownloadEnabledTabs: newAutoDownloadEnabledTabs
+    };
+  }
+
+  /**
    * Get available tabs for a channel.
-   * Returns cached result if available, otherwise detects tabs via RSS feeds.
+   * Returns cached result if available (filtered through hidden_tabs),
+   * otherwise detects tabs now via yt-dlp probing.
    * @param {string} channelId - Channel ID to get tabs for
-   * @returns {Promise<Object>} - Object with availableTabs array
+   * @returns {Promise<Object>} - Object with availableTabs array (effective set)
    */
   async getChannelAvailableTabs(channelId) {
     const channel = await Channel.findOne({
@@ -2013,18 +2147,20 @@ class ChannelModule {
       throw new Error('Channel not found in database');
     }
 
-    // Fast path: return cached tabs
+    // Fast path: return cached tabs (filtered through hidden_tabs)
     if (channel.available_tabs) {
       return {
-        availableTabs: channel.available_tabs.split(','),
+        availableTabs: this.computeEffectiveTabs(channel.available_tabs, channel.hidden_tabs),
       };
     }
 
-    // No tabs cached - detect them now (fast via RSS feeds)
+    // No tabs cached - detect them now via yt-dlp probing
     const result = await this.detectAndSaveChannelTabs(channelId);
+    const detectedTabs = result?.availableTabs || [];
+    const hiddenTabsCsv = channel.hidden_tabs || null;
 
     return {
-      availableTabs: result?.availableTabs || [],
+      availableTabs: this.computeEffectiveTabs(detectedTabs.join(','), hiddenTabsCsv),
     };
   }
 

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -6,6 +6,8 @@ const plexModule = require('./plexModule');
 const { Op } = require('sequelize');
 const logger = require('../logger');
 const ratingMapper = require('./ratingMapper');
+
+const { MEDIA_TAB_TYPE_MAP, VALID_TAB_TYPES, parseTabCsv } = require('./tabsUtils');
 const {
   GLOBAL_DEFAULT_SENTINEL,
   ROOT_SENTINEL,
@@ -517,6 +519,10 @@ class ChannelSettingsModule {
       throw new Error('Channel not found');
     }
 
+    const detectedTabs = parseTabCsv(channel.available_tabs);
+    const hiddenTabsSet = new Set(parseTabCsv(channel.hidden_tabs));
+    const availableTabs = detectedTabs.filter((tab) => !hiddenTabsSet.has(tab));
+
     return {
       channel_id: channel.channel_id,
       uploader: channel.uploader,
@@ -528,7 +534,51 @@ class ChannelSettingsModule {
       audio_format: channel.audio_format,
       default_rating: channel.default_rating,
       skip_video_folder: channel.skip_video_folder,
+      detected_tabs: detectedTabs,
+      hidden_tabs: Array.from(hiddenTabsSet),
+      available_tabs: availableTabs,
     };
+  }
+
+  /**
+   * Validate a hidden_tabs array from a user request.
+   * @param {any} hiddenTabs - The value provided in the update payload
+   * @param {string|null} detectedTabsCsv - The channel's current available_tabs (detected)
+   * @returns {{ valid: boolean, error?: string, normalized?: string[] }}
+   */
+  validateHiddenTabs(hiddenTabs, detectedTabsCsv) {
+    if (hiddenTabs === null || hiddenTabs === undefined) {
+      return { valid: true, normalized: [] };
+    }
+    if (!Array.isArray(hiddenTabs)) {
+      return { valid: false, error: 'Invalid hidden_tabs: must be an array of tab types' };
+    }
+
+    const normalized = [];
+    for (const entry of hiddenTabs) {
+      if (typeof entry !== 'string' || !VALID_TAB_TYPES.has(entry)) {
+        return {
+          valid: false,
+          error: `Invalid hidden_tabs entry: ${entry}. Allowed values: videos, shorts, streams`
+        };
+      }
+      if (!normalized.includes(entry)) {
+        normalized.push(entry);
+      }
+    }
+
+    const detected = parseTabCsv(detectedTabsCsv);
+    if (detected.length > 0) {
+      const remaining = detected.filter((tab) => !normalized.includes(tab));
+      if (remaining.length === 0) {
+        return {
+          valid: false,
+          error: 'At least one tab must remain visible'
+        };
+      }
+    }
+
+    return { valid: true, normalized };
   }
 
   /**
@@ -624,6 +674,16 @@ class ChannelSettingsModule {
       }
     }
 
+    // Validate hidden_tabs if provided
+    let normalizedHiddenTabs = null;
+    if (settings.hidden_tabs !== undefined) {
+      const validation = this.validateHiddenTabs(settings.hidden_tabs, channel.available_tabs);
+      if (!validation.valid) {
+        throw new Error(validation.error);
+      }
+      normalizedHiddenTabs = validation.normalized;
+    }
+
     // Store old subfolder for potential move
     const oldSubFolder = channel.sub_folder;
     const newSubFolder = settings.sub_folder !== undefined ?
@@ -663,6 +723,25 @@ class ChannelSettingsModule {
     if (settings.skip_video_folder !== undefined) {
       updateData.skip_video_folder = settings.skip_video_folder;
     }
+    if (normalizedHiddenTabs !== null) {
+      updateData.hidden_tabs = normalizedHiddenTabs.length > 0
+        ? normalizedHiddenTabs.join(',')
+        : null;
+
+      // When a tab is hidden, strip its corresponding media type from
+      // auto_download_enabled_tabs so we don't auto-download something the
+      // user has hidden from view.
+      const hiddenMediaTypes = new Set(
+        normalizedHiddenTabs
+          .map((tabType) => MEDIA_TAB_TYPE_MAP[tabType])
+          .filter(Boolean)
+      );
+      const currentAuto = parseTabCsv(channel.auto_download_enabled_tabs);
+      const filteredAuto = currentAuto.filter((mt) => !hiddenMediaTypes.has(mt));
+      if (filteredAuto.length !== currentAuto.length) {
+        updateData.auto_download_enabled_tabs = filteredAuto.join(',');
+      }
+    }
 
     // Update database FIRST to ensure changes are persisted before slow file operations
     // This prevents issues where HTTP requests timeout during file operations
@@ -698,6 +777,11 @@ class ChannelSettingsModule {
       }
     }
 
+    const detectedTabsAfter = parseTabCsv(updatedChannel.available_tabs);
+    const hiddenTabsAfter = parseTabCsv(updatedChannel.hidden_tabs);
+    const hiddenSetAfter = new Set(hiddenTabsAfter);
+    const availableTabsAfter = detectedTabsAfter.filter((tab) => !hiddenSetAfter.has(tab));
+
     return {
       settings: {
         channel_id: updatedChannel.channel_id,
@@ -710,6 +794,9 @@ class ChannelSettingsModule {
         audio_format: updatedChannel.audio_format,
         default_rating: updatedChannel.default_rating,
         skip_video_folder: updatedChannel.skip_video_folder,
+        detected_tabs: detectedTabsAfter,
+        hidden_tabs: hiddenTabsAfter,
+        available_tabs: availableTabsAfter,
       },
       folderMoved: subFolderChanged,
       moveResult

--- a/server/modules/tabsUtils.js
+++ b/server/modules/tabsUtils.js
@@ -1,0 +1,36 @@
+/**
+ * Shared tab-type constants and helpers used by channelModule and
+ * channelSettingsModule. Both modules originally duplicated these
+ * definitions; this module is the single source of truth.
+ */
+
+const TAB_TYPES = Object.freeze({
+  VIDEOS: 'videos',
+  SHORTS: 'shorts',
+  LIVE: 'streams',
+});
+
+const MEDIA_TAB_TYPE_MAP = Object.freeze({
+  videos: 'video',
+  shorts: 'short',
+  streams: 'livestream',
+});
+
+const VALID_TAB_TYPES = new Set(Object.values(TAB_TYPES));
+
+/**
+ * Parse a comma-separated tab CSV string into a trimmed, non-empty array.
+ * @param {string|null|undefined} csv
+ * @returns {string[]}
+ */
+function parseTabCsv(csv) {
+  if (!csv) return [];
+  return csv.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+}
+
+module.exports = {
+  TAB_TYPES,
+  MEDIA_TAB_TYPE_MAP,
+  VALID_TAB_TYPES,
+  parseTabCsv,
+};

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -394,6 +394,73 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
 
   /**
    * @swagger
+   * /api/channels/{channelId}/tabs/redetect:
+   *   post:
+   *     summary: Force re-detection of a channel's available tabs
+   *     description: >
+   *       Bypasses the cached `available_tabs` value and re-probes the
+   *       channel's tabs via yt-dlp. Preserves `hidden_tabs` and
+   *       rewrites `auto_download_enabled_tabs` to drop entries whose
+   *       tab is no longer detected or is currently hidden. Use this
+   *       when a channel's cached tab list is known to be wrong.
+   *     tags: [Channels]
+   *     parameters:
+   *       - in: path
+   *         name: channelId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: YouTube channel ID
+   *     responses:
+   *       200:
+   *         description: Tabs re-detected successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 availableTabs:
+   *                   type: array
+   *                   description: Effective tabs (detected minus hidden)
+   *                   items:
+   *                     type: string
+   *                     enum: [videos, shorts, streams]
+   *                 detectedTabs:
+   *                   type: array
+   *                   description: Raw tabs found by yt-dlp
+   *                   items:
+   *                     type: string
+   *                     enum: [videos, shorts, streams]
+   *                 hiddenTabs:
+   *                   type: array
+   *                   items:
+   *                     type: string
+   *                     enum: [videos, shorts, streams]
+   *                 autoDownloadEnabledTabs:
+   *                   type: string
+   *       404:
+   *         description: Channel not found
+   *       500:
+   *         description: Failed to re-detect tabs
+   */
+  router.post('/api/channels/:channelId/tabs/redetect', verifyToken, async (req, res) => {
+    const { channelId } = req.params;
+    req.log.info({ channelId }, 'Forcing re-detection of available tabs for channel');
+
+    try {
+      const result = await channelModule.redetectChannelTabs(channelId);
+      res.status(200).json(result);
+    } catch (error) {
+      if (error.message === 'Channel not found in database') {
+        return res.status(404).json({ error: 'Channel not found in database' });
+      }
+      req.log.error({ err: error, channelId }, 'Failed to re-detect available tabs');
+      res.status(500).json({ error: 'Failed to re-detect available tabs' });
+    }
+  });
+
+  /**
+   * @swagger
    * /api/channels/{channelId}/settings:
    *   get:
    *     summary: Get channel settings


### PR DESCRIPTION
- Add hidden_tabs column on channels with a migration so users can hide detected YouTube tabs (videos/shorts/streams) from the channel page, the channel list, and auto-download
- Add a TabsEditor component inside the channel settings dialog with a checkbox per detected tab and a "Refresh from YouTube" button
- Add POST /api/channels/:channelId/tabs/redetect and channelModule.redetectChannelTabs to force a fresh yt-dlp probe, bypassing the cached available_tabs value; guard concurrent calls through activeFetches
- Preserve hidden_tabs on redetect and drop auto_download_enabled_tabs entries whose tab type is hidden or no longer detected
- Filter available_tabs in channel responses (mapChannelToResponse, mapChannelListEntry, getChannelAvailableTabs, buildChannelVideosResponse, getChannelSettings) through hidden_tabs so consumers see the effective set
- Sync ChannelVideos to a parent-supplied channelAvailableTabs prop so the tab strip updates immediately after a hidden_tabs save instead of waiting for the next channel reload
- Extract TAB_TYPES, MEDIA_TAB_TYPE_MAP, and parseTabCsv into server/modules/tabsUtils.js so channelModule and channelSettingsModule share one source of truth
- Reject saves that would hide every detected tab on both client and server, and disable the Save button when all tabs are unchecked

<img width="780" height="531" alt="image" src="https://github.com/user-attachments/assets/20d3d17d-7e16-4680-9690-4a8573c64c9e" />
