### PR TITLE
Release: Video detail modal, per-subfolder Plex libraries, and more!

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 ### Backend (server/)
 - `server.js`: Express entry point. `db.js`: Sequelize setup. `logger.js`: Pino logger with request correlation.
 - `models/`: Sequelize models (channel, video, job, jobvideo, jobvideodownload, channelvideo, session, apikey). Associations: Channel hasMany Videos, Job hasMany JobVideos.
-- `routes/`: API handlers (auth, channels, videos, config, jobs, plex, setup, subscriptions, apikeys, health). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.
-- `modules/`: class-based singletons holding business logic. Top-level modules include `channelModule`, `downloadModule`, `plexModule`, `jobModule`, `configModule`, `videosModule`, `webSocketServer`, `databaseHealthModule`, `notificationModule`, `channelSettingsModule`, `videoDeletionModule`, `nfoGenerator`, `cronJobs`, `apiKeyModule`, `ytdlpModule`, `messageEmitter`.
+- `routes/`: API handlers (auth, channels, videos, videoDetail, config, jobs, plex, setup, subscriptions, apikeys, health). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.
+- `modules/`: class-based singletons holding business logic. Top-level modules include `channelModule`, `downloadModule`, `plexModule`, `jobModule`, `configModule`, `videosModule`, `videoMetadataModule`, `webSocketServer`, `databaseHealthModule`, `notificationModule`, `channelSettingsModule`, `videoDeletionModule`, `nfoGenerator`, `cronJobs`, `apiKeyModule`, `ytdlpModule`, `messageEmitter`.
 - `modules/download/`: download orchestration (`downloadExecutor`, `ytdlpCommandBuilder`, `DownloadProgressMonitor`, `tempPathManager`, `videoMetadataProcessor`).
 - `modules/filesystem/`: path/file abstraction (`pathBuilder`, `directoryManager`, `fileOperations`, `sanitizer`, `constants`). Good example of the sub-module aggregator pattern.
 - `modules/notifications/`: multi-service notifications via Apprise (`serviceRegistry`, `formatters/`, `senders/`). Good example of a pluggable service registry.
@@ -41,6 +41,7 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 ### Frontend (client/src/)
 - `App.tsx`: app routing plus a global `fetch()` override that detects 503 `requiresDbFix` responses and surfaces the database error overlay. You can use normal `fetch()` anywhere; database errors are handled automatically.
 - `components/`: feature directories and pages. Complex features pair a top-level `FeatureName.tsx` with a same-named `FeatureName/` directory holding `components/`, `hooks/`, and `__tests__/`. Examples of this sibling-file layout: `ChannelManager.tsx` + `ChannelManager/`, `Configuration.tsx` + `Configuration/`, `ChannelPage.tsx` + `ChannelPage/`. Newer features (e.g. `SubscriptionImport/`) put the main component at `FeatureName/index.tsx` instead; either layout is acceptable for new features.
+- `components/shared/`: reusable components used across multiple features (e.g. `VideoModal/` for the video detail modal, `ThumbnailClickOverlay` for clickable thumbnail hotspots, `DeleteVideosDialog`).
 - `hooks/`: app-wide custom hooks for data fetching and state.
 - `contexts/` and `providers/`: React Context for cross-cutting concerns (auth token, WebSocket, theme).
 - `config/configSchema.ts`: the `CONFIG_FIELDS` registry. Use this pattern when adding new configuration fields; it auto-derives types, defaults, and change tracking.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,644 +10,254 @@ Youtarr is a Dockerized application that automatically downloads videos from You
 - **Frontend**: React/TypeScript application with Material-UI components
 - **Infrastructure**: Docker Compose setup with separate containers for app and database
 
-## Architecture
+## Scope Discipline
 
-### Backend Structure (server/)
-- `server.js`: Main Express server entry point
-- `db.js`: Database connection and Sequelize setup
-- `logger.js`: Pino-based structured logging with request correlation
-- `models/`: Sequelize models (channel, video, job, jobvideo, jobvideodownload, channelvideo, session, apikey)
-- `routes/`: API route handlers
-  - `auth.js`: Authentication and session management
-  - `channels.js`: Channel subscription and refresh
-  - `videos.js`: Video browsing and download triggers
-  - `config.js`: Application configuration
-  - `jobs.js`: Download job status
-  - `plex.js`: Plex integration
-  - `setup.js`: Initial setup wizard
-  - `subscriptions.js`: Subscription import (Takeout CSV, cookies upload, import jobs)
-  - `apikeys.js`: API key management
-  - `health.js`: Health check endpoints
-- `modules/`: Core business logic modules
-  - `channelModule.js`: YouTube channel management
-  - `downloadModule.js`: Video download handling via yt-dlp
-  - `plexModule.js`: Plex Media Server integration
-  - `jobModule.js`: Background job processing
-  - `configModule.js`: Configuration management
-  - `videosModule.js`: Video metadata and processing
-  - `webSocketServer.js`: WebSocket communication for real-time updates
-  - `databaseHealthModule.js`: Database connection validation and schema health checks
-  - `notificationModule.js`: Multi-service notifications via Apprise (Discord, Slack, Telegram, Email, Pushover, Gotify, Ntfy, Matrix, etc.)
-  - `channelSettingsModule.js`: Per-channel settings (subfolders, quality overrides)
-  - `videoDeletionModule.js`: Video file and database deletion with dry-run support
-  - `nfoGenerator.js`: NFO metadata file generation for Jellyfin/Kodi/Emby
-  - Additional modules: `cronJobs.js` (scheduled tasks), `apiKeyModule.js` (API key auth), `ytdlpModule.js` (yt-dlp updates), `messageEmitter.js` (WebSocket broadcasting)
-- `modules/download/`: Download orchestration
-  - `downloadExecutor.js`: Main download orchestration
-  - `ytdlpCommandBuilder.js`: yt-dlp command construction
-  - `DownloadProgressMonitor.js`: Real-time progress tracking
-  - `tempPathManager.js`: Temporary file management
-  - `videoMetadataProcessor.js`: Metadata extraction
-- `modules/filesystem/`: File system abstraction layer
-  - `pathBuilder.js`: Download path construction
-  - `directoryManager.js`: Directory creation and management
-  - `fileOperations.js`: File move/copy operations
-  - `sanitizer.js`: Filename sanitization
-  - `constants.js`: Filesystem constants
-- `modules/notifications/`: Multi-service notification system
-  - `serviceRegistry.js`: Service detection (Discord, Slack, Telegram, Email, etc.)
-  - `formatters/`: Service-specific message formatters
-  - `senders/`: Delivery mechanisms (Discord webhooks, Apprise)
-- `modules/subscriptionImport/`: Bulk subscription import orchestration
-  - `index.js`: Aggregator entry point
-  - `importJobRunner.js`: Import job execution and channel resolution
-  - `takeoutParser.js`: Google Takeout CSV parsing
-  - `cookiesFetcher.js`: Cookie-based channel fetching
-  - `thumbnailEnricher.js`: Channel thumbnail resolution
-  - `concurrencyLimiter.js`: Parallel request throttling
-  - `errorClassifier.js`: Import error categorization
-  - `constants.js`: Import-related constants
+**IMPORTANT: Change only what the task requires.** This rule overrides every other rule in this file when they conflict.
+
+- **Bug fixes**: make the minimum change needed to fix the bug. Do not rewrite surrounding code for style, extract helpers you don't need for the fix, or clean up while you're there.
+- **Features**: touch only files the feature requires. Write new code to the standards below. Leave pre-existing code alone unless the feature forces you to change it.
+- **Refactors**: only when the user explicitly asks for a refactor, and only as wide as the user scopes it.
+- **Unrelated issues you notice** (oversized files, duplication, legacy patterns, missing tests, `console.log` calls, `any` types, drifted error-response shapes): list them in your final report so the user can decide whether to address them. **Do not fix them.**
+- **When in doubt**: ask. A small clarifying question is cheaper than an unwanted refactor.
+
+The size and quality rules in this file apply to code you are **creating or substantially rewriting**. They are not a mandate to refactor existing code you pass through.
 
 ## Task Handling
 
-For multi-part requests (e.g., 'review this PR AND explain WebSocket handling'), explicitly acknowledge all parts and complete each one before considering the task done.
+For multi-part requests (e.g., "review this PR AND explain WebSocket handling"), explicitly acknowledge all parts and complete each one before considering the task done.
 
-### Frontend Structure (client/src/)
-- `App.tsx`: Main application component with routing
-- `components/`: React components organized by feature
-  - `ChannelManager/`: Channel subscription management (with `hooks/`, `components/`, and `components/chips/` subdirectories)
-  - `ChannelPage/`: Individual channel detail page (with `hooks/` and `components/` subdirectories)
-  - `DownloadManager/`: Download queue and history
-  - `VideosPage/`: Video browsing and filtering
-  - `Configuration/`: App settings with 10+ sections in `sections/` subdirectory, reusable UI in `common/`, and feature hooks in `hooks/`
-  - `InitialSetup.tsx`: First-time setup wizard
-  - `LocalLogin.tsx`: Local user authentication form
-  - `StorageStatus.tsx`: Real-time storage status display
-  - `SubscriptionImport/`: Bulk channel import from YouTube (with `hooks/`, `components/`, and `__tests__/` subdirectories)
-  - `shared/`: Shared/reusable components (e.g., DeleteVideosDialog) and hooks
-  - Additional pages: `ChangelogPage.tsx`, `PlexAuthDialog.tsx`, `DatabaseErrorOverlay.tsx`, `ErrorBoundary.tsx`
-- `hooks/`: Custom React hooks for data fetching and state management
-- `theme.ts`: Material-UI theme configuration (light/dark mode)
-- `config/`: Configuration schemas and validation (Zod schemas)
-- `types/`: TypeScript type definitions
-- `contexts/`: React Context definitions (e.g., WebSocketContext)
-- `providers/`: Context provider implementations (e.g., WebSocketProvider)
-- `utils/`: Utility functions and helpers
+## Architecture
 
-#### Frontend API Error Handling
-**Database Error Detection:** The global `fetch()` function is automatically overridden in `App.tsx` to detect database errors across all API calls. This means:
+### Backend (server/)
+- `server.js`: Express entry point. `db.js`: Sequelize setup. `logger.js`: Pino logger with request correlation.
+- `models/`: Sequelize models (channel, video, job, jobvideo, jobvideodownload, channelvideo, session, apikey). Associations: Channel hasMany Videos, Job hasMany JobVideos.
+- `routes/`: API handlers (auth, channels, videos, config, jobs, plex, setup, subscriptions, apikeys, health). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.
+- `modules/`: class-based singletons holding business logic. Top-level modules include `channelModule`, `downloadModule`, `plexModule`, `jobModule`, `configModule`, `videosModule`, `webSocketServer`, `databaseHealthModule`, `notificationModule`, `channelSettingsModule`, `videoDeletionModule`, `nfoGenerator`, `cronJobs`, `apiKeyModule`, `ytdlpModule`, `messageEmitter`.
+- `modules/download/`: download orchestration (`downloadExecutor`, `ytdlpCommandBuilder`, `DownloadProgressMonitor`, `tempPathManager`, `videoMetadataProcessor`).
+- `modules/filesystem/`: path/file abstraction (`pathBuilder`, `directoryManager`, `fileOperations`, `sanitizer`, `constants`). Good example of the sub-module aggregator pattern.
+- `modules/notifications/`: multi-service notifications via Apprise (`serviceRegistry`, `formatters/`, `senders/`). Good example of a pluggable service registry.
+- `modules/subscriptionImport/`: bulk channel import (`importJobRunner`, `takeoutParser`, `cookiesFetcher`, `thumbnailEnricher`, `concurrencyLimiter`, `errorClassifier`).
 
-- ✅ You can use normal `fetch()` syntax anywhere in the frontend
-- ✅ Database errors (503 responses with `requiresDbFix: true`) are automatically detected
-- ✅ The database error overlay appears automatically during outages
-- ✅ No special wrapper functions or imports needed
-
-**Implementation:** When the backend returns a 503 status with `requiresDbFix: true` in the JSON response, the overridden fetch automatically dispatches a custom event that triggers the database error overlay with appropriate messaging and polling for recovery.
+### Frontend (client/src/)
+- `App.tsx`: app routing plus a global `fetch()` override that detects 503 `requiresDbFix` responses and surfaces the database error overlay. You can use normal `fetch()` anywhere; database errors are handled automatically.
+- `components/`: feature directories and pages. Complex features pair a top-level `FeatureName.tsx` with a same-named `FeatureName/` directory holding `components/`, `hooks/`, and `__tests__/`. Examples of this sibling-file layout: `ChannelManager.tsx` + `ChannelManager/`, `Configuration.tsx` + `Configuration/`, `ChannelPage.tsx` + `ChannelPage/`. Newer features (e.g. `SubscriptionImport/`) put the main component at `FeatureName/index.tsx` instead; either layout is acceptable for new features.
+- `hooks/`: app-wide custom hooks for data fetching and state.
+- `contexts/` and `providers/`: React Context for cross-cutting concerns (auth token, WebSocket, theme).
+- `config/configSchema.ts`: the `CONFIG_FIELDS` registry. Use this pattern when adding new configuration fields; it auto-derives types, defaults, and change tracking.
+- `theme.ts`: Material-UI theme (light/dark mode). `types/`, `utils/`: shared types and helpers.
 
 ### Database
-- MariaDB 10.3 with utf8mb4 support for full Unicode
-- Sequelize migrations in `migrations/`
-- Models use associations: Channel hasMany Videos, Job hasMany JobVideos
+- MariaDB 10.3 with utf8mb4. Migrations in `migrations/` run automatically on container startup. Create new migrations with `./scripts/db-create-migration.sh migration-name`.
 
-## Code Quality Standards
+### Reference docs (consult these instead of re-deriving from code)
+- `docs/DEVELOPMENT.md`: dev environment setup, `./scripts/build-dev.sh` (flags: `--install-deps`, `--no-cache`) and `./scripts/start-dev.sh` (flags: `--no-auth`, `--debug`, `--headless-auth`, `--pull-latest`, `--dev`, `--arm`, `--external-db`), Vite HMR dev server option (`cd client && npm run dev` on port 3000), running tests, Swagger/OpenAPI docs at `/swagger` and `/swagger.json`.
+- `docs/DOCKER.md`: Docker architecture (two containers), Compose file variants (main, ARM override, external-db), volume layout, NAS configuration, backup/restore, platform deployment (`DATA_PATH`, `AUTH_ENABLED`, `PLEX_URL`).
+- `docs/DATABASE.md`: schema tables, internal vs external database, migration workflow, idempotent migration helpers, troubleshooting.
+- `docs/ENVIRONMENT_VARIABLES.md`: all env vars (`DB_*`, `YOUTUBE_OUTPUT_DIR`, `DATA_PATH`, `YOUTARR_UID/GID`, `AUTH_ENABLED`, `AUTH_PRESET_*`, `PLEX_URL`, `LOG_LEVEL`, `TZ`, `YOUTARR_IMAGE`).
+- `docs/CONFIG.md`: `config/config.json` schema. Real field names include `plexApiKey`, `plexYoutubeLibraryId`, `plexSubfolderLibraryMappings`, `plexIP`/`plexPort`/`plexViaHttps`/`plexUrl`, `channelAutoDownload`, `channelDownloadFrequency` (cron), `channelFilesToDownload`, `preferredResolution`, `videoCodec`, `defaultSubfolder`, plus groups for SponsorBlock, notifications (`appriseUrls`), download performance, and auto-removal. Legacy `cronSchedule` is auto-migrated to `channelDownloadFrequency` on startup.
+- `docs/AUTHENTICATION.md`: Plex OAuth, local auth (bcrypt, `username`/`passwordHash`), API keys (`x-api-key` header, rate-limited, download-only scope), session management (`x-access-token`, 7-day expiry), headless bootstrap via `AUTH_PRESET_*`.
+- `docs/API_INTEGRATION.md`: API key integration for external tools (bookmarklets, iOS Shortcuts, Android Tasker, Home Assistant, cURL/Python/JS). Documents the `/api/videos/download` endpoint, rate limits, and CORS/auth-proxy bypass for Cloudflare Zero Trust and Authelia.
+- `docs/TROUBLESHOOTING.md`: common runtime issues.
+
+### Implementation notes (non-obvious behaviors)
+- **Plex integration** uses OAuth; the user must be the Plex server admin. The target Plex library must be "Other Videos" with the "Personal Media" agent.
+- **Video downloads**: yt-dlp writes to a temp location, then post-processing finalizes files into the channel's target directory. Resume-on-partial-download is supported.
+- **WebSocket server** shares the HTTP server port (3011 in container, 3087 on host) via the `ws` library; there is no separate WS port.
+- **Deno** is installed in the container; yt-dlp uses it automatically for JS-heavy extractors.
+
+## Code Quality Standards (for new and rewritten code)
+
+These standards apply when you are authoring new code or doing an explicit rewrite. See **Scope Discipline** above.
 
 ### General Principles
-
-- **DRY (Don't Repeat Yourself)**: Extract duplicated logic into shared utilities or modules. If you see the same pattern 3+ times, it should be abstracted.
-- **Single Responsibility**: Each module, class, or function should have one clear purpose. If a function name requires "and" to describe it, split it.
-- **Keep files focused**: Backend modules should stay under ~500 lines. Frontend components should stay under ~300 lines. If a file grows beyond this, extract sub-modules or child components. (Several legacy files exceed these limits -- `channelModule.js` at 2356 lines, `downloadExecutor.js` at 1505 lines, `VideosPage.tsx` at 1047 lines -- these should not be used as examples to follow.)
-- **No magic numbers**: Use named constants. Timeouts, retry counts, limits, and default values should be defined as named constants at the top of the file or in a shared constants module, not embedded inline.
-- **Prefer early returns**: Reduce nesting by returning early for error/edge cases rather than wrapping the happy path in deep conditionals.
+- **DRY when writing the third copy**: if you find yourself writing the same logic a third time in your own new code, extract it.
+- **Single responsibility**: each module, class, or function should have one clear purpose. If a function name requires "and" to describe it, split it.
+- **Right-size your extractions**: do not create helpers, components, or hooks for one-time operations. Three similar lines of code is better than a premature abstraction. If a helper is used in exactly one place, inline it.
+- **File size targets for new files**: backend modules under ~500 lines, frontend components under ~300 lines. Several legacy files exceed these limits (notably `channelModule.js`, `jobModule.js`, `channelSettingsModule.js`, `videoDeletionModule.js`, `VideosPage.tsx`, `ChannelVideos.tsx`, `DownloadProgress.tsx`) - do not use them as examples. The codebase is migrating toward these targets over time.
+- **Named constants for magic values**: in new code, timeouts, retry counts, limits, and defaults should be named constants at the top of the file or in a shared constants module.
+- **Early returns** for error and edge cases, to keep happy-path nesting shallow.
+- **Comments**: only where the logic is not self-evident. Do not add docstrings, type comments, or explanatory prose to code you did not change.
 
 ### Backend Standards (Node.js/Express)
 
 #### Logging
-- **Always use the Pino logger** (`require('../logger')` or `require('../../logger')`), never `console.log` or `console.error`. The logger provides structured output, log levels, and automatic sensitive-data redaction.
-- **Use structured logging** with context objects: `logger.error({ err: error, videoId }, 'Download failed')` -- not string interpolation.
-- **Use appropriate log levels**: `error` for failures that need attention, `warn` for recoverable issues, `info` for significant operations, `debug` for diagnostic detail.
+- **Always use the Pino logger** (`require('../logger')`), never `console.log` or `console.error`.
+- **Structured logging** with context objects: `logger.error({ err: error, videoId }, 'Download failed')`, not string interpolation.
+- **Levels**: `error` for failures needing attention, `warn` for recoverable issues, `info` for significant operations, `debug` for diagnostic detail.
 
 #### Error Handling
-- **Standard API error response format**: All error responses from routes must use this structure:
-  ```javascript
-  res.status(statusCode).json({ error: 'Human-readable error message' });
-  ```
-- **Always catch async errors** in route handlers. Use try-catch and return proper HTTP status codes. Never let unhandled promise rejections escape.
-- **Log errors with context**: Include relevant IDs, operation names, and the error object using structured logging (see above).
-- **Use specific error codes** where applicable (e.g., 400 for bad input, 404 for not found, 409 for conflicts, 503 for service unavailable).
+- **Standard error response shape**: `res.status(statusCode).json({ error: 'Human-readable message' })`. The codebase has drift (`{ success: false, error }`, `{ status, message }`); new code must use `{ error }`.
+- **Always catch async errors** in route handlers with try-catch. Never let unhandled promise rejections escape.
+- **Specific status codes**: 400 for bad input, 401 for unauthenticated, 403 for forbidden, 404 for not found, 409 for conflicts, 503 for service unavailable.
+- **Log errors with context**: include relevant IDs, operation names, and the error object.
 
 #### Route Patterns
-- **Use the dependency injection factory pattern** for all route files. Routes export a factory function that receives dependencies:
+- **Dependency injection factory pattern** for all new route files:
   ```javascript
   function createMyRoutes({ verifyToken, myModule }) {
     const router = express.Router();
-    // ... route definitions
+    // ...
     return router;
   }
   module.exports = createMyRoutes;
   ```
-  This is the established pattern (see `server/routes/index.js`). Never import modules directly in route files.
-- **Keep routes thin**: Routes should validate input, call module methods, and format responses. Business logic belongs in modules.
+  Never import modules directly inside route files; receive them as factory arguments.
+- **Keep routes thin**: validate input, call module methods, format responses. Business logic belongs in modules.
 
 #### Module Patterns
-- **Class-based singletons**: Modules export a single instance (`module.exports = new MyModule()`). Follow this pattern for new modules.
-- **Avoid circular dependencies**: If module A and module B need each other, restructure the dependency (extract shared logic, use events, or pass dependencies at call time). Do not use late-binding `require()` inside methods as a workaround.
-- **Use the established sub-module pattern** for complex features. Good examples to follow:
-  - `server/modules/filesystem/` -- clean aggregator index with namespaced exports
-  - `server/modules/notifications/` -- service registry with pluggable formatters and senders
+- **Class-based singletons**: new modules export a single instance (`module.exports = new MyModule()`).
+- **Avoid circular dependencies**: restructure the dependency graph, extract shared logic, use events, or pass dependencies at call time. Do not use late-binding `require()` inside methods as a workaround. Some existing modules (e.g., `cronJobs.js`) use late-binding; do not copy the pattern.
+- **Sub-module aggregator pattern** for complex features: see `server/modules/filesystem/` and `server/modules/notifications/` as good examples.
 
 #### Database
-- **Use Sequelize model methods** for queries, not raw SQL, unless there's a specific performance reason.
-- **Create migrations using the script**: `./scripts/db-create-migration.sh migration-name`. Never manually create migration files.
-- **Use transactions** for multi-step database operations that must be atomic.
+- **Sequelize model methods** for queries, not raw SQL, unless there is a specific performance reason. Raw queries must use explicit parameter binding.
+- **Create migrations using the script**: `./scripts/db-create-migration.sh migration-name`. Never create migration files manually.
+- **Transactions** for multi-step operations that must be atomic.
 
 ### Frontend Standards (React/TypeScript)
 
 #### TypeScript
-- **No `any` types**: Use proper types for all variables, parameters, and return values. Especially:
-  - Error handlers: Use `unknown` and type-narrow instead of `catch (err: any)`
-  - API responses: Define interfaces for all response shapes
-  - WebSocket messages: Type the message payloads
-  - Event handlers: Use React's built-in event types
-- **Define interfaces** for component props, API responses, and shared data structures. Co-locate types with their feature when specific, or place in `client/src/types/` when shared.
-- **Use the CONFIG_FIELDS registry pattern** (`client/src/config/configSchema.ts`) when adding new configuration fields -- it auto-derives types, defaults, and change tracking.
+- **No `any` in new code**. Use proper types everywhere:
+  - Error handlers: `catch (err: unknown)` with type narrowing.
+  - API responses, WebSocket payloads: define interfaces.
+  - Event handlers: use React's built-in event types.
+- **Define interfaces** for props, API payloads, and shared data. Co-locate feature-specific types with the feature; put shared types in `client/src/types/`.
+- **CONFIG_FIELDS registry**: use `client/src/config/configSchema.ts` when adding new configuration fields.
+- The codebase has ~300 existing `any` occurrences; do not add more.
 
 #### Component Structure
-- **Decompose large components**: If a component has more than ~10 state variables or exceeds ~300 lines, extract logic into custom hooks and UI into child components.
-- **Feature directory structure**: For complex features, organize as:
+- **When authoring or rewriting a component**: aim for fewer than 10 `useState` calls and under 300 lines. If you cross that threshold while writing new code, extract logic into custom hooks and UI into child components.
+- **Feature directory layout** for new complex features, either of these is acceptable:
   ```
+  # Sibling-file layout (most common in this repo)
+  FeatureName.tsx              # the main component
   FeatureName/
-  ├── components/       # Child components
-  ├── hooks/           # Feature-specific hooks
-  ├── __tests__/       # Tests and stories
-  └── index.tsx        # Main component (or separate file)
+  ├── components/
+  ├── hooks/
+  └── __tests__/
+
+  # index.tsx layout
+  FeatureName/
+  ├── components/
+  ├── hooks/
+  ├── __tests__/
+  └── index.tsx
   ```
-  Good examples: `ChannelManager/`, `Configuration/`, `ChannelPage/`.
+  Sibling-file examples: `ChannelManager.tsx`, `Configuration.tsx`, `ChannelPage.tsx`. `index.tsx` example: `SubscriptionImport/`.
 
 #### Custom Hooks
-- **Extract data fetching and state logic** into custom hooks. Each hook should manage one concern (e.g., `useChannelList` for channel data, `useConfigSave` for save operations).
-- **Standard hook return pattern**: Return an object with `{ data, loading, error, ...actions }` for consistency across hooks.
-- **Clean up effects**: Always return cleanup functions from `useEffect` for subscriptions, timers, and event listeners.
-- **Memoize expensive computations**: Use `useMemo` for derived data and `useCallback` for callbacks passed to children, but don't over-memoize trivial values.
+- **Extract data fetching and multi-step state logic** into hooks. Each hook owns one concern.
+- **Return shape**: `{ data, loading, error, ...actions }` for consistency.
+- **Do not extract one-off state**: local component state read in exactly one place stays inline.
+- **Cleanup effects**: always return cleanup from `useEffect` for subscriptions, timers, and event listeners.
+- **Memoize deliberately**: `useMemo` for genuinely expensive derivations, `useCallback` for callbacks passed to memoized children. Do not over-memoize trivial values.
 
 #### Styling
-- **Use MUI's `sx` prop** for all styling. Do not use inline `style` attributes -- they bypass the theme system and don't support responsive breakpoints, hover states, or dark mode.
-  ```typescript
-  // Good
-  <Box sx={{ p: 2, display: 'flex', bgcolor: 'background.paper' }}>
-  
-  // Bad
-  <Box style={{ padding: '16px', display: 'flex' }}>
-  ```
-- **Use theme values** instead of hardcoded colors: `theme.palette.primary.main` not `'#1976d2'`.
-- **Use responsive breakpoints**: `useMediaQuery(theme.breakpoints.down('sm'))` for mobile-responsive behavior.
+- **Use MUI's `sx` prop** for styling, not inline `style`. `sx` is theme-aware, responsive, and supports hover states and dark mode.
+- **Theme values**: `theme.palette.primary.main`, not `'#1976d2'`.
+- **Responsive breakpoints**: `useMediaQuery(theme.breakpoints.down('sm'))`.
 
 #### API Calls
-- **Use Axios** for API calls (not `fetch`). This is the established pattern for data-fetching hooks.
-- **Include auth headers via the token prop**: `headers: { 'x-access-token': token }`. Hooks receive `token` from their calling component.
-- **Type API responses**: Define interfaces for request and response payloads.
-- **Handle errors with specific status codes** where applicable (403, 404, 503) rather than generic catch-all messages.
+- **Use Axios** in new hooks and components. A few legacy hooks use raw `fetch()` (`client/src/hooks/useConfig.ts` and `client/src/components/Configuration/hooks/usePlexConnection.ts`); do not copy them.
+- **Auth headers**: `headers: { 'x-access-token': token }`. Hooks receive `token` from the calling component.
+- **Type requests and responses** with interfaces.
+- **Handle specific status codes** (403, 404, 503) rather than generic catch-alls.
+- **Exception**: the global `fetch()` override in `App.tsx` is the one place `fetch` is intentional, for database error detection.
 
 #### State Management
-- Use React Context for cross-cutting concerns (auth token, WebSocket, theme).
-- Use local `useState` / `useReducer` for component-specific state.
-- Use custom events sparingly and only for decoupled communication (e.g., `CONFIG_UPDATED_EVENT`).
+- React Context for cross-cutting concerns (auth, WebSocket, theme).
+- Local `useState` / `useReducer` for component-specific state.
+- Custom events sparingly, only for decoupled communication (e.g., `CONFIG_UPDATED_EVENT`).
 
-## Important Tool Usage
+## Security
 
-### File Searching
-- **Always use `rg` (ripgrep) instead of `grep`** - it's faster and more powerful
-- ripgrep is pre-installed and should be your default search tool
-- Example: `rg "pattern" --type ts` instead of `grep -r "pattern" *.ts`
+Youtarr shells out to `yt-dlp` and writes files using user-influenced paths, so this section is not optional.
 
-## Common Development Commands
+- **Validate untrusted input at route boundaries**. Check types, lengths, and shape before passing anything to modules. Return 400 with `{ error }` for invalid input.
+- **Never interpolate user data into shell commands or filesystem paths directly.** Use the existing helpers: `modules/download/ytdlpCommandBuilder.js`, `modules/filesystem/pathBuilder.js`, `modules/filesystem/sanitizer.js`. If a new helper is needed, add it to those modules, not inline in a route.
+- **Auth by default**: new routes must wire `verifyToken` unless the user explicitly says the route is public. If you add a public route, call it out in your final report so the user can confirm.
+- **Never log secrets**. Pino redacts known keys, but do not bypass redaction by interpolating tokens, passwords, cookies, or API keys into log messages.
+- **Treat uploaded files as untrusted**: Takeout CSV and cookies uploads in the subscription import flow must be validated, size-limited, and parsed defensively.
+- **Sequelize protects against SQL injection only when using model methods**. Raw queries require explicit parameterization.
+- **Rate-limit endpoints that accept external identifiers or credentials** (follow the existing pattern in `server/routes/videos.js` and `server/routes/auth.js`).
 
-### Development with Docker
-For development, use the Docker-based "build-and-test" workflow. See [Development Guide](docs/DEVELOPMENT.md) for detailed instructions:
+## Testing
 
-```bash
-# Build development environment
-./scripts/build-dev.sh
-
-# Start development environment
-./scripts/start-dev.sh
-
-# Additional start-dev.sh options:
-# ./scripts/start-dev.sh --no-auth        # Disable authentication
-# ./scripts/start-dev.sh --headless-auth  # Bootstrap auth credentials for headless deployments
-# ./scripts/start-dev.sh --pull-latest    # Pull latest git commits and Docker images
-# ./scripts/start-dev.sh --debug          # Enable debug logging
-
-# Access the app at http://localhost:3087
-
-# After making code changes, rebuild and restart:
-./scripts/build-dev.sh
-./scripts/start-dev.sh  # Automatically stops and restarts
-
-# View logs
-docker compose logs -f
-
-# Stop development environment
-./scripts/stop-dev.sh
-```
-
-**Development Setup Characteristics:**
-- ❌ No hot reload - code changes require rebuild
-- ✅ Tests code in actual Docker environment
-- ✅ Consistent with production container
-- ✅ Includes all system dependencies (yt-dlp, ffmpeg)
-- ℹ️ For faster iteration during active development, consider running backend/frontend outside Docker, then test in Docker before committing
-
-### Production with Docker
-```bash
-# Start application (creates .env on first run, pulls latest, starts containers)
-./start.sh
-
-# Start script options:
-./start.sh --pull-latest    # Update before starting
-./start.sh --dev            # Use bleeding-edge dev image
-./start.sh --arm            # Force ARM compose file
-./start.sh --external-db    # Use external database
-./start.sh --no-auth        # Disable authentication
-./start.sh --headless-auth  # Bootstrap auth credentials
-./start.sh --debug          # Enable debug logging
-
-# Stop application
-./stop.sh
-
-# View logs
-docker compose logs -f
-```
-
-### Code Quality
-```bash
-# Run ESLint on both frontend and backend
-npm run lint
-
-# Additional lint commands
-npm run lint:frontend    # Frontend only
-npm run lint:backend     # Backend only
-npm run lint:ts          # TypeScript type checking
-npm run lint:fix         # Auto-fix linting issues
-
-# Run tests with coverage
-npm run test:coverage
-
-# Lint is also configured with Husky for pre-commit hooks
-```
-
-### Testing
-
-**Always run tests from the project root:**
+**Run tests from the project root.** See `docs/DEVELOPMENT.md` for the full workflow.
 
 ```bash
-# Run all frontend tests
-npm run test:frontend
-
-# Run specific frontend test
-npm run test:frontend -- client/src/hooks/__tests__/useStorageStatus.test.ts
-
-# Run all backend tests
-npm run test:backend
-
-# Run specific backend test
-npm run test:backend -- server/modules/__tests__/videosModule.test.js
+npm run test:frontend                                        # all frontend tests
+npm run test:frontend -- client/src/hooks/__tests__/foo.ts   # one frontend test
+npm run test:backend                                         # all backend tests
+npm run test:backend -- server/modules/__tests__/foo.test.js # one backend test
+npm run lint                                                  # lint front + back
+npm run lint:ts                                               # TypeScript typecheck
 ```
 
-#### Important Testing Guidelines
-When writing tests with React Testing Library, **always follow these rules to avoid linting errors**:
+### Test Execution Policy
+**NEVER skip tests.** No `test.skip()`, no `describe.skip()`, no commented-out failing tests. Fix failing tests or delete them if obsolete. If a test is written, it must run and pass in CI.
 
-1. **Never use direct DOM queries** like `querySelector`, `parentElement`, or other native DOM methods
-   - ❌ BAD: `button.querySelector('[data-testid="AddIcon"]')`
-   - ✅ GOOD: `screen.getByTestId('AddIcon')`
+### React Testing Library Rules
+- **No direct DOM queries**: no `querySelector`, `parentElement`, or other native DOM access. Use `getByRole`, `getByLabelText`, `getByText`, `getByTestId`, and `within()` for scoped queries. ESLint enforces this via `testing-library/no-node-access`.
+- **No conditional `expect`** calls.
+- **Assert behavior, not implementation**. Test what the code does, not how.
 
-2. **Use Testing Library queries exclusively**:
-   - Avoid direct Node access. Prefer using the methods from Testing Library!
-   - `getBy...` / `queryBy...` / `findBy...` for single elements
-   - `getAllBy...` / `queryAllBy...` / `findAllBy...` for multiple elements
-   - Common queries: `ByRole`, `ByLabelText`, `ByPlaceholderText`, `ByText`, `ByTestId`
+### Jest Mocking Gotchas (project-specific)
+These are real landmines that cost time, not general Jest advice. Full examples live in existing tests under `server/modules/__tests__/` and `client/src/**/__tests__/`; consult them before mocking a new dependency.
 
-3. **For parent element access**, restructure your tests:
-   - Instead of `.parentElement`, use more specific queries
-   - Consider using `within()` for scoped queries
-   - Use accessible roles and labels rather than DOM structure
+1. **Mocking React components**: do NOT use JSX inside `jest.mock()`. Jest hoists the mock and JSX fails with "Invalid variable access." Use `React.createElement` via `require('react')` inside the factory.
+2. **Mocking axios**: use a factory (`jest.mock('axios', () => ({ get: jest.fn(), post: jest.fn(), ... }))`) and `require('axios')` after the mock. Direct ES6 `import axios from 'axios'` fails with ESM errors.
+3. **Mocking `fetch` JSON**: mock `json` as `jest.fn().mockResolvedValueOnce(...)`, not an async arrow function; the latter returns the wrong shape.
+4. **Mock path resolution**: mock paths are relative to the test file, not the component under test. Double-check `../` vs `../../`.
 
-4. **ESLint will flag violations** with: `testing-library/no-node-access`
-   - This rule ensures tests remain maintainable and less brittle
-   - Tests should interact with components as users would
+### Backend Test Setup
+- Place `jest.mock()` calls before `require()` imports.
+- Use `jest.resetModules()` and `jest.clearAllMocks()` in `beforeEach`, then re-require the module under test.
+- Mock only external dependencies (db, fs, HTTP, logger). Over-mocking internal module methods usually indicates a design issue.
 
-5. **Avoid calling `expect` conditionally**
+### Hook Test Setup
+- Use `renderHook` with explicit type annotations for parameterized hooks (e.g., `renderHook(({ token }: { token: string | null }) => useMyHook(token), { initialProps: { token: null } })`).
+- Use `waitFor` for async state changes, not arbitrary timeouts.
+- For polling/interval tests, use fake timers (`jest.useFakeTimers()`) and clean up with `jest.runOnlyPendingTimers()` + `jest.useRealTimers()` in `afterEach`.
+- Test cleanup on unmount.
 
-#### Jest Mocking Best Practices
+### Test Quality
+- Each test asserts one thing. A test with 15 assertions is testing too much.
+- Meaningful names: `'returns empty array when no channels exist'`, not `'test case 1'`.
+- Minimal setup: only what the specific test needs; use `beforeEach` for genuinely shared setup.
+- Do not test private implementation details. If you need to expose internals to test them, the API design needs work.
 
-1. **Mocking React Components in Tests**
-   - Jest has hoisting issues when mocking components with JSX
-   - ❌ BAD: Using JSX directly in jest.mock() causes "Invalid variable access" errors
-   ```javascript
-   jest.mock('../Component', () => {
-     return function MockComponent() {
-       return <div>Mock</div>; // This will fail!
-     }
-   });
-   ```
-   - ✅ GOOD: Use React.createElement to avoid hoisting issues
-   ```javascript
-   jest.mock('../Component', () => ({
-     __esModule: true,
-     default: function MockComponent(props) {
-       const React = require('react');
-       return React.createElement('div', { 'data-testid': 'mock' }, 'Mock');
-     }
-   }));
-   ```
+## Documentation Sync
 
-2. **Mocking axios**
-   - Use a factory function with `jest.mock()` to mock only the HTTP methods you need
-   - Import axios using `require()` after the mock (not ES6 import)
-   - ❌ BAD: `import axios from 'axios'` (will fail with ESM import errors)
-   - ✅ GOOD: Use factory function and require
-   ```javascript
-   // Mock axios with only the methods you need
-   jest.mock('axios', () => ({
-     get: jest.fn(),
-     post: jest.fn(),
-     delete: jest.fn(),
-   }));
+When a code change creates or invalidates information in this file or in `docs/`, update the docs in the same PR. This is not optional; stale docs are how we got here.
 
-   const axios = require('axios');
-
-   // In your test
-   axios.get.mockResolvedValueOnce({ data: mockData });
-   ```
-
-3. **Mocking fetch() Calls**
-   - Always mock the json() method as a jest function that returns a promise
-   - ❌ BAD: `json: async () => ({ data })`
-   - ✅ GOOD: `json: jest.fn().mockResolvedValueOnce({ data })`
-   ```javascript
-   mockFetch.mockResolvedValueOnce({
-     ok: true,
-     status: 200,
-     json: jest.fn().mockResolvedValueOnce({ data: 'value' })
-   });
-   ```
-
-4. **Mock Path Resolution**
-   - Mock paths must be relative to the test file location, not the component
-   - Double-check parent directory references (../ vs ../../)
-
-#### Hook Testing Patterns
-
-When testing custom React hooks, follow these patterns:
-
-1. **Basic Hook Testing Setup**
-   ```typescript
-   import { renderHook, waitFor } from '@testing-library/react';
-   import { useMyHook } from '../useMyHook';
-
-   describe('useMyHook', () => {
-     const { result } = renderHook(() => useMyHook(params));
-
-     expect(result.current.data).toBe(expected);
-   });
-   ```
-
-2. **Testing Hooks with Parameters (TypeScript)**
-   - Always provide explicit type annotations for renderHook callbacks
-   ```typescript
-   const { result, rerender } = renderHook(
-     ({ token }: { token: string | null }) => useStorageStatus(token),
-     { initialProps: { token: null as string | null } }
-   );
-
-   // Change props to trigger re-render
-   rerender({ token: 'new-token' });
-   ```
-
-3. **Testing Async Hooks**
-   - Use `waitFor` to wait for async state updates
-   - Wait for specific state changes, not just arbitrary delays
-   ```typescript
-   await waitFor(() => {
-     expect(result.current.loading).toBe(false);
-   });
-
-   await waitFor(() => {
-     expect(result.current.data).toEqual(expectedData);
-   });
-   ```
-
-4. **Testing Hooks with Timers (Polling, Intervals)**
-   - Use fake timers to control time-based behavior
-   - Clean up properly to avoid test interference
-   ```typescript
-   beforeEach(() => {
-     jest.clearAllMocks();
-     jest.useFakeTimers();
-   });
-
-   afterEach(() => {
-     jest.runOnlyPendingTimers();
-     jest.useRealTimers();
-   });
-
-   test('polls at interval', async () => {
-     // Initial fetch
-     await waitFor(() => {
-       expect(mockFn).toHaveBeenCalledTimes(1);
-     });
-
-     // Advance timers
-     jest.advanceTimersByTime(60000);
-
-     await waitFor(() => {
-       expect(mockFn).toHaveBeenCalledTimes(2);
-     });
-   });
-   ```
-
-5. **Testing Hook Cleanup (useEffect cleanup)**
-   ```typescript
-   test('cleans up on unmount', async () => {
-     const { unmount } = renderHook(() => useMyHook());
-
-     unmount();
-
-     // Verify cleanup happened (e.g., intervals cleared)
-     jest.advanceTimersByTime(60000);
-     expect(mockFn).toHaveBeenCalledTimes(1); // No additional calls
-   });
-   ```
-
-#### Backend Test Patterns
-
-Backend tests use Jest with extensive mocking. Follow these patterns:
-
-1. **Mock setup order**: Place all `jest.mock()` calls before `require()` imports. Use `jest.resetModules()` in `beforeEach` to ensure clean state.
-2. **Module loading after mocks**: Re-require the module under test in `beforeEach` after resetting modules:
-   ```javascript
-   let myModule;
-   beforeEach(() => {
-     jest.resetModules();
-     jest.clearAllMocks();
-     myModule = require('../myModule');
-   });
-   ```
-3. **Test structure**: Use descriptive `describe` blocks organized by method, and `test`/`it` blocks that describe the expected behavior (not the implementation).
-4. **Avoid over-mocking**: Only mock external dependencies (database, file system, HTTP). If you need to mock internal module methods to test, the module likely has a design issue.
-
-#### Test Quality Standards
-- **Tests must assert behavior, not implementation**: Test what the code does (outputs, side effects, state changes), not how it does it internally.
-- **Each test should test one thing**: A test with 15 assertions is testing too many things. Split it up.
-- **Use meaningful test names**: `'returns empty array when no channels exist'` not `'test case 1'`.
-- **Keep test setup minimal**: Only set up what the specific test needs. Use `beforeEach` for truly shared setup only.
-- **Don't test private implementation details**: If you need to expose internals just for testing, the API design needs work.
-
-#### Test Execution Policy
-**NEVER skip tests** - All tests must either pass or be fixed:
-- ❌ Never use `test.skip()` or `describe.skip()`
-- ❌ Never comment out failing tests
-- ✅ Fix failing tests immediately or remove them if obsolete
-- ✅ Tests should be comprehensive and actually test functionality
-- If a test is created, it must run and pass in CI/CD
-
-#### Running Individual Tests
-
-**Run from project root** using the appropriate npm script:
-
-Frontend tests:
-```bash
-npm run test:frontend -- client/src/hooks/__tests__/useStorageStatus.test.ts
-```
-
-Backend tests:
-```bash
-npm run test:backend -- server/modules/__tests__/videosModule.test.js
-```
-
-## Key Configuration
-
-### Environment Variables (Docker)
-- `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`: Database connection
-- `YOUTUBE_OUTPUT_DIR`: Host directory for downloaded videos (set in .env file)
-- `DATA_PATH`: Optional override for video storage path (used in platform deployments like Elfhosted)
-- `YOUTARR_UID`, `YOUTARR_GID`: Container user/group IDs for file permissions
-- `AUTH_PRESET_USERNAME`, `AUTH_PRESET_PASSWORD`: Headless auth bootstrap credentials
-- `LOG_LEVEL`: Logging verbosity (warn/info/debug)
-- `TZ`: Timezone for scheduled jobs
-
-### Application Config (config/config.json)
-- `plexApiKey`: Plex authentication token
-- `youtubeOutputDirectory`: Where videos are saved
-- `plexLibrarySection`: Plex library ID for YouTube videos
-- `youtubeApiKey`: Optional, for browsing channel videos in-app
-- `cronSchedule`: Download schedule (default: every 6 hours)
-
-## Important Implementation Details
-
-### Plex Integration
-- Uses Plex OAuth for authentication - must use same account as Plex server admin
-- Automatically triggers library scan after downloads
-- Videos organized in channel-named subdirectories
-- Plex library must be "Other Videos" type with "Personal Media" agent
-
-### Video Downloads
-- Uses yt-dlp for downloading (included in Docker image)
-- Downloads video, thumbnail, and metadata (.info.json)
-- Post-processes files for Plex compatibility
-- Supports resume on partial downloads
-
-### WebSocket Communication
-- Real-time updates for download progress
-- Channel refresh status
-- Job status updates
-- Uses ws library, shares HTTP server port (3011 in container, 3087 on host)
-
-### API Documentation
-- Swagger/OpenAPI documentation available at `/swagger`
-- All endpoints annotated for automatic documentation generation
-
-### Database Migrations
-- Run automatically on container startup
-- **Create new migrations using the script**: `./scripts/db-create-migration.sh migration-name`
-  - This uses sequelize-cli with the correct config and generates a properly timestamped migration file
-  - Alternative command: `npm run db:create-migration -- --name migration-name`
-  - ❌ Never manually create migration files - always use the script
-- Migrations support utf8mb4 for emoji support
-
-## Docker Architecture
-- Two containers: `youtarr` (app) and `youtarr-db` (MariaDB)
-- Health checks ensure database is ready before app starts
-- Volumes persist database data and configuration
-- Network isolation with `youtarr-network`
-- Deno is installed in the container to enhance yt-dlp performance (yt-dlp automatically uses Deno when available in PATH)
-
-### Docker Compose Files
-- `docker-compose.yml`: Main production configuration
-- `docker-compose.dev.yml`: Development overrides (code mounting, debug logging)
-- `docker-compose.arm.yml`: ARM architecture support (Apple Silicon, Raspberry Pi)
-- `docker-compose.external-db.yml`: External database configuration
-
-## Port Mappings
-
-Both development and production use the same port configuration:
-- Application (backend + frontend): 3087 (host) → 3011 (container)
-- WebSocket: shares application port (3087/3011)
-- Database: 3321 (both host and container)
-
-**Note:** Access the app via http://localhost:3087. In development, the setup serves pre-built static React files (no webpack dev server).
+- **New top-level route file or module**: add a one-liner to the Architecture section above.
+- **New feature directory under `client/src/components/`**: add a one-liner to the Frontend section.
+- **New or changed env var**: update `docs/ENVIRONMENT_VARIABLES.md`.
+- **New or changed config field**: update `docs/CONFIG.md` and register the field in `client/src/config/configSchema.ts`.
+- **New dev command or flag**: update `docs/DEVELOPMENT.md`.
+- **Schema changes**: update `docs/DATABASE.md`.
+- **API changes**: Swagger annotations live with the routes; update them so `/swagger` stays accurate.
 
 ## Git Workflow
 
-### Branch Strategy
-- **`dev`** - Default branch for active development; all PRs target this branch
-- **`main`** - Stable release branch; merging `dev` → `main` triggers a production release
-- **Feature branches** - Create from `dev`, merge back to `dev` via PR
+### Branches
+- **`dev`**: default branch for active development; all contributor PRs target `dev`.
+- **`main`**: stable release branch; merging `dev` -> `main` triggers a production release.
+- **Feature branches**: create from `dev`, merge back to `dev` via PR.
 
-### Release Process
-- Merging to `dev` → Builds RC image (`dev-latest`, `dev-rc.<sha>`)
-- Merging `dev` to `main` → Triggers production release with semantic versioning
-- Commit prefixes: `feat:` (minor), `fix:` (patch), `BREAKING CHANGE:` (major)
-- Docker images auto-published to `dialmaster/youtarr` on release
+### Release
+- Merging to `dev` builds an RC image (`dev-latest`, `dev-rc.<sha>`).
+- Merging `dev` -> `main` triggers a production release with semantic versioning.
+- Commit prefixes: `feat:` (minor), `fix:` (patch), `BREAKING CHANGE:` (major).
+- Docker images auto-publish to `dialmaster/youtarr` on release.
 
-### PR Guidelines
-- All contributor PRs should target `dev` (not `main`)
-- PRs to `dev` get automatic Claude Code reviews
-- CI runs on PRs to both `dev` and `main`
-
-## Anti-Patterns to Avoid
-
-These are common mistakes found in the codebase that should not be repeated in new code:
-
-### Backend
-- **`console.log` / `console.error`**: Always use the Pino logger. Several legacy files still use console -- don't follow that pattern.
-- **God modules**: Modules over 500 lines with multiple responsibilities. Break them up by extracting focused sub-modules.
-- **Late-binding `require()` inside functions**: This is a workaround for circular dependencies. Instead, restructure the dependency graph, pass the dependency as a parameter, or use an event emitter. (Several existing modules use this pattern, including `cronJobs.js` and others — migrate over time but do NOT refactor these as part of unrelated feature work or bug fixes.)
-- **Inconsistent error response shapes**: Don't mix `{ error: '...' }`, `{ success: false, error: '...' }`, and `{ status: 'error', message: '...' }`. Use `{ error: '...' }` consistently.
-- **Fire-and-forget promises**: Don't call an async function without awaiting or attaching error handling. Unhandled rejections crash the process.
-- **Hardcoded paths and timeouts**: Define as named constants, not inline literals.
-
-### Frontend
-- **`any` type escape hatch**: Don't use `any` to silence TypeScript. Use `unknown` with type narrowing for genuinely unknown types, or define proper interfaces.
-- **Monolith components**: Components with 10+ `useState` calls and hundreds of lines. Extract custom hooks for logic and child components for UI.
-- **Inline `style` prop**: Use MUI's `sx` prop for theme-aware, responsive styling.
-- **Mixed fetch/axios**: Use Axios consistently for API calls. The only exception is the global fetch override in `App.tsx` for database error detection.
-- **Prop drilling through many layers**: Use React Context or restructure component hierarchy if a prop is passed through 3+ levels unchanged.
-
-## Code Review
-
-When reviewing PRs or analyzing code, always complete the full analysis before ending - don't stop after just reading files. Provide actionable findings even if the session might end soon.
-
-### What to Check
-- **Consistency**: Does the new code follow established patterns in the codebase (dependency injection in routes, class-based modules, typed hooks)?
-- **File size**: Are new/modified files staying within reasonable limits (~500 lines backend, ~300 lines frontend)?
-- **Error handling**: Are errors properly caught, logged (with context), and returned to the caller?
-- **Type safety**: No `any` types in TypeScript? Proper error typing?
-- **Test coverage**: Do tests cover the new behavior? Are they testing behavior, not implementation?
-- **DRY**: Is there duplicated logic that should be extracted?
-- **Naming**: Are functions, variables, and files named clearly and consistently?
+### PRs
+- Contributor PRs target `dev`, not `main`.
+- PRs to `dev` get automatic Claude Code reviews.
+- CI runs on PRs to both `dev` and `main`.
 
 ## Debugging
 
 ### CI/CD
-
-When debugging CI/CD or GitHub Actions issues, check both the permissions AND the actual command execution logs. A fix isn't complete until the underlying behavior is verified working.
+When debugging CI/CD or GitHub Actions issues, check both the permissions AND the actual command execution logs. A fix is not complete until the underlying behavior is verified working.

--- a/README.md
+++ b/README.md
@@ -153,10 +153,8 @@ Interested in contributing to Youtarr? We welcome contributions of all kinds!
 ![VideoModal](https://github.com/user-attachments/assets/e27f8adb-73fc-4cc8-826e-bec1ac505b18)
 
 ### SponsorBlock Settings
-<img width="1476" height="1186" alt="SponsorBlock Settings" src="https://github.com/user-attachments/assets/86fb9b48-2284-4ef9-a76b-e083a2d70584" />
+![SponsorBlock](https://github.com/user-attachments/assets/0bcf1d1a-2d8c-4dff-9e67-abbe369e64d5)
 
-### Auto-Removal Preview
-<img width="1466" height="1227" alt="Auto-Removal Preview" src="https://github.com/user-attachments/assets/12629a9f-56be-4c71-8c43-e6673504f388" />
 </details>
 
 ## Legal Disclaimer

--- a/README.md
+++ b/README.md
@@ -136,16 +136,21 @@ Interested in contributing to Youtarr? We welcome contributions of all kinds!
 <summary>Click to view screenshots</summary>
 
 ### Channel Management
-<img width="1888" height="1072" alt="Channel Management" src="https://github.com/user-attachments/assets/a4e8172c-eb7f-44bb-a891-a9d436ee9b73" />
+![ChannelsPage](https://github.com/user-attachments/assets/75adf139-f202-499d-9eee-1c81b71a4355)
 
 ### Video Browser
-<img width="1489" height="976" alt="Video Browser" src="https://github.com/user-attachments/assets/cbf765c6-67d1-431b-a393-0ac0c4e2f7e2" />
+![ChannelPage](https://github.com/user-attachments/assets/f658c97b-3898-477c-82d1-4a15d6b34207)
+
 
 ### Configuration
-<img width="1890" height="1383" alt="Configuration" src="https://github.com/user-attachments/assets/b8d586b1-fe5b-4cb4-a61a-79d1905cc44e" />
+![ConfigurationPage](https://github.com/user-attachments/assets/9aba2e17-9d53-4adb-9c05-c6f9dc926dcf)
+
 
 ### Download Manager
-<img width="1472" height="1236" alt="Download Manager" src="https://github.com/user-attachments/assets/cd71937b-8423-42b3-9ddd-070f69c80662" />
+![DownloadsPage](https://github.com/user-attachments/assets/5aa84c3c-6bc7-478b-b97d-c8f1e46e8ca2)
+
+### Individual Video Modal
+![VideoModal](https://github.com/user-attachments/assets/e27f8adb-73fc-4cc8-826e-bec1ac505b18)
 
 ### SponsorBlock Settings
 <img width="1476" height="1186" alt="SponsorBlock Settings" src="https://github.com/user-attachments/assets/86fb9b48-2284-4ef9-a76b-e083a2d70584" />

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ https://github.com/user-attachments/assets/cc153624-c905-42c2-8ee9-9c213816be3a
 - **Smart Downloads**: Pre-validate manually pasted URLs with metadata preview before downloading
 - **Channel Subscriptions**: Subscribe to channels and auto-download new videos, shorts, and streams with per-tab controls
 - **Browse Channels**: View and search all videos from subscribed channels with advanced filtering, tabbed views for Videos/Shorts/Streams, and contextual publish date accuracy tips
+- **In-App Playback**: Click any thumbnail to open a detail modal with extended metadata and in-browser streaming of downloaded videos; no media server required
 - **Channel Grouping & Multi-Library Support**: Organize channels into custom subfolders (e.g., `__kids`, `__music`, `__news`) to create separate media server libraries
 - **Smart Organization**: Videos organized by channel with metadata and thumbnails
 - **SponsorBlock Integration**: Remove sponsored segments automatically

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Youtarr is a self-hosted YouTube downloader that automatically downloads videos 
 
 > **Like Youtarr?** Consider [supporting the project on Patreon](https://www.patreon.com/c/ChrisDial) to help keep it free and actively developed!
 
-https://github.com/user-attachments/assets/cc153624-c905-42c2-8ee9-9c213816be3a
+https://github.com/user-attachments/assets/34e5b50b-1a38-4f0b-9f84-bd47cefe4348
 
 ## Why Youtarr?
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4381,9 +4381,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -10340,9 +10340,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/client/src/components/ChannelPage.tsx
+++ b/client/src/components/ChannelPage.tsx
@@ -360,6 +360,7 @@ function ChannelPage({ token }: ChannelPageProps) {
         token={token}
         channelAutoDownloadTabs={channel?.auto_download_enabled_tabs}
         channelId={channel_id || undefined}
+        channelName={channel?.uploader || ''}
         channelVideoQuality={channel?.video_quality || null}
         channelAudioFormat={channel?.audio_format || null}
         channelAvailableTabs={channel?.available_tabs ?? null}

--- a/client/src/components/ChannelPage.tsx
+++ b/client/src/components/ChannelPage.tsx
@@ -34,12 +34,14 @@ function ChannelPage({ token }: ChannelPageProps) {
     min_duration: number | null;
     max_duration: number | null;
     title_filter_regex: string | null;
+    hidden_tabs?: string[];
+    availableTabs?: string[];
   }) => {
     setChannel((prev) => {
       if (!prev) {
         return prev;
       }
-      return {
+      const next: Channel = {
         ...prev,
         sub_folder: updated.sub_folder,
         video_quality: updated.video_quality,
@@ -48,6 +50,17 @@ function ChannelPage({ token }: ChannelPageProps) {
         max_duration: updated.max_duration,
         title_filter_regex: updated.title_filter_regex,
       };
+      if (updated.availableTabs !== undefined) {
+        next.available_tabs = updated.availableTabs.length > 0
+          ? updated.availableTabs.join(',')
+          : null;
+      }
+      if (updated.hidden_tabs !== undefined) {
+        next.hidden_tabs = updated.hidden_tabs.length > 0
+          ? updated.hidden_tabs.join(',')
+          : null;
+      }
+      return next;
     });
   };
 
@@ -349,6 +362,7 @@ function ChannelPage({ token }: ChannelPageProps) {
         channelId={channel_id || undefined}
         channelVideoQuality={channel?.video_quality || null}
         channelAudioFormat={channel?.audio_format || null}
+        channelAvailableTabs={channel?.available_tabs ?? null}
       />
 
       {channel && channel_id && (

--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -32,6 +32,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import RatingBadge from '../shared/RatingBadge';
 import { useConfig } from '../../hooks/useConfig';
 import { SubfolderAutocomplete } from '../shared/SubfolderAutocomplete';
+import TabsEditor, { TabsEditorRefreshResult } from './components/TabsEditor';
 
 interface ChannelSettings {
   sub_folder: string | null;
@@ -42,6 +43,12 @@ interface ChannelSettings {
   audio_format: string | null;
   default_rating: string | null;
   skip_video_folder: boolean | null;
+  hidden_tabs: string[];
+}
+
+interface ChannelTabsState {
+  detectedTabs: string[];
+  availableTabs: string[];
 }
 
 interface FilterPreviewVideo {
@@ -63,7 +70,7 @@ interface ChannelSettingsDialogProps {
   channelId: string;
   channelName: string;
   token: string | null;
-  onSettingsSaved?: (settings: ChannelSettings) => void;
+  onSettingsSaved?: (settings: ChannelSettings & ChannelTabsState) => void;
 }
 
 const regexExamples = [
@@ -100,7 +107,8 @@ function ChannelSettingsDialog({
     title_filter_regex: null,
     audio_format: null,
     default_rating: null,
-    skip_video_folder: null
+    skip_video_folder: null,
+    hidden_tabs: []
   });
   const [originalSettings, setOriginalSettings] = useState<ChannelSettings>({
     sub_folder: null,
@@ -110,8 +118,10 @@ function ChannelSettingsDialog({
     title_filter_regex: null,
     audio_format: null,
     default_rating: null,
-    skip_video_folder: null
+    skip_video_folder: null,
+    hidden_tabs: []
   });
+  const [detectedTabs, setDetectedTabs] = useState<string[]>([]);
   const [subfolders, setSubfolders] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -194,9 +204,11 @@ function ChannelSettingsDialog({
           skip_video_folder: Object.prototype.hasOwnProperty.call(settingsData, 'skip_video_folder')
             ? settingsData.skip_video_folder
             : null,
+          hidden_tabs: Array.isArray(settingsData.hidden_tabs) ? settingsData.hidden_tabs : [],
         };
         setSettings(loadedSettings);
         setOriginalSettings(loadedSettings);
+        setDetectedTabs(Array.isArray(settingsData.detected_tabs) ? settingsData.detected_tabs : []);
 
         // Convert seconds to minutes for UI
         if (settingsData.min_duration) {
@@ -251,7 +263,8 @@ function ChannelSettingsDialog({
           title_filter_regex: settings.title_filter_regex || null,
           audio_format: settings.audio_format || null,
           default_rating: settings.default_rating || null,
-          skip_video_folder: settings.skip_video_folder
+          skip_video_folder: settings.skip_video_folder,
+          hidden_tabs: settings.hidden_tabs
         })
       });
 
@@ -273,6 +286,16 @@ function ChannelSettingsDialog({
       }
 
       const result = await response.json();
+      const resultHiddenTabs: string[] = Array.isArray(result?.settings?.hidden_tabs)
+        ? result.settings.hidden_tabs
+        : settings.hidden_tabs;
+      const resultDetectedTabs: string[] = Array.isArray(result?.settings?.detected_tabs)
+        ? result.settings.detected_tabs
+        : detectedTabs;
+      const resultAvailableTabs: string[] = Array.isArray(result?.settings?.available_tabs)
+        ? result.settings.available_tabs
+        : resultDetectedTabs.filter((tab) => !resultHiddenTabs.includes(tab));
+
       const updatedSettings: ChannelSettings = {
         sub_folder: result?.settings?.sub_folder ?? settings.sub_folder ?? null,
         video_quality: result?.settings?.video_quality ?? settings.video_quality ?? null,
@@ -286,14 +309,20 @@ function ChannelSettingsDialog({
         skip_video_folder: result?.settings && Object.prototype.hasOwnProperty.call(result.settings, 'skip_video_folder')
           ? result.settings.skip_video_folder
           : settings.skip_video_folder ?? null,
+        hidden_tabs: resultHiddenTabs,
       };
 
       setSettings(updatedSettings);
       setOriginalSettings(updatedSettings);
+      setDetectedTabs(resultDetectedTabs);
       setSuccess(true);
 
       if (onSettingsSaved) {
-        onSettingsSaved(updatedSettings);
+        onSettingsSaved({
+          ...updatedSettings,
+          detectedTabs: resultDetectedTabs,
+          availableTabs: resultAvailableTabs,
+        });
       }
 
       // Show success message briefly then close
@@ -319,6 +348,9 @@ function ChannelSettingsDialog({
   };
 
   const hasChanges = () => {
+    const tabsChanged =
+      settings.hidden_tabs.length !== originalSettings.hidden_tabs.length ||
+      settings.hidden_tabs.some((tab) => !originalSettings.hidden_tabs.includes(tab));
     return settings.sub_folder !== originalSettings.sub_folder ||
            settings.video_quality !== originalSettings.video_quality ||
            settings.min_duration !== originalSettings.min_duration ||
@@ -326,7 +358,23 @@ function ChannelSettingsDialog({
            settings.title_filter_regex !== originalSettings.title_filter_regex ||
           settings.audio_format !== originalSettings.audio_format ||
           settings.default_rating !== originalSettings.default_rating ||
-          settings.skip_video_folder !== originalSettings.skip_video_folder;
+          settings.skip_video_folder !== originalSettings.skip_video_folder ||
+          tabsChanged;
+  };
+
+  const allTabsHidden = detectedTabs.length > 0 &&
+    detectedTabs.every((tab) => settings.hidden_tabs.includes(tab));
+
+  const handleHiddenTabsChange = (nextHidden: string[]) => {
+    setSettings((prev) => ({ ...prev, hidden_tabs: nextHidden }));
+  };
+
+  const handleTabsRefresh = (result: TabsEditorRefreshResult) => {
+    setDetectedTabs(result.detectedTabs);
+    setSettings((prev) => ({ ...prev, hidden_tabs: result.hiddenTabs }));
+    setOriginalSettings((prev) => ({ ...prev, hidden_tabs: result.hiddenTabs }));
+    // The backend also updates available_tabs/auto_download_enabled_tabs on refresh,
+    // but the dialog will reflect those the next time the parent reloads channel info.
   };
 
   const handlePreviewFilter = async () => {
@@ -418,6 +466,18 @@ function ChannelSettingsDialog({
                 Settings saved successfully!
               </Alert>
             )}
+
+            <TabsEditor
+              channelId={channelId}
+              token={token}
+              detectedTabs={detectedTabs}
+              hiddenTabs={settings.hidden_tabs}
+              onHiddenTabsChange={handleHiddenTabsChange}
+              onRefresh={handleTabsRefresh}
+              disabled={saving}
+            />
+
+            <Divider sx={{ my: 0 }} />
 
             <FormControl fullWidth>
               <InputLabel id="video-quality-label" shrink>Channel Video Quality Override</InputLabel>
@@ -752,7 +812,7 @@ function ChannelSettingsDialog({
         <Button
           onClick={handleSave}
           variant="contained"
-          disabled={saving || loading || !hasChanges()}
+          disabled={saving || loading || !hasChanges() || allTabsHidden}
         >
           {saving ? <CircularProgress size={24} /> : 'Save'}
         </Button>

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -1205,7 +1205,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
 
       {modalVideo && (
         <VideoModal
-          open={modalVideo !== null}
+          open
           onClose={() => setModalVideo(null)}
           video={channelVideoToModalData(modalVideo, channelName, channelId)}
           token={token}

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -931,6 +931,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onHoverChange={setHoveredVideo}
                       onToggleDeletion={toggleDeletionSelection}
                       onToggleIgnore={toggleIgnore}
+                      onToggleProtection={() => {}}
                       onMobileTooltip={setMobileTooltip}
                     />
                   ))}

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -56,13 +56,20 @@ interface ChannelVideosProps {
   channelId?: string;
   channelVideoQuality?: string | null;
   channelAudioFormat?: string | null;
+  /**
+   * Effective available_tabs for the channel (comma-separated, already
+   * filtered through hidden_tabs). When provided, takes precedence over
+   * the tabs fetched from /api/channels/:channelId/tabs so the strip
+   * updates immediately after the user changes hidden_tabs in settings.
+   */
+  channelAvailableTabs?: string | null;
 }
 
 type ViewMode = 'table' | 'grid' | 'list';
 type SortBy = 'date' | 'title' | 'duration' | 'size';
 type SortOrder = 'asc' | 'desc';
 
-function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelId, channelVideoQuality, channelAudioFormat }: ChannelVideosProps) {
+function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelId, channelVideoQuality, channelAudioFormat, channelAvailableTabs }: ChannelVideosProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -293,6 +300,24 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
       setAvailableTabs(availableTabsFromVideos);
     }
   }, [availableTabsFromVideos]);
+
+  // Sync from the parent-supplied channel.available_tabs when it changes
+  // (e.g. right after the user saves a hidden_tabs change in settings).
+  useEffect(() => {
+    if (channelAvailableTabs === undefined) return;
+
+    const nextTabs = channelAvailableTabs
+      ? channelAvailableTabs.split(',').map((tab) => tab.trim()).filter((tab) => tab.length > 0)
+      : [];
+
+    if (nextTabs.length === 0) return;
+
+    setAvailableTabs(nextTabs);
+    setSelectedTab((current) => {
+      if (current && nextTabs.includes(current)) return current;
+      return nextTabs.includes('videos') ? 'videos' : nextTabs[0];
+    });
+  }, [channelAvailableTabs]);
 
   // Clear local status overrides when videos are refetched (page change, tab change, etc)
   useEffect(() => {

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -258,6 +258,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     maxDuration: filters.maxDuration,
     dateFrom: filters.dateFrom,
     dateTo: filters.dateTo,
+    protectedFilter,
   }), [
     channelId,
     page,
@@ -272,6 +273,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     filters.maxDuration,
     filters.dateFrom,
     filters.dateTo,
+    protectedFilter,
   ]);
 
   const {
@@ -361,11 +363,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     });
   }, [videos, localIgnoreStatus, localProtectedStatus]);
 
-  // Videos are already filtered, sorted, and paginated by the server
-  // Apply client-side protected filter (after optimistic overrides are applied)
-  const paginatedVideos = protectedFilter
-    ? videosWithOverrides.filter(v => v.protected)
-    : videosWithOverrides;
+  const paginatedVideos = videosWithOverrides;
 
   // Use server-provided total count for pagination
   const totalPages = Math.ceil(totalCount / pageSize) || 1;
@@ -1028,7 +1026,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                   onSortChange={handleSortChange}
                   onToggleDeletion={toggleDeletionSelection}
                   onToggleIgnore={toggleIgnore}
-                  onToggleProtection={() => {}}
+                  onToggleProtection={handleToggleProtection}
                   onMobileTooltip={setMobileTooltip}
                 />
               )}

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -949,6 +949,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onCheckChange={handleCheckChange}
                       onToggleDeletion={toggleDeletionSelection}
                       onToggleIgnore={toggleIgnore}
+                      onToggleProtection={() => {}}
                       onMobileTooltip={setMobileTooltip}
                     />
                   ))}
@@ -968,6 +969,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                   onSortChange={handleSortChange}
                   onToggleDeletion={toggleDeletionSelection}
                   onToggleIgnore={toggleIgnore}
+                  onToggleProtection={() => {}}
                   onMobileTooltip={setMobileTooltip}
                 />
               )}

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -52,11 +52,15 @@ import { useChannelVideosPageSize, ALLOWED_PAGE_SIZES, type PageSize } from './h
 import ChannelVideosFilters from './components/ChannelVideosFilters';
 import { useConfig } from '../../hooks/useConfig';
 import { useTriggerDownloads } from '../../hooks/useTriggerDownloads';
+import VideoModal from '../shared/VideoModal';
+import { VideoModalData } from '../shared/VideoModal/types';
+import { ChannelVideo } from '../../types/ChannelVideo';
 
 interface ChannelVideosProps {
   token: string | null;
   channelAutoDownloadTabs?: string;
   channelId?: string;
+  channelName?: string;
   channelVideoQuality?: string | null;
   channelAudioFormat?: string | null;
   /**
@@ -72,7 +76,33 @@ type ViewMode = 'table' | 'grid' | 'list';
 type SortBy = 'date' | 'title' | 'duration' | 'size';
 type SortOrder = 'asc' | 'desc';
 
-function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelId, channelVideoQuality, channelAudioFormat, channelAvailableTabs }: ChannelVideosProps) {
+function channelVideoToModalData(video: ChannelVideo, channelName: string, channelId: string | undefined): VideoModalData {
+  const status = getVideoStatus(video);
+  return {
+    youtubeId: video.youtube_id,
+    title: video.title,
+    channelName,
+    thumbnailUrl: video.thumbnail,
+    duration: video.duration,
+    publishedAt: video.publishedAt || null,
+    addedAt: null,
+    mediaType: video.media_type || 'video',
+    status,
+    isDownloaded: video.added && !video.removed,
+    filePath: video.filePath || null,
+    fileSize: video.fileSize || null,
+    audioFilePath: video.audioFilePath || null,
+    audioFileSize: video.audioFileSize || null,
+    isProtected: video.protected || false,
+    isIgnored: video.ignored || false,
+    normalizedRating: video.normalized_rating || null,
+    ratingSource: video.rating_source || null,
+    databaseId: video.id || null,
+    channelId: channelId || null,
+  };
+}
+
+function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelId, channelName = '', channelVideoQuality, channelAudioFormat, channelAvailableTabs }: ChannelVideosProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -103,6 +133,9 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   const [selectedForDeletion, setSelectedForDeletion] = useState<string[]>([]);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Modal state
+  const [modalVideo, setModalVideo] = useState<ChannelVideo | null>(null);
 
   // Local state to track ignore status changes without refetching
   const [localIgnoreStatus, setLocalIgnoreStatus] = useState<Record<string, boolean>>({});
@@ -1074,6 +1107,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onToggleIgnore={toggleIgnore}
                       onToggleProtection={handleToggleProtection}
                       onMobileTooltip={setMobileTooltip}
+                      onVideoClick={setModalVideo}
                     />
                   ))}
                 </Grid>
@@ -1092,6 +1126,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onToggleIgnore={toggleIgnore}
                       onToggleProtection={handleToggleProtection}
                       onMobileTooltip={setMobileTooltip}
+                      onVideoClick={setModalVideo}
                     />
                   ))}
                 </Box>
@@ -1112,6 +1147,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                   onToggleIgnore={toggleIgnore}
                   onToggleProtection={handleToggleProtection}
                   onMobileTooltip={setMobileTooltip}
+                  onVideoClick={setModalVideo}
                 />
               )}
 
@@ -1166,6 +1202,31 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
         onSuccessMessageClose={() => setSuccessMessage(null)}
         onErrorMessageClose={() => setErrorMessage(null)}
       />
+
+      {modalVideo && (
+        <VideoModal
+          open={modalVideo !== null}
+          onClose={() => setModalVideo(null)}
+          video={channelVideoToModalData(modalVideo, channelName, channelId)}
+          token={token}
+          onVideoDeleted={() => {
+            setModalVideo(null);
+            refetchVideos();
+          }}
+          onProtectionChanged={(youtubeId, isProtected) => {
+            setLocalProtectedStatus(prev => ({ ...prev, [youtubeId]: isProtected }));
+          }}
+          onIgnoreChanged={(youtubeId, isIgnored) => {
+            setLocalIgnoreStatus(prev => ({ ...prev, [youtubeId]: isIgnored }));
+          }}
+          onDownloadQueued={() => {
+            setModalVideo(null);
+          }}
+          onRatingChanged={() => {
+            refetchVideos();
+          }}
+        />
+      )}
     </>
   );
 }

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -963,7 +963,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                 ))}
               </Grid>
             </Box>
-          ) : videos.length === 0 || paginatedVideos.length === 0 ? (
+          ) : videos.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 4 }}>
               <Typography variant="body1" color="text.secondary">
                 {hasAnyActiveFilter || searchQuery

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -100,6 +100,9 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   // Local state to track protection status changes without refetching
   const [localProtectedStatus, setLocalProtectedStatus] = useState<Record<string, boolean>>({});
 
+  // Protected filter state
+  const [protectedFilter, setProtectedFilter] = useState(false);
+
   // Filter state
   const {
     filters,
@@ -111,8 +114,12 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     setDateTo,
     clearAllFilters,
     hasActiveFilters,
-    activeFilterCount,
+    activeFilterCount: baseActiveFilterCount,
   } = useChannelVideoFilters();
+
+  // Include protectedFilter in the active filter count and hasActiveFilters
+  const activeFilterCount = baseActiveFilterCount + (protectedFilter ? 1 : 0);
+  const hasAnyActiveFilter = hasActiveFilters || protectedFilter;
 
   const { deleteVideosByYoutubeIds, loading: deleteLoading } = useVideoDeletion();
   const { toggleProtection, successMessage: protectionSuccess, error: protectionError, clearMessages: clearProtectionMessages } = useVideoProtection(token);
@@ -355,7 +362,10 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   }, [videos, localIgnoreStatus, localProtectedStatus]);
 
   // Videos are already filtered, sorted, and paginated by the server
-  const paginatedVideos = videosWithOverrides;
+  // Apply client-side protected filter (after optimistic overrides are applied)
+  const paginatedVideos = protectedFilter
+    ? videosWithOverrides.filter(v => v.protected)
+    : videosWithOverrides;
 
   // Use server-provided total count for pagination
   const totalPages = Math.ceil(totalCount / pageSize) || 1;
@@ -617,7 +627,13 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     setCheckedBoxes([]); // Clear selections when changing tabs
     setSelectedForDeletion([]); // Clear deletion selections when changing tabs
     clearAllFilters(); // Clear filters when changing tabs
+    setProtectedFilter(false); // Clear protected filter when changing tabs
   };
+
+  const handleClearAllFilters = useCallback(() => {
+    clearAllFilters();
+    setProtectedFilter(false);
+  }, [clearAllFilters]);
 
   const handleAutoDownloadChange = async (enabled: boolean) => {
     if (!channelId || !token || !selectedTab) return;
@@ -888,11 +904,13 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
           onMaxDurationChange={setMaxDuration}
           onDateFromChange={setDateFrom}
           onDateToChange={setDateTo}
-          onClearAll={clearAllFilters}
-          hasActiveFilters={hasActiveFilters}
+          onClearAll={handleClearAllFilters}
+          hasActiveFilters={hasAnyActiveFilter}
           activeFilterCount={activeFilterCount}
           hideDateFilter={selectedTab === 'shorts'}
           filtersExpanded={filtersExpanded}
+          protectedFilter={protectedFilter}
+          onProtectedFilterChange={setProtectedFilter}
         />
 
         {/* Tabs */}
@@ -928,7 +946,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
 
         {/* Content area */}
         <Box sx={{ p: 2 }} {...(isMobile ? handlers : {})}>
-          {videoFailed && videos.length === 0 && !hasActiveFilters && !searchQuery ? (
+          {videoFailed && videos.length === 0 && !hasAnyActiveFilter && !searchQuery ? (
             <Alert severity="error">
               Failed to fetch channel videos. Please try again later.
             </Alert>
@@ -947,10 +965,10 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                 ))}
               </Grid>
             </Box>
-          ) : videos.length === 0 ? (
+          ) : videos.length === 0 || paginatedVideos.length === 0 ? (
             <Box sx={{ textAlign: 'center', py: 4 }}>
               <Typography variant="body1" color="text.secondary">
-                {hasActiveFilters || searchQuery
+                {hasAnyActiveFilter || searchQuery
                   ? 'No videos found matching your search and filter criteria'
                   : 'No videos found'}
               </Typography>

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -35,6 +35,7 @@ import { useNavigate } from 'react-router-dom';
 import { useSwipeable } from 'react-swipeable';
 import { DownloadSettings } from '../DownloadManager/ManualDownload/types';
 import { useVideoDeletion } from '../shared/useVideoDeletion';
+import { useVideoProtection } from '../shared/useVideoProtection';
 import { getVideoStatus } from '../../utils/videoStatus';
 import VideoCard from './VideoCard';
 import VideoListItem from './VideoListItem';
@@ -96,6 +97,9 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   // Local state to track ignore status changes without refetching
   const [localIgnoreStatus, setLocalIgnoreStatus] = useState<Record<string, boolean>>({});
 
+  // Local state to track protection status changes without refetching
+  const [localProtectedStatus, setLocalProtectedStatus] = useState<Record<string, boolean>>({});
+
   // Filter state
   const {
     filters,
@@ -111,6 +115,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   } = useChannelVideoFilters();
 
   const { deleteVideosByYoutubeIds, loading: deleteLoading } = useVideoDeletion();
+  const { toggleProtection, successMessage: protectionSuccess, error: protectionError, clearMessages: clearProtectionMessages } = useVideoProtection(token);
 
   const { channel_id: routeChannelId } = useParams();
   const channelId = propChannelId ?? routeChannelId ?? undefined;
@@ -280,9 +285,10 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     }
   }, [availableTabsFromVideos]);
 
-  // Clear local ignore status overrides when videos are refetched (page change, tab change, etc)
+  // Clear local status overrides when videos are refetched (page change, tab change, etc)
   useEffect(() => {
     setLocalIgnoreStatus({});
+    setLocalProtectedStatus({});
   }, [page, selectedTab, hideDownloaded, searchQuery, sortBy, sortOrder, filters]);
 
   // Reset page to 1 when filters change
@@ -327,20 +333,26 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
 
   const navigate = useNavigate();
 
-  // Apply local ignore status overrides to videos (for optimistic updates)
+  // Apply local ignore and protection status overrides to videos (for optimistic updates)
   const videosWithOverrides = useMemo(() => {
     return videos.map(video => {
-      // If we have a local override for this video, use it
-      if (video.youtube_id in localIgnoreStatus) {
-        return {
-          ...video,
+      const hasIgnoreOverride = video.youtube_id in localIgnoreStatus;
+      const hasProtectedOverride = video.youtube_id in localProtectedStatus;
+
+      if (!hasIgnoreOverride && !hasProtectedOverride) return video;
+
+      return {
+        ...video,
+        ...(hasIgnoreOverride ? {
           ignored: localIgnoreStatus[video.youtube_id],
           ignored_at: localIgnoreStatus[video.youtube_id] ? new Date().toISOString() : null,
-        };
-      }
-      return video;
+        } : {}),
+        ...(hasProtectedOverride ? {
+          protected: localProtectedStatus[video.youtube_id],
+        } : {}),
+      };
     });
-  }, [videos, localIgnoreStatus]);
+  }, [videos, localIgnoreStatus, localProtectedStatus]);
 
   // Videos are already filtered, sorted, and paginated by the server
   const paginatedVideos = videosWithOverrides;
@@ -416,6 +428,35 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
 
   const handleRefreshCancel = () => {
     setRefreshConfirmOpen(false);
+  };
+
+  // Forward protection hook messages to the shared success/error state
+  useEffect(() => {
+    if (protectionSuccess) {
+      setSuccessMessage(protectionSuccess);
+      clearProtectionMessages();
+    }
+  }, [protectionSuccess, clearProtectionMessages]);
+
+  useEffect(() => {
+    if (protectionError) {
+      setErrorMessage(protectionError);
+      clearProtectionMessages();
+    }
+  }, [protectionError, clearProtectionMessages]);
+
+  const handleToggleProtection = async (youtubeId: string) => {
+    const video = paginatedVideos.find(v => v.youtube_id === youtubeId);
+    if (!video || !video.id) return;
+
+    const currentState = video.protected || false;
+    const newState = await toggleProtection(video.id, currentState);
+    if (newState !== undefined) {
+      setLocalProtectedStatus(prev => ({
+        ...prev,
+        [youtubeId]: newState,
+      }));
+    }
   };
 
   const toggleDeletionSelection = (youtubeId: string) => {
@@ -931,7 +972,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onHoverChange={setHoveredVideo}
                       onToggleDeletion={toggleDeletionSelection}
                       onToggleIgnore={toggleIgnore}
-                      onToggleProtection={() => {}}
+                      onToggleProtection={handleToggleProtection}
                       onMobileTooltip={setMobileTooltip}
                     />
                   ))}
@@ -949,7 +990,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onCheckChange={handleCheckChange}
                       onToggleDeletion={toggleDeletionSelection}
                       onToggleIgnore={toggleIgnore}
-                      onToggleProtection={() => {}}
+                      onToggleProtection={handleToggleProtection}
                       onMobileTooltip={setMobileTooltip}
                     />
                   ))}

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -20,6 +20,8 @@ import {
   Pagination,
   Tabs,
   Tab,
+  Select,
+  MenuItem,
 } from '@mui/material';
 
 import DownloadIcon from '@mui/icons-material/Download';
@@ -46,6 +48,7 @@ import { useChannelVideos } from './hooks/useChannelVideos';
 import { useRefreshChannelVideos } from './hooks/useRefreshChannelVideos';
 import { useChannelFetchStatus } from './hooks/useChannelFetchStatus';
 import { useChannelVideoFilters } from './hooks/useChannelVideoFilters';
+import { useChannelVideosPageSize, ALLOWED_PAGE_SIZES, type PageSize } from './hooks/useChannelVideosPageSize';
 import ChannelVideosFilters from './components/ChannelVideosFilters';
 import { useConfig } from '../../hooks/useConfig';
 import { useTriggerDownloads } from '../../hooks/useTriggerDownloads';
@@ -88,7 +91,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   const [tabAutoDownloadStatus, setTabAutoDownloadStatus] = useState<Record<string, boolean>>({});
 
   // Data states
-  const pageSize = isMobile ? 8 : 16;
+  const [pageSize, setPageSize] = useChannelVideosPageSize();
   const [page, setPage] = useState(1);
   const [checkedBoxes, setCheckedBoxes] = useState<string[]>([]);
   const [hideDownloaded, setHideDownloaded] = useState(false);
@@ -693,6 +696,11 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     setPage(value);
   };
 
+  const handlePageSizeChange = (newSize: PageSize) => {
+    setPageSize(newSize);
+    setPage(1);
+  };
+
   const handleViewModeChange = (event: React.MouseEvent<HTMLElement>, newMode: ViewMode | null) => {
     if (newMode !== null) {
       setViewMode(newMode);
@@ -953,17 +961,68 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
           </Box>
         )}
 
-        {/* Pagination - directly under tabs */}
-        {totalPages > 1 && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 2, px: 2, borderBottom: '1px solid', borderColor: 'divider' }}>
-            <Pagination
-              count={totalPages}
-              page={page}
-              onChange={handlePageChange}
-              color="primary"
-              size={isMobile ? 'small' : 'medium'}
-              siblingCount={isMobile ? 0 : 1}
-            />
+        {/* Pagination and page size selector */}
+        {!videosLoading && totalCount > 0 && (
+          <Box sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 1,
+            py: 1.5,
+            px: 2,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            position: 'relative',
+            minHeight: 48,
+          }}>
+            {totalPages > 1 && (
+              <Pagination
+                count={totalPages}
+                page={page}
+                onChange={handlePageChange}
+                color="primary"
+                size={isMobile ? 'small' : 'medium'}
+                siblingCount={isMobile ? 0 : 1}
+              />
+            )}
+            <Box sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              position: { sm: 'absolute' },
+              right: { sm: 16 },
+            }}>
+              {!isMobile && (
+                <Typography variant="body2" color="text.secondary">
+                  Per page:
+                </Typography>
+              )}
+              <Select
+                size="small"
+                value={pageSize}
+                onChange={(e) => {
+                  const val = Number(e.target.value);
+                  if ((ALLOWED_PAGE_SIZES as readonly number[]).includes(val)) {
+                    handlePageSizeChange(val as PageSize);
+                  }
+                }}
+                aria-label="videos per page"
+                sx={{
+                  minWidth: 64,
+                  '& .MuiSelect-select': {
+                    py: 0.5,
+                    fontSize: '0.875rem',
+                  },
+                }}
+              >
+                {ALLOWED_PAGE_SIZES.map((size) => (
+                  <MenuItem key={size} value={size}>
+                    {size}
+                  </MenuItem>
+                ))}
+              </Select>
+            </Box>
           </Box>
         )}
 

--- a/client/src/components/ChannelPage/VideoCard.tsx
+++ b/client/src/components/ChannelPage/VideoCard.tsx
@@ -23,6 +23,7 @@ import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
 import RatingBadge from '../shared/RatingBadge';
 import ProtectionShieldButton from '../shared/ProtectionShieldButton';
+import ThumbnailClickOverlay from '../shared/ThumbnailClickOverlay';
 
 interface VideoCardProps {
   video: ChannelVideo;
@@ -36,6 +37,7 @@ interface VideoCardProps {
   onToggleIgnore: (youtubeId: string) => void;
   onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
+  onVideoClick?: (video: ChannelVideo) => void;
 }
 
 function VideoCard({
@@ -50,6 +52,7 @@ function VideoCard({
   onToggleIgnore,
   onToggleProtection,
   onMobileTooltip,
+  onVideoClick,
 }: VideoCardProps) {
   const theme = useTheme();
   const status = getVideoStatus(video);
@@ -104,6 +107,16 @@ function VideoCard({
               }}
               loading="lazy"
             />
+
+            {/* Center hotspot for opening video modal */}
+            {onVideoClick && (
+              <ThumbnailClickOverlay
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  onVideoClick(video);
+                }}
+              />
+            )}
 
             {/* YouTube Removed Banner */}
             {video.youtube_removed ? (
@@ -266,6 +279,10 @@ function VideoCard({
           <Box sx={{ p: isMobile ? 1.5 : 2, flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
             <Typography
               variant="body2"
+              onClick={onVideoClick ? (e: React.MouseEvent) => {
+                e.stopPropagation();
+                onVideoClick(video);
+              } : undefined}
               sx={{
                 mb: 1,
                 overflow: 'hidden',
@@ -275,6 +292,8 @@ function VideoCard({
                 WebkitBoxOrient: 'vertical',
                 lineHeight: 1.3,
                 minHeight: '2.6em',
+                cursor: onVideoClick ? 'pointer' : 'default',
+                '&:hover': onVideoClick ? { textDecoration: 'underline' } : {},
               }}
               title={decodeHtml(video.title)}
             >

--- a/client/src/components/ChannelPage/VideoCard.tsx
+++ b/client/src/components/ChannelPage/VideoCard.tsx
@@ -13,8 +13,6 @@ import {
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
-import ShieldIcon from '@mui/icons-material/Shield';
-import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration } from '../../utils';
@@ -24,6 +22,7 @@ import { getVideoStatus, getStatusColor, getStatusIcon, getStatusLabel, getMedia
 import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
 import RatingBadge from '../shared/RatingBadge';
+import ProtectionShieldButton from '../shared/ProtectionShieldButton';
 
 interface VideoCardProps {
   video: ChannelVideo;
@@ -252,37 +251,14 @@ function VideoCard({
 
             {/* Protection shield for downloaded videos */}
             {video.added && !video.removed && (
-              <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
-                <IconButton
-                  aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onToggleProtection(video.youtube_id);
-                  }}
-                  sx={{
-                    position: 'absolute',
-                    bottom: 6,
-                    left: 6,
-                    bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
-                    color: video.protected ? 'white' : 'grey.500',
-                    padding: 0.5,
-                    opacity: video.protected ? 1 : 0.6,
-                    '&:hover': {
-                      bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
-                      opacity: 1,
-                    },
-                    transition: 'all 0.2s',
-                    boxShadow: video.protected ? '0 0 6px rgba(25,118,210,0.5)' : 'none',
-                    zIndex: 2,
-                  }}
-                  size="small"
-                >
-                  {video.protected
-                    ? <ShieldIcon sx={{ fontSize: 16 }} />
-                    : <ShieldOutlinedIcon sx={{ fontSize: 16 }} />
-                  }
-                </IconButton>
-              </Tooltip>
+              <ProtectionShieldButton
+                isProtected={video.protected || false}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleProtection(video.youtube_id);
+                }}
+                sx={{ position: 'absolute', bottom: 6, left: 6, zIndex: 2 }}
+              />
             )}
           </Box>
 

--- a/client/src/components/ChannelPage/VideoCard.tsx
+++ b/client/src/components/ChannelPage/VideoCard.tsx
@@ -13,6 +13,8 @@ import {
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration } from '../../utils';
@@ -33,6 +35,7 @@ interface VideoCardProps {
   onHoverChange: (videoId: string | null) => void;
   onToggleDeletion: (youtubeId: string) => void;
   onToggleIgnore: (youtubeId: string) => void;
+  onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
 }
 
@@ -46,6 +49,7 @@ function VideoCard({
   onHoverChange,
   onToggleDeletion,
   onToggleIgnore,
+  onToggleProtection,
   onMobileTooltip,
 }: VideoCardProps) {
   const theme = useTheme();
@@ -192,6 +196,7 @@ function VideoCard({
             {/* Delete icon for downloaded videos that exist on disk */}
             {video.added && !video.removed && (
               <IconButton
+                aria-label="Delete video"
                 onClick={(e) => {
                   e.stopPropagation();
                   onToggleDeletion(video.youtube_id);
@@ -241,6 +246,41 @@ function VideoCard({
                   size="small"
                 >
                   {isIgnored ? <CheckCircleOutlineIcon fontSize="small" /> : <BlockIcon fontSize="small" />}
+                </IconButton>
+              </Tooltip>
+            )}
+
+            {/* Protection shield for downloaded videos */}
+            {video.added && !video.removed && (
+              <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
+                <IconButton
+                  aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggleProtection(video.youtube_id);
+                  }}
+                  sx={{
+                    position: 'absolute',
+                    bottom: 6,
+                    left: 6,
+                    bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
+                    color: video.protected ? 'white' : 'grey.500',
+                    padding: 0.5,
+                    opacity: video.protected ? 1 : 0.6,
+                    '&:hover': {
+                      bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
+                      opacity: 1,
+                    },
+                    transition: 'all 0.2s',
+                    boxShadow: video.protected ? '0 0 6px rgba(25,118,210,0.5)' : 'none',
+                    zIndex: 2,
+                  }}
+                  size="small"
+                >
+                  {video.protected
+                    ? <ShieldIcon sx={{ fontSize: 16 }} />
+                    : <ShieldOutlinedIcon sx={{ fontSize: 16 }} />
+                  }
                 </IconButton>
               </Tooltip>
             )}

--- a/client/src/components/ChannelPage/VideoListItem.tsx
+++ b/client/src/components/ChannelPage/VideoListItem.tsx
@@ -23,6 +23,7 @@ import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
 import RatingBadge from '../shared/RatingBadge';
 import ProtectionShieldButton from '../shared/ProtectionShieldButton';
+import ThumbnailClickOverlay from '../shared/ThumbnailClickOverlay';
 
 interface VideoListItemProps {
   video: ChannelVideo;
@@ -33,6 +34,7 @@ interface VideoListItemProps {
   onToggleIgnore: (youtubeId: string) => void;
   onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
+  onVideoClick?: (video: ChannelVideo) => void;
 }
 
 function VideoListItem({
@@ -44,6 +46,7 @@ function VideoListItem({
   onToggleIgnore,
   onToggleProtection,
   onMobileTooltip,
+  onVideoClick,
 }: VideoListItemProps) {
   const theme = useTheme();
   const status = getVideoStatus(video);
@@ -92,6 +95,16 @@ function VideoListItem({
             }}
             loading="lazy"
           />
+
+          {/* Center hotspot for opening video modal */}
+          {onVideoClick && (
+            <ThumbnailClickOverlay
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                onVideoClick(video);
+              }}
+            />
+          )}
 
           {/* YouTube Removed Banner */}
           {video.youtube_removed ? (
@@ -244,6 +257,10 @@ function VideoListItem({
           {/* Title */}
           <Typography
             variant="body2"
+            onClick={onVideoClick ? (e: React.MouseEvent) => {
+              e.stopPropagation();
+              onVideoClick(video);
+            } : undefined}
             sx={{
               mb: 0.5,
               overflow: 'hidden',
@@ -253,6 +270,8 @@ function VideoListItem({
               WebkitBoxOrient: 'vertical',
               lineHeight: 1.3,
               fontSize: '0.875rem',
+              cursor: onVideoClick ? 'pointer' : 'default',
+              '&:hover': onVideoClick ? { textDecoration: 'underline' } : {},
             }}
             title={decodeHtml(video.title)}
           >

--- a/client/src/components/ChannelPage/VideoListItem.tsx
+++ b/client/src/components/ChannelPage/VideoListItem.tsx
@@ -14,8 +14,6 @@ import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import ShieldIcon from '@mui/icons-material/Shield';
-import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration } from '../../utils';
 import { ChannelVideo } from '../../types/ChannelVideo';
@@ -24,6 +22,7 @@ import { getVideoStatus, getStatusColor, getStatusIcon, getStatusLabel, getMedia
 import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
 import RatingBadge from '../shared/RatingBadge';
+import ProtectionShieldButton from '../shared/ProtectionShieldButton';
 
 interface VideoListItemProps {
   video: ChannelVideo;
@@ -228,36 +227,15 @@ function VideoListItem({
 
           {/* Protection shield for downloaded videos */}
           {video.added && !video.removed && (
-            <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
-              <IconButton
-                aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onToggleProtection(video.youtube_id);
-                }}
-                sx={{
-                  position: 'absolute',
-                  bottom: 3,
-                  left: 3,
-                  bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
-                  color: video.protected ? 'white' : 'grey.500',
-                  padding: 0.3,
-                  opacity: video.protected ? 1 : 0.6,
-                  '&:hover': {
-                    bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
-                    opacity: 1,
-                  },
-                  transition: 'all 0.2s',
-                  boxShadow: video.protected ? '0 0 4px rgba(25,118,210,0.5)' : 'none',
-                }}
-                size="small"
-              >
-                {video.protected
-                  ? <ShieldIcon sx={{ fontSize: 14 }} />
-                  : <ShieldOutlinedIcon sx={{ fontSize: 14 }} />
-                }
-              </IconButton>
-            </Tooltip>
+            <ProtectionShieldButton
+              isProtected={video.protected || false}
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggleProtection(video.youtube_id);
+              }}
+              size="small"
+              sx={{ position: 'absolute', bottom: 3, left: 3 }}
+            />
           )}
         </Box>
 

--- a/client/src/components/ChannelPage/VideoListItem.tsx
+++ b/client/src/components/ChannelPage/VideoListItem.tsx
@@ -14,6 +14,8 @@ import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration } from '../../utils';
 import { ChannelVideo } from '../../types/ChannelVideo';
@@ -30,6 +32,7 @@ interface VideoListItemProps {
   onCheckChange: (videoId: string, isChecked: boolean) => void;
   onToggleDeletion: (youtubeId: string) => void;
   onToggleIgnore: (youtubeId: string) => void;
+  onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
 }
 
@@ -40,6 +43,7 @@ function VideoListItem({
   onCheckChange,
   onToggleDeletion,
   onToggleIgnore,
+  onToggleProtection,
   onMobileTooltip,
 }: VideoListItemProps) {
   const theme = useTheme();
@@ -168,6 +172,7 @@ function VideoListItem({
           {/* Delete icon for downloaded videos that exist on disk */}
           {video.added && !video.removed && (
             <IconButton
+              aria-label="Delete video"
               onClick={(e) => {
                 e.stopPropagation();
                 onToggleDeletion(video.youtube_id);
@@ -217,6 +222,40 @@ function VideoListItem({
                 size="small"
               >
                 {isIgnored ? <CheckCircleOutlineIcon sx={{ fontSize: 18 }} /> : <BlockIcon sx={{ fontSize: 18 }} />}
+              </IconButton>
+            </Tooltip>
+          )}
+
+          {/* Protection shield for downloaded videos */}
+          {video.added && !video.removed && (
+            <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
+              <IconButton
+                aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleProtection(video.youtube_id);
+                }}
+                sx={{
+                  position: 'absolute',
+                  bottom: 3,
+                  left: 3,
+                  bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
+                  color: video.protected ? 'white' : 'grey.500',
+                  padding: 0.3,
+                  opacity: video.protected ? 1 : 0.6,
+                  '&:hover': {
+                    bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
+                    opacity: 1,
+                  },
+                  transition: 'all 0.2s',
+                  boxShadow: video.protected ? '0 0 4px rgba(25,118,210,0.5)' : 'none',
+                }}
+                size="small"
+              >
+                {video.protected
+                  ? <ShieldIcon sx={{ fontSize: 14 }} />
+                  : <ShieldOutlinedIcon sx={{ fontSize: 14 }} />
+                }
               </IconButton>
             </Tooltip>
           )}

--- a/client/src/components/ChannelPage/VideoTableView.tsx
+++ b/client/src/components/ChannelPage/VideoTableView.tsx
@@ -25,6 +25,7 @@ import { decodeHtml } from '../../utils/formatters';
 import { getVideoStatus, getStatusColor, getStatusIcon, getStatusLabel, getMediaTypeInfo } from '../../utils/videoStatus';
 import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
+import ThumbnailClickOverlay from '../shared/ThumbnailClickOverlay';
 
 type SortBy = 'date' | 'title' | 'duration' | 'size';
 type SortOrder = 'asc' | 'desc';
@@ -43,6 +44,7 @@ interface VideoTableViewProps {
   onToggleIgnore: (youtubeId: string) => void;
   onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
+  onVideoClick?: (video: ChannelVideo) => void;
 }
 
 function VideoTableView({
@@ -59,6 +61,7 @@ function VideoTableView({
   onToggleIgnore,
   onToggleProtection,
   onMobileTooltip,
+  onVideoClick,
 }: VideoTableViewProps) {
   return (
     <TableContainer>
@@ -209,6 +212,15 @@ function VideoTableView({
                       }}
                       loading="lazy"
                     />
+                    {/* Center hotspot for opening video modal */}
+                    {onVideoClick && (
+                      <ThumbnailClickOverlay
+                        onClick={(e: React.MouseEvent) => {
+                          e.stopPropagation();
+                          onVideoClick(video);
+                        }}
+                      />
+                    )}
                     {video.youtube_removed && (
                       <Box
                         sx={{
@@ -232,7 +244,18 @@ function VideoTableView({
                   </Box>
                 </TableCell>
                 <TableCell>
-                  <Typography variant="body2" sx={{ mb: 0.5 }}>
+                  <Typography
+                    variant="body2"
+                    onClick={onVideoClick ? (e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      onVideoClick(video);
+                    } : undefined}
+                    sx={{
+                      mb: 0.5,
+                      cursor: onVideoClick ? 'pointer' : 'default',
+                      '&:hover': onVideoClick ? { textDecoration: 'underline' } : {},
+                    }}
+                  >
                     {decodeHtml(video.title)}
                   </Typography>
                 </TableCell>

--- a/client/src/components/ChannelPage/VideoTableView.tsx
+++ b/client/src/components/ChannelPage/VideoTableView.tsx
@@ -17,6 +17,9 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
+import Tooltip from '@mui/material/Tooltip';
 import RatingBadge from '../shared/RatingBadge';
 import { formatDuration } from '../../utils';
 import { ChannelVideo } from '../../types/ChannelVideo';
@@ -40,6 +43,7 @@ interface VideoTableViewProps {
   onSortChange: (newSortBy: SortBy) => void;
   onToggleDeletion: (youtubeId: string) => void;
   onToggleIgnore: (youtubeId: string) => void;
+  onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
 }
 
@@ -55,6 +59,7 @@ function VideoTableView({
   onSortChange,
   onToggleDeletion,
   onToggleIgnore,
+  onToggleProtection,
   onMobileTooltip,
 }: VideoTableViewProps) {
   return (
@@ -142,6 +147,7 @@ function VideoTableView({
                   {/* Delete icon for downloaded videos that exist on disk */}
                   {video.added && !video.removed && (
                     <IconButton
+                      aria-label="Delete video"
                       onClick={(e) => {
                         e.stopPropagation();
                         onToggleDeletion(video.youtube_id);
@@ -157,6 +163,31 @@ function VideoTableView({
                     >
                       <DeleteIcon fontSize="small" />
                     </IconButton>
+                  )}
+                  {/* Protection shield for downloaded videos */}
+                  {video.added && !video.removed && (
+                    <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
+                      <IconButton
+                        aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onToggleProtection(video.youtube_id);
+                        }}
+                        sx={{
+                          color: video.protected ? 'primary.main' : 'action.active',
+                          '&:hover': {
+                            color: 'primary.main',
+                            bgcolor: 'primary.light',
+                          },
+                        }}
+                        size="small"
+                      >
+                        {video.protected
+                          ? <ShieldIcon fontSize="small" />
+                          : <ShieldOutlinedIcon fontSize="small" />
+                        }
+                      </IconButton>
+                    </Tooltip>
                   )}
                   {/* Ignore/Unignore button - for videos not currently on disk (never downloaded or missing) */}
                   {!isStillLive && (!video.added || video.removed) && (

--- a/client/src/components/ChannelPage/VideoTableView.tsx
+++ b/client/src/components/ChannelPage/VideoTableView.tsx
@@ -17,10 +17,8 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import DeleteIcon from '@mui/icons-material/Delete';
 import BlockIcon from '@mui/icons-material/Block';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import ShieldIcon from '@mui/icons-material/Shield';
-import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
-import Tooltip from '@mui/material/Tooltip';
 import RatingBadge from '../shared/RatingBadge';
+import ProtectionShieldButton from '../shared/ProtectionShieldButton';
 import { formatDuration } from '../../utils';
 import { ChannelVideo } from '../../types/ChannelVideo';
 import { decodeHtml } from '../../utils/formatters';
@@ -166,28 +164,14 @@ function VideoTableView({
                   )}
                   {/* Protection shield for downloaded videos */}
                   {video.added && !video.removed && (
-                    <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'} arrow>
-                      <IconButton
-                        aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onToggleProtection(video.youtube_id);
-                        }}
-                        sx={{
-                          color: video.protected ? 'primary.main' : 'action.active',
-                          '&:hover': {
-                            color: 'primary.main',
-                            bgcolor: 'primary.light',
-                          },
-                        }}
-                        size="small"
-                      >
-                        {video.protected
-                          ? <ShieldIcon fontSize="small" />
-                          : <ShieldOutlinedIcon fontSize="small" />
-                        }
-                      </IconButton>
-                    </Tooltip>
+                    <ProtectionShieldButton
+                      isProtected={video.protected || false}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onToggleProtection(video.youtube_id);
+                      }}
+                      variant="inline"
+                    />
                   )}
                   {/* Ignore/Unignore button - for videos not currently on disk (never downloaded or missing) */}
                   {!isStillLive && (!video.added || video.removed) && (

--- a/client/src/components/ChannelPage/__tests__/ChannelSettingsDialog.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelSettingsDialog.test.tsx
@@ -13,6 +13,17 @@ jest.mock('../../../hooks/useConfig', () => ({
   useConfig: jest.fn(),
 }));
 
+// Mock axios because TabsEditor (rendered inside the dialog) uses axios.post
+// for the refresh button. Existing dialog tests do not click refresh so the
+// mock is passive for them; it's only exercised by the refresh-path test.
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  isAxiosError: jest.fn(() => false),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const mockAxios = require('axios');
+
 const mockUseConfig = useConfig as jest.MockedFunction<typeof useConfig>;
 
 describe('ChannelSettingsDialog', () => {
@@ -46,6 +57,8 @@ describe('ChannelSettingsDialog', () => {
     jest.clearAllMocks();
     mockFetch = jest.fn();
     global.fetch = mockFetch;
+    mockAxios.post.mockReset();
+    mockAxios.isAxiosError.mockReturnValue(false);
     mockRefetchConfig.mockResolvedValue(undefined);
     // Reset mockUseConfig to default
     mockUseConfig.mockReturnValue({
@@ -989,10 +1002,12 @@ describe('ChannelSettingsDialog', () => {
       await user.click(saveButton);
 
       await waitFor(() => {
-        expect(mockOnSettingsSaved).toHaveBeenCalledWith({
-          ...mockChannelSettings,
-          video_quality: '720',
-        });
+        expect(mockOnSettingsSaved).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ...mockChannelSettings,
+            video_quality: '720',
+          })
+        );
       });
     });
 
@@ -1572,6 +1587,186 @@ describe('ChannelSettingsDialog', () => {
       });
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Channel Tabs integration', () => {
+    test('loads detected_tabs and hidden_tabs from settings and reflects them in TabsEditor', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            ...mockChannelSettings,
+            detected_tabs: ['videos', 'shorts', 'streams'],
+            hidden_tabs: ['shorts'],
+            available_tabs: ['videos', 'streams'],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        });
+
+      render(<ChannelSettingsDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeChecked();
+      expect(screen.getByTestId('tabs-editor-checkbox-shorts')).not.toBeChecked();
+      expect(screen.getByTestId('tabs-editor-checkbox-streams')).toBeChecked();
+    });
+
+    test('save request includes hidden_tabs in the PUT body', async () => {
+      const user = userEvent.setup();
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            ...mockChannelSettings,
+            detected_tabs: ['videos', 'shorts', 'streams'],
+            hidden_tabs: [],
+            available_tabs: ['videos', 'shorts', 'streams'],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            settings: {
+              ...mockChannelSettings,
+              hidden_tabs: ['shorts'],
+              detected_tabs: ['videos', 'shorts', 'streams'],
+              available_tabs: ['videos', 'streams'],
+            },
+          }),
+        });
+
+      render(<ChannelSettingsDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('tabs-editor-checkbox-shorts'));
+
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        const saveCall = mockFetch.mock.calls.find(
+          ([url, init]) =>
+            url === '/api/channels/channel123/settings' && init?.method === 'PUT'
+        );
+        expect(saveCall).toBeDefined();
+      });
+
+      const saveCall = mockFetch.mock.calls.find(
+        ([url, init]) =>
+          url === '/api/channels/channel123/settings' && init?.method === 'PUT'
+      )!;
+      const body = JSON.parse(saveCall[1].body as string);
+      expect(body.hidden_tabs).toEqual(['shorts']);
+    });
+
+    test('save button is disabled when every detected tab is hidden', async () => {
+      const user = userEvent.setup();
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            ...mockChannelSettings,
+            detected_tabs: ['videos', 'shorts'],
+            hidden_tabs: [],
+            available_tabs: ['videos', 'shorts'],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        });
+
+      render(<ChannelSettingsDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('tabs-editor-checkbox-videos'));
+      await user.click(screen.getByTestId('tabs-editor-checkbox-shorts'));
+
+      expect(screen.getByText('At least one tab must remain visible.')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    });
+
+    test('refresh updates detected tabs and resets originalSettings so Save stays disabled', async () => {
+      const user = userEvent.setup();
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            ...mockChannelSettings,
+            detected_tabs: ['videos', 'shorts'],
+            hidden_tabs: ['shorts'],
+            available_tabs: ['videos'],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockSubfolders),
+        });
+
+      // Backend's redetect probe now also finds 'streams' and keeps 'shorts' hidden
+      mockAxios.post.mockResolvedValueOnce({
+        data: {
+          availableTabs: ['videos', 'streams'],
+          detectedTabs: ['videos', 'shorts', 'streams'],
+          hiddenTabs: ['shorts'],
+        },
+      });
+
+      render(<ChannelSettingsDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      // Initial state: only videos + shorts detected, streams not yet present
+      expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeChecked();
+      expect(screen.getByTestId('tabs-editor-checkbox-shorts')).not.toBeChecked();
+      expect(screen.queryByTestId('tabs-editor-checkbox-streams')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+      // Click refresh; TabsEditor posts via axios and receives the new state
+      await user.click(screen.getByTestId('tabs-editor-refresh'));
+
+      await waitFor(() => {
+        expect(mockAxios.post).toHaveBeenCalledWith(
+          '/api/channels/channel123/tabs/redetect',
+          null,
+          { headers: { 'x-access-token': 'test-token' } }
+        );
+      });
+
+      // After refresh: streams now rendered; videos + streams checked, shorts still hidden
+      await waitFor(() => {
+        expect(screen.getByTestId('tabs-editor-checkbox-streams')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeChecked();
+      expect(screen.getByTestId('tabs-editor-checkbox-shorts')).not.toBeChecked();
+      expect(screen.getByTestId('tabs-editor-checkbox-streams')).toBeChecked();
+
+      // Critical invariant: handleTabsRefresh resets originalSettings.hidden_tabs
+      // to the refresh result, so hasChanges() is false and Save stays disabled.
+      // If that reset is broken, Save would be ENABLED here.
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
     });
   });
 });

--- a/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
@@ -1,4 +1,5 @@
-import { screen, waitFor } from '@testing-library/react';
+import React, { useState } from 'react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -953,6 +954,167 @@ describe('ChannelVideos Component', () => {
       expect(screen.getByTestId('video-card-video1')).toBeInTheDocument();
       expect(screen.getByTestId('video-card-ignored1')).toBeInTheDocument();
       expect(screen.getByTestId('video-card-video2')).toBeInTheDocument();
+    });
+  });
+
+  describe('channelAvailableTabs prop sync', () => {
+    // Controlled harness: holds channelAvailableTabs in state and exposes a
+    // setter that tests call to simulate the parent passing a new value.
+    // This avoids interactions with RTL's `rerender` + wrapper option.
+    //
+    // Both the sync effect AND the internal tabs-fetch effect write to
+    // availableTabs state. To make these tests deterministic regardless of
+    // unrelated prior tests' scheduling, we ALSO mock the tabs fetch to
+    // return the same data the sync effect would produce so whichever effect
+    // "wins" the race yields an equivalent result. For tests that need the
+    // sync-effect state to be visible after a prop change, we seed the
+    // initial prop and let the sync effect establish state on mount.
+    let setTabsProp: ((val: string | null | undefined) => void) | null = null;
+
+    const Harness = ({ initial }: { initial?: string | null }) => {
+      const [prop, setProp] = useState<string | null | undefined>(initial);
+      setTabsProp = setProp;
+      return <ChannelVideos token={mockToken} channelAvailableTabs={prop} />;
+    };
+
+    // Build a fetch mock that always returns the same availableTabs the
+    // sync effect would set, so the fetch effect never introduces a
+    // different state into the race.
+    const mockTabsFetch = (tabs: string[]) => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ availableTabs: tabs }),
+      });
+    };
+
+    beforeEach(() => {
+      setTabsProp = null;
+    });
+
+    test('updates the rendered tab strip when parent passes a new channelAvailableTabs value', async () => {
+      // Both the fetch effect and the sync effect would set 3 tabs on mount
+      mockTabsFetch(['videos', 'shorts', 'streams']);
+
+      renderWithProviders(<Harness initial="videos,shorts,streams" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      });
+      expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
+
+      // Parent now passes a filtered list down (shorts hidden)
+      act(() => {
+        setTabsProp?.('videos,streams');
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('tab', { name: /Shorts/i })).not.toBeInTheDocument();
+      });
+      expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Videos/i })).toBeInTheDocument();
+    });
+
+    test('preserves the current selected tab when it remains in the new list', async () => {
+      const user = userEvent.setup();
+      mockTabsFetch(['videos', 'shorts', 'streams']);
+
+      renderWithProviders(<Harness initial="videos,shorts,streams" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('tab', { name: /Shorts/i }));
+
+      await waitFor(() => {
+        expect(useChannelVideos).toHaveBeenLastCalledWith(
+          expect.objectContaining({ tabType: 'shorts' })
+        );
+      });
+
+      // Parent passes [videos, shorts] (streams hidden, shorts still present)
+      act(() => {
+        setTabsProp?.('videos,shorts');
+      });
+
+      // Selected tab should still be shorts
+      await waitFor(() => {
+        expect(useChannelVideos).toHaveBeenLastCalledWith(
+          expect.objectContaining({ tabType: 'shorts' })
+        );
+      });
+      expect(screen.queryByRole('tab', { name: /Live/i })).not.toBeInTheDocument();
+    });
+
+    test('falls back to videos when the current tab is dropped from the new list', async () => {
+      const user = userEvent.setup();
+      mockTabsFetch(['videos', 'shorts', 'streams']);
+
+      renderWithProviders(<Harness initial="videos,shorts,streams" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      });
+
+      // Select the shorts tab
+      await user.click(screen.getByRole('tab', { name: /Shorts/i }));
+
+      await waitFor(() => {
+        expect(useChannelVideos).toHaveBeenLastCalledWith(
+          expect.objectContaining({ tabType: 'shorts' })
+        );
+      });
+
+      // Parent hides shorts; new list = [videos, streams], current 'shorts' is gone
+      act(() => {
+        setTabsProp?.('videos,streams');
+      });
+
+      // Selected tab should fall back to 'videos' (preferred fallback)
+      await waitFor(() => {
+        expect(useChannelVideos).toHaveBeenLastCalledWith(
+          expect.objectContaining({ tabType: 'videos' })
+        );
+      });
+    });
+
+    test('leaves the tab strip alone when channelAvailableTabs is undefined', async () => {
+      // Fetch and sync effect agree on 3 tabs from mount
+      mockTabsFetch(['videos', 'shorts', 'streams']);
+
+      renderWithProviders(<Harness initial="videos,shorts,streams" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
+      });
+
+      // Explicit undefined: the sync effect must early-return and leave state alone
+      act(() => {
+        setTabsProp?.(undefined);
+      });
+
+      expect(screen.getByRole('tab', { name: /Videos/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
+    });
+
+    test('leaves the tab strip alone when channelAvailableTabs is an empty string', async () => {
+      mockTabsFetch(['videos', 'shorts', 'streams']);
+
+      renderWithProviders(<Harness initial="videos,shorts,streams" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
+      });
+
+      // Empty string parses to empty array, so the sync effect should early-return
+      act(() => {
+        setTabsProp?.('');
+      });
+
+      expect(screen.getByRole('tab', { name: /Videos/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Shorts/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Live/i })).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
@@ -532,6 +532,7 @@ describe('ChannelVideos Component', () => {
         maxDuration: null,
         dateFrom: null,
         dateTo: null,
+        protectedFilter: false,
       });
     });
 

--- a/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -174,6 +174,7 @@ describe('ChannelVideos Component', () => {
     mockFetch.mockReset();
     (useMediaQuery as jest.Mock).mockReturnValue(false);
     mockNavigate.mockClear();
+    localStorage.removeItem('youtarr.channelVideos.pageSize');
 
     // Default mock responses
     useChannelVideos.mockReturnValue({
@@ -434,6 +435,180 @@ describe('ChannelVideos Component', () => {
     });
   });
 
+  describe('Page Size Selector', () => {
+    test('renders page size selector when videos exist', () => {
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      expect(screen.getByLabelText('videos per page')).toBeInTheDocument();
+    });
+
+    test('does not render page size selector when no videos', () => {
+      useChannelVideos.mockReturnValue({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      expect(screen.queryByLabelText('videos per page')).not.toBeInTheDocument();
+    });
+
+    test('does not render page size selector while loading', () => {
+      useChannelVideos.mockReturnValue({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: true,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      expect(screen.queryByLabelText('videos per page')).not.toBeInTheDocument();
+    });
+
+    test('selector shows default value of 16', () => {
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      const select = screen.getByLabelText('videos per page');
+      expect(select).toHaveTextContent('16');
+    });
+
+    test('selector reads stored value from localStorage', () => {
+      localStorage.setItem('youtarr.channelVideos.pageSize', '32');
+
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      expect(useChannelVideos).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageSize: 32,
+        })
+      );
+    });
+
+    test('changing page size updates fetch params and writes to localStorage', async () => {
+      const user = userEvent.setup();
+
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 48, // enough for multiple pages at size 16
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      // Navigate to page 2 first so we can verify page resets to 1
+      await waitFor(() => {
+        expect(screen.getAllByRole('navigation').length).toBeGreaterThan(0);
+      });
+      const page2Buttons = screen.getAllByRole('button', { name: 'Go to page 2' });
+      await user.click(page2Buttons[0]);
+
+      expect(useChannelVideos).toHaveBeenLastCalledWith(
+        expect.objectContaining({ page: 2 })
+      );
+
+      // Open the MUI Select dropdown by clicking its displayed value text.
+      // MUI Select (non-native) opens on mouseDown on the inner trigger div.
+      // The "Per page:" label precedes the Select, and the Select displays "16".
+      // Use within() on the labeled container to find the trigger by its text content.
+      const selectContainer = screen.getByLabelText('videos per page');
+      const trigger = within(selectContainer).getByText('16');
+      fireEvent.mouseDown(trigger);
+
+      // Choose 32
+      const option = await screen.findByRole('option', { name: '32' });
+      await user.click(option);
+
+      expect(localStorage.getItem('youtarr.channelVideos.pageSize')).toBe('32');
+      expect(useChannelVideos).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          pageSize: 32,
+          page: 1,
+        })
+      );
+    });
+
+    test('renders selector without pagination buttons when only one page', () => {
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      // Selector should be present
+      expect(screen.getByLabelText('videos per page')).toBeInTheDocument();
+
+      // Only 1 page total (3 videos < 16 per page), so no page 2 button should exist
+      expect(screen.queryByRole('button', { name: 'Go to page 2' })).not.toBeInTheDocument();
+    });
+
+    test('renders both selector and pagination when multiple pages', () => {
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 32,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      // Both should be present
+      expect(screen.getByLabelText('videos per page')).toBeInTheDocument();
+      expect(screen.getAllByRole('navigation').length).toBeGreaterThan(0);
+    });
+  });
+
   describe('Error Handling', () => {
     test('handles tab fetch error gracefully', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -679,12 +854,12 @@ describe('ChannelVideos Component', () => {
       (useMediaQuery as jest.Mock).mockReturnValue(true);
     });
 
-    test('uses mobile page size', () => {
+    test('uses same page size on mobile as desktop (unified setting)', () => {
       renderChannelVideos();
 
       expect(useChannelVideos).toHaveBeenCalledWith(
         expect.objectContaining({
-          pageSize: 8, // Mobile page size
+          pageSize: 16,
         })
       );
     });

--- a/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
@@ -36,6 +36,7 @@ describe('VideoCard Component', () => {
     onHoverChange: jest.fn(),
     onToggleDeletion: jest.fn(),
     onToggleIgnore: jest.fn(),
+    onToggleProtection: jest.fn(),
   };
 
   beforeEach(() => {
@@ -391,7 +392,7 @@ describe('VideoCard Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -413,7 +414,7 @@ describe('VideoCard Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -717,6 +718,46 @@ describe('VideoCard Component', () => {
       renderWithProviders(<VideoCard {...defaultProps} />);
       const img = screen.getByAltText('Test Video Title');
       expect(img).toHaveAttribute('loading', 'lazy');
+    });
+  });
+
+  describe('Protection Shield', () => {
+    test('renders shield icon for downloaded video', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoCard {...defaultProps} video={downloadedVideo} />);
+      expect(screen.getByLabelText('Protect from auto-deletion')).toBeInTheDocument();
+    });
+
+    test('renders active shield icon for protected video', () => {
+      const protectedVideo = { ...mockVideo, added: true, removed: false, protected: true };
+      renderWithProviders(<VideoCard {...defaultProps} video={protectedVideo} />);
+      expect(screen.getByLabelText('Remove protection')).toBeInTheDocument();
+    });
+
+    test('does not render shield icon for non-downloaded video', () => {
+      renderWithProviders(<VideoCard {...defaultProps} />);
+      expect(screen.queryByLabelText('Protect from auto-deletion')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Remove protection')).not.toBeInTheDocument();
+    });
+
+    test('calls onToggleProtection when shield icon is clicked', async () => {
+      const user = userEvent.setup();
+      const onToggleProtection = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoCard
+          {...defaultProps}
+          video={downloadedVideo}
+          onToggleProtection={onToggleProtection}
+        />
+      );
+
+      const shieldButton = screen.getByLabelText('Protect from auto-deletion');
+      await user.click(shieldButton);
+
+      expect(onToggleProtection).toHaveBeenCalledTimes(1);
+      expect(onToggleProtection).toHaveBeenCalledWith('test123');
     });
   });
 

--- a/client/src/components/ChannelPage/__tests__/VideoListItem.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoListItem.test.tsx
@@ -33,6 +33,7 @@ describe('VideoListItem Component', () => {
     onCheckChange: jest.fn(),
     onToggleDeletion: jest.fn(),
     onToggleIgnore: jest.fn(),
+    onToggleProtection: jest.fn(),
   };
 
   beforeEach(() => {
@@ -435,7 +436,7 @@ describe('VideoListItem Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -457,7 +458,7 @@ describe('VideoListItem Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -759,6 +760,46 @@ describe('VideoListItem Component', () => {
       const ignoredVideo = { ...mockVideo, ignored: true };
       renderWithProviders(<VideoListItem {...defaultProps} video={ignoredVideo} />);
       expect(screen.getByText('Ignored')).toBeInTheDocument();
+    });
+  });
+
+  describe('Protection Shield', () => {
+    test('renders shield icon for downloaded video', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoListItem {...defaultProps} video={downloadedVideo} />);
+      expect(screen.getByLabelText('Protect from auto-deletion')).toBeInTheDocument();
+    });
+
+    test('renders active shield icon for protected video', () => {
+      const protectedVideo = { ...mockVideo, added: true, removed: false, protected: true };
+      renderWithProviders(<VideoListItem {...defaultProps} video={protectedVideo} />);
+      expect(screen.getByLabelText('Remove protection')).toBeInTheDocument();
+    });
+
+    test('does not render shield icon for non-downloaded video', () => {
+      renderWithProviders(<VideoListItem {...defaultProps} />);
+      expect(screen.queryByLabelText('Protect from auto-deletion')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Remove protection')).not.toBeInTheDocument();
+    });
+
+    test('calls onToggleProtection when shield icon is clicked', async () => {
+      const user = userEvent.setup();
+      const onToggleProtection = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoListItem
+          {...defaultProps}
+          video={downloadedVideo}
+          onToggleProtection={onToggleProtection}
+        />
+      );
+
+      const shieldButton = screen.getByLabelText('Protect from auto-deletion');
+      await user.click(shieldButton);
+
+      expect(onToggleProtection).toHaveBeenCalledTimes(1);
+      expect(onToggleProtection).toHaveBeenCalledWith('test123');
     });
   });
 });

--- a/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
@@ -39,6 +39,7 @@ describe('VideoTableView Component', () => {
     onSortChange: jest.fn(),
     onToggleDeletion: jest.fn(),
     onToggleIgnore: jest.fn(),
+    onToggleProtection: jest.fn(),
   };
 
   beforeEach(() => {
@@ -462,7 +463,7 @@ describe('VideoTableView Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -484,7 +485,7 @@ describe('VideoTableView Component', () => {
         />
       );
 
-      const deleteButton = screen.getByRole('button');
+      const deleteButton = screen.getByLabelText('Delete video');
       await user.click(deleteButton);
 
       expect(onToggleDeletion).toHaveBeenCalledTimes(1);
@@ -950,6 +951,46 @@ describe('VideoTableView Component', () => {
       expect(checkboxes[0]).toBeChecked();
       expect(checkboxes[1]).toBeChecked();
       expect(checkboxes[2]).toBeChecked();
+    });
+  });
+
+  describe('Protection Shield', () => {
+    test('renders shield icon for downloaded video', () => {
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[downloadedVideo]} />);
+      expect(screen.getByLabelText('Protect from auto-deletion')).toBeInTheDocument();
+    });
+
+    test('renders active shield icon for protected video', () => {
+      const protectedVideo = { ...mockVideo, added: true, removed: false, protected: true };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[protectedVideo]} />);
+      expect(screen.getByLabelText('Remove protection')).toBeInTheDocument();
+    });
+
+    test('does not render shield icon for non-downloaded video', () => {
+      renderWithProviders(<VideoTableView {...defaultProps} />);
+      expect(screen.queryByLabelText('Protect from auto-deletion')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Remove protection')).not.toBeInTheDocument();
+    });
+
+    test('calls onToggleProtection when shield icon is clicked', async () => {
+      const user = userEvent.setup();
+      const onToggleProtection = jest.fn();
+      const downloadedVideo = { ...mockVideo, added: true, removed: false };
+
+      renderWithProviders(
+        <VideoTableView
+          {...defaultProps}
+          videos={[downloadedVideo]}
+          onToggleProtection={onToggleProtection}
+        />
+      );
+
+      const shieldButton = screen.getByLabelText('Protect from auto-deletion');
+      await user.click(shieldButton);
+
+      expect(onToggleProtection).toHaveBeenCalledTimes(1);
+      expect(onToggleProtection).toHaveBeenCalledWith('test123');
     });
   });
 });

--- a/client/src/components/ChannelPage/components/ChannelVideosFilters.tsx
+++ b/client/src/components/ChannelPage/components/ChannelVideosFilters.tsx
@@ -3,10 +3,12 @@ import {
   Box,
   Button,
   Badge,
+  Chip,
   Collapse,
   Typography,
 } from '@mui/material';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import ShieldIcon from '@mui/icons-material/Shield';
 import DurationFilterInput from './DurationFilterInput';
 import DateRangeFilterInput from './DateRangeFilterInput';
 import FilterChips from './FilterChips';
@@ -27,6 +29,8 @@ interface ChannelVideosFiltersProps {
   activeFilterCount: number;
   hideDateFilter?: boolean;
   filtersExpanded?: boolean; // For desktop, controlled by parent
+  protectedFilter?: boolean;
+  onProtectedFilterChange?: (value: boolean) => void;
 }
 
 function ChannelVideosFilters({
@@ -43,6 +47,8 @@ function ChannelVideosFilters({
   activeFilterCount,
   hideDateFilter = false,
   filtersExpanded = false,
+  protectedFilter = false,
+  onProtectedFilterChange,
 }: ChannelVideosFiltersProps) {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
@@ -98,6 +104,8 @@ function ChannelVideosFilters({
           onClearAll={onClearAll}
           hasActiveFilters={hasActiveFilters}
           hideDateFilter={hideDateFilter}
+          protectedFilter={protectedFilter}
+          onProtectedFilterChange={onProtectedFilterChange}
         />
       </Box>
     );
@@ -125,6 +133,17 @@ function ChannelVideosFilters({
             <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
               Shorts do not have date information
             </Typography>
+          )}
+          {onProtectedFilterChange && (
+            <Chip
+              icon={<ShieldIcon />}
+              label="Protected"
+              variant={protectedFilter ? 'filled' : 'outlined'}
+              color={protectedFilter ? 'primary' : 'default'}
+              size="small"
+              onClick={() => onProtectedFilterChange(!protectedFilter)}
+              sx={{ cursor: 'pointer' }}
+            />
           )}
           {hasActiveFilters && (
             <Button

--- a/client/src/components/ChannelPage/components/MobileFilterDrawer.tsx
+++ b/client/src/components/ChannelPage/components/MobileFilterDrawer.tsx
@@ -5,9 +5,11 @@ import {
   Typography,
   IconButton,
   Button,
+  Chip,
   Divider,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import ShieldIcon from '@mui/icons-material/Shield';
 import DurationFilterInput from './DurationFilterInput';
 import DateRangeFilterInput from './DateRangeFilterInput';
 import { VideoFilters } from '../hooks/useChannelVideoFilters';
@@ -25,6 +27,8 @@ interface MobileFilterDrawerProps {
   onClearAll: () => void;
   hasActiveFilters: boolean;
   hideDateFilter?: boolean;
+  protectedFilter?: boolean;
+  onProtectedFilterChange?: (value: boolean) => void;
 }
 
 function MobileFilterDrawer({
@@ -40,6 +44,8 @@ function MobileFilterDrawer({
   onClearAll,
   hasActiveFilters,
   hideDateFilter = false,
+  protectedFilter = false,
+  onProtectedFilterChange,
 }: MobileFilterDrawerProps) {
   return (
     <Drawer
@@ -98,6 +104,24 @@ function MobileFilterDrawer({
             <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic' }}>
               Shorts do not have date information
             </Typography>
+          </Box>
+        )}
+
+        {/* Protected Filter */}
+        {onProtectedFilterChange && (
+          <Box sx={{ mb: 3 }}>
+            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+              Status
+            </Typography>
+            <Chip
+              icon={<ShieldIcon />}
+              label="Protected"
+              variant={protectedFilter ? 'filled' : 'outlined'}
+              color={protectedFilter ? 'primary' : 'default'}
+              size="small"
+              onClick={() => onProtectedFilterChange(!protectedFilter)}
+              sx={{ cursor: 'pointer' }}
+            />
           </Box>
         )}
 

--- a/client/src/components/ChannelPage/components/TabsEditor.tsx
+++ b/client/src/components/ChannelPage/components/TabsEditor.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  FormControlLabel,
+  FormGroup,
+  Typography
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+
+const TAB_TYPE_ORDER: string[] = ['videos', 'shorts', 'streams'];
+const TAB_LABEL: Record<string, string> = {
+  videos: 'Videos',
+  shorts: 'Shorts',
+  streams: 'Live / Streams'
+};
+
+export interface TabsEditorRefreshResult {
+  availableTabs: string[];
+  detectedTabs: string[];
+  hiddenTabs: string[];
+}
+
+interface TabsEditorProps {
+  channelId: string;
+  token: string | null;
+  detectedTabs: string[];
+  hiddenTabs: string[];
+  onHiddenTabsChange: (nextHidden: string[]) => void;
+  onRefresh: (result: TabsEditorRefreshResult) => void;
+  disabled?: boolean;
+}
+
+function TabsEditor({
+  channelId,
+  token,
+  detectedTabs,
+  hiddenTabs,
+  onHiddenTabsChange,
+  onRefresh,
+  disabled = false
+}: TabsEditorProps) {
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+
+  const hiddenSet = new Set(hiddenTabs);
+  const effectiveTabs = detectedTabs.filter((tab) => !hiddenSet.has(tab));
+  const allHidden = detectedTabs.length > 0 && effectiveTabs.length === 0;
+
+  // Ensure tabs always render in a stable order, even if the backend returns them shuffled.
+  const orderedDetectedTabs = TAB_TYPE_ORDER.filter((tab) => detectedTabs.includes(tab));
+
+  const handleToggle = (tab: string, visible: boolean) => {
+    // `visible` true  = checkbox checked = tab NOT hidden
+    // `visible` false = checkbox unchecked = tab IS hidden
+    const next = new Set(hiddenSet);
+    if (visible) {
+      next.delete(tab);
+    } else {
+      next.add(tab);
+    }
+    onHiddenTabsChange(Array.from(next));
+  };
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    setRefreshError(null);
+    try {
+      const { data } = await axios.post<TabsEditorRefreshResult>(
+        `/api/channels/${channelId}/tabs/redetect`,
+        null,
+        { headers: { 'x-access-token': token || '' } }
+      );
+      onRefresh({
+        availableTabs: Array.isArray(data.availableTabs) ? data.availableTabs : [],
+        detectedTabs: Array.isArray(data.detectedTabs) ? data.detectedTabs : [],
+        hiddenTabs: Array.isArray(data.hiddenTabs) ? data.hiddenTabs : []
+      });
+    } catch (err) {
+      let message = 'Failed to refresh tabs';
+      if (axios.isAxiosError(err) && err.response?.data?.error) {
+        message = err.response.data.error;
+      } else if (err instanceof Error) {
+        message = err.message;
+      }
+      setRefreshError(message);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+        Channel Tabs
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        Choose which YouTube tabs to use for this channel. Unchecking a tab hides it from the
+        channel page and the channel list, and disables its auto-download. Use &quot;Refresh
+        from YouTube&quot; if the detected tabs look wrong (e.g. a channel only shows as having
+        Shorts).
+      </Typography>
+
+      {orderedDetectedTabs.length === 0 ? (
+        <Alert severity="info" sx={{ mt: 1 }}>
+          No tabs have been detected for this channel yet. Click &quot;Refresh from YouTube&quot;
+          to run detection now.
+        </Alert>
+      ) : (
+        <FormGroup row sx={{ mt: 0.5 }}>
+          {orderedDetectedTabs.map((tab) => (
+            <FormControlLabel
+              key={tab}
+              control={
+                <Checkbox
+                  inputProps={{ 'data-testid': `tabs-editor-checkbox-${tab}` } as React.InputHTMLAttributes<HTMLInputElement>}
+                  checked={!hiddenSet.has(tab)}
+                  onChange={(e) => handleToggle(tab, e.target.checked)}
+                  disabled={disabled || refreshing}
+                />
+              }
+              label={TAB_LABEL[tab] || tab}
+            />
+          ))}
+        </FormGroup>
+      )}
+
+      {allHidden && (
+        <Alert severity="error">
+          At least one tab must remain visible.
+        </Alert>
+      )}
+
+      {refreshError && (
+        <Alert severity="error" onClose={() => setRefreshError(null)}>
+          {refreshError}
+        </Alert>
+      )}
+
+      <Box sx={{ mt: 0.5 }}>
+        <Button
+          data-testid="tabs-editor-refresh"
+          variant="outlined"
+          size="small"
+          startIcon={refreshing ? <CircularProgress size={14} /> : <RefreshIcon />}
+          onClick={handleRefresh}
+          disabled={disabled || refreshing}
+        >
+          {refreshing ? 'Refreshing...' : 'Refresh from YouTube'}
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+export default TabsEditor;

--- a/client/src/components/ChannelPage/components/__tests__/TabsEditor.test.tsx
+++ b/client/src/components/ChannelPage/components/__tests__/TabsEditor.test.tsx
@@ -1,0 +1,147 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import TabsEditor from '../TabsEditor';
+import { renderWithProviders } from '../../../../test-utils';
+
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  isAxiosError: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const axios = require('axios');
+
+describe('TabsEditor', () => {
+  const defaultProps = {
+    channelId: 'UC123',
+    token: 'test-token',
+    detectedTabs: ['videos', 'shorts', 'streams'],
+    hiddenTabs: [] as string[],
+    onHiddenTabsChange: jest.fn(),
+    onRefresh: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    axios.isAxiosError.mockReturnValue(false);
+  });
+
+  test('renders a checkbox for each detected tab and marks them checked', () => {
+    renderWithProviders(<TabsEditor {...defaultProps} />);
+
+    expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeChecked();
+    expect(screen.getByTestId('tabs-editor-checkbox-shorts')).toBeChecked();
+    expect(screen.getByTestId('tabs-editor-checkbox-streams')).toBeChecked();
+  });
+
+  test('reflects hidden tabs as unchecked', () => {
+    renderWithProviders(<TabsEditor {...defaultProps} hiddenTabs={['shorts']} />);
+
+    expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeChecked();
+    expect(screen.getByTestId('tabs-editor-checkbox-shorts')).not.toBeChecked();
+    expect(screen.getByTestId('tabs-editor-checkbox-streams')).toBeChecked();
+  });
+
+  test('calls onHiddenTabsChange when a checkbox is unchecked', async () => {
+    const user = userEvent.setup();
+    const onHiddenTabsChange = jest.fn();
+    renderWithProviders(
+      <TabsEditor {...defaultProps} onHiddenTabsChange={onHiddenTabsChange} />
+    );
+
+    await user.click(screen.getByTestId('tabs-editor-checkbox-shorts'));
+
+    expect(onHiddenTabsChange).toHaveBeenCalledWith(['shorts']);
+  });
+
+  test('calls onHiddenTabsChange with remaining tabs when re-enabling a hidden tab', async () => {
+    const user = userEvent.setup();
+    const onHiddenTabsChange = jest.fn();
+    renderWithProviders(
+      <TabsEditor
+        {...defaultProps}
+        hiddenTabs={['shorts', 'streams']}
+        onHiddenTabsChange={onHiddenTabsChange}
+      />
+    );
+
+    await user.click(screen.getByTestId('tabs-editor-checkbox-streams'));
+
+    expect(onHiddenTabsChange).toHaveBeenCalledWith(['shorts']);
+  });
+
+  test('shows all-hidden error when every tab is hidden', () => {
+    renderWithProviders(
+      <TabsEditor {...defaultProps} hiddenTabs={['videos', 'shorts', 'streams']} />
+    );
+
+    expect(screen.getByText('At least one tab must remain visible.')).toBeInTheDocument();
+  });
+
+  test('shows empty-state message when no tabs have been detected', () => {
+    renderWithProviders(<TabsEditor {...defaultProps} detectedTabs={[]} />);
+
+    expect(
+      screen.getByText(/No tabs have been detected for this channel yet/)
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('tabs-editor-checkbox-videos')).not.toBeInTheDocument();
+  });
+
+  test('refresh button posts to /tabs/redetect and forwards result to onRefresh', async () => {
+    const user = userEvent.setup();
+    const onRefresh = jest.fn();
+    axios.post.mockResolvedValueOnce({
+      data: {
+        availableTabs: ['videos', 'streams'],
+        detectedTabs: ['videos', 'shorts', 'streams'],
+        hiddenTabs: ['shorts'],
+      },
+    });
+
+    renderWithProviders(
+      <TabsEditor {...defaultProps} hiddenTabs={['shorts']} onRefresh={onRefresh} />
+    );
+
+    await user.click(screen.getByTestId('tabs-editor-refresh'));
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/channels/UC123/tabs/redetect',
+        null,
+        { headers: { 'x-access-token': 'test-token' } }
+      );
+    });
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledWith({
+        availableTabs: ['videos', 'streams'],
+        detectedTabs: ['videos', 'shorts', 'streams'],
+        hiddenTabs: ['shorts'],
+      });
+    });
+  });
+
+  test('shows an error message when refresh fails', async () => {
+    const user = userEvent.setup();
+    axios.isAxiosError.mockReturnValue(true);
+    axios.post.mockRejectedValueOnce({
+      response: { status: 500, data: { error: 'yt-dlp exploded' } },
+    });
+
+    renderWithProviders(<TabsEditor {...defaultProps} />);
+
+    await user.click(screen.getByTestId('tabs-editor-refresh'));
+
+    await waitFor(() => {
+      expect(screen.getByText('yt-dlp exploded')).toBeInTheDocument();
+    });
+  });
+
+  test('disables checkboxes and refresh button while disabled prop is true', () => {
+    renderWithProviders(<TabsEditor {...defaultProps} disabled />);
+
+    expect(screen.getByTestId('tabs-editor-checkbox-videos')).toBeDisabled();
+    expect(screen.getByTestId('tabs-editor-refresh')).toBeDisabled();
+  });
+});

--- a/client/src/components/ChannelPage/hooks/__tests__/useChannelVideosPageSize.test.ts
+++ b/client/src/components/ChannelPage/hooks/__tests__/useChannelVideosPageSize.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, act } from '@testing-library/react';
+import { useChannelVideosPageSize, ALLOWED_PAGE_SIZES } from '../useChannelVideosPageSize';
+
+const STORAGE_KEY = 'youtarr.channelVideos.pageSize';
+
+describe('useChannelVideosPageSize', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('returns default 16 when localStorage is empty', () => {
+    const { result } = renderHook(() => useChannelVideosPageSize());
+    expect(result.current[0]).toBe(16);
+  });
+
+  test('returns stored value when localStorage holds a valid page size', () => {
+    localStorage.setItem(STORAGE_KEY, '32');
+    const { result } = renderHook(() => useChannelVideosPageSize());
+    expect(result.current[0]).toBe(32);
+  });
+
+  test.each([8, 16, 32, 64, 128])('accepts valid page size %i', (size) => {
+    localStorage.setItem(STORAGE_KEY, String(size));
+    const { result } = renderHook(() => useChannelVideosPageSize());
+    expect(result.current[0]).toBe(size);
+  });
+
+  test.each(['foo', '7', '256', '', 'NaN', '0', '-1', '16.5'])(
+    'returns default 16 for invalid localStorage value "%s"',
+    (badValue) => {
+      localStorage.setItem(STORAGE_KEY, badValue);
+      const { result } = renderHook(() => useChannelVideosPageSize());
+      expect(result.current[0]).toBe(16);
+    }
+  );
+
+  test('setPageSize writes to localStorage and updates state', () => {
+    const { result } = renderHook(() => useChannelVideosPageSize());
+    expect(result.current[0]).toBe(16);
+
+    act(() => {
+      result.current[1](64);
+    });
+
+    expect(result.current[0]).toBe(64);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('64');
+  });
+
+  test('handles localStorage.setItem throwing without crashing', () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => useChannelVideosPageSize());
+
+    act(() => {
+      result.current[1](32);
+    });
+
+    // State still updates even though localStorage write failed
+    expect(result.current[0]).toBe(32);
+
+    setItemSpy.mockRestore();
+  });
+
+  test('handles localStorage.getItem throwing without crashing', () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+
+    const { result } = renderHook(() => useChannelVideosPageSize());
+    expect(result.current[0]).toBe(16);
+
+    getItemSpy.mockRestore();
+  });
+
+});

--- a/client/src/components/ChannelPage/hooks/useChannelVideos.ts
+++ b/client/src/components/ChannelPage/hooks/useChannelVideos.ts
@@ -15,6 +15,7 @@ interface UseChannelVideosParams {
   maxDuration?: number | null;
   dateFrom?: Date | null;
   dateTo?: Date | null;
+  protectedFilter?: boolean;
 }
 
 interface UseChannelVideosResult {
@@ -43,6 +44,7 @@ export function useChannelVideos({
   maxDuration,
   dateFrom,
   dateTo,
+  protectedFilter,
 }: UseChannelVideosParams): UseChannelVideosResult {
   const [videos, setVideos] = useState<ChannelVideo[]>([]);
   const [totalCount, setTotalCount] = useState<number>(0);
@@ -86,6 +88,9 @@ export function useChannelVideos({
       if (dateTo) {
         queryParams.append('dateTo', dateTo.toISOString().split('T')[0]);
       }
+      if (protectedFilter) {
+        queryParams.append('protectedFilter', 'true');
+      }
 
       const response = await fetch(`/getchannelvideos/${channelId}?${queryParams}`, {
         headers: {
@@ -114,7 +119,7 @@ export function useChannelVideos({
     } finally {
       setLoading(false);
     }
-  }, [channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, token, minDuration, maxDuration, dateFrom, dateTo]);
+  }, [channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, token, minDuration, maxDuration, dateFrom, dateTo, protectedFilter]);
 
   useEffect(() => {
     fetchVideos();

--- a/client/src/components/ChannelPage/hooks/useChannelVideosPageSize.ts
+++ b/client/src/components/ChannelPage/hooks/useChannelVideosPageSize.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'youtarr.channelVideos.pageSize';
+const ALLOWED_PAGE_SIZES = [8, 16, 32, 64, 128] as const;
+const DEFAULT_PAGE_SIZE = 16;
+
+type PageSize = (typeof ALLOWED_PAGE_SIZES)[number];
+
+function readStoredPageSize(): PageSize {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return DEFAULT_PAGE_SIZE;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return DEFAULT_PAGE_SIZE;
+    if (!(ALLOWED_PAGE_SIZES as readonly number[]).includes(parsed)) return DEFAULT_PAGE_SIZE;
+    return parsed as PageSize;
+  } catch {
+    return DEFAULT_PAGE_SIZE;
+  }
+}
+
+export function useChannelVideosPageSize(): [PageSize, (next: PageSize) => void] {
+  const [pageSize, setPageSizeState] = useState<PageSize>(readStoredPageSize);
+
+  const setPageSize = useCallback((next: PageSize) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(next));
+    } catch {
+      // localStorage may be unavailable (private mode, quota); keep in-memory value
+    }
+    setPageSizeState(next);
+  }, []);
+
+  return [pageSize, setPageSize];
+}
+
+export { ALLOWED_PAGE_SIZES, DEFAULT_PAGE_SIZE };
+export type { PageSize };

--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -103,6 +103,7 @@ function Configuration({ token }: ConfigurationProps) {
   const {
     plexConnectionStatus,
     setPlexConnectionStatus,
+    plexLibraries,
     openPlexLibrarySelector,
     openPlexAuthDialog,
     setOpenPlexAuthDialog,
@@ -238,6 +239,7 @@ function Configuration({ token }: ConfigurationProps) {
         config={config}
         isPlatformManaged={isPlatformManaged}
         plexConnectionStatus={plexConnectionStatus}
+        plexLibraries={plexLibraries}
         hasPlexServerConfigured={hasPlexServerConfigured}
         onConfigChange={handleConfigChange}
         onTestConnection={testPlexConnection}
@@ -332,7 +334,8 @@ function Configuration({ token }: ConfigurationProps) {
         open={openPlexLibrarySelector}
         handleClose={closeLibrarySelector}
         setLibraryId={setLibraryId}
-        token={token}
+        libraries={plexLibraries}
+        currentLibraryId={config.plexYoutubeLibraryId}
       />
 
       <Snackbar

--- a/client/src/components/Configuration.tsx
+++ b/client/src/components/Configuration.tsx
@@ -244,6 +244,7 @@ function Configuration({ token }: ConfigurationProps) {
         onOpenLibrarySelector={openLibrarySelector}
         onOpenPlexAuthDialog={() => setOpenPlexAuthDialog(true)}
         onMobileTooltipClick={setMobileTooltip}
+        token={token}
       />
 
       <SponsorBlockSection

--- a/client/src/components/Configuration/hooks/__tests__/usePlexConnection.test.ts
+++ b/client/src/components/Configuration/hooks/__tests__/usePlexConnection.test.ts
@@ -210,6 +210,48 @@ describe('usePlexConnection', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
+
+    test('flips plexConnectionStatus to testing while the initial check is in flight', async () => {
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      // Keep the fetch pending so we can observe the intermediate state
+      let resolveFetch: (value: Response) => void = () => {};
+      mockFetch.mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          })
+      );
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      // While the fetch is pending, the status should read "testing" rather
+      // than the default "not_tested"
+      await waitFor(() => {
+        expect(result.current.plexConnectionStatus).toBe('testing');
+      });
+
+      // Resolve the fetch with a successful payload and verify the final state
+      await act(async () => {
+        resolveFetch({
+          ok: true,
+          status: 200,
+          json: jest.fn().mockResolvedValueOnce([{ id: '1', title: 'YouTube' }]),
+        } as unknown as Response);
+      });
+
+      await waitFor(() => {
+        expect(result.current.plexConnectionStatus).toBe('connected');
+      });
+    });
   });
 
   describe('checkPlexConnection Function', () => {
@@ -1478,6 +1520,173 @@ describe('usePlexConnection', () => {
       const url = callArgs[0] as string;
       const params = new URLSearchParams(url.split('?')[1]);
       expect(params.get('testIP')).toBe('10.0.0.1');
+    });
+  });
+
+  describe('plexLibraries state', () => {
+    test('starts as an empty array before any fetch', () => {
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: false,
+        })
+      );
+
+      expect(result.current.plexLibraries).toEqual([]);
+    });
+
+    test('populates plexLibraries after a successful initial check', async () => {
+      const libraries = [
+        { id: '1', title: 'YouTube' },
+        { id: '31', title: 'Adults Library' },
+      ];
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(libraries),
+      } as any);
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.plexLibraries).toEqual(libraries);
+      });
+    });
+
+    test('clears plexLibraries when the initial check returns an empty list', async () => {
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce([]),
+      } as any);
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.plexConnectionStatus).toBe('not_connected');
+      });
+      expect(result.current.plexLibraries).toEqual([]);
+    });
+
+    test('clears plexLibraries when the initial check fails', async () => {
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.plexConnectionStatus).toBe('not_connected');
+      });
+      expect(result.current.plexLibraries).toEqual([]);
+    });
+
+    test('populates plexLibraries after a successful testPlexConnection call', async () => {
+      const initialLibraries = [{ id: '1', title: 'YouTube' }];
+      const updatedLibraries = [
+        { id: '1', title: 'YouTube' },
+        { id: '42', title: 'Kids Shows' },
+      ];
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      // Initial mount check consumes the first response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(initialLibraries),
+      } as any);
+      // testPlexConnection consumes the second response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(updatedLibraries),
+      } as any);
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.plexLibraries).toEqual(initialLibraries);
+      });
+
+      await act(async () => {
+        await result.current.testPlexConnection();
+      });
+
+      expect(result.current.plexLibraries).toEqual(updatedLibraries);
+    });
+
+    test('clears plexLibraries when testPlexConnection fails', async () => {
+      const initialLibraries = [{ id: '1', title: 'YouTube' }];
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      // Initial mount check succeeds and populates libraries
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce(initialLibraries),
+      } as any);
+      // testPlexConnection rejects
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const { result } = renderHook(() =>
+        usePlexConnection({
+          token: mockToken,
+          config: mockConfig,
+          setConfig: mockSetConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: true,
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.plexLibraries).toEqual(initialLibraries);
+      });
+
+      await act(async () => {
+        await result.current.testPlexConnection();
+      });
+
+      expect(result.current.plexLibraries).toEqual([]);
     });
   });
 });

--- a/client/src/components/Configuration/hooks/usePlexConnection.ts
+++ b/client/src/components/Configuration/hooks/usePlexConnection.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { ConfigState, PlexConnectionStatus, SnackbarState } from '../types';
+import { PlexLibrary } from '../../../utils/plexLibraries';
 
 interface UsePlexConnectionParams {
   token: string | null;
@@ -19,12 +20,18 @@ export const usePlexConnection = ({
   hasPlexServerConfigured,
 }: UsePlexConnectionParams) => {
   const [plexConnectionStatus, setPlexConnectionStatus] = useState<PlexConnectionStatus>('not_tested');
+  const [plexLibraries, setPlexLibraries] = useState<PlexLibrary[]>([]);
   const [openPlexLibrarySelector, setOpenPlexLibrarySelector] = useState(false);
   const [openPlexAuthDialog, setOpenPlexAuthDialog] = useState(false);
   const [didInitialPlexCheck, setDidInitialPlexCheck] = useState(false);
 
   const checkPlexConnection = useCallback(() => {
     if (hasPlexServerConfigured) {
+      // Flip to "testing" up front so the chip reads "Testing..." during the
+      // in-flight request. Without this, a slow failing fetch (e.g. Plex is
+      // unreachable) would leave the chip stuck on "Not Tested" for the whole
+      // fetch window, misleading the user into thinking nothing is happening.
+      setPlexConnectionStatus('testing');
       fetch('/getplexlibraries', {
         headers: {
           'x-access-token': token || '',
@@ -32,10 +39,17 @@ export const usePlexConnection = ({
       })
         .then((response) => response.json())
         .then((data) => {
-          setPlexConnectionStatus(Array.isArray(data) && data.length > 0 ? 'connected' : 'not_connected');
+          if (Array.isArray(data) && data.length > 0) {
+            setPlexConnectionStatus('connected');
+            setPlexLibraries(data as PlexLibrary[]);
+          } else {
+            setPlexConnectionStatus('not_connected');
+            setPlexLibraries([]);
+          }
         })
         .catch(() => {
           setPlexConnectionStatus('not_connected');
+          setPlexLibraries([]);
         });
     }
   }, [hasPlexServerConfigured, token]);
@@ -110,6 +124,7 @@ export const usePlexConnection = ({
 
       if (Array.isArray(data) && data.length > 0) {
         setPlexConnectionStatus('connected');
+        setPlexLibraries(data as PlexLibrary[]);
         // Plex credentials are auto-saved. Update initial snapshot for those fields.
         setInitialConfig((prev) => (
           prev
@@ -123,6 +138,7 @@ export const usePlexConnection = ({
         });
       } else {
         setPlexConnectionStatus('not_connected');
+        setPlexLibraries([]);
         setSnackbar({
           open: true,
           message: 'Could not retrieve Plex libraries. Check your settings.',
@@ -132,6 +148,7 @@ export const usePlexConnection = ({
     } catch (error) {
       console.error('Error testing Plex connection:', error);
       setPlexConnectionStatus('not_connected');
+      setPlexLibraries([]);
       setSnackbar({
         open: true,
         message: 'Failed to connect to Plex server. Check IP and API key.',
@@ -178,6 +195,7 @@ export const usePlexConnection = ({
   return {
     plexConnectionStatus,
     setPlexConnectionStatus,
+    plexLibraries,
     openPlexLibrarySelector,
     openPlexAuthDialog,
     setOpenPlexAuthDialog,

--- a/client/src/components/Configuration/sections/PlexIntegrationSection.tsx
+++ b/client/src/components/Configuration/sections/PlexIntegrationSection.tsx
@@ -15,6 +15,7 @@ import InfoIcon from '@mui/icons-material/Info';
 import { ConfigurationAccordion } from '../common/ConfigurationAccordion';
 import { InfoTooltip } from '../common/InfoTooltip';
 import { ConfigState, PlatformManagedState, PlexConnectionStatus } from '../types';
+import { PlexSubfolderMappings } from './PlexSubfolderMappings';
 
 interface PlexIntegrationSectionProps {
   config: ConfigState;
@@ -26,6 +27,7 @@ interface PlexIntegrationSectionProps {
   onOpenLibrarySelector: () => void;
   onOpenPlexAuthDialog: () => void;
   onMobileTooltipClick?: (text: string) => void;
+  token?: string | null;
 }
 
 export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
@@ -38,10 +40,11 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
   onOpenLibrarySelector,
   onOpenPlexAuthDialog,
   onMobileTooltipClick,
+  token = null,
 }) => {
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
-    let parsedValue: any = value;
+    let parsedValue: string = value;
 
     if (name === 'plexPort') {
       const digitsOnly = value.replace(/[^0-9]/g, '');
@@ -287,6 +290,15 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
               Selected Library ID: {config.plexYoutubeLibraryId}
             </Typography>
           )}
+        </Grid>
+
+        <Grid item xs={12}>
+          <PlexSubfolderMappings
+            mappings={config.plexSubfolderLibraryMappings ?? []}
+            onMappingsChange={(mappings) => onConfigChange({ plexSubfolderLibraryMappings: mappings })}
+            token={token}
+            plexConnectionStatus={plexConnectionStatus}
+          />
         </Grid>
       </Grid>
     </ConfigurationAccordion>

--- a/client/src/components/Configuration/sections/PlexIntegrationSection.tsx
+++ b/client/src/components/Configuration/sections/PlexIntegrationSection.tsx
@@ -16,11 +16,14 @@ import { ConfigurationAccordion } from '../common/ConfigurationAccordion';
 import { InfoTooltip } from '../common/InfoTooltip';
 import { ConfigState, PlatformManagedState, PlexConnectionStatus } from '../types';
 import { PlexSubfolderMappings } from './PlexSubfolderMappings';
+import { PlexLibrary } from '../../../utils/plexLibraries';
+import { DefaultPlexLibraryDisplay } from './components/DefaultPlexLibraryDisplay';
 
 interface PlexIntegrationSectionProps {
   config: ConfigState;
   isPlatformManaged: PlatformManagedState;
   plexConnectionStatus: PlexConnectionStatus;
+  plexLibraries: PlexLibrary[];
   hasPlexServerConfigured: boolean;
   onConfigChange: (updates: Partial<ConfigState>) => void;
   onTestConnection: () => void;
@@ -34,6 +37,7 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
   config,
   isPlatformManaged,
   plexConnectionStatus,
+  plexLibraries,
   hasPlexServerConfigured,
   onConfigChange,
   onTestConnection,
@@ -68,7 +72,7 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
       case 'connected':
         return 'Connected';
       case 'not_connected':
-        return 'Not Connected';
+        return 'Unreachable';
       case 'testing':
         return 'Testing...';
       default:
@@ -110,8 +114,8 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
 
       {plexConnectionStatus === 'not_connected' && (
         <Alert severity="warning" sx={{ mb: 2 }}>
-          Unable to connect to Plex server. Library refresh will not work.
-          Please check your IP and API key, then click "Test Connection".
+          Plex is currently unreachable. Verify your Plex server is running and
+          that the IP, port, and API key above are correct, then click "Test Connection".
         </Alert>
       )}
 
@@ -278,18 +282,21 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
               disabled={plexConnectionStatus !== 'connected'}
               data-testid="select-library-button"
             >
-              Select Plex Library
+              Select Default Library
             </Button>
             <InfoTooltip
               text="Test Connection will verify and auto-save your Plex credentials if successful."
               onMobileClick={onMobileTooltipClick}
             />
           </Box>
-          {config.plexYoutubeLibraryId && (
-            <Typography variant="body2" sx={{ mt: 1 }}>
-              Selected Library ID: {config.plexYoutubeLibraryId}
-            </Typography>
-          )}
+          <DefaultPlexLibraryDisplay
+            libraries={plexLibraries}
+            libraryId={config.plexYoutubeLibraryId}
+            plexConnectionStatus={plexConnectionStatus}
+            hasPlexServerConfigured={hasPlexServerConfigured}
+            hasPlexApiKey={Boolean(config.plexApiKey)}
+            onMobileTooltipClick={onMobileTooltipClick}
+          />
         </Grid>
 
         <Grid item xs={12}>
@@ -298,6 +305,7 @@ export const PlexIntegrationSection: React.FC<PlexIntegrationSectionProps> = ({
             onMappingsChange={(mappings) => onConfigChange({ plexSubfolderLibraryMappings: mappings })}
             token={token}
             plexConnectionStatus={plexConnectionStatus}
+            plexLibraries={plexLibraries}
           />
         </Grid>
       </Grid>

--- a/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
+++ b/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
@@ -87,19 +87,21 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
     setLoadingData(true);
     setFetchError(false);
 
-    Promise.all([
+    Promise.allSettled([
       axios.get<unknown>('/getplexlibraries', { headers, signal })
         .then((res) => (Array.isArray(res.data) ? (res.data as PlexLibrary[]) : [])),
       axios.get<unknown>('/api/channels/subfolders', { headers, signal })
         .then((res) => (Array.isArray(res.data) ? (res.data as string[]) : [])),
     ])
-      .then(([libs, folders]) => {
+      .then(([libsResult, foldersResult]) => {
         if (signal.aborted) return;
+        const libs = libsResult.status === 'fulfilled' ? libsResult.value : [];
+        const folders = foldersResult.status === 'fulfilled' ? foldersResult.value : [];
         setLibraries(libs);
         setSubfolders(folders);
-      })
-      .catch(() => {
-        if (!signal.aborted) setFetchError(true);
+        if (libsResult.status === 'rejected' || foldersResult.status === 'rejected') {
+          setFetchError(true);
+        }
       })
       .finally(() => {
         if (!signal.aborted) setLoadingData(false);
@@ -108,8 +110,11 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
     return () => controller.abort();
   }, [isConnected, token]);
 
-  const getLibraryTitle = (libraryId: string): string =>
-    libraries.find((lib) => lib.id === libraryId)?.title ?? libraryId;
+  const getLibraryTitle = (libraryId: string): string => {
+    const lib = libraries.find((l) => l.id === libraryId);
+    if (lib) return lib.title;
+    return libraries.length === 0 ? `Library ID: ${libraryId}` : libraryId;
+  };
 
   const isMappingDuplicate = (subfolder: string | null): boolean =>
     mappings.some((m) => m.subfolder === subfolder);

--- a/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
+++ b/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
@@ -1,0 +1,299 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Divider,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { PlexConnectionStatus } from '../types';
+
+export interface PlexSubfolderMapping {
+  subfolder: string | null;
+  libraryId: string;
+}
+
+interface PlexLibrary {
+  id: string;
+  title: string;
+}
+
+interface PlexSubfolderMappingsProps {
+  mappings: PlexSubfolderMapping[];
+  onMappingsChange: (mappings: PlexSubfolderMapping[]) => void;
+  token: string | null;
+  plexConnectionStatus: PlexConnectionStatus;
+}
+
+/**
+ * Internal sentinel for the "Root folder" Select option.
+ * Uses a long namespaced string that cannot collide with any real subfolder
+ * value: the API returns subfolders with the `__` prefix convention, so a
+ * channel would need sub_folder = 'ROOT_LIBRARY_MAPPING__' to collide here,
+ * which is effectively impossible in practice.
+ */
+const ROOT_SELECT_VALUE = '__YOUTARR_ROOT_LIBRARY_MAPPING__';
+
+/** Strip the __ filesystem prefix from a subfolder name returned by the API. */
+const stripPrefix = (folder: string): string => folder.replace(/^__/, '');
+
+/** Convert a Select value back to the stored mapping subfolder (null for root). */
+const selectValueToSubfolder = (value: string): string | null =>
+  value === ROOT_SELECT_VALUE ? null : stripPrefix(value);
+
+/** Format a mapping's subfolder for display in the table. */
+const formatMappingSubfolder = (subfolder: string | null): string =>
+  subfolder ? `__${subfolder}` : 'Root folder';
+
+export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
+  mappings,
+  onMappingsChange,
+  token,
+  plexConnectionStatus,
+}) => {
+  const [libraries, setLibraries] = useState<PlexLibrary[]>([]);
+  const [subfolders, setSubfolders] = useState<string[]>([]);
+  const [loadingData, setLoadingData] = useState(false);
+  const [fetchError, setFetchError] = useState(false);
+  const [newSubfolder, setNewSubfolder] = useState<string>('');
+  const [newLibraryId, setNewLibraryId] = useState<string>('');
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const isConnected = plexConnectionStatus === 'connected';
+
+  useEffect(() => {
+    if (!isConnected) return;
+
+    const controller = new AbortController();
+    const { signal } = controller;
+    const headers = { 'x-access-token': token || '' };
+
+    setLoadingData(true);
+    setFetchError(false);
+
+    Promise.all([
+      axios.get<unknown>('/getplexlibraries', { headers, signal })
+        .then((res) => (Array.isArray(res.data) ? (res.data as PlexLibrary[]) : [])),
+      axios.get<unknown>('/api/channels/subfolders', { headers, signal })
+        .then((res) => (Array.isArray(res.data) ? (res.data as string[]) : [])),
+    ])
+      .then(([libs, folders]) => {
+        if (signal.aborted) return;
+        setLibraries(libs);
+        setSubfolders(folders);
+      })
+      .catch(() => {
+        if (!signal.aborted) setFetchError(true);
+      })
+      .finally(() => {
+        if (!signal.aborted) setLoadingData(false);
+      });
+
+    return () => controller.abort();
+  }, [isConnected, token]);
+
+  const getLibraryTitle = (libraryId: string): string =>
+    libraries.find((lib) => lib.id === libraryId)?.title ?? libraryId;
+
+  const isMappingDuplicate = (subfolder: string | null): boolean =>
+    mappings.some((m) => m.subfolder === subfolder);
+
+  const handleAddMapping = () => {
+    if (!newSubfolder || !newLibraryId) return;
+
+    const subfolder = selectValueToSubfolder(newSubfolder);
+    if (isMappingDuplicate(subfolder)) return;
+
+    onMappingsChange([...mappings, { subfolder, libraryId: newLibraryId }]);
+    setNewSubfolder('');
+    setNewLibraryId('');
+    setShowAddForm(false);
+  };
+
+  const handleDeleteMapping = (subfolder: string | null) => {
+    onMappingsChange(mappings.filter((m) => m.subfolder !== subfolder));
+  };
+
+  const isAddDisabled =
+    !newSubfolder ||
+    !newLibraryId ||
+    isMappingDuplicate(selectValueToSubfolder(newSubfolder));
+
+  // When disconnected and no mappings exist yet, the whole section is unnecessary noise.
+  // When disconnected but mappings exist, keep the table visible so users can delete entries.
+  if (!isConnected && mappings.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Divider sx={{ mb: 2 }} />
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        <Typography variant="subtitle2">
+          Per-Subfolder Library Mappings
+        </Typography>
+        {!showAddForm && (
+          <Tooltip title={!isConnected ? 'Connect to Plex to add new mappings' : ''}>
+            <span>
+              <Button
+                size="small"
+                startIcon={<AddIcon />}
+                onClick={() => setShowAddForm(true)}
+                data-testid="add-mapping-button"
+                disabled={loadingData || !isConnected}
+              >
+                Add Mapping
+              </Button>
+            </span>
+          </Tooltip>
+        )}
+      </Box>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+        Map each subfolder to a specific Plex library. Subfolders without a mapping use the
+        default library selected above.
+      </Typography>
+
+      {loadingData && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+          <CircularProgress size={16} />
+          <Typography variant="caption" color="text.secondary">
+            Loading libraries and subfolders…
+          </Typography>
+        </Box>
+      )}
+
+      {fetchError && (
+        <Alert severity="warning" sx={{ mb: 1.5 }}>
+          Could not load Plex libraries or subfolders. Check your connection and try refreshing.
+        </Alert>
+      )}
+
+      {mappings.length > 0 && (
+        <Table size="small" sx={{ mb: 2 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Subfolder</TableCell>
+              <TableCell>Plex Library</TableCell>
+              <TableCell padding="checkbox" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {mappings.map((mapping) => (
+              <TableRow key={`${mapping.subfolder === null ? '\x00root' : mapping.subfolder}-${mapping.libraryId}`}>
+                <TableCell>
+                  <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                    {formatMappingSubfolder(mapping.subfolder)}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2">
+                    {getLibraryTitle(mapping.libraryId)}
+                  </Typography>
+                </TableCell>
+                <TableCell padding="checkbox">
+                  <IconButton
+                    size="small"
+                    onClick={() => handleDeleteMapping(mapping.subfolder)}
+                    aria-label={`Remove mapping for ${formatMappingSubfolder(mapping.subfolder)}`}
+                    data-testid={`delete-mapping-${mapping.subfolder ?? 'root'}`}
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {mappings.length === 0 && !showAddForm && !loadingData && (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+          No per-subfolder mappings configured. All downloads will refresh the default library.
+        </Typography>
+      )}
+
+      {showAddForm && isConnected && (
+        <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'flex-start', flexWrap: 'wrap', mt: 1 }}>
+          <FormControl size="small" sx={{ minWidth: 160 }}>
+            <InputLabel id="new-mapping-subfolder-label">Subfolder</InputLabel>
+            <Select
+              labelId="new-mapping-subfolder-label"
+              label="Subfolder"
+              value={newSubfolder}
+              onChange={(e: SelectChangeEvent) => setNewSubfolder(e.target.value)}
+              data-testid="new-mapping-subfolder-select"
+              disabled={loadingData}
+            >
+              <MenuItem value={ROOT_SELECT_VALUE}>Root folder</MenuItem>
+              {subfolders.map((folder) => (
+                <MenuItem
+                  key={folder}
+                  value={folder}
+                  disabled={isMappingDuplicate(selectValueToSubfolder(folder))}
+                >
+                  {folder}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <FormControl size="small" sx={{ minWidth: 180 }}>
+            <InputLabel id="new-mapping-library-label">Plex Library</InputLabel>
+            <Select
+              labelId="new-mapping-library-label"
+              label="Plex Library"
+              value={newLibraryId}
+              onChange={(e: SelectChangeEvent) => setNewLibraryId(e.target.value)}
+              data-testid="new-mapping-library-select"
+              disabled={loadingData}
+            >
+              {libraries.map((lib) => (
+                <MenuItem key={lib.id} value={lib.id}>
+                  {lib.title}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Button
+            variant="contained"
+            size="small"
+            onClick={handleAddMapping}
+            disabled={isAddDisabled}
+            data-testid="confirm-add-mapping-button"
+            sx={{ height: 40 }}
+          >
+            Add
+          </Button>
+          <Button
+            size="small"
+            onClick={() => {
+              setShowAddForm(false);
+              setNewSubfolder('');
+              setNewLibraryId('');
+            }}
+            sx={{ height: 40 }}
+          >
+            Cancel
+          </Button>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
+++ b/client/src/components/Configuration/sections/PlexSubfolderMappings.tsx
@@ -23,15 +23,12 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { PlexConnectionStatus } from '../types';
+import { PlexLibrary, resolveLibraryDisplay } from '../../../utils/plexLibraries';
+import { PlexLibraryLabel } from './components/PlexLibraryLabel';
 
 export interface PlexSubfolderMapping {
   subfolder: string | null;
   libraryId: string;
-}
-
-interface PlexLibrary {
-  id: string;
-  title: string;
 }
 
 interface PlexSubfolderMappingsProps {
@@ -39,6 +36,7 @@ interface PlexSubfolderMappingsProps {
   onMappingsChange: (mappings: PlexSubfolderMapping[]) => void;
   token: string | null;
   plexConnectionStatus: PlexConnectionStatus;
+  plexLibraries: PlexLibrary[];
 }
 
 /**
@@ -66,8 +64,8 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
   onMappingsChange,
   token,
   plexConnectionStatus,
+  plexLibraries,
 }) => {
-  const [libraries, setLibraries] = useState<PlexLibrary[]>([]);
   const [subfolders, setSubfolders] = useState<string[]>([]);
   const [loadingData, setLoadingData] = useState(false);
   const [fetchError, setFetchError] = useState(false);
@@ -87,21 +85,15 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
     setLoadingData(true);
     setFetchError(false);
 
-    Promise.allSettled([
-      axios.get<unknown>('/getplexlibraries', { headers, signal })
-        .then((res) => (Array.isArray(res.data) ? (res.data as PlexLibrary[]) : [])),
-      axios.get<unknown>('/api/channels/subfolders', { headers, signal })
-        .then((res) => (Array.isArray(res.data) ? (res.data as string[]) : [])),
-    ])
-      .then(([libsResult, foldersResult]) => {
+    axios
+      .get<unknown>('/api/channels/subfolders', { headers, signal })
+      .then((res) => {
         if (signal.aborted) return;
-        const libs = libsResult.status === 'fulfilled' ? libsResult.value : [];
-        const folders = foldersResult.status === 'fulfilled' ? foldersResult.value : [];
-        setLibraries(libs);
-        setSubfolders(folders);
-        if (libsResult.status === 'rejected' || foldersResult.status === 'rejected') {
-          setFetchError(true);
-        }
+        setSubfolders(Array.isArray(res.data) ? (res.data as string[]) : []);
+      })
+      .catch(() => {
+        if (signal.aborted) return;
+        setFetchError(true);
       })
       .finally(() => {
         if (!signal.aborted) setLoadingData(false);
@@ -109,12 +101,6 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
 
     return () => controller.abort();
   }, [isConnected, token]);
-
-  const getLibraryTitle = (libraryId: string): string => {
-    const lib = libraries.find((l) => l.id === libraryId);
-    if (lib) return lib.title;
-    return libraries.length === 0 ? `Library ID: ${libraryId}` : libraryId;
-  };
 
   const isMappingDuplicate = (subfolder: string | null): boolean =>
     mappings.some((m) => m.subfolder === subfolder);
@@ -178,14 +164,14 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
           <CircularProgress size={16} />
           <Typography variant="caption" color="text.secondary">
-            Loading libraries and subfolders…
+            Loading subfolders...
           </Typography>
         </Box>
       )}
 
       {fetchError && (
         <Alert severity="warning" sx={{ mb: 1.5 }}>
-          Could not load Plex libraries or subfolders. Check your connection and try refreshing.
+          Could not load channel subfolders. Check your connection and try refreshing.
         </Alert>
       )}
 
@@ -199,30 +185,31 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {mappings.map((mapping) => (
-              <TableRow key={`${mapping.subfolder === null ? '\x00root' : mapping.subfolder}-${mapping.libraryId}`}>
-                <TableCell>
-                  <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                    {formatMappingSubfolder(mapping.subfolder)}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Typography variant="body2">
-                    {getLibraryTitle(mapping.libraryId)}
-                  </Typography>
-                </TableCell>
-                <TableCell padding="checkbox">
-                  <IconButton
-                    size="small"
-                    onClick={() => handleDeleteMapping(mapping.subfolder)}
-                    aria-label={`Remove mapping for ${formatMappingSubfolder(mapping.subfolder)}`}
-                    data-testid={`delete-mapping-${mapping.subfolder ?? 'root'}`}
-                  >
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </TableCell>
-              </TableRow>
-            ))}
+            {mappings.map((mapping) => {
+              const display = resolveLibraryDisplay(plexLibraries, mapping.libraryId);
+              return (
+                <TableRow key={`${mapping.subfolder === null ? '\x00root' : mapping.subfolder}-${mapping.libraryId}`}>
+                  <TableCell>
+                    <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                      {formatMappingSubfolder(mapping.subfolder)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <PlexLibraryLabel display={display} />
+                  </TableCell>
+                  <TableCell padding="checkbox">
+                    <IconButton
+                      size="small"
+                      onClick={() => handleDeleteMapping(mapping.subfolder)}
+                      aria-label={`Remove mapping for ${formatMappingSubfolder(mapping.subfolder)}`}
+                      data-testid={`delete-mapping-${mapping.subfolder ?? 'root'}`}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
           </TableBody>
         </Table>
       )}
@@ -268,7 +255,7 @@ export const PlexSubfolderMappings: React.FC<PlexSubfolderMappingsProps> = ({
               data-testid="new-mapping-library-select"
               disabled={loadingData}
             >
-              {libraries.map((lib) => (
+              {plexLibraries.map((lib) => (
                 <MenuItem key={lib.id} value={lib.id}>
                   {lib.title}
                 </MenuItem>

--- a/client/src/components/Configuration/sections/__tests__/PlexIntegrationSection.story.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexIntegrationSection.story.tsx
@@ -25,6 +25,7 @@ const meta: Meta<typeof PlexIntegrationSection> = {
   },
   args: {
     plexConnectionStatus: 'not_tested',
+    plexLibraries: [],
     hasPlexServerConfigured: true,
     isPlatformManaged: { plexUrl: false, authEnabled: true, useTmpForDownloads: false } as PlatformManagedState,
     onTestConnection: fn(),

--- a/client/src/components/Configuration/sections/__tests__/PlexIntegrationSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexIntegrationSection.test.tsx
@@ -27,6 +27,7 @@ const createSectionProps = (
   config: createConfig(),
   isPlatformManaged: createPlatformManagedState(),
   plexConnectionStatus: 'not_tested',
+  plexLibraries: [],
   hasPlexServerConfigured: false,
   onConfigChange: jest.fn(),
   onTestConnection: jest.fn(),
@@ -85,10 +86,10 @@ describe('PlexIntegrationSection Component', () => {
       expect(screen.getByText('Connected')).toBeInTheDocument();
     });
 
-    test('displays "Not Connected" chip when status is not_connected', () => {
+    test('displays "Unreachable" chip when status is not_connected', () => {
       const props = createSectionProps({ plexConnectionStatus: 'not_connected' });
       renderWithProviders(<PlexIntegrationSection {...props} />);
-      expect(screen.getByText('Not Connected')).toBeInTheDocument();
+      expect(screen.getByText('Unreachable')).toBeInTheDocument();
     });
 
     test('displays "Testing..." chip when status is testing', () => {
@@ -104,8 +105,10 @@ describe('PlexIntegrationSection Component', () => {
     test('shows warning when connection status is not_connected', () => {
       const props = createSectionProps({ plexConnectionStatus: 'not_connected' });
       renderWithProviders(<PlexIntegrationSection {...props} />);
-      expect(screen.getByText(/Unable to connect to Plex server/i)).toBeInTheDocument();
-      expect(screen.getByText(/check your IP and API key/i)).toBeInTheDocument();
+      expect(screen.getByText(/Plex is currently unreachable/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Verify your Plex server is running and that the IP, port, and API key/i)
+      ).toBeInTheDocument();
     });
 
     test('shows info when status is not_tested but has config', () => {
@@ -564,11 +567,12 @@ describe('PlexIntegrationSection Component', () => {
     });
   });
 
-  describe('Select Plex Library Button', () => {
-    test('renders Select Plex Library button', () => {
+  describe('Select Default Library Button', () => {
+    test('renders Select Default Library button', () => {
       const props = createSectionProps();
       renderWithProviders(<PlexIntegrationSection {...props} />);
       expect(screen.getByTestId('select-library-button')).toBeInTheDocument();
+      expect(screen.getByText('Select Default Library')).toBeInTheDocument();
     });
 
     test('calls onOpenLibrarySelector when clicked', async () => {
@@ -623,29 +627,162 @@ describe('PlexIntegrationSection Component', () => {
     });
   });
 
-  describe('Selected Library Display', () => {
-    test('displays selected library ID when present', () => {
+  describe('Default Library Display', () => {
+    test('shows "Library ID:" fallback when libraries have not been fetched yet', () => {
       const props = createSectionProps({
         config: createConfig({ plexYoutubeLibraryId: '12345' }),
+        plexLibraries: [],
       });
       renderWithProviders(<PlexIntegrationSection {...props} />);
-      expect(screen.getByText(/Selected Library ID: 12345/i)).toBeInTheDocument();
+      expect(screen.getByText('Default Plex Library:')).toBeInTheDocument();
+      expect(screen.getByText('Library ID: 12345')).toBeInTheDocument();
+      // No duplicated "(id: 12345)" suffix when the id is already the primary display
+      expect(screen.queryByText('(id: 12345)')).not.toBeInTheDocument();
     });
 
-    test('does not display library ID text when not set', () => {
+    test('shows the resolved library title with an "(id: X)" suffix when the id matches an entry', () => {
+      const props = createSectionProps({
+        config: createConfig({ plexYoutubeLibraryId: '31' }),
+        plexConnectionStatus: 'connected',
+        plexLibraries: [
+          { id: '1', title: 'Movies' },
+          { id: '31', title: 'Adults Library' },
+        ],
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(screen.getByText('Default Plex Library:')).toBeInTheDocument();
+      expect(screen.getByText('Adults Library')).toBeInTheDocument();
+      expect(screen.getByText('(id: 31)')).toBeInTheDocument();
+    });
+
+    test('falls back to the raw id when libraries are loaded but no entry matches, without an "(id: X)" suffix', () => {
+      const props = createSectionProps({
+        config: createConfig({ plexYoutubeLibraryId: '999' }),
+        plexConnectionStatus: 'connected',
+        plexLibraries: [{ id: '1', title: 'Movies' }],
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(screen.getByText('Default Plex Library:')).toBeInTheDocument();
+      expect(screen.getByText('999')).toBeInTheDocument();
+      expect(screen.queryByText('(id: 999)')).not.toBeInTheDocument();
+    });
+
+    test('does not render the default library line when plexYoutubeLibraryId is empty', () => {
       const props = createSectionProps({
         config: createConfig({ plexYoutubeLibraryId: '' }),
       });
       renderWithProviders(<PlexIntegrationSection {...props} />);
-      expect(screen.queryByText(/Selected Library ID:/i)).not.toBeInTheDocument();
+      expect(screen.queryByText('Default Plex Library:')).not.toBeInTheDocument();
     });
 
-    test('displays correct library ID value', () => {
+    test('handles alphanumeric library ids in the resolved case', () => {
       const props = createSectionProps({
         config: createConfig({ plexYoutubeLibraryId: 'my-custom-lib-99' }),
+        plexConnectionStatus: 'connected',
+        plexLibraries: [{ id: 'my-custom-lib-99', title: 'My Custom Library' }],
       });
       renderWithProviders(<PlexIntegrationSection {...props} />);
-      expect(screen.getByText(/Selected Library ID: my-custom-lib-99/i)).toBeInTheDocument();
+      expect(screen.getByText('Default Plex Library:')).toBeInTheDocument();
+      expect(screen.getByText('My Custom Library')).toBeInTheDocument();
+      expect(screen.getByText('(id: my-custom-lib-99)')).toBeInTheDocument();
+    });
+
+    test('shows a warning caption when Plex is unreachable and a default library is set', () => {
+      const props = createSectionProps({
+        config: createConfig({ plexYoutubeLibraryId: '31' }),
+        plexConnectionStatus: 'not_connected',
+        plexLibraries: [],
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(screen.getByTestId('default-library-unreachable-warning')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Cannot reach Plex; showing saved library ID/i)
+      ).toBeInTheDocument();
+    });
+
+    test('does not show the unreachable warning when Plex is connected', () => {
+      const props = createSectionProps({
+        config: createConfig({ plexYoutubeLibraryId: '31' }),
+        plexConnectionStatus: 'connected',
+        plexLibraries: [{ id: '31', title: 'Adults Library' }],
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(
+        screen.queryByTestId('default-library-unreachable-warning')
+      ).not.toBeInTheDocument();
+    });
+
+    test('does not show the unreachable warning when no default library is configured', () => {
+      const props = createSectionProps({
+        config: createConfig({ plexYoutubeLibraryId: '' }),
+        plexConnectionStatus: 'not_connected',
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(
+        screen.queryByTestId('default-library-unreachable-warning')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('No Default Library Warning', () => {
+    test('shows a warning when Plex is configured but no default library is set', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          plexYoutubeLibraryId: '',
+          plexIP: '192.168.1.100',
+          plexApiKey: 'test-key',
+        }),
+        hasPlexServerConfigured: true,
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(screen.getByTestId('no-default-library-warning')).toBeInTheDocument();
+      expect(screen.getByText('No Default Plex Library Configured')).toBeInTheDocument();
+    });
+
+    test('hides the warning when a default library is configured', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          plexYoutubeLibraryId: '31',
+          plexIP: '192.168.1.100',
+          plexApiKey: 'test-key',
+        }),
+        hasPlexServerConfigured: true,
+        plexLibraries: [{ id: '31', title: 'Adults Library' }],
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(
+        screen.queryByTestId('no-default-library-warning')
+      ).not.toBeInTheDocument();
+    });
+
+    test('hides the warning when Plex server is not configured at all', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          plexYoutubeLibraryId: '',
+          plexIP: '',
+          plexApiKey: '',
+        }),
+        hasPlexServerConfigured: false,
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(
+        screen.queryByTestId('no-default-library-warning')
+      ).not.toBeInTheDocument();
+    });
+
+    test('hides the warning when server IP is set but API key is missing', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          plexYoutubeLibraryId: '',
+          plexIP: '192.168.1.100',
+          plexApiKey: '',
+        }),
+        hasPlexServerConfigured: true,
+      });
+      renderWithProviders(<PlexIntegrationSection {...props} />);
+      expect(
+        screen.queryByTestId('no-default-library-warning')
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -716,7 +853,7 @@ describe('PlexIntegrationSection Component', () => {
       expect(screen.getByText('Connected')).toBeInTheDocument();
 
       rerender(<PlexIntegrationSection {...props} plexConnectionStatus="not_connected" />);
-      expect(screen.getByText('Not Connected')).toBeInTheDocument();
+      expect(screen.getByText('Unreachable')).toBeInTheDocument();
     });
 
     test('handles platform managed configuration changes', () => {
@@ -824,7 +961,7 @@ describe('PlexIntegrationSection Component', () => {
       renderWithProviders(<PlexIntegrationSection {...props} />);
       const button = screen.getByTestId('select-library-button');
       expect(button).not.toBeDisabled();
-      expect(screen.queryByText(/Selected Library ID:/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Default Plex Library:/i)).not.toBeInTheDocument();
     });
 
     test('handles various port input values', async () => {
@@ -870,7 +1007,7 @@ describe('PlexIntegrationSection Component', () => {
 
       expect(screen.getByText('Get Key')).toBeInTheDocument();
       expect(screen.getByText('Test Connection')).toBeInTheDocument();
-      expect(screen.getByText('Select Plex Library')).toBeInTheDocument();
+      expect(screen.getByText('Select Default Library')).toBeInTheDocument();
     });
 
     test('alerts are displayed when appropriate', () => {
@@ -880,7 +1017,7 @@ describe('PlexIntegrationSection Component', () => {
       renderWithProviders(<PlexIntegrationSection {...props} />);
 
       // Check for specific alert content instead of role
-      expect(screen.getByText(/Unable to connect to Plex server/i)).toBeInTheDocument();
+      expect(screen.getByText(/Plex is currently unreachable/i)).toBeInTheDocument();
     });
 
     test('link has proper attributes for external navigation', () => {

--- a/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
@@ -20,9 +20,7 @@ const MOCK_LIBRARIES = [
 const MOCK_SUBFOLDERS = ['__kids', '__music'];
 
 function setupAxiosMocks() {
-  axios.get
-    .mockResolvedValueOnce({ data: MOCK_LIBRARIES })
-    .mockResolvedValueOnce({ data: MOCK_SUBFOLDERS });
+  axios.get.mockResolvedValue({ data: MOCK_SUBFOLDERS });
 }
 
 const DEFAULT_PROPS = {
@@ -30,6 +28,7 @@ const DEFAULT_PROPS = {
   onMappingsChange: jest.fn(),
   token: 'test-token',
   plexConnectionStatus: 'connected' as PlexConnectionStatus,
+  plexLibraries: MOCK_LIBRARIES,
 };
 
 describe('PlexSubfolderMappings', () => {
@@ -65,7 +64,21 @@ describe('PlexSubfolderMappings', () => {
       expect(screen.getByTestId('delete-mapping-kids')).toBeInTheDocument();
     });
 
-    test('shows "Library ID:" fallback for library title when disconnected', () => {
+    test('shows "Library ID:" fallback for library title when disconnected and libraries are empty', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          plexConnectionStatus="not_connected"
+          plexLibraries={[]}
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      expect(screen.getByText('Library ID: 2')).toBeInTheDocument();
+      // No duplicated "(id: 2)" when id is already the primary display
+      expect(screen.queryByText('(id: 2)')).not.toBeInTheDocument();
+    });
+
+    test('still shows the resolved library title when disconnected if libraries prop was populated earlier', () => {
       renderWithProviders(
         <PlexSubfolderMappings
           {...DEFAULT_PROPS}
@@ -73,7 +86,8 @@ describe('PlexSubfolderMappings', () => {
           mappings={[{ subfolder: 'kids', libraryId: '2' }]}
         />
       );
-      expect(screen.getByText('Library ID: 2')).toBeInTheDocument();
+      expect(screen.getByText('Kids Shows')).toBeInTheDocument();
+      expect(screen.getByText('(id: 2)')).toBeInTheDocument();
     });
 
     test('Add Mapping button is disabled when disconnected with existing mappings', () => {
@@ -126,26 +140,24 @@ describe('PlexSubfolderMappings', () => {
   });
 
   describe('loading and error states', () => {
-    test('shows loading indicator while fetches are in progress', () => {
+    test('shows loading indicator while the subfolder fetch is in progress', () => {
       axios.get.mockReturnValue(new Promise(() => {}));
       renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
-      expect(screen.getByText(/Loading libraries and subfolders/)).toBeInTheDocument();
+      expect(screen.getByText(/Loading subfolders/)).toBeInTheDocument();
     });
 
-    test('shows error alert when fetch fails', async () => {
+    test('shows error alert when the subfolder fetch fails', async () => {
       axios.get.mockRejectedValue(new Error('Network error'));
       renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
       await waitFor(() => {
         expect(
-          screen.getByText(/Could not load Plex libraries or subfolders/)
+          screen.getByText(/Could not load channel subfolders/)
         ).toBeInTheDocument();
       });
     });
 
-    test('shows partial data and error alert when one endpoint fails', async () => {
-      axios.get
-        .mockResolvedValueOnce({ data: MOCK_LIBRARIES })
-        .mockRejectedValueOnce(new Error('Subfolders failed'));
+    test('still shows mapping rows with resolved library titles when the subfolder fetch fails', async () => {
+      axios.get.mockRejectedValue(new Error('Subfolders failed'));
       renderWithProviders(
         <PlexSubfolderMappings
           {...DEFAULT_PROPS}
@@ -153,11 +165,12 @@ describe('PlexSubfolderMappings', () => {
         />
       );
       await waitFor(() => {
-        expect(screen.getByText('Kids Shows')).toBeInTheDocument();
+        expect(
+          screen.getByText(/Could not load channel subfolders/)
+        ).toBeInTheDocument();
       });
-      expect(
-        screen.getByText(/Could not load Plex libraries or subfolders/)
-      ).toBeInTheDocument();
+      expect(screen.getByText('Kids Shows')).toBeInTheDocument();
+      expect(screen.getByText('(id: 2)')).toBeInTheDocument();
     });
   });
 
@@ -188,7 +201,7 @@ describe('PlexSubfolderMappings', () => {
       });
     });
 
-    test('renders the library title from the fetched libraries list', async () => {
+    test('renders the library title with an "(id: X)" suffix for resolved libraries', async () => {
       setupAxiosMocks();
       renderWithProviders(
         <PlexSubfolderMappings
@@ -199,6 +212,7 @@ describe('PlexSubfolderMappings', () => {
       await waitFor(() => {
         expect(screen.getByText('Kids Shows')).toBeInTheDocument();
       });
+      expect(screen.getByText('(id: 2)')).toBeInTheDocument();
     });
   });
 
@@ -257,7 +271,7 @@ describe('PlexSubfolderMappings', () => {
         expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
       });
       await waitFor(() => {
-        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Loading subfolders/)).not.toBeInTheDocument();
       });
 
       await user.click(screen.getByTestId('add-mapping-button'));
@@ -281,7 +295,7 @@ describe('PlexSubfolderMappings', () => {
         expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
       });
       await waitFor(() => {
-        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Loading subfolders/)).not.toBeInTheDocument();
       });
 
       await user.click(screen.getByTestId('add-mapping-button'));
@@ -303,7 +317,7 @@ describe('PlexSubfolderMappings', () => {
         expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
       });
       await waitFor(() => {
-        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Loading subfolders/)).not.toBeInTheDocument();
       });
 
       await user.click(screen.getByTestId('add-mapping-button'));
@@ -330,7 +344,7 @@ describe('PlexSubfolderMappings', () => {
         expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
       });
       await waitFor(() => {
-        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Loading subfolders/)).not.toBeInTheDocument();
       });
 
       await user.click(screen.getByTestId('add-mapping-button'));
@@ -357,7 +371,7 @@ describe('PlexSubfolderMappings', () => {
         expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
       });
       await waitFor(() => {
-        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Loading subfolders/)).not.toBeInTheDocument();
       });
 
       await user.click(screen.getByTestId('add-mapping-button'));

--- a/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
@@ -65,6 +65,17 @@ describe('PlexSubfolderMappings', () => {
       expect(screen.getByTestId('delete-mapping-kids')).toBeInTheDocument();
     });
 
+    test('shows "Library ID:" fallback for library title when disconnected', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          plexConnectionStatus="not_connected"
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      expect(screen.getByText('Library ID: 2')).toBeInTheDocument();
+    });
+
     test('Add Mapping button is disabled when disconnected with existing mappings', () => {
       renderWithProviders(
         <PlexSubfolderMappings
@@ -129,6 +140,24 @@ describe('PlexSubfolderMappings', () => {
           screen.getByText(/Could not load Plex libraries or subfolders/)
         ).toBeInTheDocument();
       });
+    });
+
+    test('shows partial data and error alert when one endpoint fails', async () => {
+      axios.get
+        .mockResolvedValueOnce({ data: MOCK_LIBRARIES })
+        .mockRejectedValueOnce(new Error('Subfolders failed'));
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Kids Shows')).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText(/Could not load Plex libraries or subfolders/)
+      ).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexSubfolderMappings.test.tsx
@@ -1,0 +1,402 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { PlexSubfolderMappings, PlexSubfolderMapping } from '../PlexSubfolderMappings';
+import { renderWithProviders } from '../../../../test-utils';
+import { PlexConnectionStatus } from '../../types';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+const axios = require('axios');
+
+const MOCK_LIBRARIES = [
+  { id: '1', title: 'YouTube' },
+  { id: '2', title: 'Kids Shows' },
+];
+
+const MOCK_SUBFOLDERS = ['__kids', '__music'];
+
+function setupAxiosMocks() {
+  axios.get
+    .mockResolvedValueOnce({ data: MOCK_LIBRARIES })
+    .mockResolvedValueOnce({ data: MOCK_SUBFOLDERS });
+}
+
+const DEFAULT_PROPS = {
+  mappings: [] as PlexSubfolderMapping[],
+  onMappingsChange: jest.fn(),
+  token: 'test-token',
+  plexConnectionStatus: 'connected' as PlexConnectionStatus,
+};
+
+describe('PlexSubfolderMappings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when plexConnectionStatus is not connected', () => {
+    test('renders nothing when status is not_tested and no mappings exist', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} plexConnectionStatus="not_tested" />
+      );
+      expect(screen.queryByText('Per-Subfolder Library Mappings')).not.toBeInTheDocument();
+    });
+
+    test('renders nothing when status is not_connected and no mappings exist', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} plexConnectionStatus="not_connected" />
+      );
+      expect(screen.queryByText('Per-Subfolder Library Mappings')).not.toBeInTheDocument();
+    });
+
+    test('shows existing mappings with delete buttons when disconnected', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          plexConnectionStatus="not_connected"
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      expect(screen.getByText('Per-Subfolder Library Mappings')).toBeInTheDocument();
+      expect(screen.getByText('__kids')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-mapping-kids')).toBeInTheDocument();
+    });
+
+    test('Add Mapping button is disabled when disconnected with existing mappings', () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          plexConnectionStatus="not_connected"
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      expect(screen.getByTestId('add-mapping-button')).toBeDisabled();
+    });
+  });
+
+  describe('when plexConnectionStatus is connected', () => {
+    beforeEach(() => {
+      setupAxiosMocks();
+    });
+
+    test('shows the section title "Per-Subfolder Library Mappings"', async () => {
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+      await waitFor(() => {
+        expect(screen.getByText('Per-Subfolder Library Mappings')).toBeInTheDocument();
+      });
+    });
+
+    test('shows "No per-subfolder mappings configured" when mappings array is empty', async () => {
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+      await waitFor(() => {
+        expect(
+          screen.getByText(/No per-subfolder mappings configured/)
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('shows the "Add Mapping" button', async () => {
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+    });
+
+    test('does NOT call axios when not connected', () => {
+      axios.get.mockReset();
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} plexConnectionStatus="not_connected" />
+      );
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loading and error states', () => {
+    test('shows loading indicator while fetches are in progress', () => {
+      axios.get.mockReturnValue(new Promise(() => {}));
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+      expect(screen.getByText(/Loading libraries and subfolders/)).toBeInTheDocument();
+    });
+
+    test('shows error alert when fetch fails', async () => {
+      axios.get.mockRejectedValue(new Error('Network error'));
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Could not load Plex libraries or subfolders/)
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('existing mappings display', () => {
+    test('renders a table row for each mapping showing subfolder name with __ prefix', async () => {
+      setupAxiosMocks();
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText('__kids')).toBeInTheDocument();
+      });
+    });
+
+    test('renders "Root folder" label for a mapping with subfolder: null', async () => {
+      setupAxiosMocks();
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: null, libraryId: '1' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Root folder')).toBeInTheDocument();
+      });
+    });
+
+    test('renders the library title from the fetched libraries list', async () => {
+      setupAxiosMocks();
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Kids Shows')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('adding a mapping', () => {
+    beforeEach(() => {
+      setupAxiosMocks();
+    });
+
+    test('clicking "Add Mapping" shows the subfolder and library selects', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      expect(screen.getByRole('button', { name: 'Subfolder' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Plex Library' })).toBeInTheDocument();
+    });
+
+    test('clicking "Cancel" hides the form', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+      expect(screen.getByRole('button', { name: 'Subfolder' })).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(screen.queryByRole('button', { name: 'Subfolder' })).not.toBeInTheDocument();
+    });
+
+    test('"Add" button is disabled when no subfolder is selected', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      expect(screen.getByTestId('confirm-add-mapping-button')).toBeDisabled();
+    });
+
+    test('"Add" button is disabled when no library is selected', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<PlexSubfolderMappings {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      await user.click(screen.getByRole('button', { name: 'Subfolder' }));
+      await user.click(screen.getByRole('option', { name: '__kids' }));
+
+      expect(screen.getByTestId('confirm-add-mapping-button')).toBeDisabled();
+    });
+
+    test('"Add" button is disabled when the selected subfolder is already mapped (duplicate)', async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: 'kids', libraryId: '1' }]}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      await user.click(screen.getByRole('button', { name: 'Subfolder' }));
+
+      const kidsOption = screen.getByRole('option', { name: '__kids' });
+      expect(kidsOption).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    test('selecting a subfolder and library and clicking "Add" calls onMappingsChange with the new mapping appended', async () => {
+      const user = userEvent.setup();
+      const onMappingsChange = jest.fn();
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} onMappingsChange={onMappingsChange} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      await user.click(screen.getByRole('button', { name: 'Subfolder' }));
+      await user.click(screen.getByRole('option', { name: '__kids' }));
+
+      await user.click(screen.getByRole('button', { name: 'Plex Library' }));
+      await user.click(screen.getByRole('option', { name: 'YouTube' }));
+
+      await user.click(screen.getByTestId('confirm-add-mapping-button'));
+
+      expect(onMappingsChange).toHaveBeenCalledWith([{ subfolder: 'kids', libraryId: '1' }]);
+    });
+
+    test('adding a root-folder mapping stores subfolder: null', async () => {
+      const user = userEvent.setup();
+      const onMappingsChange = jest.fn();
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} onMappingsChange={onMappingsChange} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      await user.click(screen.getByRole('button', { name: 'Subfolder' }));
+      await user.click(screen.getByRole('option', { name: 'Root folder' }));
+
+      await user.click(screen.getByRole('button', { name: 'Plex Library' }));
+      await user.click(screen.getByRole('option', { name: 'YouTube' }));
+
+      await user.click(screen.getByTestId('confirm-add-mapping-button'));
+
+      expect(onMappingsChange).toHaveBeenCalledWith([{ subfolder: null, libraryId: '1' }]);
+    });
+
+    test('the stored subfolder value has no __ prefix', async () => {
+      const user = userEvent.setup();
+      const onMappingsChange = jest.fn();
+      renderWithProviders(
+        <PlexSubfolderMappings {...DEFAULT_PROPS} onMappingsChange={onMappingsChange} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('add-mapping-button')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.queryByText(/Loading libraries/)).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('add-mapping-button'));
+
+      await user.click(screen.getByRole('button', { name: 'Subfolder' }));
+      await user.click(screen.getByRole('option', { name: '__music' }));
+
+      await user.click(screen.getByRole('button', { name: 'Plex Library' }));
+      await user.click(screen.getByRole('option', { name: 'Kids Shows' }));
+
+      await user.click(screen.getByTestId('confirm-add-mapping-button'));
+
+      const calledWith = onMappingsChange.mock.calls[0][0] as PlexSubfolderMapping[];
+      expect(calledWith[0].subfolder).toBe('music');
+    });
+  });
+
+  describe('deleting a mapping', () => {
+    beforeEach(() => {
+      setupAxiosMocks();
+    });
+
+    test('clicking the delete button for a mapping calls onMappingsChange with that mapping removed', async () => {
+      const user = userEvent.setup();
+      const onMappingsChange = jest.fn();
+      const mappings: PlexSubfolderMapping[] = [
+        { subfolder: 'kids', libraryId: '2' },
+        { subfolder: 'music', libraryId: '1' },
+      ];
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={mappings}
+          onMappingsChange={onMappingsChange}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('delete-mapping-kids')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTestId('delete-mapping-kids'));
+
+      expect(onMappingsChange).toHaveBeenCalledWith([{ subfolder: 'music', libraryId: '1' }]);
+    });
+
+    test('the delete button data-testid is delete-mapping-kids for subfolder kids', async () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: 'kids', libraryId: '2' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('delete-mapping-kids')).toBeInTheDocument();
+      });
+    });
+
+    test('the delete button data-testid is delete-mapping-root for null subfolder', async () => {
+      renderWithProviders(
+        <PlexSubfolderMappings
+          {...DEFAULT_PROPS}
+          mappings={[{ subfolder: null, libraryId: '1' }]}
+        />
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('delete-mapping-root')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/client/src/components/Configuration/sections/components/DefaultPlexLibraryDisplay.tsx
+++ b/client/src/components/Configuration/sections/components/DefaultPlexLibraryDisplay.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { InfoTooltip } from '../../common/InfoTooltip';
+import { PlexConnectionStatus } from '../../types';
+import {
+  PlexLibrary,
+  resolveLibraryDisplay,
+} from '../../../../utils/plexLibraries';
+import { PlexLibraryLabel } from './PlexLibraryLabel';
+
+const DEFAULT_LIBRARY_TOOLTIP =
+  'Youtarr refreshes this library after downloads to the root folder, or to any subfolder that does not have its own mapping below.';
+
+interface DefaultPlexLibraryDisplayProps {
+  libraries: PlexLibrary[];
+  libraryId: string | undefined;
+  plexConnectionStatus: PlexConnectionStatus;
+  hasPlexServerConfigured: boolean;
+  hasPlexApiKey: boolean;
+  onMobileTooltipClick?: (text: string) => void;
+}
+
+/**
+ * Renders the "Default Plex Library: ..." line below the Test Connection /
+ * Select Default Library buttons in PlexIntegrationSection.
+ *
+ * Three states:
+ *   1. libraryId set and connected   -> show resolved title + id
+ *   2. libraryId set but unreachable -> show id fallback + warning caption
+ *   3. libraryId unset but Plex is configured -> "No Default Plex Library Configured"
+ *   4. libraryId unset and Plex not configured -> render nothing
+ */
+export const DefaultPlexLibraryDisplay: React.FC<DefaultPlexLibraryDisplayProps> = ({
+  libraries,
+  libraryId,
+  plexConnectionStatus,
+  hasPlexServerConfigured,
+  hasPlexApiKey,
+  onMobileTooltipClick,
+}) => {
+  if (libraryId) {
+    const display = resolveLibraryDisplay(libraries, libraryId);
+    return (
+      <Box sx={{ mt: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 0.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            Default Plex Library:
+          </Typography>
+          <PlexLibraryLabel display={display} boldPrimary />
+          <InfoTooltip
+            text={DEFAULT_LIBRARY_TOOLTIP}
+            onMobileClick={onMobileTooltipClick}
+          />
+        </Box>
+        {plexConnectionStatus === 'not_connected' && (
+          <Typography
+            variant="caption"
+            color="warning.main"
+            sx={{ display: 'block', mt: 0.25 }}
+            data-testid="default-library-unreachable-warning"
+          >
+            Cannot reach Plex; showing saved library ID.
+          </Typography>
+        )}
+      </Box>
+    );
+  }
+
+  if (hasPlexServerConfigured && hasPlexApiKey) {
+    return (
+      <Box
+        sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 1 }}
+        data-testid="no-default-library-warning"
+      >
+        <WarningAmberIcon fontSize="small" sx={{ color: 'warning.main' }} />
+        <Typography variant="body2" color="warning.main">
+          No Default Plex Library Configured
+        </Typography>
+      </Box>
+    );
+  }
+
+  return null;
+};

--- a/client/src/components/Configuration/sections/components/PlexLibraryLabel.tsx
+++ b/client/src/components/Configuration/sections/components/PlexLibraryLabel.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { PlexLibraryDisplay } from '../../../../utils/plexLibraries';
+
+interface PlexLibraryLabelProps {
+  display: PlexLibraryDisplay;
+  /**
+   * When true, the primary text (title or id) renders with fontWeight 600.
+   * Used by DefaultPlexLibraryDisplay; PlexSubfolderMappings uses the default.
+   */
+  boldPrimary?: boolean;
+}
+
+/**
+ * Render a `PlexLibraryDisplay` discriminated union once. Both consumers
+ * (DefaultPlexLibraryDisplay in PlexIntegrationSection and the mapping table
+ * in PlexSubfolderMappings) use this. Adding a fourth display branch only
+ * requires editing this file, not every consumer.
+ */
+export const PlexLibraryLabel: React.FC<PlexLibraryLabelProps> = ({
+  display,
+  boldPrimary = false,
+}) => {
+  const primarySx = boldPrimary ? { fontWeight: 600 } : undefined;
+
+  const renderContent = () => {
+    switch (display.kind) {
+      case 'resolved':
+        return (
+          <>
+            <Typography variant="body2" sx={primarySx}>
+              {display.title}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              (id: {display.id})
+            </Typography>
+          </>
+        );
+      case 'id-fallback':
+        return (
+          <Typography variant="body2" sx={primarySx}>
+            Library ID: {display.id}
+          </Typography>
+        );
+      case 'id-only':
+        return (
+          <Typography variant="body2" sx={primarySx}>
+            {display.id}
+          </Typography>
+        );
+      default: {
+        const _exhaustive: never = display;
+        return _exhaustive;
+      }
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'inline-flex', alignItems: 'baseline', gap: 0.5, flexWrap: 'wrap' }}>
+      {renderContent()}
+    </Box>
+  );
+};

--- a/client/src/components/Configuration/sections/components/__tests__/DefaultPlexLibraryDisplay.test.tsx
+++ b/client/src/components/Configuration/sections/components/__tests__/DefaultPlexLibraryDisplay.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { DefaultPlexLibraryDisplay } from '../DefaultPlexLibraryDisplay';
+import { PlexLibrary } from '../../../../../utils/plexLibraries';
+
+const LIBRARIES: PlexLibrary[] = [
+  { id: '1', title: 'Movies' },
+  { id: '7', title: 'YouTube' },
+];
+
+describe('DefaultPlexLibraryDisplay', () => {
+  test('renders resolved title with id when libraryId matches a library', () => {
+    render(
+      <DefaultPlexLibraryDisplay
+        libraries={LIBRARIES}
+        libraryId="7"
+        plexConnectionStatus="connected"
+        hasPlexServerConfigured
+        hasPlexApiKey
+      />
+    );
+    expect(screen.getByText('Default Plex Library:')).toBeInTheDocument();
+    expect(screen.getByText('YouTube')).toBeInTheDocument();
+    expect(screen.getByText('(id: 7)')).toBeInTheDocument();
+  });
+
+  test('renders id-fallback when libraries are empty (offline) and a libraryId is set', () => {
+    render(
+      <DefaultPlexLibraryDisplay
+        libraries={[]}
+        libraryId="7"
+        plexConnectionStatus="not_connected"
+        hasPlexServerConfigured
+        hasPlexApiKey
+      />
+    );
+    expect(screen.getByText('Library ID: 7')).toBeInTheDocument();
+    expect(screen.getByTestId('default-library-unreachable-warning')).toBeInTheDocument();
+    expect(
+      screen.getByText('Cannot reach Plex; showing saved library ID.')
+    ).toBeInTheDocument();
+  });
+
+  test('renders id-only (no warning) when libraries populated but id missing from list', () => {
+    render(
+      <DefaultPlexLibraryDisplay
+        libraries={LIBRARIES}
+        libraryId="999"
+        plexConnectionStatus="connected"
+        hasPlexServerConfigured
+        hasPlexApiKey
+      />
+    );
+    expect(screen.getByText('999')).toBeInTheDocument();
+    expect(screen.queryByText(/Library ID:/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('default-library-unreachable-warning')).not.toBeInTheDocument();
+  });
+
+  test('does NOT render the unreachable warning when status is connected', () => {
+    render(
+      <DefaultPlexLibraryDisplay
+        libraries={LIBRARIES}
+        libraryId="7"
+        plexConnectionStatus="connected"
+        hasPlexServerConfigured
+        hasPlexApiKey
+      />
+    );
+    expect(screen.queryByTestId('default-library-unreachable-warning')).not.toBeInTheDocument();
+  });
+
+  test('shows "No Default Plex Library Configured" when libraryId is missing and Plex is configured', () => {
+    render(
+      <DefaultPlexLibraryDisplay
+        libraries={[]}
+        libraryId={undefined}
+        plexConnectionStatus="not_tested"
+        hasPlexServerConfigured
+        hasPlexApiKey
+      />
+    );
+    expect(screen.getByTestId('no-default-library-warning')).toBeInTheDocument();
+    expect(screen.getByText('No Default Plex Library Configured')).toBeInTheDocument();
+  });
+
+  test('renders nothing when libraryId missing AND plex not yet configured', () => {
+    const { container } = render(
+      <DefaultPlexLibraryDisplay
+        libraries={[]}
+        libraryId={undefined}
+        plexConnectionStatus="not_tested"
+        hasPlexServerConfigured={false}
+        hasPlexApiKey={false}
+      />
+    );
+    expect(screen.queryByTestId('no-default-library-warning')).not.toBeInTheDocument();
+    expect(screen.queryByText('Default Plex Library:')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders nothing when libraryId missing AND plex configured but no api key', () => {
+    const { container } = render(
+      <DefaultPlexLibraryDisplay
+        libraries={[]}
+        libraryId={undefined}
+        plexConnectionStatus="not_tested"
+        hasPlexServerConfigured
+        hasPlexApiKey={false}
+      />
+    );
+    expect(screen.queryByTestId('no-default-library-warning')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/client/src/components/Configuration/sections/components/__tests__/PlexLibraryLabel.test.tsx
+++ b/client/src/components/Configuration/sections/components/__tests__/PlexLibraryLabel.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { PlexLibraryLabel } from '../PlexLibraryLabel';
+
+describe('PlexLibraryLabel', () => {
+  test('resolved branch renders title and id pair', () => {
+    render(
+      <PlexLibraryLabel
+        display={{ kind: 'resolved', title: 'Movies', id: '7' }}
+      />
+    );
+    expect(screen.getByText('Movies')).toBeInTheDocument();
+    expect(screen.getByText('(id: 7)')).toBeInTheDocument();
+  });
+
+  test('id-fallback branch renders "Library ID: <id>"', () => {
+    render(
+      <PlexLibraryLabel display={{ kind: 'id-fallback', id: '42' }} />
+    );
+    expect(screen.getByText('Library ID: 42')).toBeInTheDocument();
+  });
+
+  test('id-only branch renders just the raw id', () => {
+    render(<PlexLibraryLabel display={{ kind: 'id-only', id: '99' }} />);
+    expect(screen.getByText('99')).toBeInTheDocument();
+    expect(screen.queryByText(/Library ID/)).not.toBeInTheDocument();
+  });
+
+  test('boldPrimary applies fontWeight 600 to the primary text on resolved', () => {
+    render(
+      <PlexLibraryLabel
+        display={{ kind: 'resolved', title: 'Movies', id: '7' }}
+        boldPrimary
+      />
+    );
+    const title = screen.getByText('Movies');
+    expect(title).toHaveStyle({ fontWeight: '600' });
+  });
+
+  test('boldPrimary applies fontWeight 600 on id-fallback', () => {
+    render(
+      <PlexLibraryLabel
+        display={{ kind: 'id-fallback', id: '42' }}
+        boldPrimary
+      />
+    );
+    expect(screen.getByText('Library ID: 42')).toHaveStyle({ fontWeight: '600' });
+  });
+
+  test('boldPrimary applies fontWeight 600 on id-only', () => {
+    render(
+      <PlexLibraryLabel
+        display={{ kind: 'id-only', id: '99' }}
+        boldPrimary
+      />
+    );
+    expect(screen.getByText('99')).toHaveStyle({ fontWeight: '600' });
+  });
+
+  test('without boldPrimary, primary text is not bold', () => {
+    render(
+      <PlexLibraryLabel
+        display={{ kind: 'id-fallback', id: '42' }}
+      />
+    );
+    expect(screen.getByText('Library ID: 42')).not.toHaveStyle({ fontWeight: '600' });
+  });
+});

--- a/client/src/components/PlexLibrarySelector.tsx
+++ b/client/src/components/PlexLibrarySelector.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import {
   SelectChangeEvent,
+  FormControl,
   InputLabel,
   Modal,
   Select,
@@ -13,6 +14,7 @@ import {
 import CloseIcon from "@mui/icons-material/Close";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
+import { PlexLibrary } from "../utils/plexLibraries";
 
 interface PlexLibrarySelectorProps {
   open: boolean;
@@ -21,65 +23,40 @@ interface PlexLibrarySelectorProps {
     libraryId: string;
     libraryTitle: string;
   }) => void;
-  token: string | null;
-}
-
-interface PlexLibrary {
-  id: string;
-  title: string;
+  libraries: PlexLibrary[];
+  currentLibraryId?: string;
 }
 
 function PlexLibrarySelector({
   open,
   handleClose,
   setLibraryId,
-  token,
+  libraries,
+  currentLibraryId,
 }: PlexLibrarySelectorProps) {
-  const [libraries, setLibraries] = useState<PlexLibrary[]>([]);
   const [selectedLibrary, setSelectedLibrary] = useState<string>("");
-  const [plexError, setPlexError] = useState<boolean>(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
-  useEffect(() => {
-    if (!open) return;
+  const plexError = libraries.length === 0;
 
-    setPlexError(false);
-    fetch(`/getplexlibraries`, {
-      headers: {
-        "x-access-token": token || "",
-      },
-    })
-      .then((response) => {
-        if (!response.ok) {
-          console.error("Failed to fetch Plex libraries");
-          setLibraries([]);
-          setPlexError(true);
-          return [];
-        }
-        return response.json();
-      })
-      .then((data) => {
-        if (Array.isArray(data)) {
-          setLibraries(data);
-          setPlexError(false);
-        } else {
-          setLibraries([]);
-          setPlexError(true);
-        }
-      })
-      .catch((error) => {
-        console.error("Error fetching Plex libraries:", error);
-        setLibraries([]);
-        setPlexError(true);
-      });
-  }, [open, token]);
-
+  // Reset selection when the modal closes so the next open starts clean.
   useEffect(() => {
     if (!open) {
       setSelectedLibrary("");
     }
   }, [open]);
+
+  // Pre-select the currently configured library once libraries are available.
+  // The `prev || currentLibraryId` guard ensures we do not clobber a user's
+  // manual pick if this effect re-fires (e.g. libraries reference changes)
+  // while the modal is still open.
+  useEffect(() => {
+    if (!open || !currentLibraryId) return;
+    if (libraries.some((lib) => lib.id === currentLibraryId)) {
+      setSelectedLibrary((prev) => prev || currentLibraryId);
+    }
+  }, [open, currentLibraryId, libraries]);
 
   const handleLibraryChange = (event: SelectChangeEvent<string>) => {
     const libraryId = event.target.value as string;
@@ -94,6 +71,9 @@ function PlexLibrarySelector({
     });
     setSelectedLibrary("");
   };
+
+  const isSaveDisabled =
+    selectedLibrary === "" || selectedLibrary === currentLibraryId;
 
   return (
     <Modal open={open} onClose={handleClose} onBackdropClick={handleClose}>
@@ -133,44 +113,33 @@ function PlexLibrarySelector({
               <p>Note: Without connecting to Plex, downloading videos will still work, but you will not be able to refresh the library in Plex.</p>
             </Box>
           ) : (
-            <>
-              <InputLabel id="select-plex-library">
-                Select a Plex Library
-              </InputLabel>
+            <FormControl fullWidth>
+              <InputLabel id="select-plex-library">Plex Library</InputLabel>
               <Select
-                fullWidth
                 value={selectedLibrary}
                 onChange={handleLibraryChange}
-                label="Select a Plex Library"
+                label="Plex Library"
                 labelId="select-plex-library"
               >
-                {libraries.length === 0 ? (
-                  <MenuItem value="" disabled>
-                    No libraries available
+                {libraries.map((library) => (
+                  <MenuItem value={library.id} key={library.id}>
+                    {library.title}
                   </MenuItem>
-                ) : (
-                  libraries.map((library) => (
-                    <MenuItem value={library.id} key={library.id}>
-                      {library.title}
-                    </MenuItem>
-                  ))
-                )}
+                ))}
               </Select>
-            </>
+            </FormControl>
           )}
           {!plexError && (
-            <>
-              <Box style={{ marginTop: "16px" }}>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={handleSaveSelection}
-                  disabled={selectedLibrary === ""}
-                >
-                  Save Selection
-                </Button>
-              </Box>
-            </>
+            <Box sx={{ mt: 2 }}>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleSaveSelection}
+                disabled={isSaveDisabled}
+              >
+                Save Selection
+              </Button>
+            </Box>
           )}
         </Card>
       </Box>

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -713,6 +713,7 @@ function VideosPage({ token }: VideosPageProps) {
                                 </IconButton>
                               )}
                               {/* Protection shield */}
+                              {!video.removed && (
                               <ProtectionShieldButton
                                 isProtected={video.protected || false}
                                 onClick={(e) => {
@@ -721,6 +722,7 @@ function VideosPage({ token }: VideosPageProps) {
                                 }}
                                 sx={{ position: 'absolute', bottom: 6, left: 6, zIndex: 3 }}
                               />
+                              )}
                             </Box>
                             <Typography variant='subtitle1' textAlign='center'>
                               {video.youTubeVideoName}
@@ -1010,11 +1012,13 @@ function VideosPage({ token }: VideosPageProps) {
                           </TableCell>
                           <TableCell>
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                              <ProtectionShieldButton
-                                isProtected={video.protected || false}
-                                onClick={() => handleToggleProtection(video.id)}
-                                variant="inline"
-                              />
+                              {!video.removed && (
+                                <ProtectionShieldButton
+                                  isProtected={video.protected || false}
+                                  onClick={() => handleToggleProtection(video.id)}
+                                  variant="inline"
+                                />
+                              )}
                               <Tooltip title="Delete video from disk">
                                 <span>
                                   <IconButton

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -54,6 +54,34 @@ import RatingBadge from './shared/RatingBadge';
 import ChangeRatingDialog from './shared/ChangeRatingDialog';
 import VideoActionsDropdown from './shared/VideoActionsDropdown';
 import ProtectionShieldButton from './shared/ProtectionShieldButton';
+import VideoModal from './shared/VideoModal';
+import ThumbnailClickOverlay from './shared/ThumbnailClickOverlay';
+import { VideoModalData } from './shared/VideoModal/types';
+
+function videoDataToModalData(video: VideoData): VideoModalData {
+  return {
+    youtubeId: video.youtubeId,
+    title: video.youTubeVideoName,
+    channelName: video.youTubeChannelName,
+    thumbnailUrl: `/images/videothumb-${video.youtubeId}.jpg`,
+    duration: video.duration,
+    publishedAt: video.originalDate || null,
+    addedAt: video.timeCreated || null,
+    mediaType: video.media_type || 'video',
+    status: video.removed ? 'missing' : 'downloaded',
+    isDownloaded: !video.removed,
+    filePath: video.filePath || null,
+    fileSize: video.fileSize ? Number(video.fileSize) : null,
+    audioFilePath: video.audioFilePath || null,
+    audioFileSize: video.audioFileSize ? Number(video.audioFileSize) : null,
+    isProtected: video.protected || false,
+    isIgnored: false,
+    normalizedRating: video.normalized_rating || null,
+    ratingSource: video.rating_source || null,
+    databaseId: video.id,
+    channelId: video.channel_id || null,
+  };
+}
 
 interface VideosPageProps {
   token: string | null;
@@ -91,6 +119,7 @@ function VideosPage({ token }: VideosPageProps) {
   const { deleteVideos, loading: deleteLoading } = useVideoDeletion();
   const { toggleProtection, successMessage: protectionSuccess, error: protectionError, clearMessages: clearProtectionMessages } = useVideoProtection(token);
   const [protectedFilter, setProtectedFilter] = useState(false);
+  const [modalVideo, setModalVideo] = useState<VideoData | null>(null);
 
   const videosPerPage = isMobile ? 6 : 12;
 
@@ -645,6 +674,13 @@ function VideosPage({ token }: VideosPageProps) {
                                   }
                                 />
                               )}
+                              {/* Center hotspot for opening video modal */}
+                              <ThumbnailClickOverlay
+                                onClick={(e: React.MouseEvent) => {
+                                  e.stopPropagation();
+                                  setModalVideo(video);
+                                }}
+                              />
                               {video.youtube_removed ? (
                                 <Box
                                   style={{
@@ -724,7 +760,12 @@ function VideosPage({ token }: VideosPageProps) {
                               />
                               )}
                             </Box>
-                            <Typography variant='subtitle1' textAlign='center'>
+                            <Typography
+                              variant='subtitle1'
+                              textAlign='center'
+                              onClick={() => setModalVideo(video)}
+                              sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                            >
                               {video.youTubeVideoName}
                               {video.duration && (
                                 <Typography
@@ -874,6 +915,13 @@ function VideosPage({ token }: VideosPageProps) {
                                   }
                                 />
                               )}
+                              {/* Center hotspot for opening video modal */}
+                              <ThumbnailClickOverlay
+                                onClick={(e: React.MouseEvent) => {
+                                  e.stopPropagation();
+                                  setModalVideo(video);
+                                }}
+                              />
                               {video.youtube_removed ? (
                                 <Box
                                   style={{
@@ -942,7 +990,11 @@ function VideosPage({ token }: VideosPageProps) {
                             })()}
                           </TableCell>
                           <TableCell style={{ fontSize: 'medium' }}>
-                            <Typography variant='subtitle1'>
+                            <Typography
+                              variant='subtitle1'
+                              onClick={() => setModalVideo(video)}
+                              sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                            >
                               {video.youTubeVideoName}
                             </Typography>
                             {video.duration && (
@@ -1118,6 +1170,35 @@ function VideosPage({ token }: VideosPageProps) {
           {protectionError}
         </Alert>
       </Snackbar>
+
+      {modalVideo && (
+        <VideoModal
+          open={modalVideo !== null}
+          onClose={() => setModalVideo(null)}
+          video={videoDataToModalData(modalVideo)}
+          token={token}
+          onVideoDeleted={() => {
+            setModalVideo(null);
+            fetchVideos();
+          }}
+          onProtectionChanged={(youtubeId, isProtected) => {
+            setVideos((prev: VideoData[]) =>
+              prev.map((v: VideoData) =>
+                v.youtubeId === youtubeId ? { ...v, protected: isProtected } : v
+              )
+            );
+          }}
+          onRatingChanged={(youtubeId, rating) => {
+            setVideos((prev: VideoData[]) =>
+              prev.map((v: VideoData) =>
+                v.youtubeId === youtubeId
+                  ? { ...v, normalized_rating: rating, rating_source: rating ? 'Manual Override' : null }
+                  : v
+              )
+            );
+          }}
+        />
+      )}
     </Card>
   );
 }

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -32,6 +32,8 @@ import Pagination from '@mui/material/Pagination';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import DeleteIcon from '@mui/icons-material/Delete';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration, formatYTDate } from '../utils';
@@ -48,6 +50,7 @@ import ScheduleIcon from '@mui/icons-material/Schedule';
 import DeleteVideosDialog from './shared/DeleteVideosDialog';
 import { useVideoDeletion } from './shared/useVideoDeletion';
 import DownloadFormatIndicator from './shared/DownloadFormatIndicator';
+import { useVideoProtection } from './shared/useVideoProtection';
 import RatingBadge from './shared/RatingBadge';
 import ChangeRatingDialog from './shared/ChangeRatingDialog';
 import VideoActionsDropdown from './shared/VideoActionsDropdown';
@@ -86,6 +89,8 @@ function VideosPage({ token }: VideosPageProps) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const { deleteVideos, loading: deleteLoading } = useVideoDeletion();
+  const { toggleProtection, successMessage: protectionSuccess, error: protectionError, clearMessages: clearProtectionMessages } = useVideoProtection(token);
+  const [protectedFilter, setProtectedFilter] = useState(false);
 
   const videosPerPage = isMobile ? 6 : 12;
 
@@ -119,6 +124,7 @@ function VideosPage({ token }: VideosPageProps) {
     if (filter) params.append('channelFilter', filter);
     if (dateFrom) params.append('dateFrom', dateFrom.toISOString().split('T')[0]);
     if (dateTo) params.append('dateTo', dateTo.toISOString().split('T')[0]);
+    if (protectedFilter) params.append('protectedFilter', 'true');
 
     try {
       const response = await axios.get<PaginatedVideosResponse>(`/getVideos?${params.toString()}`, {
@@ -146,7 +152,7 @@ function VideosPage({ token }: VideosPageProps) {
     } finally {
       setLoading(false);
     }
-  }, [token, page, videosPerPage, orderBy, sortOrder, search, filter, dateFrom, dateTo]);
+  }, [token, page, videosPerPage, orderBy, sortOrder, search, filter, dateFrom, dateTo, protectedFilter]);
 
   useEffect(() => {
     fetchVideos();
@@ -315,6 +321,21 @@ function VideosPage({ token }: VideosPageProps) {
     setDeleteDialogOpen(true);
   };
 
+  const handleToggleProtection = async (videoId: number) => {
+    const video = videos.find((v: VideoData) => v.id === videoId);
+    if (!video) return;
+
+    const currentState = video.protected || false;
+    const newState = await toggleProtection(video.id, currentState);
+    if (newState !== undefined) {
+      setVideos((prev: VideoData[]) =>
+        prev.map((v: VideoData) =>
+          v.id === videoId ? { ...v, protected: newState } : v
+        )
+      );
+    }
+  };
+
   const handlers = useSwipeable({
     onSwipedLeft: () => {
       if (page < totalPages) {
@@ -362,6 +383,18 @@ function VideosPage({ token }: VideosPageProps) {
               ),
             }}
           />
+
+          <Box display="flex" gap={1} flexWrap="wrap">
+            <Chip
+              icon={<ShieldIcon />}
+              label="Protected"
+              variant={protectedFilter ? 'filled' : 'outlined'}
+              color={protectedFilter ? 'primary' : 'default'}
+              size="small"
+              onClick={() => setProtectedFilter(!protectedFilter)}
+              sx={{ cursor: 'pointer' }}
+            />
+          </Box>
 
           {!isMobile && (
             <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -673,6 +706,33 @@ function VideosPage({ token }: VideosPageProps) {
                                   <DeleteIcon fontSize="small" />
                                 </IconButton>
                               )}
+                              {/* Protection shield */}
+                              <IconButton
+                                aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleToggleProtection(video.id);
+                                }}
+                                sx={{
+                                  position: 'absolute',
+                                  bottom: 6,
+                                  left: 6,
+                                  bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
+                                  color: video.protected ? 'white' : 'grey.500',
+                                  padding: 0.5,
+                                  opacity: video.protected ? 1 : 0.6,
+                                  '&:hover': {
+                                    bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
+                                    opacity: 1,
+                                  },
+                                  transition: 'all 0.2s',
+                                  boxShadow: video.protected ? '0 0 4px rgba(25,118,210,0.5)' : 'none',
+                                  zIndex: 3,
+                                }}
+                                size="small"
+                              >
+                                {video.protected ? <ShieldIcon sx={{ fontSize: 16 }} /> : <ShieldOutlinedIcon sx={{ fontSize: 16 }} />}
+                              </IconButton>
                             </Box>
                             <Typography variant='subtitle1' textAlign='center'>
                               {video.youTubeVideoName}
@@ -961,18 +1021,32 @@ function VideosPage({ token }: VideosPageProps) {
                             </Stack>
                           </TableCell>
                           <TableCell>
-                            <Tooltip title="Delete video from disk">
-                              <span>
-                                <IconButton
-                                  color="error"
-                                  size="small"
-                                  onClick={() => handleDeleteSingleVideo(video.id)}
-                                  disabled={video.removed || deleteLoading}
-                                >
-                                  <DeleteIcon />
-                                </IconButton>
-                              </span>
-                            </Tooltip>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                              <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}>
+                                <span>
+                                  <IconButton
+                                    color={video.protected ? 'primary' : 'default'}
+                                    size="small"
+                                    onClick={() => handleToggleProtection(video.id)}
+                                    sx={{ opacity: video.protected ? 1 : 0.5 }}
+                                  >
+                                    {video.protected ? <ShieldIcon /> : <ShieldOutlinedIcon />}
+                                  </IconButton>
+                                </span>
+                              </Tooltip>
+                              <Tooltip title="Delete video from disk">
+                                <span>
+                                  <IconButton
+                                    color="error"
+                                    size="small"
+                                    onClick={() => handleDeleteSingleVideo(video.id)}
+                                    disabled={video.removed || deleteLoading}
+                                  >
+                                    <DeleteIcon />
+                                  </IconButton>
+                                </span>
+                              </Tooltip>
+                            </Box>
                           </TableCell>
                         </>
                       )}
@@ -1038,6 +1112,25 @@ function VideosPage({ token }: VideosPageProps) {
       >
         <Alert onClose={() => setErrorMessage(null)} severity="error">
           {errorMessage}
+        </Alert>
+      </Snackbar>
+
+      <Snackbar
+        open={protectionSuccess !== null}
+        autoHideDuration={4000}
+        onClose={clearProtectionMessages}
+      >
+        <Alert onClose={clearProtectionMessages} severity="success">
+          {protectionSuccess}
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={protectionError !== null}
+        autoHideDuration={4000}
+        onClose={clearProtectionMessages}
+      >
+        <Alert onClose={clearProtectionMessages} severity="error">
+          {protectionError}
         </Alert>
       </Snackbar>
     </Card>

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -33,7 +33,6 @@ import FilterListIcon from '@mui/icons-material/FilterList';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ShieldIcon from '@mui/icons-material/Shield';
-import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { formatDuration, formatYTDate } from '../utils';
@@ -54,6 +53,7 @@ import { useVideoProtection } from './shared/useVideoProtection';
 import RatingBadge from './shared/RatingBadge';
 import ChangeRatingDialog from './shared/ChangeRatingDialog';
 import VideoActionsDropdown from './shared/VideoActionsDropdown';
+import ProtectionShieldButton from './shared/ProtectionShieldButton';
 
 interface VideosPageProps {
   token: string | null;
@@ -707,32 +707,14 @@ function VideosPage({ token }: VideosPageProps) {
                                 </IconButton>
                               )}
                               {/* Protection shield */}
-                              <IconButton
-                                aria-label={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}
+                              <ProtectionShieldButton
+                                isProtected={video.protected || false}
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   handleToggleProtection(video.id);
                                 }}
-                                sx={{
-                                  position: 'absolute',
-                                  bottom: 6,
-                                  left: 6,
-                                  bgcolor: video.protected ? 'primary.main' : 'rgba(0,0,0,0.5)',
-                                  color: video.protected ? 'white' : 'grey.500',
-                                  padding: 0.5,
-                                  opacity: video.protected ? 1 : 0.6,
-                                  '&:hover': {
-                                    bgcolor: video.protected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
-                                    opacity: 1,
-                                  },
-                                  transition: 'all 0.2s',
-                                  boxShadow: video.protected ? '0 0 4px rgba(25,118,210,0.5)' : 'none',
-                                  zIndex: 3,
-                                }}
-                                size="small"
-                              >
-                                {video.protected ? <ShieldIcon sx={{ fontSize: 16 }} /> : <ShieldOutlinedIcon sx={{ fontSize: 16 }} />}
-                              </IconButton>
+                                sx={{ position: 'absolute', bottom: 6, left: 6, zIndex: 3 }}
+                              />
                             </Box>
                             <Typography variant='subtitle1' textAlign='center'>
                               {video.youTubeVideoName}
@@ -1022,18 +1004,11 @@ function VideosPage({ token }: VideosPageProps) {
                           </TableCell>
                           <TableCell>
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                              <Tooltip title={video.protected ? 'Remove protection' : 'Protect from auto-deletion'}>
-                                <span>
-                                  <IconButton
-                                    color={video.protected ? 'primary' : 'default'}
-                                    size="small"
-                                    onClick={() => handleToggleProtection(video.id)}
-                                    sx={{ opacity: video.protected ? 1 : 0.5 }}
-                                  >
-                                    {video.protected ? <ShieldIcon /> : <ShieldOutlinedIcon />}
-                                  </IconButton>
-                                </span>
-                              </Tooltip>
+                              <ProtectionShieldButton
+                                isProtected={video.protected || false}
+                                onClick={() => handleToggleProtection(video.id)}
+                                variant="inline"
+                              />
                               <Tooltip title="Delete video from disk">
                                 <span>
                                   <IconButton

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -384,21 +384,9 @@ function VideosPage({ token }: VideosPageProps) {
             }}
           />
 
-          <Box display="flex" gap={1} flexWrap="wrap">
-            <Chip
-              icon={<ShieldIcon />}
-              label="Protected"
-              variant={protectedFilter ? 'filled' : 'outlined'}
-              color={protectedFilter ? 'primary' : 'default'}
-              size="small"
-              onClick={() => setProtectedFilter(!protectedFilter)}
-              sx={{ cursor: 'pointer' }}
-            />
-          </Box>
-
           {!isMobile && (
             <LocalizationProvider dateAdapter={AdapterDateFns}>
-              <Stack direction="row" spacing={2}>
+              <Stack direction="row" spacing={2} alignItems="center">
                 <DatePicker
                   label="From Date"
                   value={dateFrom}
@@ -416,6 +404,15 @@ function VideosPage({ token }: VideosPageProps) {
                     setPage(1);
                   }}
                   renderInput={(params) => <TextField {...params} variant="outlined" fullWidth />}
+                />
+                <Chip
+                  icon={<ShieldIcon />}
+                  label={protectedFilter ? 'Protected Only' : 'Protected'}
+                  variant={protectedFilter ? 'filled' : 'outlined'}
+                  color={protectedFilter ? 'primary' : 'default'}
+                  onClick={() => setProtectedFilter(!protectedFilter)}
+                  onDelete={protectedFilter ? () => setProtectedFilter(false) : undefined}
+                  sx={{ cursor: 'pointer', height: 36 }}
                 />
                 {(dateFrom || dateTo) && (
                   <Button
@@ -455,7 +452,7 @@ function VideosPage({ token }: VideosPageProps) {
         </Stack>
 
         {isMobile && (
-          <Box display='flex' justifyContent='center' mb={2}>
+          <Box display='flex' justifyContent='center' gap={1} mb={2}>
             <Button
               variant='outlined'
               startIcon={<FilterListIcon />}
@@ -463,6 +460,15 @@ function VideosPage({ token }: VideosPageProps) {
             >
               Filter by Channel
             </Button>
+            <Chip
+              icon={<ShieldIcon />}
+              label={protectedFilter ? 'Protected Only' : 'Protected'}
+              variant={protectedFilter ? 'filled' : 'outlined'}
+              color={protectedFilter ? 'primary' : 'default'}
+              onClick={() => setProtectedFilter(!protectedFilter)}
+              onDelete={protectedFilter ? () => setProtectedFilter(false) : undefined}
+              sx={{ cursor: 'pointer', height: 36 }}
+            />
             <FilterMenu
               anchorEl={anchorEl}
               handleClose={handleClose}

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -1173,7 +1173,7 @@ function VideosPage({ token }: VideosPageProps) {
 
       {modalVideo && (
         <VideoModal
-          open={modalVideo !== null}
+          open
           onClose={() => setModalVideo(null)}
           video={videoDataToModalData(modalVideo)}
           token={token}

--- a/client/src/components/__tests__/PlexLibrarySelector.story.tsx
+++ b/client/src/components/__tests__/PlexLibrarySelector.story.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
-import { http, HttpResponse } from 'msw';
 import PlexLibrarySelector from '../PlexLibrarySelector';
 
 const meta: Meta<typeof PlexLibrarySelector> = {
@@ -10,19 +9,10 @@ const meta: Meta<typeof PlexLibrarySelector> = {
     open: true,
     handleClose: fn(),
     setLibraryId: fn(),
-    token: 'storybook-token',
-  },
-  parameters: {
-    msw: {
-      handlers: [
-        http.get('/getplexlibraries', () =>
-          HttpResponse.json([
-            { id: '1', title: 'Movies' },
-            { id: '2', title: 'TV Shows' },
-          ])
-        ),
-      ],
-    },
+    libraries: [
+      { id: '1', title: 'Movies' },
+      { id: '2', title: 'TV Shows' },
+    ],
   },
 };
 
@@ -32,7 +22,7 @@ type Story = StoryObj<typeof PlexLibrarySelector>;
 export const SelectLibrary: Story = {
   play: async ({ canvasElement, args }) => {
     const body = within(canvasElement.ownerDocument.body);
-    await userEvent.click(body.getByLabelText('Select a Plex Library'));
+    await userEvent.click(body.getByLabelText('Plex Library'));
     await userEvent.click(await body.findByText('Movies'));
 
     await userEvent.click(body.getByRole('button', { name: 'Save Selection' }));

--- a/client/src/components/__tests__/PlexLibrarySelector.test.tsx
+++ b/client/src/components/__tests__/PlexLibrarySelector.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import PlexLibrarySelector from '../PlexLibrarySelector';
+import { PlexLibrary } from '../../utils/plexLibraries';
+
+const LIBRARIES: PlexLibrary[] = [
+  { id: '1', title: 'Movies' },
+  { id: '2', title: 'TV Shows' },
+  { id: '31', title: 'Adults Library' },
+];
+
+describe('PlexLibrarySelector', () => {
+  const handleClose = jest.fn();
+  const setLibraryId = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('pre-selects the currently configured library when it matches a provided library', async () => {
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+        currentLibraryId="31"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Adults Library')).toBeInTheDocument();
+    });
+  });
+
+  test('does not pre-select when currentLibraryId is not in the provided libraries', async () => {
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+        currentLibraryId="999"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Selection' })).toBeDisabled();
+    });
+    expect(screen.queryByText('Movies')).not.toBeInTheDocument();
+    expect(screen.queryByText('Adults Library')).not.toBeInTheDocument();
+  });
+
+  test('does not pre-select when no currentLibraryId is provided', async () => {
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Selection' })).toBeDisabled();
+    });
+  });
+
+  test('disables Save Selection when the pre-selected library equals currentLibraryId', async () => {
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+        currentLibraryId="1"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Movies')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Save Selection' })).toBeDisabled();
+  });
+
+  test('enables Save Selection after the user picks a different library', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+        currentLibraryId="1"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Movies')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText('Plex Library'));
+    await user.click(await screen.findByRole('option', { name: 'TV Shows' }));
+
+    expect(screen.getByRole('button', { name: 'Save Selection' })).toBeEnabled();
+  });
+
+  test('calls setLibraryId with the chosen library and title on save', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={LIBRARIES}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Selection' })).toBeDisabled();
+    });
+
+    await user.click(screen.getByLabelText('Plex Library'));
+    await user.click(await screen.findByRole('option', { name: 'TV Shows' }));
+    await user.click(screen.getByRole('button', { name: 'Save Selection' }));
+
+    expect(setLibraryId).toHaveBeenCalledWith({
+      libraryId: '2',
+      libraryTitle: 'TV Shows',
+    });
+  });
+
+  test('shows the "Unable to connect" error block when libraries is empty', () => {
+    render(
+      <PlexLibrarySelector
+        open
+        handleClose={handleClose}
+        setLibraryId={setLibraryId}
+        libraries={[]}
+      />
+    );
+
+    expect(
+      screen.getByText('Unable to connect to Plex server. Please check:')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save Selection' })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/shared/ProtectionShieldButton.tsx
+++ b/client/src/components/shared/ProtectionShieldButton.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { IconButton, Tooltip } from '@mui/material';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
+import { SxProps, Theme } from '@mui/material/styles';
+
+type ShieldVariant = 'overlay' | 'inline';
+type ShieldSize = 'small' | 'medium';
+
+interface ProtectionShieldButtonProps {
+  isProtected: boolean;
+  onClick: (e: React.MouseEvent) => void;
+  variant?: ShieldVariant;
+  size?: ShieldSize;
+  sx?: SxProps<Theme>;
+}
+
+function ProtectionShieldButton({
+  isProtected,
+  onClick,
+  variant = 'overlay',
+  size = 'medium',
+  sx,
+}: ProtectionShieldButtonProps) {
+  const tooltipText = isProtected ? 'Remove protection' : 'Protect from auto-deletion';
+
+  const overlayStyles: SxProps<Theme> = {
+    bgcolor: isProtected ? 'primary.main' : 'rgba(0,0,0,0.5)',
+    color: isProtected ? 'white' : 'grey.500',
+    padding: size === 'small' ? 0.3 : 0.5,
+    opacity: isProtected ? 1 : 0.6,
+    '&:hover': {
+      bgcolor: isProtected ? 'primary.dark' : 'rgba(0,0,0,0.8)',
+      opacity: 1,
+    },
+    transition: 'all 0.2s',
+    boxShadow: isProtected ? '0 0 6px rgba(25,118,210,0.5)' : 'none',
+  };
+
+  const inlineStyles: SxProps<Theme> = {
+    color: isProtected ? 'primary.main' : 'action.active',
+    opacity: isProtected ? 1 : 0.5,
+    '&:hover': {
+      color: 'primary.main',
+      bgcolor: 'primary.light',
+    },
+  };
+
+  const baseStyles = variant === 'overlay' ? overlayStyles : inlineStyles;
+  const iconFontSize = size === 'small' ? 14 : 16;
+
+  return (
+    <Tooltip title={tooltipText} arrow>
+      <IconButton
+        aria-label={tooltipText}
+        onClick={onClick}
+        sx={[
+          baseStyles,
+          ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+        ]}
+        size="small"
+      >
+        {isProtected
+          ? (variant === 'inline'
+              ? <ShieldIcon fontSize="small" />
+              : <ShieldIcon sx={{ fontSize: iconFontSize }} />)
+          : (variant === 'inline'
+              ? <ShieldOutlinedIcon fontSize="small" />
+              : <ShieldOutlinedIcon sx={{ fontSize: iconFontSize }} />)
+        }
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+export default ProtectionShieldButton;

--- a/client/src/components/shared/ThumbnailClickOverlay.tsx
+++ b/client/src/components/shared/ThumbnailClickOverlay.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box, SxProps, Theme } from '@mui/material';
+
+interface ThumbnailClickOverlayProps {
+  onClick: (e: React.MouseEvent) => void;
+  sx?: SxProps<Theme>;
+}
+
+const ThumbnailClickOverlay: React.FC<ThumbnailClickOverlayProps> = ({ onClick, sx }) => (
+  <Box
+    onClick={onClick}
+    sx={{
+      position: 'absolute',
+      top: '25%',
+      left: '25%',
+      width: '50%',
+      height: '50%',
+      cursor: 'pointer',
+      zIndex: 1,
+      ...sx as object,
+    }}
+  />
+);
+
+export default ThumbnailClickOverlay;

--- a/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
+++ b/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
@@ -1,0 +1,424 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { VideoModalData } from '../types';
+
+// Mock axios
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  delete: jest.fn(),
+  patch: jest.fn(),
+}));
+
+const axios = require('axios');
+
+// Mock useVideoMetadata - uses a ref object so resetMocks doesn't clear the return value
+const videoMetadataReturn = {
+  metadata: null as null,
+  loading: false,
+  error: null as string | null,
+};
+jest.mock('../hooks/useVideoMetadata', () => ({
+  useVideoMetadata: () => videoMetadataReturn,
+}));
+
+// Mock useVideoProtection - use plain object refs to survive resetMocks
+const mockToggleProtection = jest.fn();
+const protectionReturn = {
+  get toggleProtection() { return mockToggleProtection; },
+  loading: false,
+  error: null as string | null,
+  successMessage: null as string | null,
+  clearMessages: () => {},
+};
+jest.mock('../../useVideoProtection', () => ({
+  useVideoProtection: () => protectionReturn,
+}));
+
+// Mock useVideoDeletion
+const mockDeleteVideosByYoutubeIds = jest.fn();
+const deletionReturn = {
+  deleteVideos: () => Promise.resolve({ success: true, deleted: [], failed: [] }),
+  get deleteVideosByYoutubeIds() { return mockDeleteVideosByYoutubeIds; },
+  loading: false,
+  error: null as string | null,
+};
+jest.mock('../../useVideoDeletion', () => ({
+  useVideoDeletion: () => deletionReturn,
+}));
+
+// Mock sub-components that don't need full rendering
+jest.mock('../components/VideoPlayer', () => ({
+  __esModule: true,
+  default: function MockVideoPlayer() {
+    const React = require('react');
+    return React.createElement('div', { 'data-testid': 'video-player' }, 'VideoPlayer');
+  },
+}));
+
+jest.mock('../components/VideoMetadata', () => ({
+  __esModule: true,
+  default: function MockVideoMetadata() {
+    const React = require('react');
+    return React.createElement('div', { 'data-testid': 'video-metadata' }, 'VideoMetadata');
+  },
+}));
+
+jest.mock('../components/VideoTechnical', () => ({
+  __esModule: true,
+  default: function MockVideoTechnical() {
+    const React = require('react');
+    return React.createElement('div', { 'data-testid': 'video-technical' }, 'VideoTechnical');
+  },
+}));
+
+jest.mock('../../DeleteVideosDialog', () => ({
+  __esModule: true,
+  default: function MockDeleteDialog(props: { open: boolean; onConfirm: () => void; onClose: () => void }) {
+    const React = require('react');
+    if (!props.open) return null;
+    return React.createElement('div', { 'data-testid': 'delete-dialog' },
+      React.createElement('button', { 'data-testid': 'confirm-delete', onClick: props.onConfirm }, 'Confirm Delete'),
+      React.createElement('button', { 'data-testid': 'cancel-delete', onClick: props.onClose }, 'Cancel')
+    );
+  },
+}));
+
+jest.mock('../../../DownloadManager/ManualDownload/DownloadSettingsDialog', () => ({
+  __esModule: true,
+  default: function MockDownloadDialog(props: { open: boolean; onConfirm: () => void; onClose: () => void }) {
+    const React = require('react');
+    if (!props.open) return null;
+    return React.createElement('div', { 'data-testid': 'download-dialog' },
+      React.createElement('button', { 'data-testid': 'confirm-download', onClick: props.onConfirm }, 'Confirm Download'),
+    );
+  },
+}));
+
+jest.mock('../../ChangeRatingDialog', () => ({
+  __esModule: true,
+  default: function MockRatingDialog(props: { open: boolean; onApply: (rating: string | null) => Promise<void>; onClose: () => void }) {
+    const React = require('react');
+    if (!props.open) return null;
+    return React.createElement('div', { 'data-testid': 'rating-dialog' },
+      React.createElement('button', {
+        'data-testid': 'apply-rating',
+        onClick: () => props.onApply('PG-13'),
+      }, 'Apply PG-13'),
+      React.createElement('button', {
+        'data-testid': 'clear-rating',
+        onClick: () => props.onApply(null),
+      }, 'Clear Rating'),
+    );
+  },
+}));
+
+jest.mock('../../RatingBadge', () => ({
+  __esModule: true,
+  default: function MockRatingBadge(props: { rating: string | null }) {
+    const React = require('react');
+    return props.rating
+      ? React.createElement('span', { 'data-testid': 'rating-badge' }, props.rating)
+      : null;
+  },
+}));
+
+import VideoModal from '../index';
+
+const theme = createTheme();
+
+const baseVideo: VideoModalData = {
+  youtubeId: 'test123',
+  title: 'Test Video Title',
+  channelName: 'Test Channel',
+  thumbnailUrl: 'https://example.com/thumb.jpg',
+  duration: 120,
+  publishedAt: '2024-01-15',
+  addedAt: '2024-01-16',
+  mediaType: 'video',
+  status: 'downloaded',
+  isDownloaded: true,
+  filePath: '/videos/test.mp4',
+  fileSize: 1024000,
+  audioFilePath: null,
+  audioFileSize: null,
+  isProtected: false,
+  isIgnored: false,
+  normalizedRating: null,
+  ratingSource: null,
+  databaseId: 42,
+  channelId: 'UC123',
+};
+
+const neverDownloadedVideo: VideoModalData = {
+  ...baseVideo,
+  status: 'never_downloaded',
+  isDownloaded: false,
+  filePath: null,
+  fileSize: null,
+};
+
+function renderModal(props: Partial<React.ComponentProps<typeof VideoModal>> = {}) {
+  const defaultProps = {
+    open: true,
+    onClose: jest.fn(),
+    video: baseVideo,
+    token: 'test-token',
+  };
+
+  return render(
+    <ThemeProvider theme={theme}>
+      <VideoModal {...defaultProps} {...props} />
+    </ThemeProvider>
+  );
+}
+
+describe('VideoModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    protectionReturn.error = null;
+  });
+
+  test('renders video title when open', () => {
+    renderModal();
+    expect(screen.getByText('Test Video Title')).toBeInTheDocument();
+  });
+
+  test('renders status chip', () => {
+    renderModal();
+    expect(screen.getByText('Downloaded')).toBeInTheDocument();
+  });
+
+  test('renders rating badge when rating exists', () => {
+    renderModal({
+      video: { ...baseVideo, normalizedRating: 'PG-13', ratingSource: 'manual' },
+    });
+    expect(screen.getByTestId('rating-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('rating-badge')).toHaveTextContent('PG-13');
+  });
+
+  test('renders delete button for downloaded videos', () => {
+    renderModal();
+    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+  });
+
+  test('renders ignore button for non-downloaded videos', () => {
+    renderModal({ video: neverDownloadedVideo });
+    expect(screen.getByRole('button', { name: /ignore/i })).toBeInTheDocument();
+  });
+
+  test('calls onClose when close button clicked', async () => {
+    const onClose = jest.fn();
+    renderModal({ onClose });
+
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    await userEvent.click(closeButton);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not render when closed', () => {
+    renderModal({ open: false });
+    expect(screen.queryByText('Test Video Title')).not.toBeInTheDocument();
+  });
+
+  describe('handleProtectionToggle', () => {
+    test('calls toggleProtection and fires onProtectionChanged on success', async () => {
+      const onProtectionChanged = jest.fn();
+      mockToggleProtection.mockResolvedValueOnce(true);
+
+      renderModal({ onProtectionChanged });
+
+      const protectButton = screen.getByRole('button', { name: /protect from auto-deletion/i });
+      await userEvent.click(protectButton);
+
+      await waitFor(() => {
+        expect(mockToggleProtection).toHaveBeenCalledWith(42, false);
+      });
+
+      await waitFor(() => {
+        expect(onProtectionChanged).toHaveBeenCalledWith('test123', true);
+      });
+
+      expect(screen.getByText('Video protected from auto-deletion')).toBeInTheDocument();
+    });
+
+    test('shows error snackbar and reverts on protection failure', async () => {
+      protectionReturn.error = 'Server error';
+      mockToggleProtection.mockResolvedValueOnce(undefined);
+
+      renderModal();
+
+      const protectButton = screen.getByRole('button', { name: /protect from auto-deletion/i });
+      await userEvent.click(protectButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Server error')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('handleDeleteConfirm', () => {
+    test('calls deleteVideosByYoutubeIds and fires onVideoDeleted on success', async () => {
+      const onVideoDeleted = jest.fn();
+      const onClose = jest.fn();
+      mockDeleteVideosByYoutubeIds.mockResolvedValueOnce({
+        success: true,
+        deleted: ['test123'],
+        failed: [],
+      });
+
+      renderModal({ onVideoDeleted, onClose });
+
+      // Click the Delete button to open the dialog
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await userEvent.click(deleteButton);
+
+      // Confirm the deletion in the dialog
+      const confirmButton = screen.getByTestId('confirm-delete');
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        expect(mockDeleteVideosByYoutubeIds).toHaveBeenCalledWith(['test123'], 'test-token');
+      });
+
+      await waitFor(() => {
+        expect(onVideoDeleted).toHaveBeenCalledWith('test123');
+      });
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test('shows error snackbar on deletion failure', async () => {
+      mockDeleteVideosByYoutubeIds.mockResolvedValueOnce({
+        success: false,
+        deleted: [],
+        failed: [{ youtubeId: 'test123', error: 'Permission denied' }],
+      });
+
+      renderModal();
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await userEvent.click(deleteButton);
+
+      const confirmButton = screen.getByTestId('confirm-delete');
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Permission denied')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('handleIgnoreToggle', () => {
+    test('calls ignore API and fires onIgnoreChanged on success', async () => {
+      const onIgnoreChanged = jest.fn();
+      axios.post.mockResolvedValueOnce({ data: { success: true } });
+
+      renderModal({ video: neverDownloadedVideo, onIgnoreChanged });
+
+      const ignoreButton = screen.getByRole('button', { name: /ignore/i });
+      await userEvent.click(ignoreButton);
+
+      await waitFor(() => {
+        expect(axios.post).toHaveBeenCalledWith(
+          '/api/channels/videos/test123/ignore',
+          { ignored: true },
+          { headers: { 'x-access-token': 'test-token' } }
+        );
+      });
+
+      await waitFor(() => {
+        expect(onIgnoreChanged).toHaveBeenCalledWith('test123', true);
+      });
+
+      expect(screen.getByText('Video ignored')).toBeInTheDocument();
+    });
+
+    test('shows error snackbar on ignore API failure', async () => {
+      axios.post.mockRejectedValueOnce({
+        response: { data: { error: 'Network error' } },
+      });
+
+      renderModal({ video: neverDownloadedVideo });
+
+      const ignoreButton = screen.getByRole('button', { name: /ignore/i });
+      await userEvent.click(ignoreButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Network error')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('handleRatingApply', () => {
+    test('calls rating API and fires onRatingChanged on success', async () => {
+      const onRatingChanged = jest.fn();
+      axios.post.mockResolvedValueOnce({ data: { success: true } });
+
+      renderModal({ onRatingChanged });
+
+      // Click the Rate button to open the rating dialog
+      const rateButton = screen.getByRole('button', { name: /rate/i });
+      await userEvent.click(rateButton);
+
+      // Apply a rating
+      const applyButton = screen.getByTestId('apply-rating');
+      await userEvent.click(applyButton);
+
+      await waitFor(() => {
+        expect(axios.post).toHaveBeenCalledWith(
+          '/api/videos/rating',
+          { videoIds: [42], rating: 'PG-13' },
+          { headers: { 'x-access-token': 'test-token' } }
+        );
+      });
+
+      await waitFor(() => {
+        expect(onRatingChanged).toHaveBeenCalledWith('test123', 'PG-13');
+      });
+
+      expect(screen.getByText('Rating updated')).toBeInTheDocument();
+    });
+
+    test('shows error snackbar on rating API failure', async () => {
+      axios.post.mockRejectedValueOnce({
+        response: { data: { error: 'Rating update failed' } },
+      });
+
+      renderModal();
+
+      const rateButton = screen.getByRole('button', { name: /rate/i });
+      await userEvent.click(rateButton);
+
+      const applyButton = screen.getByTestId('apply-rating');
+      await userEvent.click(applyButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Rating update failed')).toBeInTheDocument();
+      });
+    });
+
+    test('shows error snackbar when video has no databaseId', async () => {
+      const videoWithoutDbId = { ...baseVideo, databaseId: null };
+      axios.post.mockResolvedValueOnce({ data: { success: true } });
+
+      renderModal({ video: videoWithoutDbId });
+
+      const rateButton = screen.getByRole('button', { name: /rate/i });
+      await userEvent.click(rateButton);
+
+      const applyButton = screen.getByTestId('apply-rating');
+      await userEvent.click(applyButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Cannot update rating: video not in database')).toBeInTheDocument();
+      });
+
+      // Should not have called the API
+      expect(axios.post).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
+++ b/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
@@ -191,12 +191,13 @@ describe('VideoModal', () => {
     expect(screen.getByText('Downloaded')).toBeInTheDocument();
   });
 
-  test('renders rating badge when rating exists', () => {
+  test('renders rating in action button when rating exists', () => {
     renderModal({
       video: { ...baseVideo, normalizedRating: 'PG-13', ratingSource: 'manual' },
     });
-    expect(screen.getByTestId('rating-badge')).toBeInTheDocument();
-    expect(screen.getByTestId('rating-badge')).toHaveTextContent('PG-13');
+    const ratingButton = screen.getByRole('button', { name: /change rating/i });
+    expect(ratingButton).toBeInTheDocument();
+    expect(ratingButton).toHaveTextContent('PG-13');
   });
 
   test('renders delete button for downloaded videos', () => {
@@ -361,7 +362,7 @@ describe('VideoModal', () => {
       renderModal({ onRatingChanged });
 
       // Click the Rate button to open the rating dialog
-      const rateButton = screen.getByRole('button', { name: /rate/i });
+      const rateButton = screen.getByRole('button', { name: /change rating/i });
       await userEvent.click(rateButton);
 
       // Apply a rating
@@ -390,7 +391,7 @@ describe('VideoModal', () => {
 
       renderModal();
 
-      const rateButton = screen.getByRole('button', { name: /rate/i });
+      const rateButton = screen.getByRole('button', { name: /change rating/i });
       await userEvent.click(rateButton);
 
       const applyButton = screen.getByTestId('apply-rating');
@@ -407,7 +408,7 @@ describe('VideoModal', () => {
 
       renderModal({ video: videoWithoutDbId });
 
-      const rateButton = screen.getByRole('button', { name: /rate/i });
+      const rateButton = screen.getByRole('button', { name: /change rating/i });
       await userEvent.click(rateButton);
 
       const applyButton = screen.getByTestId('apply-rating');

--- a/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
+++ b/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
@@ -49,6 +49,23 @@ jest.mock('../../useVideoDeletion', () => ({
   useVideoDeletion: () => deletionReturn,
 }));
 
+// Mock useTriggerDownloads
+const mockTriggerDownloads = jest.fn();
+jest.mock('../../../../hooks/useTriggerDownloads', () => ({
+  useTriggerDownloads: () => ({
+    get triggerDownloads() { return mockTriggerDownloads; },
+    loading: false,
+    error: null,
+  }),
+}));
+
+// Mock react-router-dom useNavigate
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
 // Mock sub-components that don't need full rendering
 jest.mock('../components/VideoPlayer', () => ({
   __esModule: true,
@@ -88,11 +105,11 @@ jest.mock('../../DeleteVideosDialog', () => ({
 
 jest.mock('../../../DownloadManager/ManualDownload/DownloadSettingsDialog', () => ({
   __esModule: true,
-  default: function MockDownloadDialog(props: { open: boolean; onConfirm: () => void; onClose: () => void }) {
+  default: function MockDownloadDialog(props: { open: boolean; onConfirm: (settings: null) => void; onClose: () => void }) {
     const React = require('react');
     if (!props.open) return null;
     return React.createElement('div', { 'data-testid': 'download-dialog' },
-      React.createElement('button', { 'data-testid': 'confirm-download', onClick: props.onConfirm }, 'Confirm Download'),
+      React.createElement('button', { 'data-testid': 'confirm-download', onClick: () => props.onConfirm(null) }, 'Confirm Download'),
     );
   },
 }));
@@ -125,6 +142,7 @@ jest.mock('../../RatingBadge', () => ({
   },
 }));
 
+import { MemoryRouter } from 'react-router-dom';
 import VideoModal from '../index';
 
 const theme = createTheme();
@@ -169,9 +187,11 @@ function renderModal(props: Partial<React.ComponentProps<typeof VideoModal>> = {
   };
 
   return render(
-    <ThemeProvider theme={theme}>
-      <VideoModal {...defaultProps} {...props} />
-    </ThemeProvider>
+    <MemoryRouter>
+      <ThemeProvider theme={theme}>
+        <VideoModal {...defaultProps} {...props} />
+      </ThemeProvider>
+    </MemoryRouter>
   );
 }
 
@@ -179,6 +199,7 @@ describe('VideoModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     protectionReturn.error = null;
+    mockTriggerDownloads.mockResolvedValue(true);
   });
 
   test('renders video title when open', () => {

--- a/client/src/components/shared/VideoModal/components/VideoActions.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoActions.tsx
@@ -1,28 +1,55 @@
 import React from 'react';
-import { Box, Button } from '@mui/material';
+import { Box, Button, Chip, IconButton, Tooltip } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import StarIcon from '@mui/icons-material/Star';
+import StarOutlineIcon from '@mui/icons-material/StarOutline';
 import BlockIcon from '@mui/icons-material/Block';
 import VisibilityIcon from '@mui/icons-material/Visibility';
-import ProtectionShieldButton from '../../ProtectionShieldButton';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import { VideoModalData } from '../types';
+import { VideoStatus } from '../../../../utils/videoStatus';
+
+interface StatusChipInfo {
+  label: string;
+  color: 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+}
+
+interface MediaTypeChipInfo {
+  label: string;
+  color: 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+  icon: React.ReactElement;
+}
 
 interface VideoActionsProps {
   video: VideoModalData;
+  statusChip: StatusChipInfo;
+  mediaTypeChip: MediaTypeChipInfo | null;
   onDelete: () => void;
   onProtectionToggle: () => void;
   onIgnoreToggle: () => void;
   onRatingChange: () => void;
   protectionLoading: boolean;
+  isMobile: boolean;
 }
+
+const PILL_SX = {
+  textTransform: 'none',
+  borderRadius: 5,
+  px: 1.5,
+  minHeight: 32,
+} as const;
 
 function VideoActions({
   video,
+  statusChip,
+  mediaTypeChip,
   onDelete,
   onProtectionToggle,
   onIgnoreToggle,
   onRatingChange,
   protectionLoading,
+  isMobile,
 }: VideoActionsProps) {
   const isDownloadedAndPresent = video.isDownloaded && video.status !== 'missing';
   const showProtect = isDownloadedAndPresent;
@@ -36,55 +63,111 @@ function VideoActions({
         display: 'flex',
         flexWrap: 'wrap',
         alignItems: 'center',
-        gap: 1,
+        gap: 0.75,
+        py: 0.5,
       }}
     >
+      {/* Status indicators (filled chips - not clickable) */}
+      <Chip
+        label={statusChip.label}
+        color={statusChip.color}
+        size="small"
+      />
+      {mediaTypeChip && (
+        <Chip
+          label={mediaTypeChip.label}
+          color={mediaTypeChip.color}
+          size="small"
+          icon={mediaTypeChip.icon}
+        />
+      )}
+
+      {/* Separator between status and actions */}
+      <Box
+        sx={{
+          width: '1px',
+          height: 20,
+          bgcolor: 'divider',
+          mx: 0.25,
+        }}
+      />
+
+      {/* Action buttons (outlined pills - clickable) */}
       {showProtect && (
-        <ProtectionShieldButton
-          isProtected={video.isProtected}
+        <Button
+          size="small"
+          variant={video.isProtected ? 'contained' : 'outlined'}
+          color={video.isProtected ? 'primary' : 'inherit'}
+          startIcon={video.isProtected ? <ShieldIcon /> : <ShieldOutlinedIcon />}
           onClick={(e: React.MouseEvent) => {
             e.stopPropagation();
             if (!protectionLoading) {
               onProtectionToggle();
             }
           }}
-          variant="inline"
-          size="small"
-        />
+          disabled={protectionLoading}
+          aria-label={video.isProtected ? 'Remove protection' : 'Protect from auto-deletion'}
+          sx={PILL_SX}
+        >
+          {video.isProtected ? 'Protected' : 'Protect'}
+        </Button>
       )}
 
       {showRating && (
         <Button
           size="small"
-          startIcon={<StarIcon />}
+          variant="outlined"
+          color={video.normalizedRating ? 'warning' : 'inherit'}
+          startIcon={video.normalizedRating ? <StarIcon /> : <StarOutlineIcon />}
           onClick={onRatingChange}
-          sx={{ textTransform: 'none' }}
+          aria-label="Change rating"
+          sx={PILL_SX}
         >
-          {video.normalizedRating ? `${video.normalizedRating}` : 'Rate'}
+          {video.normalizedRating || 'Rate'}
         </Button>
       )}
 
       {showIgnore && (
         <Button
           size="small"
+          variant="outlined"
+          color="inherit"
           startIcon={video.isIgnored ? <VisibilityIcon /> : <BlockIcon />}
           onClick={onIgnoreToggle}
-          sx={{ textTransform: 'none' }}
+          aria-label={video.isIgnored ? 'Unignore' : 'Ignore'}
+          sx={PILL_SX}
         >
           {video.isIgnored ? 'Unignore' : 'Ignore'}
         </Button>
       )}
 
+      <Box sx={{ flex: 1 }} />
+
       {showDelete && (
-        <Button
-          size="small"
-          startIcon={<DeleteIcon />}
-          onClick={onDelete}
-          color="error"
-          sx={{ textTransform: 'none' }}
-        >
-          Delete
-        </Button>
+        isMobile ? (
+          <Tooltip title="Delete video">
+            <IconButton
+              size="small"
+              color="error"
+              onClick={onDelete}
+              aria-label="Delete video"
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        ) : (
+          <Button
+            size="small"
+            variant="outlined"
+            color="error"
+            startIcon={<DeleteIcon />}
+            onClick={onDelete}
+            aria-label="Delete video"
+            sx={PILL_SX}
+          >
+            Delete
+          </Button>
+        )
       )}
     </Box>
   );

--- a/client/src/components/shared/VideoModal/components/VideoActions.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoActions.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Box, Button } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import StarIcon from '@mui/icons-material/Star';
+import BlockIcon from '@mui/icons-material/Block';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import ProtectionShieldButton from '../../ProtectionShieldButton';
+import { VideoModalData } from '../types';
+
+interface VideoActionsProps {
+  video: VideoModalData;
+  onDelete: () => void;
+  onProtectionToggle: () => void;
+  onIgnoreToggle: () => void;
+  onRatingChange: () => void;
+  protectionLoading: boolean;
+}
+
+function VideoActions({
+  video,
+  onDelete,
+  onProtectionToggle,
+  onIgnoreToggle,
+  onRatingChange,
+  protectionLoading,
+}: VideoActionsProps) {
+  const isDownloadedAndPresent = video.isDownloaded && video.status !== 'missing';
+  const showProtect = isDownloadedAndPresent;
+  const showRating = isDownloadedAndPresent;
+  const showIgnore = !video.isDownloaded || video.isIgnored;
+  const showDelete = video.isDownloaded || video.status === 'missing';
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: 1,
+      }}
+    >
+      {showProtect && (
+        <ProtectionShieldButton
+          isProtected={video.isProtected}
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            if (!protectionLoading) {
+              onProtectionToggle();
+            }
+          }}
+          variant="inline"
+          size="small"
+        />
+      )}
+
+      {showRating && (
+        <Button
+          size="small"
+          startIcon={<StarIcon />}
+          onClick={onRatingChange}
+          sx={{ textTransform: 'none' }}
+        >
+          {video.normalizedRating ? `${video.normalizedRating}` : 'Rate'}
+        </Button>
+      )}
+
+      {showIgnore && (
+        <Button
+          size="small"
+          startIcon={video.isIgnored ? <VisibilityIcon /> : <BlockIcon />}
+          onClick={onIgnoreToggle}
+          sx={{ textTransform: 'none' }}
+        >
+          {video.isIgnored ? 'Unignore' : 'Ignore'}
+        </Button>
+      )}
+
+      {showDelete && (
+        <Button
+          size="small"
+          startIcon={<DeleteIcon />}
+          onClick={onDelete}
+          color="error"
+          sx={{ textTransform: 'none' }}
+        >
+          Delete
+        </Button>
+      )}
+    </Box>
+  );
+}
+
+export default VideoActions;

--- a/client/src/components/shared/VideoModal/components/VideoMetadata.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoMetadata.tsx
@@ -1,0 +1,250 @@
+import React, { useState, useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  Chip,
+  Link,
+  Skeleton,
+  Collapse,
+  Button,
+} from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import { VideoModalData, VideoExtendedMetadata } from '../types';
+import { YOUTUBE_URL_BASE } from '../constants';
+
+interface VideoMetadataProps {
+  video: VideoModalData;
+  metadata: VideoExtendedMetadata | null;
+  loading: boolean;
+}
+
+const DESCRIPTION_PREVIEW_LENGTH = 300;
+const VISIBLE_TAGS_COUNT = 6;
+
+function formatCount(count: number): string {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+  }
+  if (count >= 1_000) {
+    return `${(count / 1_000).toFixed(1).replace(/\.0$/, '')}K`;
+  }
+  return count.toLocaleString();
+}
+
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(secs).padStart(2, '0')}`;
+}
+
+function parseDate(dateStr: string): Date | null {
+  // Handle YYYYMMDD format from yt-dlp
+  if (/^\d{8}$/.test(dateStr)) {
+    const year = parseInt(dateStr.substring(0, 4), 10);
+    const month = parseInt(dateStr.substring(4, 6), 10) - 1;
+    const day = parseInt(dateStr.substring(6, 8), 10);
+    return new Date(year, month, day);
+  }
+  // Handle ISO strings and other formats
+  const parsed = new Date(dateStr);
+  return isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function formatDate(dateStr: string | null): string | null {
+  if (!dateStr) return null;
+  const date = parseDate(dateStr);
+  if (!date) return null;
+  return date.toLocaleDateString();
+}
+
+function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const [tagsExpanded, setTagsExpanded] = useState(false);
+
+  const publishDate = useMemo(
+    () => formatDate(metadata?.uploadDate ?? video.publishedAt),
+    [metadata?.uploadDate, video.publishedAt]
+  );
+
+  const description = metadata?.description ?? null;
+  const needsTruncation = description !== null && description.length > DESCRIPTION_PREVIEW_LENGTH;
+
+  const allTags = useMemo(() => {
+    const tags = metadata?.tags ?? [];
+    const categories = metadata?.categories ?? [];
+    const combined = [...new Set([...categories, ...tags])];
+    return combined;
+  }, [metadata?.tags, metadata?.categories]);
+
+  const visibleTags = tagsExpanded ? allTags : allTags.slice(0, VISIBLE_TAGS_COUNT);
+  const hiddenTagsCount = allTags.length - VISIBLE_TAGS_COUNT;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {/* Stats row */}
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1.5 }}>
+        <Typography variant="body2" sx={{ fontWeight: 600, color: 'text.primary' }}>
+          {video.channelName}
+        </Typography>
+
+        {publishDate && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <CalendarTodayIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            <Typography variant="body2" color="text.secondary">
+              {publishDate}
+            </Typography>
+          </Box>
+        )}
+
+        {video.duration !== null && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <AccessTimeIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            <Typography variant="body2" color="text.secondary">
+              {formatDuration(video.duration)}
+            </Typography>
+          </Box>
+        )}
+
+        {loading ? (
+          <>
+            <Skeleton width={60} height={20} />
+            <Skeleton width={60} height={20} />
+            <Skeleton width={60} height={20} />
+          </>
+        ) : (
+          <>
+            {metadata?.viewCount !== null && metadata?.viewCount !== undefined && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <VisibilityIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <Typography variant="body2" color="text.secondary">
+                  {formatCount(metadata.viewCount)}
+                </Typography>
+              </Box>
+            )}
+
+            {metadata?.likeCount !== null && metadata?.likeCount !== undefined && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <ThumbUpIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <Typography variant="body2" color="text.secondary">
+                  {formatCount(metadata.likeCount)}
+                </Typography>
+              </Box>
+            )}
+
+            {metadata?.commentCount !== null && metadata?.commentCount !== undefined && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <ChatBubbleOutlineIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <Typography variant="body2" color="text.secondary">
+                  {formatCount(metadata.commentCount)}
+                </Typography>
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+
+      {/* Tags / Categories */}
+      {loading ? (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" width={70} height={24} />
+          ))}
+        </Box>
+      ) : allTags.length > 0 ? (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', alignItems: 'center' }}>
+          {visibleTags.map((tag) => (
+            <Chip key={tag} label={tag} size="small" variant="outlined" />
+          ))}
+          {hiddenTagsCount > 0 && !tagsExpanded && (
+            <Chip
+              label={`+${hiddenTagsCount} more`}
+              size="small"
+              onClick={() => setTagsExpanded(true)}
+              sx={{ cursor: 'pointer' }}
+            />
+          )}
+          {tagsExpanded && allTags.length > VISIBLE_TAGS_COUNT && (
+            <Chip
+              label="Show less"
+              size="small"
+              onClick={() => setTagsExpanded(false)}
+              sx={{ cursor: 'pointer' }}
+            />
+          )}
+        </Box>
+      ) : null}
+
+      {/* Description */}
+      {loading ? (
+        <Box>
+          <Skeleton width="100%" height={20} />
+          <Skeleton width="100%" height={20} />
+          <Skeleton width="80%" height={20} />
+        </Box>
+      ) : description ? (
+        <Box>
+          <Collapse in={descriptionExpanded} collapsedSize={60}>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+            >
+              {descriptionExpanded
+                ? description
+                : needsTruncation
+                  ? `${description.substring(0, DESCRIPTION_PREVIEW_LENGTH)}...`
+                  : description}
+            </Typography>
+          </Collapse>
+          {needsTruncation && (
+            <Button
+              size="small"
+              onClick={() => setDescriptionExpanded(!descriptionExpanded)}
+              endIcon={descriptionExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+              sx={{ textTransform: 'none', mt: 0.5, p: 0, minWidth: 0 }}
+            >
+              {descriptionExpanded ? 'Show less' : 'Show more'}
+            </Button>
+          )}
+        </Box>
+      ) : null}
+
+      {/* Footer: YouTube ID and link */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          pt: 1,
+          borderTop: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          ID: {video.youtubeId}
+        </Typography>
+        <Link
+          href={`${YOUTUBE_URL_BASE}${video.youtubeId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          underline="hover"
+          variant="caption"
+        >
+          Open on YouTube
+        </Link>
+      </Box>
+    </Box>
+  );
+}
+
+export default VideoMetadata;

--- a/client/src/components/shared/VideoModal/components/VideoMetadata.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoMetadata.tsx
@@ -91,24 +91,31 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      {/* Stats row */}
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1.5 }}>
+      {/* Channel and date */}
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1 }}>
         <Typography variant="body2" sx={{ fontWeight: 600, color: 'text.primary' }}>
           {video.channelName}
         </Typography>
-
         {publishDate && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <CalendarTodayIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
-            <Typography variant="body2" color="text.secondary">
-              {publishDate}
+          <>
+            <Typography variant="body2" color="text.disabled" sx={{ lineHeight: 1 }}>
+              ·
             </Typography>
-          </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <CalendarTodayIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
+              <Typography variant="body2" color="text.secondary">
+                {publishDate}
+              </Typography>
+            </Box>
+          </>
         )}
+      </Box>
 
+      {/* Stats row */}
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1.5 }}>
         {video.duration !== null && (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <AccessTimeIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            <AccessTimeIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
             <Typography variant="body2" color="text.secondary">
               {formatDuration(video.duration)}
             </Typography>
@@ -119,13 +126,12 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
           <>
             <Skeleton width={60} height={20} />
             <Skeleton width={60} height={20} />
-            <Skeleton width={60} height={20} />
           </>
         ) : (
           <>
             {metadata?.viewCount !== null && metadata?.viewCount !== undefined && (
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <VisibilityIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <VisibilityIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
                 <Typography variant="body2" color="text.secondary">
                   {formatCount(metadata.viewCount)}
                 </Typography>
@@ -134,7 +140,7 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
 
             {metadata?.likeCount !== null && metadata?.likeCount !== undefined && (
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <ThumbUpIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <ThumbUpIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
                 <Typography variant="body2" color="text.secondary">
                   {formatCount(metadata.likeCount)}
                 </Typography>
@@ -143,7 +149,7 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
 
             {metadata?.commentCount !== null && metadata?.commentCount !== undefined && (
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <ChatBubbleOutlineIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <ChatBubbleOutlineIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
                 <Typography variant="body2" color="text.secondary">
                   {formatCount(metadata.commentCount)}
                 </Typography>
@@ -169,8 +175,9 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
             <Chip
               label={`+${hiddenTagsCount} more`}
               size="small"
+              color="primary"
               onClick={() => setTagsExpanded(true)}
-              sx={{ cursor: 'pointer' }}
+              sx={{ cursor: 'pointer', fontWeight: 500 }}
             />
           )}
           {tagsExpanded && allTags.length > VISIBLE_TAGS_COUNT && (
@@ -193,25 +200,37 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
         </Box>
       ) : description ? (
         <Box>
-          <Collapse in={descriptionExpanded} collapsedSize={60}>
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-            >
-              {descriptionExpanded
-                ? description
-                : needsTruncation
-                  ? `${description.substring(0, DESCRIPTION_PREVIEW_LENGTH)}...`
-                  : description}
-            </Typography>
-          </Collapse>
+          <Box sx={{ position: 'relative' }}>
+            <Collapse in={descriptionExpanded} collapsedSize={72}>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+              >
+                {description}
+              </Typography>
+            </Collapse>
+            {!descriptionExpanded && needsTruncation && (
+              <Box
+                sx={{
+                  position: 'absolute',
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  height: 36,
+                  background: (theme) =>
+                    `linear-gradient(to bottom, transparent, ${theme.palette.background.paper})`,
+                  pointerEvents: 'none',
+                }}
+              />
+            )}
+          </Box>
           {needsTruncation && (
             <Button
               size="small"
               onClick={() => setDescriptionExpanded(!descriptionExpanded)}
               endIcon={descriptionExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-              sx={{ textTransform: 'none', mt: 0.5, p: 0, minWidth: 0 }}
+              sx={{ textTransform: 'none', mt: 0.5, fontWeight: 500 }}
             >
               {descriptionExpanded ? 'Show less' : 'Show more'}
             </Button>
@@ -230,9 +249,25 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
           borderColor: 'divider',
         }}
       >
-        <Typography variant="caption" color="text.secondary">
-          ID: {video.youtubeId}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+          <Typography variant="caption" color="text.secondary">
+            YouTube ID
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{
+              fontFamily: 'monospace',
+              bgcolor: 'action.hover',
+              color: 'text.primary',
+              px: 0.75,
+              py: 0.25,
+              borderRadius: 0.5,
+              fontSize: '0.7rem',
+            }}
+          >
+            {video.youtubeId}
+          </Typography>
+        </Box>
         <Link
           href={`${YOUTUBE_URL_BASE}${video.youtubeId}`}
           target="_blank"

--- a/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
@@ -1,0 +1,245 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  IconButton,
+  Tooltip,
+  Link,
+} from '@mui/material';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import CloudOffIcon from '@mui/icons-material/CloudOff';
+import DownloadIcon from '@mui/icons-material/Download';
+import BlockIcon from '@mui/icons-material/Block';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import StopIcon from '@mui/icons-material/Stop';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { VideoModalData } from '../types';
+import { YOUTUBE_URL_BASE } from '../constants';
+
+interface VideoPlayerProps {
+  video: VideoModalData;
+  token: string | null;
+  onDownloadClick: () => void;
+  isMobile: boolean;
+}
+
+// Fixed player heights as percentage of viewport.
+// The dialog is ~85vh. These heights leave room for title + metadata below.
+const PLAYER_HEIGHT_DESKTOP = '50vh';
+const PLAYER_HEIGHT_MOBILE = '25vh';
+
+function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerProps) {
+  const [playbackStarted, setPlaybackStarted] = useState(false);
+  const [streamError, setStreamError] = useState(false);
+
+  useEffect(() => {
+    setPlaybackStarted(false);
+    setStreamError(false);
+  }, [video.youtubeId]);
+
+  const canStream = video.isDownloaded && video.status !== 'missing';
+  const streamUrl = token
+    ? `/api/videos/${video.youtubeId}/stream?token=${encodeURIComponent(token)}`
+    : null;
+
+  const handlePlay = useCallback(() => {
+    setPlaybackStarted(true);
+  }, []);
+
+  const handleStreamError = useCallback(() => {
+    setStreamError(true);
+    setPlaybackStarted(false);
+  }, []);
+
+  const handleStop = useCallback(() => {
+    setPlaybackStarted(false);
+  }, []);
+
+  const youtubeUrl = `${YOUTUBE_URL_BASE}${video.youtubeId}`;
+  const isPlaying = canStream && playbackStarted && streamUrl && !streamError;
+  const playerHeight = isMobile ? PLAYER_HEIGHT_MOBILE : PLAYER_HEIGHT_DESKTOP;
+
+  // Two different sizing strategies:
+  // - Thumbnail: natural flow (width: 100%, height: auto) so it fills
+  //   the width with no black bars, capped by maxHeight.
+  // - Video playback: fixed height container with absolute positioning,
+  //   because <video> elements don't respect maxHeight in flex layouts.
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: '100%',
+        // When playing, use fixed height for the video element.
+        // When showing thumbnail, let the image determine the height naturally.
+        ...(isPlaying && { height: playerHeight, bgcolor: 'black' }),
+        overflow: 'hidden',
+        borderRadius: 1,
+      }}
+    >
+      {/* Video element - absolutely positioned when playing */}
+      {isPlaying && (
+        <Box
+          component="video"
+          data-testid="video-stream-element"
+          src={streamUrl}
+          controls
+          autoPlay
+          onError={handleStreamError}
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'contain',
+          }}
+        />
+      )}
+
+      {/* Thumbnail - scales to the largest size that fits both width and height
+          constraints while preserving aspect ratio. No cropping, no black bars. */}
+      {!isPlaying && (
+        <Box
+          component="img"
+          src={video.thumbnailUrl}
+          alt={video.title}
+          sx={{
+            display: 'block',
+            maxWidth: '100%',
+            maxHeight: playerHeight,
+            width: 'auto',
+            height: 'auto',
+            mx: 'auto',
+          }}
+        />
+      )}
+
+      {/* Overlay content - shown when not playing */}
+      {!isPlaying && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: 'rgba(0,0,0,0.4)',
+            gap: 1,
+          }}
+        >
+          {streamError ? (
+            <>
+              <CloudOffIcon sx={{ fontSize: 48, color: 'common.white' }} />
+              <Typography variant="body2" sx={{ color: 'common.white' }}>
+                Unable to stream video
+              </Typography>
+              <Link
+                href={youtubeUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                underline="hover"
+                variant="body2"
+                sx={{ color: 'primary.light' }}
+              >
+                Open on YouTube
+              </Link>
+            </>
+          ) : canStream ? (
+            <IconButton
+              onClick={handlePlay}
+              aria-label="Play video"
+              sx={{
+                bgcolor: 'rgba(0,0,0,0.6)',
+                color: 'common.white',
+                '&:hover': { bgcolor: 'rgba(0,0,0,0.8)' },
+                width: 64,
+                height: 64,
+              }}
+            >
+              <PlayArrowIcon sx={{ fontSize: 40 }} />
+            </IconButton>
+          ) : video.status === 'ignored' ? (
+            <>
+              <BlockIcon sx={{ fontSize: 48, color: 'common.white' }} />
+              <Typography variant="body1" sx={{ color: 'common.white', fontWeight: 500 }}>
+                Ignored
+              </Typography>
+            </>
+          ) : video.status === 'missing' ? (
+            <>
+              <WarningAmberIcon sx={{ fontSize: 48, color: 'warning.light' }} />
+              <Typography variant="body1" sx={{ color: 'common.white', fontWeight: 500 }}>
+                File Missing
+              </Typography>
+              <Button
+                variant="contained"
+                startIcon={<DownloadIcon />}
+                onClick={onDownloadClick}
+                size="small"
+                sx={{ textTransform: 'none', mt: 1 }}
+              >
+                Re-download Video
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="contained"
+              startIcon={<DownloadIcon />}
+              onClick={onDownloadClick}
+              size="small"
+              sx={{ textTransform: 'none' }}
+            >
+              Download Video
+            </Button>
+          )}
+        </Box>
+      )}
+
+      {/* Stop button - shown during playback */}
+      {isPlaying && (
+        <Tooltip title="Stop playback">
+          <IconButton
+            size="small"
+            onClick={handleStop}
+            aria-label="Stop playback"
+            sx={{
+              position: 'absolute',
+              top: 8,
+              left: 8,
+              color: 'common.white',
+              bgcolor: 'rgba(0,0,0,0.5)',
+              '&:hover': { bgcolor: 'rgba(0,0,0,0.7)' },
+              zIndex: 2,
+            }}
+          >
+            <StopIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
+
+      {/* Playback info tooltip - shown when video can stream */}
+      {canStream && !streamError && (
+        <Tooltip title="Video is served directly without transcoding. Playback may buffer on slow connections.">
+          <IconButton
+            size="small"
+            sx={{
+              position: 'absolute',
+              top: 8,
+              right: 8,
+              color: 'common.white',
+              bgcolor: 'rgba(0,0,0,0.5)',
+              '&:hover': { bgcolor: 'rgba(0,0,0,0.7)' },
+              zIndex: 2,
+            }}
+          >
+            <InfoOutlinedIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Box>
+  );
+}
+
+export default VideoPlayer;

--- a/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
@@ -14,6 +14,7 @@ import BlockIcon from '@mui/icons-material/Block';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import StopIcon from '@mui/icons-material/Stop';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import LockIcon from '@mui/icons-material/Lock';
 import { VideoModalData } from '../types';
 import { YOUTUBE_URL_BASE } from '../constants';
 
@@ -187,6 +188,16 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
               >
                 Re-download Video
               </Button>
+            </>
+          ) : video.status === 'members_only' ? (
+            <>
+              <LockIcon sx={{ fontSize: 48, color: 'common.white' }} />
+              <Typography variant="body1" sx={{ color: 'common.white', fontWeight: 500 }}>
+                Members Only
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'common.white', opacity: 0.85, textAlign: 'center', px: 2 }}>
+                Youtarr cannot download this video or fetch its metadata
+              </Typography>
             </>
           ) : (
             <Button

--- a/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
@@ -70,9 +70,10 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
       sx={{
         position: 'relative',
         width: '100%',
-        // When playing, use fixed height for the video element.
-        // When showing thumbnail, let the image determine the height naturally.
-        ...(isPlaying && { height: playerHeight, bgcolor: 'black' }),
+        bgcolor: 'black',
+        border: 1,
+        borderColor: 'divider',
+        ...(isPlaying && { height: playerHeight }),
         overflow: 'hidden',
         borderRadius: 1,
       }}
@@ -125,7 +126,7 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
-            bgcolor: 'rgba(0,0,0,0.4)',
+            background: 'linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.5) 100%)',
             gap: 1,
           }}
         >
@@ -151,14 +152,18 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
               onClick={handlePlay}
               aria-label="Play video"
               sx={{
-                bgcolor: 'rgba(0,0,0,0.6)',
+                bgcolor: 'rgba(0,0,0,0.7)',
                 color: 'common.white',
-                '&:hover': { bgcolor: 'rgba(0,0,0,0.8)' },
-                width: 64,
-                height: 64,
+                '&:hover': {
+                  bgcolor: 'rgba(0,0,0,0.85)',
+                  transform: 'scale(1.1)',
+                },
+                transition: 'transform 0.2s ease, background-color 0.2s ease',
+                width: 72,
+                height: 72,
               }}
             >
-              <PlayArrowIcon sx={{ fontSize: 40 }} />
+              <PlayArrowIcon sx={{ fontSize: 48 }} />
             </IconButton>
           ) : video.status === 'ignored' ? (
             <>

--- a/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
@@ -6,6 +6,7 @@ import {
   IconButton,
   Tooltip,
   Link,
+  ClickAwayListener,
 } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
@@ -33,10 +34,12 @@ const PLAYER_HEIGHT_MOBILE = '25vh';
 function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerProps) {
   const [playbackStarted, setPlaybackStarted] = useState(false);
   const [streamError, setStreamError] = useState(false);
+  const [infoTooltipOpen, setInfoTooltipOpen] = useState(false);
 
   useEffect(() => {
     setPlaybackStarted(false);
     setStreamError(false);
+    setInfoTooltipOpen(false);
   }, [video.youtubeId]);
 
   const canStream = video.isDownloaded && video.status !== 'missing';
@@ -235,24 +238,35 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
         </Tooltip>
       )}
 
-      {/* Playback info tooltip - shown when video can stream */}
+      {/* Playback info tooltip - shown when video can stream.
+          Controlled open state so a tap works on touch devices (hover doesn't exist on mobile).
+          ClickAwayListener dismisses the tooltip when tapping elsewhere. */}
       {canStream && !streamError && (
-        <Tooltip title="Video is served directly without transcoding. Playback may buffer on slow connections.">
-          <IconButton
-            size="small"
-            sx={{
-              position: 'absolute',
-              top: 8,
-              right: 8,
-              color: 'common.white',
-              bgcolor: 'rgba(0,0,0,0.5)',
-              '&:hover': { bgcolor: 'rgba(0,0,0,0.7)' },
-              zIndex: 2,
-            }}
+        <ClickAwayListener onClickAway={() => setInfoTooltipOpen(false)}>
+          <Tooltip
+            open={infoTooltipOpen}
+            onOpen={() => setInfoTooltipOpen(true)}
+            onClose={() => setInfoTooltipOpen(false)}
+            title="Video is served directly without transcoding. Playback may buffer on slow connections."
           >
-            <InfoOutlinedIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
+            <IconButton
+              size="small"
+              onClick={() => setInfoTooltipOpen((prev) => !prev)}
+              aria-label="Playback info"
+              sx={{
+                position: 'absolute',
+                top: 8,
+                right: 8,
+                color: 'common.white',
+                bgcolor: 'rgba(0,0,0,0.5)',
+                '&:hover': { bgcolor: 'rgba(0,0,0,0.7)' },
+                zIndex: 2,
+              }}
+            >
+              <InfoOutlinedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </ClickAwayListener>
       )}
     </Box>
   );

--- a/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { Box, Typography, Skeleton, Card, CardContent, Tooltip, Chip } from '@mui/material';
+import { VideoModalData, VideoExtendedMetadata } from '../types';
+
+interface VideoTechnicalProps {
+  video: VideoModalData;
+  metadata: VideoExtendedMetadata | null;
+  loading: boolean;
+}
+
+const BYTES_PER_KB = 1024;
+const BYTES_PER_MB = 1024 * 1024;
+const BYTES_PER_GB = 1024 * 1024 * 1024;
+
+const INTERNAL_PATH_PREFIX = '/usr/src/app/data/';
+
+function formatFileSize(bytes: number): string {
+  if (bytes >= BYTES_PER_GB) {
+    return `${(bytes / BYTES_PER_GB).toFixed(2)} GB`;
+  }
+  if (bytes >= BYTES_PER_MB) {
+    return `${(bytes / BYTES_PER_MB).toFixed(1)} MB`;
+  }
+  if (bytes >= BYTES_PER_KB) {
+    return `${(bytes / BYTES_PER_KB).toFixed(1)} KB`;
+  }
+  return `${bytes} B`;
+}
+
+function stripInternalPath(filePath: string): string {
+  if (filePath.startsWith(INTERNAL_PATH_PREFIX)) {
+    return filePath.slice(INTERNAL_PATH_PREFIX.length);
+  }
+  return filePath;
+}
+
+function getOrientationLabel(ratio: number): string {
+  if (ratio > 1) return 'Landscape';
+  if (ratio < 1) return 'Portrait';
+  return 'Square';
+}
+
+function formatAddedDate(dateStr: string | null): string | null {
+  if (!dateStr) return null;
+  const date = new Date(dateStr);
+  return isNaN(date.getTime()) ? null : date.toLocaleDateString();
+}
+
+function formatResolutionLabel(height: number | null): string | null {
+  if (!height) return null;
+  return `${height}p`;
+}
+
+interface DetailRowProps {
+  label: string;
+  value: string;
+}
+
+function DetailRow({ label, value }: DetailRowProps) {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', py: 0.5 }}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" color="text.primary" sx={{ fontWeight: 500 }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+interface FileRowProps {
+  label: string;
+  filePath: string;
+  fileSize: number | null;
+}
+
+function FileRow({ label, filePath, fileSize }: FileRowProps) {
+  const displayPath = stripInternalPath(filePath);
+  const sizeLabel = fileSize ? formatFileSize(fileSize) : 'Unknown size';
+
+  return (
+    <Box sx={{ py: 0.75 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography variant="body2" color="text.primary" sx={{ fontWeight: 500 }}>
+          {sizeLabel}
+        </Typography>
+      </Box>
+      <Tooltip title={displayPath} arrow placement="bottom-start" enterTouchDelay={0}>
+        <Typography
+          variant="caption"
+          color="text.disabled"
+          sx={{
+            display: 'block',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            maxWidth: '100%',
+            mt: 0.25,
+          }}
+        >
+          {displayPath}
+        </Typography>
+      </Tooltip>
+    </Box>
+  );
+}
+
+function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
+        <Box sx={{ flex: 1 }}>
+          <Skeleton variant="rounded" height={120} />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Skeleton variant="rounded" height={120} />
+        </Box>
+      </Box>
+    );
+  }
+
+  // Build technical details
+  const technicalDetails: DetailRowProps[] = [];
+  const availableResolutions = metadata?.availableResolutions ?? null;
+
+  // Download resolution - only for downloaded videos
+  if (video.isDownloaded && metadata?.height) {
+    const downloadRes = formatResolutionLabel(metadata.height);
+    if (downloadRes) {
+      technicalDetails.push({ label: 'Downloaded', value: downloadRes });
+    }
+  }
+
+  if (metadata?.fps !== null && metadata?.fps !== undefined) {
+    technicalDetails.push({ label: 'FPS', value: `${metadata.fps}` });
+  }
+  if (metadata?.aspectRatio !== null && metadata?.aspectRatio !== undefined && typeof metadata.aspectRatio === 'number') {
+    const orientation = getOrientationLabel(metadata.aspectRatio);
+    technicalDetails.push({
+      label: 'Aspect Ratio',
+      value: `${metadata.aspectRatio.toFixed(2)} (${orientation})`,
+    });
+  }
+  if (metadata?.language) {
+    technicalDetails.push({ label: 'Language', value: metadata.language });
+  }
+
+  // Build file info
+  const hasVideoFile = video.filePath !== null;
+  const hasAudioFile = video.audioFilePath !== null;
+  const relatedFiles = metadata?.relatedFiles ?? null;
+  const addedDate = formatAddedDate(video.addedAt);
+  const hasFileInfo = hasVideoFile || hasAudioFile || relatedFiles || addedDate;
+
+  const hasTechnical = technicalDetails.length > 0 || availableResolutions;
+
+  // Return null if nothing to show
+  if (!hasTechnical && !hasFileInfo) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
+      {hasTechnical && (
+        <Card variant="outlined" sx={{ flex: 1 }}>
+          <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
+            <Typography variant="subtitle2" color="text.primary" sx={{ mb: 1 }}>
+              Technical
+            </Typography>
+            {technicalDetails.map((detail) => (
+              <DetailRow key={detail.label} label={detail.label} value={detail.value} />
+            ))}
+            {availableResolutions && (
+              <Box sx={{ py: 0.5 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.75 }}>
+                  Available Resolutions
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                  {availableResolutions.map((h) => {
+                    const isDownloaded = video.isDownloaded && metadata?.height === h;
+                    return (
+                      <Chip
+                        key={h}
+                        label={`${h}p`}
+                        size="small"
+                        color={isDownloaded ? 'primary' : 'default'}
+                        variant={isDownloaded ? 'filled' : 'outlined'}
+                        sx={{ fontSize: '0.75rem', height: 24 }}
+                      />
+                    );
+                  })}
+                </Box>
+              </Box>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {hasFileInfo && (
+        <Card variant="outlined" sx={{ flex: 1 }}>
+          <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
+            <Typography variant="subtitle2" color="text.primary" sx={{ mb: 1 }}>
+              Files
+            </Typography>
+            {hasVideoFile && (
+              <FileRow
+                label="Video"
+                filePath={video.filePath!}
+                fileSize={video.fileSize}
+              />
+            )}
+            {hasAudioFile && (
+              <FileRow
+                label="Audio"
+                filePath={video.audioFilePath!}
+                fileSize={video.audioFileSize}
+              />
+            )}
+            {relatedFiles && relatedFiles.map((file) => (
+              <FileRow
+                key={file.fileName}
+                label={file.type}
+                filePath={file.fileName}
+                fileSize={file.fileSize}
+              />
+            ))}
+            {addedDate && (
+              <DetailRow label="Added" value={addedDate} />
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </Box>
+  );
+}
+
+export default VideoTechnical;

--- a/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography, Skeleton, Card, CardContent, Tooltip, Chip } from '@mui/material';
+import { Box, Typography, Skeleton, Card, CardContent, Tooltip, Chip, useTheme, useMediaQuery } from '@mui/material';
 import { VideoModalData, VideoExtendedMetadata } from '../types';
 
 interface VideoTechnicalProps {
@@ -110,6 +110,9 @@ function FileRow({ label, filePath, fileSize }: FileRowProps) {
 }
 
 function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
   if (loading) {
     return (
       <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
@@ -166,14 +169,36 @@ function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
   return (
     <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
       {hasTechnical && (
-        <Card variant="outlined" sx={{ flex: 1 }}>
+        <Card
+          variant="outlined"
+          sx={{
+            flex: 1,
+            ...(isMobile && {
+              border: 'none',
+              borderTop: 1,
+              borderColor: 'divider',
+              borderRadius: 0,
+            }),
+          }}
+        >
           <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
             <Typography variant="subtitle2" color="text.primary" sx={{ mb: 1 }}>
               Technical
             </Typography>
-            {technicalDetails.map((detail) => (
-              <DetailRow key={detail.label} label={detail.label} value={detail.value} />
-            ))}
+            <Box
+              sx={{
+                '& > div:nth-of-type(even)': {
+                  bgcolor: 'action.hover',
+                  borderRadius: 0.5,
+                  mx: -0.5,
+                  px: 0.5,
+                },
+              }}
+            >
+              {technicalDetails.map((detail) => (
+                <DetailRow key={detail.label} label={detail.label} value={detail.value} />
+              ))}
+            </Box>
             {availableResolutions && (
               <Box sx={{ py: 0.5 }}>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 0.75 }}>
@@ -201,36 +226,58 @@ function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
       )}
 
       {hasFileInfo && (
-        <Card variant="outlined" sx={{ flex: 1 }}>
+        <Card
+          variant="outlined"
+          sx={{
+            flex: 1,
+            ...(isMobile && {
+              border: 'none',
+              borderTop: 1,
+              borderColor: 'divider',
+              borderRadius: 0,
+            }),
+          }}
+        >
           <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
             <Typography variant="subtitle2" color="text.primary" sx={{ mb: 1 }}>
               Files
             </Typography>
-            {hasVideoFile && (
-              <FileRow
-                label="Video"
-                filePath={video.filePath!}
-                fileSize={video.fileSize}
-              />
-            )}
-            {hasAudioFile && (
-              <FileRow
-                label="Audio"
-                filePath={video.audioFilePath!}
-                fileSize={video.audioFileSize}
-              />
-            )}
-            {relatedFiles && relatedFiles.map((file) => (
-              <FileRow
-                key={file.fileName}
-                label={file.type}
-                filePath={file.fileName}
-                fileSize={file.fileSize}
-              />
-            ))}
-            {addedDate && (
-              <DetailRow label="Added" value={addedDate} />
-            )}
+            <Box
+              sx={{
+                '& > div:nth-of-type(even)': {
+                  bgcolor: 'action.hover',
+                  borderRadius: 0.5,
+                  mx: -0.5,
+                  px: 0.5,
+                },
+              }}
+            >
+              {hasVideoFile && (
+                <FileRow
+                  label="Video"
+                  filePath={video.filePath!}
+                  fileSize={video.fileSize}
+                />
+              )}
+              {hasAudioFile && (
+                <FileRow
+                  label="Audio"
+                  filePath={video.audioFilePath!}
+                  fileSize={video.audioFileSize}
+                />
+              )}
+              {relatedFiles && relatedFiles.map((file) => (
+                <FileRow
+                  key={file.fileName}
+                  label={file.type}
+                  filePath={file.fileName}
+                  fileSize={file.fileSize}
+                />
+              ))}
+              {addedDate && (
+                <DetailRow label="Added" value={addedDate} />
+              )}
+            </Box>
           </CardContent>
         </Card>
       )}

--- a/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
@@ -51,6 +51,21 @@ function formatResolutionLabel(height: number | null): string | null {
   return `${height}p`;
 }
 
+function formatDownloadedResolution(
+  width: number | null,
+  height: number | null,
+  tier: number | null
+): string | null {
+  if (!height) return null;
+  const base = width ? `${width}x${height}` : `${height}p`;
+  // Show the tier label when it differs from the actual height (non-16:9 videos).
+  // For 16:9 videos the tier matches the height, so appending it would be redundant.
+  if (tier && tier !== height) {
+    return `${base} (${tier}p)`;
+  }
+  return base;
+}
+
 interface DetailRowProps {
   label: string;
   value: string;
@@ -132,7 +147,11 @@ function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
 
   // Download resolution - only for downloaded videos
   if (video.isDownloaded && metadata?.height) {
-    const downloadRes = formatResolutionLabel(metadata.height);
+    const downloadRes = formatDownloadedResolution(
+      metadata.width,
+      metadata.height,
+      metadata.downloadedTier
+    );
     if (downloadRes) {
       technicalDetails.push({ label: 'Downloaded', value: downloadRes });
     }
@@ -206,7 +225,10 @@ function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
                 </Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                   {availableResolutions.map((h) => {
-                    const isDownloaded = video.isDownloaded && metadata?.height === h;
+                    // Match by tier when available (handles non-16:9 videos correctly),
+                    // fall back to raw height for backward-compatible info.json files.
+                    const downloadedMarker = metadata?.downloadedTier ?? metadata?.height ?? null;
+                    const isDownloaded = video.isDownloaded && downloadedMarker === h;
                     return (
                       <Chip
                         key={h}

--- a/client/src/components/shared/VideoModal/components/__tests__/VideoPlayer.test.tsx
+++ b/client/src/components/shared/VideoModal/components/__tests__/VideoPlayer.test.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { VideoModalData } from '../../types';
+
+// Mock MUI icons to lightweight spans
+jest.mock('@mui/icons-material/PlayArrow', () => ({
+  __esModule: true,
+  default: function MockPlayArrowIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'PlayArrowIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/CloudOff', () => ({
+  __esModule: true,
+  default: function MockCloudOffIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'CloudOffIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/Download', () => ({
+  __esModule: true,
+  default: function MockDownloadIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'DownloadIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/Block', () => ({
+  __esModule: true,
+  default: function MockBlockIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'BlockIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/InfoOutlined', () => ({
+  __esModule: true,
+  default: function MockInfoOutlinedIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'InfoOutlinedIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/Stop', () => ({
+  __esModule: true,
+  default: function MockStopIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'StopIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/WarningAmber', () => ({
+  __esModule: true,
+  default: function MockWarningAmberIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'WarningAmberIcon' });
+  },
+}));
+
+import VideoPlayer from '../VideoPlayer';
+
+const theme = createTheme();
+
+const downloadedVideo: VideoModalData = {
+  youtubeId: 'abc123',
+  title: 'Test Video',
+  channelName: 'Test Channel',
+  thumbnailUrl: 'https://example.com/thumb.jpg',
+  duration: 300,
+  publishedAt: '2024-06-01',
+  addedAt: '2024-06-02',
+  mediaType: 'video',
+  status: 'downloaded',
+  isDownloaded: true,
+  filePath: '/videos/test.mp4',
+  fileSize: 5242880,
+  audioFilePath: null,
+  audioFileSize: null,
+  isProtected: false,
+  isIgnored: false,
+  normalizedRating: null,
+  ratingSource: null,
+  databaseId: 1,
+  channelId: 'UC_test',
+};
+
+function renderPlayer(
+  videoOverride?: Partial<VideoModalData>,
+  propsOverride?: { token?: string | null; isMobile?: boolean }
+) {
+  const video = videoOverride
+    ? { ...downloadedVideo, ...videoOverride }
+    : downloadedVideo;
+
+  const defaultProps = {
+    video,
+    token: 'my-test-token',
+    onDownloadClick: jest.fn(),
+    isMobile: false,
+    ...propsOverride,
+  };
+
+  return {
+    ...render(
+      <ThemeProvider theme={theme}>
+        <VideoPlayer {...defaultProps} />
+      </ThemeProvider>
+    ),
+    onDownloadClick: defaultProps.onDownloadClick,
+  };
+}
+
+describe('VideoPlayer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders thumbnail with play overlay for a downloaded video', () => {
+    renderPlayer();
+
+    expect(screen.getByRole('img', { name: 'Test Video' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Play video' })).toBeInTheDocument();
+  });
+
+  test('renders "not downloaded" state with download button', () => {
+    renderPlayer({
+      status: 'never_downloaded',
+      isDownloaded: false,
+      filePath: null,
+      fileSize: null,
+    });
+
+    expect(screen.getByRole('button', { name: /download video/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Play video' })).not.toBeInTheDocument();
+  });
+
+  test('renders "ignored" state with block icon and label', () => {
+    renderPlayer({
+      status: 'ignored',
+      isDownloaded: false,
+      isIgnored: true,
+      filePath: null,
+      fileSize: null,
+    });
+
+    expect(screen.getByText('Ignored')).toBeInTheDocument();
+    expect(screen.getByTestId('BlockIcon')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Play video' })).not.toBeInTheDocument();
+  });
+
+  test('renders "missing file" state with warning and re-download button', () => {
+    renderPlayer({
+      status: 'missing',
+      isDownloaded: true,
+    });
+
+    expect(screen.getByText('File Missing')).toBeInTheDocument();
+    expect(screen.getByTestId('WarningAmberIcon')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /re-download video/i })).toBeInTheDocument();
+  });
+
+  test('clicking play enters playback mode with correct stream URL', async () => {
+    const user = userEvent.setup();
+    renderPlayer();
+
+    await user.click(screen.getByRole('button', { name: 'Play video' }));
+
+    // Playback mode: stop button visible, play button and thumbnail gone
+    expect(screen.getByRole('button', { name: 'Stop playback' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Play video' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'Test Video' })).not.toBeInTheDocument();
+
+    // Verify the stream URL includes the video ID and properly encoded token
+    const videoEl = screen.getByTestId('video-stream-element');
+    expect(videoEl).toHaveAttribute(
+      'src',
+      '/api/videos/abc123/stream?token=my-test-token'
+    );
+  });
+
+  test('stream error shows fallback UI with YouTube link', async () => {
+    const user = userEvent.setup();
+    renderPlayer();
+
+    // Start playback
+    await user.click(screen.getByRole('button', { name: 'Play video' }));
+
+    // Trigger error on the video element via its data-testid
+    const videoEl = screen.getByTestId('video-stream-element');
+    fireEvent.error(videoEl);
+
+    // Error fallback should appear
+    await waitFor(() => {
+      expect(screen.getByText('Unable to stream video')).toBeInTheDocument();
+    });
+
+    const youtubeLink = screen.getByRole('link', { name: 'Open on YouTube' });
+    expect(youtubeLink).toHaveAttribute(
+      'href',
+      'https://www.youtube.com/watch?v=abc123'
+    );
+  });
+
+  test('state resets when video.youtubeId changes', async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <ThemeProvider theme={theme}>
+        <VideoPlayer
+          video={downloadedVideo}
+          token="my-test-token"
+          onDownloadClick={jest.fn()}
+          isMobile={false}
+        />
+      </ThemeProvider>
+    );
+
+    // Start playback
+    await user.click(screen.getByRole('button', { name: 'Play video' }));
+    expect(screen.getByRole('button', { name: 'Stop playback' })).toBeInTheDocument();
+
+    // Rerender with a different youtubeId
+    const newVideo: VideoModalData = {
+      ...downloadedVideo,
+      youtubeId: 'xyz789',
+      title: 'Different Video',
+    };
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <VideoPlayer
+          video={newVideo}
+          token="my-test-token"
+          onDownloadClick={jest.fn()}
+          isMobile={false}
+        />
+      </ThemeProvider>
+    );
+
+    // useEffect resets playbackStarted and streamError, so thumbnail + play button return
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Play video' })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: 'Stop playback' })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/shared/VideoModal/components/__tests__/VideoPlayer.test.tsx
+++ b/client/src/components/shared/VideoModal/components/__tests__/VideoPlayer.test.tsx
@@ -61,6 +61,14 @@ jest.mock('@mui/icons-material/WarningAmber', () => ({
   },
 }));
 
+jest.mock('@mui/icons-material/Lock', () => ({
+  __esModule: true,
+  default: function MockLockIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'LockIcon' });
+  },
+}));
+
 import VideoPlayer from '../VideoPlayer';
 
 const theme = createTheme();
@@ -161,6 +169,20 @@ describe('VideoPlayer', () => {
     expect(screen.getByText('File Missing')).toBeInTheDocument();
     expect(screen.getByTestId('WarningAmberIcon')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /re-download video/i })).toBeInTheDocument();
+  });
+
+  test('renders "members only" state with lock icon and no download button', () => {
+    renderPlayer({
+      status: 'members_only',
+      isDownloaded: false,
+      filePath: null,
+      fileSize: null,
+    });
+
+    expect(screen.getByText('Members Only')).toBeInTheDocument();
+    expect(screen.getByTestId('LockIcon')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /download video/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Play video' })).not.toBeInTheDocument();
   });
 
   test('clicking play enters playback mode with correct stream URL', async () => {

--- a/client/src/components/shared/VideoModal/constants.ts
+++ b/client/src/components/shared/VideoModal/constants.ts
@@ -1,0 +1,1 @@
+export const YOUTUBE_URL_BASE = 'https://www.youtube.com/watch?v=';

--- a/client/src/components/shared/VideoModal/hooks/__tests__/useVideoMetadata.test.ts
+++ b/client/src/components/shared/VideoModal/hooks/__tests__/useVideoMetadata.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+const axios = require('axios');
+
+import { useVideoMetadata } from '../useVideoMetadata';
+import { VideoExtendedMetadata } from '../../types';
+
+const mockMetadata: VideoExtendedMetadata = {
+  description: 'A test video description',
+  viewCount: 12345,
+  likeCount: 678,
+  commentCount: 90,
+  tags: ['tag1', 'tag2'],
+  categories: ['Entertainment'],
+  uploadDate: '2024-01-15',
+  resolution: '1920x1080',
+  width: 1920,
+  height: 1080,
+  fps: 30,
+  aspectRatio: 1.777,
+  language: 'en',
+  isLive: false,
+  wasLive: false,
+  availability: 'public',
+  channelFollowerCount: 50000,
+  ageLimit: 0,
+  webpageUrl: 'https://www.youtube.com/watch?v=testId123',
+  relatedFiles: null,
+  availableResolutions: null,
+};
+
+describe('useVideoMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches metadata when youtubeId and token are provided', async () => {
+    axios.get.mockResolvedValueOnce({ data: mockMetadata });
+
+    const { result } = renderHook(() =>
+      useVideoMetadata('testId123', 'test-token')
+    );
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.metadata).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.metadata).toEqual(mockMetadata);
+    expect(result.current.error).toBeNull();
+    expect(axios.get).toHaveBeenCalledWith(
+      '/api/videos/testId123/metadata',
+      { headers: { 'x-access-token': 'test-token' } }
+    );
+  });
+
+  test('does not fetch when youtubeId is empty', () => {
+    const { result } = renderHook(() =>
+      useVideoMetadata('', 'test-token')
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.metadata).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test('does not fetch when token is null', () => {
+    const { result } = renderHook(() =>
+      useVideoMetadata('testId123', null)
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.metadata).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test('handles fetch error gracefully and metadata stays null', async () => {
+    axios.get.mockRejectedValueOnce({
+      response: { data: { error: 'Video not found' } },
+    });
+
+    const { result } = renderHook(() =>
+      useVideoMetadata('badId', 'test-token')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.metadata).toBeNull();
+    expect(result.current.error).toBe('Video not found');
+  });
+});

--- a/client/src/components/shared/VideoModal/hooks/__tests__/useVideoMetadata.test.ts
+++ b/client/src/components/shared/VideoModal/hooks/__tests__/useVideoMetadata.test.ts
@@ -31,6 +31,7 @@ const mockMetadata: VideoExtendedMetadata = {
   webpageUrl: 'https://www.youtube.com/watch?v=testId123',
   relatedFiles: null,
   availableResolutions: null,
+  downloadedTier: null,
 };
 
 describe('useVideoMetadata', () => {

--- a/client/src/components/shared/VideoModal/hooks/useVideoMetadata.ts
+++ b/client/src/components/shared/VideoModal/hooks/useVideoMetadata.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { VideoExtendedMetadata } from '../types';
+
+interface UseVideoMetadataReturn {
+  metadata: VideoExtendedMetadata | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export const useVideoMetadata = (
+  youtubeId: string,
+  token: string | null
+): UseVideoMetadataReturn => {
+  const [metadata, setMetadata] = useState<VideoExtendedMetadata | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!youtubeId || !token) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchMetadata = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await axios.get<VideoExtendedMetadata>(
+          `/api/videos/${youtubeId}/metadata`,
+          { headers: { 'x-access-token': token } }
+        );
+
+        if (!cancelled) {
+          setMetadata(response.data);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const errorMessage =
+            (err as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+            (err instanceof Error ? err.message : 'Failed to fetch video metadata');
+          setError(errorMessage);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchMetadata();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [youtubeId, token]);
+
+  return { metadata, loading, error };
+};

--- a/client/src/components/shared/VideoModal/hooks/useVideoModalActions.ts
+++ b/client/src/components/shared/VideoModal/hooks/useVideoModalActions.ts
@@ -1,0 +1,209 @@
+import { useState, useEffect, useCallback } from 'react';
+import axios from 'axios';
+import { VideoModalData } from '../types';
+import { useVideoProtection } from '../../useVideoProtection';
+import { useVideoDeletion } from '../../useVideoDeletion';
+
+interface SnackbarState {
+  open: boolean;
+  message: string;
+  severity: 'success' | 'error';
+}
+
+interface AxiosErrorShape {
+  response?: { data?: { error?: string } };
+}
+
+interface UseVideoModalActionsParams {
+  video: VideoModalData;
+  token: string | null;
+  onVideoDeleted?: (youtubeId: string) => void;
+  onProtectionChanged?: (youtubeId: string, isProtected: boolean) => void;
+  onIgnoreChanged?: (youtubeId: string, isIgnored: boolean) => void;
+  onDownloadQueued?: (youtubeId: string) => void;
+  onRatingChanged?: (youtubeId: string, rating: string | null) => void;
+  onClose: () => void;
+}
+
+interface UseVideoModalActionsReturn {
+  localVideo: VideoModalData;
+  snackbar: SnackbarState;
+  deleteDialogOpen: boolean;
+  downloadDialogOpen: boolean;
+  ratingDialogOpen: boolean;
+  protectionLoading: boolean;
+  setDeleteDialogOpen: (open: boolean) => void;
+  setDownloadDialogOpen: (open: boolean) => void;
+  setRatingDialogOpen: (open: boolean) => void;
+  handleProtectionToggle: () => Promise<void>;
+  handleDeleteConfirm: () => Promise<void>;
+  handleIgnoreToggle: () => Promise<void>;
+  handleDownloadConfirm: () => void;
+  handleRatingApply: (rating: string | null) => Promise<void>;
+  handleSnackbarClose: () => void;
+}
+
+function extractErrorMessage(err: unknown, fallback: string): string {
+  return (
+    (err as AxiosErrorShape)?.response?.data?.error ||
+    (err instanceof Error ? err.message : fallback)
+  );
+}
+
+export function useVideoModalActions({
+  video,
+  token,
+  onVideoDeleted,
+  onProtectionChanged,
+  onIgnoreChanged,
+  onDownloadQueued,
+  onRatingChanged,
+  onClose,
+}: UseVideoModalActionsParams): UseVideoModalActionsReturn {
+  const [localVideo, setLocalVideo] = useState<VideoModalData>(video);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
+  const [ratingDialogOpen, setRatingDialogOpen] = useState(false);
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  const protection = useVideoProtection(token);
+  const deletion = useVideoDeletion();
+
+  // Reset local state when a different video is opened (not on every re-render).
+  // The video prop is a new object on each parent render, so we track by youtubeId.
+  useEffect(() => {
+    setLocalVideo(video);
+  }, [video.youtubeId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const showSnackbar = useCallback((message: string, severity: 'success' | 'error') => {
+    setSnackbar({ open: true, message, severity });
+  }, []);
+
+  const handleSnackbarClose = useCallback(() => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  const handleProtectionToggle = useCallback(async () => {
+    if (!localVideo.databaseId) return;
+
+    const newState = !localVideo.isProtected;
+
+    // Optimistic update
+    setLocalVideo((prev) => ({ ...prev, isProtected: newState }));
+
+    const result = await protection.toggleProtection(
+      localVideo.databaseId,
+      localVideo.isProtected
+    );
+
+    if (result !== undefined) {
+      setLocalVideo((prev) => ({ ...prev, isProtected: result }));
+      showSnackbar(
+        result ? 'Video protected from auto-deletion' : 'Video protection removed',
+        'success'
+      );
+      onProtectionChanged?.(localVideo.youtubeId, result);
+    } else {
+      setLocalVideo((prev) => ({ ...prev, isProtected: !newState }));
+      showSnackbar(protection.error || 'Failed to update protection', 'error');
+    }
+  }, [localVideo.databaseId, localVideo.isProtected, localVideo.youtubeId, protection, showSnackbar, onProtectionChanged]);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    const result = await deletion.deleteVideosByYoutubeIds(
+      [localVideo.youtubeId],
+      token
+    );
+
+    if (result.success) {
+      showSnackbar('Video deleted successfully', 'success');
+      onVideoDeleted?.(localVideo.youtubeId);
+      setDeleteDialogOpen(false);
+      onClose();
+    } else {
+      const errorMsg = result.failed[0]?.error || 'Failed to delete video';
+      showSnackbar(errorMsg, 'error');
+      setDeleteDialogOpen(false);
+    }
+  }, [localVideo.youtubeId, token, deletion, showSnackbar, onVideoDeleted, onClose]);
+
+  const handleIgnoreToggle = useCallback(async () => {
+    const newIgnored = !localVideo.isIgnored;
+
+    try {
+      await axios.post(
+        `/api/channels/videos/${localVideo.youtubeId}/ignore`,
+        { ignored: newIgnored },
+        { headers: { 'x-access-token': token || '' } }
+      );
+
+      setLocalVideo((prev) => ({
+        ...prev,
+        isIgnored: newIgnored,
+        status: newIgnored ? 'ignored' : 'never_downloaded',
+      }));
+      showSnackbar(
+        newIgnored ? 'Video ignored' : 'Video unignored',
+        'success'
+      );
+      onIgnoreChanged?.(localVideo.youtubeId, newIgnored);
+    } catch (err: unknown) {
+      showSnackbar(extractErrorMessage(err, 'Failed to update ignore status'), 'error');
+    }
+  }, [localVideo.isIgnored, localVideo.youtubeId, token, showSnackbar, onIgnoreChanged]);
+
+  const handleDownloadConfirm = useCallback(() => {
+    setDownloadDialogOpen(false);
+    onDownloadQueued?.(localVideo.youtubeId);
+    showSnackbar('Video queued for download', 'success');
+  }, [localVideo.youtubeId, showSnackbar, onDownloadQueued]);
+
+  const handleRatingApply = useCallback(async (rating: string | null) => {
+    if (!localVideo.databaseId) {
+      showSnackbar('Cannot update rating: video not in database', 'error');
+      return;
+    }
+
+    try {
+      await axios.post(
+        '/api/videos/rating',
+        {
+          videoIds: [localVideo.databaseId],
+          rating,
+        },
+        { headers: { 'x-access-token': token || '' } }
+      );
+
+      setLocalVideo((prev) => ({
+        ...prev,
+        normalizedRating: rating,
+      }));
+      showSnackbar('Rating updated', 'success');
+      onRatingChanged?.(localVideo.youtubeId, rating);
+    } catch (err: unknown) {
+      showSnackbar(extractErrorMessage(err, 'Failed to update rating'), 'error');
+    }
+  }, [localVideo.databaseId, localVideo.youtubeId, token, showSnackbar, onRatingChanged]);
+
+  return {
+    localVideo,
+    snackbar,
+    deleteDialogOpen,
+    downloadDialogOpen,
+    ratingDialogOpen,
+    protectionLoading: protection.loading,
+    setDeleteDialogOpen,
+    setDownloadDialogOpen,
+    setRatingDialogOpen,
+    handleProtectionToggle,
+    handleDeleteConfirm,
+    handleIgnoreToggle,
+    handleDownloadConfirm,
+    handleRatingApply,
+    handleSnackbarClose,
+  };
+}

--- a/client/src/components/shared/VideoModal/hooks/useVideoModalActions.ts
+++ b/client/src/components/shared/VideoModal/hooks/useVideoModalActions.ts
@@ -1,8 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { VideoModalData } from '../types';
 import { useVideoProtection } from '../../useVideoProtection';
 import { useVideoDeletion } from '../../useVideoDeletion';
+import { useTriggerDownloads } from '../../../../hooks/useTriggerDownloads';
+import { DownloadSettings } from '../../../DownloadManager/ManualDownload/types';
 
 interface SnackbarState {
   open: boolean;
@@ -38,7 +41,7 @@ interface UseVideoModalActionsReturn {
   handleProtectionToggle: () => Promise<void>;
   handleDeleteConfirm: () => Promise<void>;
   handleIgnoreToggle: () => Promise<void>;
-  handleDownloadConfirm: () => void;
+  handleDownloadConfirm: (settings: DownloadSettings | null) => Promise<void>;
   handleRatingApply: (rating: string | null) => Promise<void>;
   handleSnackbarClose: () => void;
 }
@@ -70,8 +73,10 @@ export function useVideoModalActions({
     severity: 'success',
   });
 
+  const navigate = useNavigate();
   const protection = useVideoProtection(token);
   const deletion = useVideoDeletion();
+  const { triggerDownloads } = useTriggerDownloads(token);
 
   // Reset local state when a different video is opened (not on every re-render).
   // The video prop is a new object on each parent render, so we track by youtubeId.
@@ -156,11 +161,35 @@ export function useVideoModalActions({
     }
   }, [localVideo.isIgnored, localVideo.youtubeId, token, showSnackbar, onIgnoreChanged]);
 
-  const handleDownloadConfirm = useCallback(() => {
+  const handleDownloadConfirm = useCallback(async (settings: DownloadSettings | null) => {
     setDownloadDialogOpen(false);
-    onDownloadQueued?.(localVideo.youtubeId);
-    showSnackbar('Video queued for download', 'success');
-  }, [localVideo.youtubeId, showSnackbar, onDownloadQueued]);
+
+    const url = `https://www.youtube.com/watch?v=${localVideo.youtubeId}`;
+    const overrideSettings = settings
+      ? {
+          resolution: settings.resolution,
+          allowRedownload: settings.allowRedownload,
+          subfolder: settings.subfolder,
+          audioFormat: settings.audioFormat,
+          rating: settings.rating,
+          skipVideoFolder: settings.skipVideoFolder,
+        }
+      : undefined;
+
+    const success = await triggerDownloads({
+      urls: [url],
+      overrideSettings,
+      channelId: localVideo.channelId,
+    });
+
+    if (success) {
+      onDownloadQueued?.(localVideo.youtubeId);
+      onClose();
+      navigate('/downloads');
+    } else {
+      showSnackbar('Failed to queue download', 'error');
+    }
+  }, [localVideo.youtubeId, localVideo.channelId, triggerDownloads, showSnackbar, onDownloadQueued, onClose, navigate]);
 
   const handleRatingApply = useCallback(async (rating: string | null) => {
     if (!localVideo.databaseId) {

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -5,7 +5,6 @@ import {
   DialogContent,
   Box,
   Typography,
-  Chip,
   IconButton,
   Snackbar,
   Alert,
@@ -13,6 +12,7 @@ import {
   useTheme,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import VideoPlayer from './components/VideoPlayer';
 import VideoMetadata from './components/VideoMetadata';
 import VideoActions from './components/VideoActions';
@@ -23,7 +23,6 @@ import { VideoModalProps } from './types';
 import DeleteVideosDialog from '../DeleteVideosDialog';
 import ChangeRatingDialog from '../ChangeRatingDialog';
 import DownloadSettingsDialog from '../../DownloadManager/ManualDownload/DownloadSettingsDialog';
-import RatingBadge from '../RatingBadge';
 import { getStatusLabel, getStatusColor, getMediaTypeInfo } from '../../../utils/videoStatus';
 
 const SNACKBAR_AUTO_HIDE_MS = 4000;
@@ -85,15 +84,14 @@ function VideoModal({
         onClose={onClose}
         maxWidth="lg"
         fullWidth
+        fullScreen={isMobile}
         PaperProps={{
           sx: {
-            maxHeight: '92vh',
-            m: isMobile ? 0.5 : 1.5,
-            width: isMobile ? 'calc(100% - 8px)' : undefined,
+            ...(!isMobile && { maxHeight: '92vh', m: 1.5 }),
           },
         }}
       >
-        {/* Header bar */}
+        {/* Header bar - title + close */}
         <DialogTitle
           sx={{
             display: 'flex',
@@ -101,37 +99,48 @@ function VideoModal({
             gap: 1,
             py: 1.5,
             px: 2,
+            borderBottom: 1,
+            borderColor: 'divider',
           }}
         >
-          <Chip
-            label={getStatusLabel(localVideo.status)}
-            color={getStatusColor(localVideo.status)}
-            size="small"
-          />
-          {mediaTypeInfo && (
-            <Chip
-              label={mediaTypeInfo.label}
-              color={mediaTypeInfo.color}
+          {isMobile && (
+            <IconButton
+              onClick={onClose}
               size="small"
-              icon={mediaTypeInfo.icon}
-            />
+              aria-label="Close"
+              edge="start"
+              sx={{ mr: 0.5 }}
+            >
+              <ArrowBackIcon />
+            </IconButton>
           )}
-          {localVideo.normalizedRating && (
-            <RatingBadge
-              rating={localVideo.normalizedRating}
-              ratingSource={localVideo.ratingSource}
-              size="small"
-            />
-          )}
-          <Box sx={{ flex: 1 }} />
-          <IconButton
-            onClick={onClose}
-            size="small"
-            aria-label="Close"
-            edge="end"
+          <Typography
+            variant="h6"
+            component="span"
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              fontSize: isMobile ? '1rem' : '1.15rem',
+              fontWeight: 600,
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              wordBreak: 'break-word',
+            }}
           >
-            <CloseIcon />
-          </IconButton>
+            {localVideo.title}
+          </Typography>
+          {!isMobile && (
+            <IconButton
+              onClick={onClose}
+              size="small"
+              aria-label="Close"
+              edge="end"
+            >
+              <CloseIcon />
+            </IconButton>
+          )}
         </DialogTitle>
 
         <DialogContent sx={{ p: isMobile ? 1.5 : 2 }}>
@@ -146,16 +155,16 @@ function VideoModal({
                 />
               </Box>
               <Box sx={{ minWidth: 0 }}>
-                <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
-                  {localVideo.title}
-                </Typography>
                 <VideoActions
                   video={localVideo}
+                  statusChip={{ label: getStatusLabel(localVideo.status), color: getStatusColor(localVideo.status) }}
+                  mediaTypeChip={mediaTypeInfo}
                   onDelete={() => setDeleteDialogOpen(true)}
                   onProtectionToggle={handleProtectionToggle}
                   onIgnoreToggle={handleIgnoreToggle}
                   onRatingChange={() => setRatingDialogOpen(true)}
                   protectionLoading={protectionLoading}
+                  isMobile={isMobile}
                 />
                 <Box sx={{ mt: 2 }}>
                   <VideoMetadata
@@ -179,17 +188,17 @@ function VideoModal({
                 onDownloadClick={() => setDownloadDialogOpen(true)}
                 isMobile={isMobile}
               />
-              <Box sx={{ mt: 2 }}>
-                <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
-                  {localVideo.title}
-                </Typography>
+              <Box sx={{ mt: 1.5 }}>
                 <VideoActions
                   video={localVideo}
+                  statusChip={{ label: getStatusLabel(localVideo.status), color: getStatusColor(localVideo.status) }}
+                  mediaTypeChip={mediaTypeInfo}
                   onDelete={() => setDeleteDialogOpen(true)}
                   onProtectionToggle={handleProtectionToggle}
                   onIgnoreToggle={handleIgnoreToggle}
                   onRatingChange={() => setRatingDialogOpen(true)}
                   protectionLoading={protectionLoading}
+                  isMobile={isMobile}
                 />
               </Box>
               <Box sx={{ mt: 2 }}>

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -69,8 +69,14 @@ function VideoModal({
     onClose,
   });
 
+  // Skip metadata fetch for members-only videos that we haven't downloaded -
+  // yt-dlp cannot access them and the error just spams the server logs. For
+  // already-downloaded members-only videos, the backend still serves cached
+  // .info.json so we let the fetch proceed.
+  const skipMetadataFetch = video.status === 'members_only' && !video.isDownloaded;
+  const shouldFetchMetadata = open && !skipMetadataFetch;
   const { metadata, loading: metadataLoading } = useVideoMetadata(
-    open ? video.youtubeId : '',
+    shouldFetchMetadata ? video.youtubeId : '',
     token
   );
 

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import {
   Dialog,
   DialogTitle,
@@ -83,11 +84,12 @@ function VideoModal({
   const { config } = useConfig(token);
 
   // Fetch channel-level download settings when modal opens
-  const [channelSettings, setChannelSettings] = useState<{
+  interface ChannelSettings {
     video_quality?: string | null;
     audio_format?: string | null;
     default_rating?: string | null;
-  }>({});
+  }
+  const [channelSettings, setChannelSettings] = useState<ChannelSettings>({});
 
   useEffect(() => {
     if (!open || !video.channelId || !token) {
@@ -97,14 +99,18 @@ function VideoModal({
     const controller = new AbortController();
     const fetchSettings = async () => {
       try {
-        const resp = await fetch(`/api/channels/${video.channelId}/settings`, {
-          headers: { 'x-access-token': token },
-          signal: controller.signal,
-        });
-        if (!resp.ok) return;
-        setChannelSettings(await resp.json());
-      } catch (err: unknown) {
-        if (err instanceof DOMException && err.name === 'AbortError') return;
+        const resp = await axios.get<ChannelSettings>(
+          `/api/channels/${video.channelId}/settings`,
+          {
+            headers: { 'x-access-token': token },
+            signal: controller.signal,
+          }
+        );
+        if (!controller.signal.aborted) {
+          setChannelSettings(resp.data);
+        }
+      } catch {
+        // Request failed or was aborted; leave channelSettings at its last value.
       }
     };
     fetchSettings();

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -1,0 +1,256 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Box,
+  Typography,
+  Chip,
+  IconButton,
+  Snackbar,
+  Alert,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import VideoPlayer from './components/VideoPlayer';
+import VideoMetadata from './components/VideoMetadata';
+import VideoActions from './components/VideoActions';
+import VideoTechnical from './components/VideoTechnical';
+import { useVideoMetadata } from './hooks/useVideoMetadata';
+import { useVideoModalActions } from './hooks/useVideoModalActions';
+import { VideoModalProps } from './types';
+import DeleteVideosDialog from '../DeleteVideosDialog';
+import ChangeRatingDialog from '../ChangeRatingDialog';
+import DownloadSettingsDialog from '../../DownloadManager/ManualDownload/DownloadSettingsDialog';
+import RatingBadge from '../RatingBadge';
+import { getStatusLabel, getStatusColor, getMediaTypeInfo } from '../../../utils/videoStatus';
+
+const SNACKBAR_AUTO_HIDE_MS = 4000;
+
+function VideoModal({
+  open,
+  onClose,
+  video,
+  token,
+  onVideoDeleted,
+  onProtectionChanged,
+  onIgnoreChanged,
+  onDownloadQueued,
+  onRatingChanged,
+}: VideoModalProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const {
+    localVideo,
+    snackbar,
+    deleteDialogOpen,
+    downloadDialogOpen,
+    ratingDialogOpen,
+    protectionLoading,
+    setDeleteDialogOpen,
+    setDownloadDialogOpen,
+    setRatingDialogOpen,
+    handleProtectionToggle,
+    handleDeleteConfirm,
+    handleIgnoreToggle,
+    handleDownloadConfirm,
+    handleRatingApply,
+    handleSnackbarClose,
+  } = useVideoModalActions({
+    video,
+    token,
+    onVideoDeleted,
+    onProtectionChanged,
+    onIgnoreChanged,
+    onDownloadQueued,
+    onRatingChanged,
+    onClose,
+  });
+
+  const { metadata, loading: metadataLoading } = useVideoMetadata(
+    open ? video.youtubeId : '',
+    token
+  );
+
+  const isShort = localVideo.mediaType === 'short';
+  const useSideBySide = isShort && !isMobile;
+  const mediaTypeInfo = getMediaTypeInfo(localVideo.mediaType);
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        maxWidth="lg"
+        fullWidth
+        PaperProps={{
+          sx: {
+            maxHeight: '92vh',
+            m: isMobile ? 0.5 : 1.5,
+            width: isMobile ? 'calc(100% - 8px)' : undefined,
+          },
+        }}
+      >
+        {/* Header bar */}
+        <DialogTitle
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            py: 1.5,
+            px: 2,
+          }}
+        >
+          <Chip
+            label={getStatusLabel(localVideo.status)}
+            color={getStatusColor(localVideo.status)}
+            size="small"
+          />
+          {mediaTypeInfo && (
+            <Chip
+              label={mediaTypeInfo.label}
+              color={mediaTypeInfo.color}
+              size="small"
+              icon={mediaTypeInfo.icon}
+            />
+          )}
+          {localVideo.normalizedRating && (
+            <RatingBadge
+              rating={localVideo.normalizedRating}
+              ratingSource={localVideo.ratingSource}
+              size="small"
+            />
+          )}
+          <Box sx={{ flex: 1 }} />
+          <IconButton
+            onClick={onClose}
+            size="small"
+            aria-label="Close"
+            edge="end"
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+
+        <DialogContent sx={{ p: isMobile ? 1.5 : 2 }}>
+          {useSideBySide ? (
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Box sx={{ width: 300, flexShrink: 0 }}>
+                <VideoPlayer
+                  video={localVideo}
+                  token={token}
+                  onDownloadClick={() => setDownloadDialogOpen(true)}
+                  isMobile={isMobile}
+                />
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
+                  {localVideo.title}
+                </Typography>
+                <VideoActions
+                  video={localVideo}
+                  onDelete={() => setDeleteDialogOpen(true)}
+                  onProtectionToggle={handleProtectionToggle}
+                  onIgnoreToggle={handleIgnoreToggle}
+                  onRatingChange={() => setRatingDialogOpen(true)}
+                  protectionLoading={protectionLoading}
+                />
+                <Box sx={{ mt: 2 }}>
+                  <VideoMetadata
+                    video={localVideo}
+                    metadata={metadata}
+                    loading={metadataLoading}
+                  />
+                  <VideoTechnical
+                    video={localVideo}
+                    metadata={metadata}
+                    loading={metadataLoading}
+                  />
+                </Box>
+              </Box>
+            </Box>
+          ) : (
+            <>
+              <VideoPlayer
+                video={localVideo}
+                token={token}
+                onDownloadClick={() => setDownloadDialogOpen(true)}
+                isMobile={isMobile}
+              />
+              <Box sx={{ mt: 2 }}>
+                <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
+                  {localVideo.title}
+                </Typography>
+                <VideoActions
+                  video={localVideo}
+                  onDelete={() => setDeleteDialogOpen(true)}
+                  onProtectionToggle={handleProtectionToggle}
+                  onIgnoreToggle={handleIgnoreToggle}
+                  onRatingChange={() => setRatingDialogOpen(true)}
+                  protectionLoading={protectionLoading}
+                />
+              </Box>
+              <Box sx={{ mt: 2 }}>
+                <VideoMetadata
+                  video={localVideo}
+                  metadata={metadata}
+                  loading={metadataLoading}
+                />
+              </Box>
+              <Box sx={{ mt: 2 }}>
+                <VideoTechnical
+                  video={localVideo}
+                  metadata={metadata}
+                  loading={metadataLoading}
+                />
+              </Box>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <DeleteVideosDialog
+        open={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        onConfirm={handleDeleteConfirm}
+        videoCount={1}
+      />
+
+      <DownloadSettingsDialog
+        open={downloadDialogOpen}
+        onClose={() => setDownloadDialogOpen(false)}
+        onConfirm={handleDownloadConfirm}
+        videoCount={1}
+        mode="manual"
+        token={token}
+      />
+
+      <ChangeRatingDialog
+        open={ratingDialogOpen}
+        onClose={() => setRatingDialogOpen(false)}
+        onApply={handleRatingApply}
+        selectedCount={1}
+      />
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={SNACKBAR_AUTO_HIDE_MS}
+        onClose={handleSnackbarClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={handleSnackbarClose}
+          severity={snackbar.severity}
+          variant="filled"
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}
+
+export default VideoModal;

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -24,6 +24,7 @@ import DeleteVideosDialog from '../DeleteVideosDialog';
 import ChangeRatingDialog from '../ChangeRatingDialog';
 import DownloadSettingsDialog from '../../DownloadManager/ManualDownload/DownloadSettingsDialog';
 import { getStatusLabel, getStatusColor, getMediaTypeInfo } from '../../../utils/videoStatus';
+import { useConfig } from '../../../hooks/useConfig';
 
 const SNACKBAR_AUTO_HIDE_MS = 4000;
 
@@ -72,6 +73,44 @@ function VideoModal({
     open ? video.youtubeId : '',
     token
   );
+
+  const { config } = useConfig(token);
+
+  // Fetch channel-level download settings when modal opens
+  const [channelSettings, setChannelSettings] = useState<{
+    video_quality?: string | null;
+    audio_format?: string | null;
+    default_rating?: string | null;
+  }>({});
+
+  useEffect(() => {
+    if (!open || !video.channelId || !token) {
+      setChannelSettings({});
+      return;
+    }
+    const controller = new AbortController();
+    const fetchSettings = async () => {
+      try {
+        const resp = await fetch(`/api/channels/${video.channelId}/settings`, {
+          headers: { 'x-access-token': token },
+          signal: controller.signal,
+        });
+        if (!resp.ok) return;
+        setChannelSettings(await resp.json());
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+      }
+    };
+    fetchSettings();
+    return () => { controller.abort(); };
+  }, [open, video.channelId, token]);
+
+  const hasChannelQualityOverride = Boolean(channelSettings.video_quality);
+  const defaultResolution = channelSettings.video_quality || config.preferredResolution || '1080';
+  const defaultResolutionSource: 'channel' | 'global' = hasChannelQualityOverride ? 'channel' : 'global';
+  const hasChannelAudioOverride = Boolean(channelSettings.audio_format);
+  const defaultAudioFormat = channelSettings.audio_format || null;
+  const defaultAudioFormatSource: 'channel' | 'global' = hasChannelAudioOverride ? 'channel' : 'global';
 
   const isShort = localVideo.mediaType === 'short';
   const useSideBySide = isShort && !isMobile;
@@ -234,6 +273,11 @@ function VideoModal({
         videoCount={1}
         mode="manual"
         token={token}
+        defaultResolution={defaultResolution}
+        defaultResolutionSource={defaultResolutionSource}
+        defaultAudioFormat={defaultAudioFormat}
+        defaultAudioFormatSource={defaultAudioFormatSource}
+        defaultRating={channelSettings.default_rating ?? null}
       />
 
       <ChangeRatingDialog

--- a/client/src/components/shared/VideoModal/types.ts
+++ b/client/src/components/shared/VideoModal/types.ts
@@ -57,6 +57,7 @@ export interface VideoExtendedMetadata {
   webpageUrl: string | null;
   relatedFiles: VideoRelatedFile[] | null;
   availableResolutions: number[] | null;
+  downloadedTier: number | null;
 }
 
 export interface VideoRelatedFile {

--- a/client/src/components/shared/VideoModal/types.ts
+++ b/client/src/components/shared/VideoModal/types.ts
@@ -1,0 +1,66 @@
+import { VideoStatus } from '../../../utils/videoStatus';
+
+export interface VideoModalData {
+  youtubeId: string;
+  title: string;
+  channelName: string;
+  thumbnailUrl: string;
+  duration: number | null;
+  publishedAt: string | null;
+  addedAt: string | null;
+  mediaType: string;
+  status: VideoStatus;
+  isDownloaded: boolean;
+  filePath: string | null;
+  fileSize: number | null;
+  audioFilePath: string | null;
+  audioFileSize: number | null;
+  isProtected: boolean;
+  isIgnored: boolean;
+  normalizedRating: string | null;
+  ratingSource: string | null;
+  databaseId: number | null;
+  channelId: string | null;
+}
+
+export interface VideoModalProps {
+  open: boolean;
+  onClose: () => void;
+  video: VideoModalData;
+  token: string | null;
+  onVideoDeleted?: (youtubeId: string) => void;
+  onProtectionChanged?: (youtubeId: string, isProtected: boolean) => void;
+  onIgnoreChanged?: (youtubeId: string, isIgnored: boolean) => void;
+  onDownloadQueued?: (youtubeId: string) => void;
+  onRatingChanged?: (youtubeId: string, rating: string | null) => void;
+}
+
+export interface VideoExtendedMetadata {
+  description: string | null;
+  viewCount: number | null;
+  likeCount: number | null;
+  commentCount: number | null;
+  tags: string[] | null;
+  categories: string[] | null;
+  uploadDate: string | null;
+  resolution: string | null;
+  width: number | null;
+  height: number | null;
+  fps: number | null;
+  aspectRatio: number | null;
+  language: string | null;
+  isLive: boolean | null;
+  wasLive: boolean | null;
+  availability: string | null;
+  channelFollowerCount: number | null;
+  ageLimit: number | null;
+  webpageUrl: string | null;
+  relatedFiles: VideoRelatedFile[] | null;
+  availableResolutions: number[] | null;
+}
+
+export interface VideoRelatedFile {
+  fileName: string;
+  fileSize: number;
+  type: string;
+}

--- a/client/src/components/shared/__tests__/ProtectionShieldButton.test.tsx
+++ b/client/src/components/shared/__tests__/ProtectionShieldButton.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProtectionShieldButton from '../ProtectionShieldButton';
+
+describe('ProtectionShieldButton', () => {
+  test('renders unprotected state with correct tooltip', () => {
+    render(<ProtectionShieldButton isProtected={false} onClick={jest.fn()} />);
+    expect(screen.getByLabelText('Protect from auto-deletion')).toBeInTheDocument();
+  });
+
+  test('renders protected state with correct tooltip', () => {
+    render(<ProtectionShieldButton isProtected={true} onClick={jest.fn()} />);
+    expect(screen.getByLabelText('Remove protection')).toBeInTheDocument();
+  });
+
+  test('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    render(<ProtectionShieldButton isProtected={false} onClick={onClick} />);
+    fireEvent.click(screen.getByLabelText('Protect from auto-deletion'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders inline variant', () => {
+    render(<ProtectionShieldButton isProtected={false} onClick={jest.fn()} variant="inline" />);
+    expect(screen.getByLabelText('Protect from auto-deletion')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/shared/__tests__/useVideoProtection.test.ts
+++ b/client/src/components/shared/__tests__/useVideoProtection.test.ts
@@ -1,0 +1,108 @@
+import { renderHook, act } from '@testing-library/react';
+
+jest.mock('axios', () => ({
+  patch: jest.fn(),
+}));
+
+const axios = require('axios');
+
+import { useVideoProtection } from '../useVideoProtection';
+
+describe('useVideoProtection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('toggleProtection calls PATCH with correct params and returns new state', async () => {
+    axios.patch.mockResolvedValueOnce({ data: { id: 1, protected: true } });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    let returnedState: boolean | undefined;
+    await act(async () => {
+      returnedState = await result.current.toggleProtection(1, false);
+    });
+
+    expect(axios.patch).toHaveBeenCalledWith(
+      '/api/videos/1/protected',
+      { protected: true },
+      { headers: { 'x-access-token': 'test-token' } }
+    );
+    expect(returnedState).toBe(true);
+  });
+
+  test('toggleProtection sends false when current state is true', async () => {
+    axios.patch.mockResolvedValueOnce({ data: { id: 1, protected: false } });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    await act(async () => {
+      await result.current.toggleProtection(1, true);
+    });
+
+    expect(axios.patch).toHaveBeenCalledWith(
+      '/api/videos/1/protected',
+      { protected: false },
+      { headers: { 'x-access-token': 'test-token' } }
+    );
+  });
+
+  test('sets successMessage on successful toggle on', async () => {
+    axios.patch.mockResolvedValueOnce({ data: { id: 1, protected: true } });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    await act(async () => {
+      await result.current.toggleProtection(1, false);
+    });
+
+    expect(result.current.successMessage).toBe('Video protected from auto-deletion');
+  });
+
+  test('sets successMessage on successful toggle off', async () => {
+    axios.patch.mockResolvedValueOnce({ data: { id: 1, protected: false } });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    await act(async () => {
+      await result.current.toggleProtection(1, true);
+    });
+
+    expect(result.current.successMessage).toBe('Video protection removed');
+  });
+
+  test('sets error on failure', async () => {
+    axios.patch.mockRejectedValueOnce({
+      response: { data: { error: 'Video not found' } }
+    });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    let returnedState: boolean | undefined;
+    await act(async () => {
+      returnedState = await result.current.toggleProtection(999, false);
+    });
+
+    expect(result.current.error).toBe('Video not found');
+    expect(returnedState).toBeUndefined();
+  });
+
+  test('clearMessages resets successMessage and error', async () => {
+    axios.patch.mockResolvedValueOnce({ data: { id: 1, protected: true } });
+
+    const { result } = renderHook(() => useVideoProtection('test-token'));
+
+    await act(async () => {
+      await result.current.toggleProtection(1, false);
+    });
+
+    expect(result.current.successMessage).toBe('Video protected from auto-deletion');
+
+    act(() => {
+      result.current.clearMessages();
+    });
+
+    expect(result.current.successMessage).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/client/src/components/shared/useVideoProtection.ts
+++ b/client/src/components/shared/useVideoProtection.ts
@@ -36,7 +36,6 @@ export const useVideoProtection = (token: string | null): UseVideoProtectionRetu
         { headers: { 'x-access-token': token || '' } }
       );
 
-      setLoading(false);
       setSuccessMessage(
         newState
           ? 'Video protected from auto-deletion'
@@ -48,8 +47,9 @@ export const useVideoProtection = (token: string | null): UseVideoProtectionRetu
         (err as { response?: { data?: { error?: string } } })?.response?.data?.error ||
         (err instanceof Error ? err.message : 'Failed to update protection status');
       setError(errorMessage);
-      setLoading(false);
       return undefined;
+    } finally {
+      setLoading(false);
     }
   }, [token]);
 

--- a/client/src/components/shared/useVideoProtection.ts
+++ b/client/src/components/shared/useVideoProtection.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback } from 'react';
+import axios from 'axios';
+
+interface UseVideoProtectionReturn {
+  toggleProtection: (videoId: number, currentState: boolean) => Promise<boolean | undefined>;
+  loading: boolean;
+  error: string | null;
+  successMessage: string | null;
+  clearMessages: () => void;
+}
+
+export const useVideoProtection = (token: string | null): UseVideoProtectionReturn => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const clearMessages = useCallback(() => {
+    setError(null);
+    setSuccessMessage(null);
+  }, []);
+
+  const toggleProtection = useCallback(async (
+    videoId: number,
+    currentState: boolean
+  ): Promise<boolean | undefined> => {
+    setLoading(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    const newState = !currentState;
+
+    try {
+      const response = await axios.patch(
+        `/api/videos/${videoId}/protected`,
+        { protected: newState },
+        { headers: { 'x-access-token': token || '' } }
+      );
+
+      setLoading(false);
+      setSuccessMessage(
+        newState
+          ? 'Video protected from auto-deletion'
+          : 'Video protection removed'
+      );
+      return response.data.protected;
+    } catch (err: unknown) {
+      const errorMessage =
+        (err as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+        (err instanceof Error ? err.message : 'Failed to update protection status');
+      setError(errorMessage);
+      setLoading(false);
+      return undefined;
+    }
+  }, [token]);
+
+  return {
+    toggleProtection,
+    loading,
+    error,
+    successMessage,
+    clearMessages,
+  };
+};

--- a/client/src/config/configSchema.ts
+++ b/client/src/config/configSchema.ts
@@ -32,6 +32,10 @@ export const CONFIG_FIELDS = {
   // Plex integration
   plexApiKey: { default: '', trackChanges: true },
   plexYoutubeLibraryId: { default: '', trackChanges: true },
+  plexSubfolderLibraryMappings: {
+    default: [] as Array<{ subfolder: string | null; libraryId: string }>,
+    trackChanges: true,
+  },
   plexIP: { default: '', trackChanges: true },
   plexPort: { default: '32400', trackChanges: true },
   plexViaHttps: { default: false, trackChanges: true },
@@ -124,6 +128,7 @@ export const DEFAULT_CONFIG: ConfigState = {
   defaultSubfolder: CONFIG_FIELDS.defaultSubfolder.default,
   plexApiKey: CONFIG_FIELDS.plexApiKey.default,
   plexYoutubeLibraryId: CONFIG_FIELDS.plexYoutubeLibraryId.default,
+  plexSubfolderLibraryMappings: CONFIG_FIELDS.plexSubfolderLibraryMappings.default,
   plexIP: CONFIG_FIELDS.plexIP.default,
   plexPort: CONFIG_FIELDS.plexPort.default,
   plexViaHttps: CONFIG_FIELDS.plexViaHttps.default,

--- a/client/src/types/Channel.ts
+++ b/client/src/types/Channel.ts
@@ -5,7 +5,10 @@ export interface Channel {
   description?: string;
   title?: string;
   auto_download_enabled_tabs?: string;
+  // Effective (detected minus user-hidden) tab list, comma-separated.
   available_tabs?: string | null;
+  // User-hidden tabs, comma-separated. Only present on the settings endpoint.
+  hidden_tabs?: string | null;
   sub_folder?: string | null;
   video_quality?: string | null;
   min_duration?: number | null;

--- a/client/src/types/ChannelVideo.ts
+++ b/client/src/types/ChannelVideo.ts
@@ -7,6 +7,7 @@
 },*/
 
 export interface ChannelVideo {
+  id?: number;
   title: string;
   youtube_id: string;
   publishedAt: string | null | undefined;
@@ -26,4 +27,5 @@ export interface ChannelVideo {
   ignored_at?: string | null;
   normalized_rating?: string | null;
   rating_source?: string | null;
+  protected?: boolean;
 }

--- a/client/src/types/VideoData.ts
+++ b/client/src/types/VideoData.ts
@@ -24,6 +24,7 @@ export interface VideoData {
   media_type?: string;
   normalized_rating?: string | null;
   rating_source?: string | null;
+  protected?: boolean;
 }
 
 export interface EnabledChannel {

--- a/client/src/utils/__tests__/plexLibraries.test.ts
+++ b/client/src/utils/__tests__/plexLibraries.test.ts
@@ -1,0 +1,40 @@
+import { resolveLibraryDisplay, PlexLibrary } from '../plexLibraries';
+
+describe('resolveLibraryDisplay', () => {
+  const LIBRARIES: PlexLibrary[] = [
+    { id: '1', title: 'YouTube' },
+    { id: '31', title: 'Adults Library' },
+    { id: '42', title: 'Kids Shows' },
+  ];
+
+  test('returns "resolved" with title and id when the id matches an entry', () => {
+    expect(resolveLibraryDisplay(LIBRARIES, '31')).toEqual({
+      kind: 'resolved',
+      title: 'Adults Library',
+      id: '31',
+    });
+  });
+
+  test('returns "id-fallback" when the libraries list is empty', () => {
+    expect(resolveLibraryDisplay([], '31')).toEqual({
+      kind: 'id-fallback',
+      id: '31',
+    });
+  });
+
+  test('returns "id-only" when the libraries list is populated but no entry matches', () => {
+    expect(resolveLibraryDisplay(LIBRARIES, '999')).toEqual({
+      kind: 'id-only',
+      id: '999',
+    });
+  });
+
+  test('handles alphanumeric library ids in the "resolved" path', () => {
+    const libs: PlexLibrary[] = [{ id: 'my-lib-99', title: 'My Lib' }];
+    expect(resolveLibraryDisplay(libs, 'my-lib-99')).toEqual({
+      kind: 'resolved',
+      title: 'My Lib',
+      id: 'my-lib-99',
+    });
+  });
+});

--- a/client/src/utils/plexLibraries.ts
+++ b/client/src/utils/plexLibraries.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared types and helpers for working with the Plex library list
+ * returned from GET /getplexlibraries.
+ */
+
+export interface PlexLibrary {
+  id: string;
+  title: string;
+}
+
+/**
+ * Discriminated display shape for rendering a Plex library id in the UI.
+ *
+ * - `resolved`: the id matched an entry in the library list, so callers can
+ *   show the title prominently and optionally append `(id: X)` without fear
+ *   of duplicating the id.
+ * - `id-fallback`: the library list is empty (disconnected, or not yet
+ *   fetched) so the raw id is the primary display and must not be decorated
+ *   with an additional "(id: X)" suffix.
+ * - `id-only`: the list is populated but no entry matches, meaning the saved
+ *   id refers to a library Plex no longer exposes. Same guidance: raw id is
+ *   the only thing to show.
+ */
+export type PlexLibraryDisplay =
+  | { kind: 'resolved'; title: string; id: string }
+  | { kind: 'id-fallback'; id: string }
+  | { kind: 'id-only'; id: string };
+
+/**
+ * Classify how a library id should be rendered given the current list.
+ */
+export function resolveLibraryDisplay(
+  libraries: PlexLibrary[],
+  libraryId: string
+): PlexLibraryDisplay {
+  const lib = libraries.find((l) => l.id === libraryId);
+  if (lib) {
+    return { kind: 'resolved', title: lib.title, id: libraryId };
+  }
+  if (libraries.length === 0) {
+    return { kind: 'id-fallback', id: libraryId };
+  }
+  return { kind: 'id-only', id: libraryId };
+}

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -11,6 +11,7 @@
   "plexViaHttps": false,
   "plexApiKey": "",
   "plexYoutubeLibraryId": "",
+  "plexSubfolderLibraryMappings": [],
   "plexUrl": "",
   "sponsorblockEnabled": false,
   "sponsorblockAction": "remove",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,8 @@ services:
       dockerfile: Dockerfile
     image: ${YOUTARR_IMAGE:-youtarr-dev:latest}
     container_name: youtarr-dev
-    # Map 3011:3011 in dev so Vite proxy can reach backend at localhost:3011
+    # Expose backend on host port 3087 (container still listens on 3011).
+    # The Vite dev server proxies to http://127.0.0.1:3087 by default.
     ports:
       - "3087:3011"
     volumes:

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -94,6 +94,19 @@ Using the start script:
 
 For deployments behind external authentication or not exposed to the internet:
 
+1. Set in `.env`:
+   ```bash
+   AUTH_ENABLED=false
+   ```
+
+2. Youtarr bypasses internal authentication, no auth will be required to access Youtarr.
+
+**Warning**: Only disable when using:
+- VPN access
+- Reverse proxy with authentication
+- Platform auth (Cloudflare Access, Authelia, etc.)
+- Never expose to internet without protection!
+
 ## API Keys
 
 API Keys provide persistent authentication for external integrations like bookmarklets, mobile shortcuts, and automation tools.
@@ -159,19 +172,6 @@ UPDATE ApiKeys SET is_active = 0 WHERE id = 1;
 ```
 
 For detailed API documentation and examples (bookmarklets, mobile shortcuts, Python, cURL, etc.), see [API Integration Guide](API_INTEGRATION.md).
-
-1. Set in `.env`:
-   ```bash
-   AUTH_ENABLED=false
-   ```
-
-2. Youtarr bypasses internal authentication, no auth will be required to access Youtarr.
-
-**Warning**: Only disable when using:
-- VPN access
-- Reverse proxy with authentication
-- Platform auth (Cloudflare Access, Authelia, etc.)
-- Never expose to internet without protection!
 
 ## Session Management
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -36,12 +36,12 @@ Configuration can be modified through:
 
 ## Core Settings
 
-### Youtube Output Directory
-- **Config Key**: *This can only be set via .env and is view only in the web UI*
+### Youtube Output Directory (env-only, not a config.json field)
+- **Set via**: `YOUTUBE_OUTPUT_DIR` environment variable in `.env` (see [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md))
 - **Type**: `string`
 - **Default**: `"./downloads"`
-- **Description**: Directory path for downloaded videos
-- **Note**: Set during initial setup or via YOUTUBE_OUTPUT_DIR environment variable
+- **Description**: Directory path on the host where downloaded videos are stored
+- **Note**: This setting is **not** stored in `config/config.json`. It is displayed read-only in the web UI and can only be changed by editing `.env` and restarting. Legacy installs that had `youtubeOutputDirectory` in `config.json` are automatically migrated to `.env` during first-run `.env` bootstrap by `scripts/_create-env.sh` (i.e. the first time the start script runs with no existing `.env`).
 
 ### Enable Automatic Downloads
 - **Config Key**: `channelAutoDownload`

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -137,8 +137,25 @@ Configuration can be modified through:
 - **Config Key**: `plexYoutubeLibraryId`
 - **Type**: `string`
 - **Default**: `""` (empty)
-- **Description**: Plex library section ID for YouTube videos
+- **Description**: Default Plex library section ID for YouTube videos. Used for all downloads that do not match a per-subfolder mapping (see below).
 - **Note**: Library refresh is automatically triggered if configured when new videos are downloaded
+
+### Plex Subfolder Library Mappings
+- **Config Key**: `plexSubfolderLibraryMappings`
+- **Type**: `Array<{ subfolder: string | null, libraryId: string }>`
+- **Default**: `[]` (empty — all downloads use the default library above)
+- **Description**: Maps channel subfolders to specific Plex library IDs, enabling different subfolders to refresh different Plex libraries after a download.
+- **Usage**: Configured via the web UI under **Plex Media Server Integration → Per-Subfolder Library Mappings** once connected to Plex.
+- **Format**: Each entry specifies a `subfolder` (the clean name without the `__` filesystem prefix, or `null` for the root/no-subfolder case) and the target `libraryId`.
+- **Example**:
+  ```json
+  "plexSubfolderLibraryMappings": [
+    { "subfolder": "kids", "libraryId": "2" },
+    { "subfolder": "music", "libraryId": "3" },
+    { "subfolder": null, "libraryId": "1" }
+  ]
+  ```
+- **Fallback**: Any subfolder not listed here will fall back to `plexYoutubeLibraryId`.
 
 ### Plex IP
 - **Config Key**: `plexIP`

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -28,6 +28,7 @@ Youtarr uses MariaDB/MySQL for storing:
 | `JobVideos`        | `JobVideo`        | Job <-> video associations        |
 | `JobVideoDownloads`| `JobVideoDownload`| Download progress tracking        |
 | `Sessions`         | `Session`         | User authentication sessions      |
+| `ApiKeys`          | `ApiKey`          | API key credentials for external integrations (bookmarklets, shortcuts, automation) |
 | `SequelizeMeta`    | NA                | Sequelize ORM migration tracking  |
 
 ## Internal Database (Default)

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -165,35 +165,46 @@ The development setup is a "build-and-test-in-Docker" workflow that ensures your
 3. Builds a Docker image with the pre-built static files
 
 **Runtime Phase** (`./scripts/start-dev.sh`):
-- Runs the Node.js Express server with `node server/server.js` (no hot reload)
-- Serves the pre-built React static files from `/app/client/build`
+- Runs the Node.js Express server with `node --watch server/server.js` - backend code changes auto-restart the server without a rebuild
+- Serves the pre-built React static files from `/app/client/build` (frontend changes require a rebuild unless you are running the Vite dev server)
 - Application accessible at http://localhost:3087
 
 ### Volume Mounts
 
-The development setup mounts these directories only:
+The development setup (`docker-compose.dev.yml`) mounts these directories into the container:
 
 ```yaml
 volumes:
-  - ./server/images:/app/server/images          # Generated thumbnails
-  - ./config:/app/config                        # Configuration files
-  -  ./jobs:/app/jobs                           # Job state
+  - ${YOUTUBE_OUTPUT_DIR:-./downloads}:/usr/src/app/data  # Downloaded videos
+  - ./server/images:/app/server/images                     # Generated thumbnails
+  - ./config:/app/config                                   # Configuration files
+  - ./jobs:/app/jobs                                       # Job state
+  # Backend source and migrations for hot reload with --watch
+  - ./server:/app/server
+  - ./migrations:/app/migrations
+  - ./package.json:/app/package.json
+  - ./package-lock.json:/app/package-lock.json
 ```
 
-**Important:** Source code (client/src/, server/*.js) is NOT mounted. This means:
-- ❌ No hot reload or live reload
-- ❌ Code changes are NOT automatically reflected
-- ✅ You must rebuild after every code change
+**Backend hot reload:** `./server/` is mounted and the container runs `node --watch server/server.js`, so backend code changes auto-restart the server without a rebuild. Check the container logs to confirm the restart.
+
+**Frontend:** `client/src/` is NOT mounted. Frontend changes reach the running app one of two ways:
+- **Full rebuild**: `./scripts/build-dev.sh` rebuilds the static bundle that the app container serves at http://localhost:3087.
+- **Vite dev server (recommended)**: run `cd client && npm run dev` in a second terminal. Vite serves the frontend on http://localhost:3000 with HMR and proxies API/WebSocket calls to the backend on host port 3087 (which `docker-compose.dev.yml` forwards to container port 3011). Override with `VITE_BACKEND_PORT` if you have remapped the host port.
 
 ### When to Rebuild
 
 You **must** rebuild (`./scripts/build-dev.sh`) for:
-- **Any** frontend code changes (React components, styles, etc.)
-- **Any** backend code changes (server.js, modules, etc.)
-- Installing new npm dependencies (use `--install-deps` flag)
-- Updating system dependencies (yt-dlp, ffmpeg - use `--no-cache` flag)
-- Changing Dockerfile
-- First time setup
+- Frontend code changes when you are using the static-bundle workflow (not needed if you are using the Vite dev server).
+- Installing new npm dependencies (use `--install-deps` flag).
+- Updating system dependencies (yt-dlp, ffmpeg - use `--no-cache` flag).
+- Changing the Dockerfile.
+- First time setup.
+
+You **do not** need to rebuild for:
+- Backend code changes (server/*.js, modules, routes) - `node --watch` picks them up automatically.
+- New migration files - `./migrations/` is mounted, though you still need to restart the container for them to run.
+- Frontend changes while the Vite dev server is running - Vite HMR updates the browser.
 
 ### Benefits of This Approach
 
@@ -385,12 +396,17 @@ ports:
 command: node --inspect=0.0.0.0:9229 server/server.js
 ```
 
-**Option 2: Console Debugging**
+**Option 2: Logger Debugging**
+
+Use the project's Pino logger (not `console.log`) so output stays structured and log levels work:
 
 ```javascript
-console.log('Debug info:', variable);
+const logger = require('../logger'); // adjust relative path as needed
+logger.debug({ variable }, 'Debug info');
 debugger; // Breakpoint
 ```
+
+Set `LOG_LEVEL=debug` in your `.env` to surface `logger.debug(...)` output.
 
 **Option 3: Exec into Container**
 
@@ -408,13 +424,16 @@ docker compose exec youtarr bash
 
 ### Database Debugging
 
-Enable Sequelize logging in `db.js`:
+Enable Sequelize SQL logging in `db.js` by routing it through the Pino logger:
 ```javascript
+const logger = require('./logger');
 const sequelize = new Sequelize({
   // ... other config
-  logging: console.log  // Enable SQL logging
+  logging: (sql) => logger.debug({ sql }, 'sequelize query')
 });
 ```
+
+Then set `LOG_LEVEL=debug` in your `.env` to see the queries.
 
 ## API Development
 
@@ -645,15 +664,24 @@ docker compose down
 
 ### Code Changes Not Reflected
 
-Code changes **always** require a rebuild since source code is not mounted in the container:
+Backend and frontend reload differently in the dev setup.
+
+**Backend code changes** (`server/*.js`, `server/modules/`, `server/routes/`, `migrations/`):
+- `./server/` and `./migrations/` are volume-mounted into the container and the container runs `node --watch`.
+- Saves auto-restart the server within a few seconds; check the container logs to confirm the restart fired.
+- No rebuild required. (New migration files still require a container restart to actually run.)
+
+**Frontend code changes** (`client/src/`):
+- `client/src/` is NOT mounted into the app container; the static bundle is baked into the image at build time.
+- If you are running the Vite dev server (`cd client && npm run dev`), HMR updates the browser automatically on http://localhost:3000 - no rebuild.
+- Otherwise, rebuild the static bundle:
 
 ```bash
-# Rebuild and restart (start-dev.sh automatically stops first)
 ./scripts/build-dev.sh
-./scripts/start-dev.sh
+./scripts/start-dev.sh  # automatically stops and restarts containers
 ```
 
-**Note:** This is expected behavior - the development setup builds the code into the image, it doesn't use live file mounting for source code.
+If a backend change is not being picked up, verify the container is actually running `node --watch` (`docker compose -f docker-compose.dev.yml logs youtarr` should show restart messages when you save) and that you edited a file under `./server/`.
 
 ### Module Not Found Errors
 
@@ -690,12 +718,13 @@ cd client && npm audit
 
 ### Backend Profiling
 
-Add to `server.js` for request timing:
+Add to `server.js` for request timing (use the Pino logger, not `console.log`):
 ```javascript
+const logger = require('./logger');
 app.use((req, res, next) => {
   const start = Date.now();
   res.on('finish', () => {
-    console.log(`${req.method} ${req.path} - ${Date.now() - start}ms`);
+    logger.info({ method: req.method, path: req.path, durationMs: Date.now() - start }, 'request');
   });
   next();
 });

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -6,6 +6,17 @@ Youtarr uses Docker Compose with two containers:
 - **youtarr**: Main application container (Node.js/React)
 - **youtarr-db**: MariaDB database container
 
+### Compose Files
+
+Youtarr ships four Compose files so each supported runtime can layer the right overrides:
+
+| File | Purpose |
+|------|---------|
+| `docker-compose.yml` | Production defaults with the bundled MariaDB container. Used by `./start.sh`. |
+| `docker-compose.dev.yml` | Development mode: mounts `./server/` and migrations into the container, runs the backend with `node --watch` for hot reload, and uses a separate `youtarr-db-dev` database with its own named volume. Used by `./scripts/start-dev.sh`. See [DEVELOPMENT.md](DEVELOPMENT.md). |
+| `docker-compose.arm.yml` | ARM override (Apple Silicon, Raspberry Pi) that switches the MariaDB data directory to a named volume to avoid virtiofs issues. Layered on top of `docker-compose.yml` via `-f`. |
+| `docker-compose.external-db.yml` | Runs Youtarr against an external MariaDB/MySQL instance instead of the bundled database. Used by `./start-with-external-db.sh`. |
+
 ## Container Details
 
 ### Application Container (youtarr)
@@ -150,6 +161,8 @@ This section covers setting up Youtarr when you cannot (or prefer not to) clone 
 
 **We strongly recommend cloning the repository if possible.** If you must proceed, follow these steps carefully.
 
+> **Critical - read this first if you use automation**: If you are templating `docker-compose.yml` via Ansible, Terraform, Kubernetes, Helm, or any tool that auto-creates empty directories for every listed volume, read [Do Not Mount the Migrations Directory](#-important-do-not-mount-the-migrations-directory) at the top of this document before continuing. Auto-creating an empty `./migrations` directory will overwrite the packaged migrations and break the database bootstrap in a way that is hard to diagnose.
+
 ### Prerequisites
 
 - Docker and Docker Compose installed
@@ -178,6 +191,14 @@ wget https://raw.githubusercontent.com/DialmasterOrg/Youtarr/main/.env.example -
 - Manually copy `docker-compose.yml` from [GitHub](https://github.com/DialmasterOrg/Youtarr/blob/main/docker-compose.yml)
 - Manually copy `.env.example` from [GitHub](https://github.com/DialmasterOrg/Youtarr/blob/main/.env.example)
 
+**Using an external MariaDB/MySQL instance?** Download [`docker-compose.external-db.yml`](https://raw.githubusercontent.com/DialmasterOrg/Youtarr/main/docker-compose.external-db.yml) instead of `docker-compose.yml` and rename it to `docker-compose.yml` locally so the rest of this guide works unchanged:
+
+```bash
+wget https://raw.githubusercontent.com/DialmasterOrg/Youtarr/main/docker-compose.external-db.yml -O docker-compose.yml
+```
+
+You will also need to set `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME` in your `.env` (see [External Database Setup](#using-an-external-database) earlier in this document). Skip the bundled-database permission steps below if you go this route.
+
 #### 3. Configure Environment
 
 ```bash
@@ -190,44 +211,72 @@ vim .env  # or nano, or your preferred editor
 
 **Required settings:**
 - `YOUTUBE_OUTPUT_DIR` - Must be set to your video storage path
-- `TZ` - Your timezone (e.g., `America/New_York`, `Europe/London`)
 
 **Optional settings:**
-- `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` - For headless setups
-- See [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md) for full reference
+- `TZ` - Your timezone (e.g., `America/New_York`, `Europe/London`). Defaults to `UTC`. Set this if scheduled downloads and nightly cleanup should run in your local time.
+- `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` - For headless setups where you cannot reach the initial-setup wizard via localhost.
+- `YOUTARR_UID` / `YOUTARR_GID` - Run the container as a non-root user (recommended for security, see step 5 below).
+- **Changing bundled-database credentials?** If you want to customize the MariaDB password, set BOTH `DB_PASSWORD` **and** `DB_ROOT_PASSWORD` to the same value. Setting only one of them will cause the app to fail to connect because the app uses `DB_PASSWORD` while MariaDB's root account is initialized from `DB_ROOT_PASSWORD`. This only applies to the bundled database; external-DB users set `DB_PASSWORD` to match their existing database.
+- See [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md) for the full reference.
 
 #### 4. Create Required Directories
 
 Youtarr needs these directories to exist before first start:
 
 ```bash
-# Create all required directories
+# Youtarr app directories (always required)
 mkdir -p config jobs server/images
 
-# Create your download directory (adjust path to match YOUTUBE_OUTPUT_DIR in .env)
+# Your download directory (adjust path to match YOUTUBE_OUTPUT_DIR in .env)
 mkdir -p downloads  # If using default ./downloads
 # OR
 mkdir -p /path/to/your/custom/location  # If using custom path
 ```
 
+**Bundled database only** (skip if you are using an external database):
+
+```bash
+# MariaDB data directory for the bundled youtarr-db container
+mkdir -p database
+```
+
+On most Linux hosts, Docker will auto-create `./database` on first run and MariaDB's entrypoint will chown it to UID 999 (the `mysql` user inside the `mariadb:10.3` image). On Synology, QNAP, and some other NAS platforms with strict UID enforcement you may need to pre-create and chown the directory yourself:
+
+```bash
+sudo chown -R 999:999 database
+```
+
+If you hit `InnoDB: Operating system error number 13` at startup, you have hit this case - see [Switching to Named Volume](DATABASE.md#switching-to-named-volume) in the database docs for an alternative that sidesteps bind-mount permission issues entirely.
+
 #### 5. Set Permissions
 
-**If using UID/GID (1000:1000):**
-```bash
-sudo chown -R 1000:1000 config jobs server/images downloads
-```
+**By default, the container runs as root (UID 0).** If you leave `YOUTARR_UID` and `YOUTARR_GID` unset in `.env`, you can skip this entire step: the container manages file ownership itself.
 
-**If you configured custom YOUTARR_UID and YOUTARR_GID in .env:**
-```bash
-# Replace 1001:1001 with your configured UID:GID
-sudo chown -R 1001:1001 config jobs server/images downloads
-```
+**Recommended (non-root)**: run the container as a non-root user so files on the host are owned by a regular account. This requires both an `.env` change and a `chown` on the host, in this order:
 
-**Permission verification:**
-```bash
-ls -la config jobs server/images downloads
-# All directories should show ownership matching your configured UID:GID
-```
+1. Add your target UID/GID to `.env` (1000:1000 is the typical first user on Linux, but use whatever matches your host account):
+
+   ```bash
+   YOUTARR_UID=1000
+   YOUTARR_GID=1000
+   ```
+
+2. Change ownership of the Youtarr directories on the host to match:
+
+   ```bash
+   sudo chown -R 1000:1000 config jobs server/images downloads
+   ```
+
+   Replace `1000:1000` with whatever you put in `.env`. If you use a custom download path, `chown` that path instead of `downloads`.
+
+3. Verify:
+
+   ```bash
+   ls -la config jobs server/images downloads
+   # All directories should show ownership matching YOUTARR_UID:YOUTARR_GID
+   ```
+
+> **Important**: The `chown` must run **after** setting `YOUTARR_UID/GID` in `.env`, and the numeric IDs must match. Running `chown 1000:1000` without setting `YOUTARR_UID=1000` leaves the container running as root, which will then either overwrite your host-side ownership or fail to write into the chown'd directories depending on your filesystem. If you are already running as root and want to switch to non-root, stop the container first, chown everything (including your `YOUTUBE_OUTPUT_DIR`), then update `.env` and start again.
 
 #### 6. Start Containers
 
@@ -271,7 +320,7 @@ docker compose down
 # 2. Backup your configuration (recommended)
 tar -czf backup-$(date +%Y%m%d).tar.gz config jobs
 
-# 3. Download updated docker-compose.yml
+# 3. Download updated compose file
 wget https://raw.githubusercontent.com/DialmasterOrg/Youtarr/main/docker-compose.yml -O docker-compose.yml
 
 # 4. Pull latest images
@@ -284,7 +333,9 @@ docker compose up -d
 docker compose logs -f
 ```
 
-**Note**: Check [.env.example](https://github.com/DialmasterOrg/Youtarr/blob/main/.env.example) for new variables after major updates.
+**Notes**:
+- Check [.env.example](https://github.com/DialmasterOrg/Youtarr/blob/main/.env.example) for new variables after major updates.
+- If you originally downloaded `docker-compose.external-db.yml` for an external database setup, swap step 3 above for `wget https://raw.githubusercontent.com/DialmasterOrg/Youtarr/main/docker-compose.external-db.yml -O docker-compose.yml`. Mixing compose files across updates will silently switch you between bundled and external database modes.
 
 ### Platform-Specific Notes
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -40,9 +40,9 @@ When using the bundled MariaDB container, these variables typically use their de
 
 ### DB_PORT
 **Required**: No
-**Default**: `3321`
+**Default**: `3321` for the internal database (docker-compose.yml), `3306` for external databases (docker-compose.external-db.yml)
 **Description**: Database port number
-**Note**: Both internal and external databases use port 3321 as the default for Youtarr
+**Note**: The bundled MariaDB container listens on 3321 (both inside the container and on the host). When pointing Youtarr at an external MariaDB/MySQL instance, the default drops to the standard 3306; override it in `.env` if your external database listens elsewhere.
 
 ### DB_USER
 **Required**: No

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -223,6 +223,21 @@ This is a known Docker Desktop issue on Windows where mount points become corrup
 
 ## Database Issues
 
+### Table Corruption After Simultaneous Database and Youtarr Update
+
+**Problem**: After updating both your external MariaDB/MySQL and Youtarr at the same time, logs show errors like:
+```
+SequelizeDatabaseError: Table 'youtarr.Jobs' doesn't exist in engine
+```
+(errno 1932), and/or tables appear empty despite having data before the update.
+
+**Cause**: When MariaDB upgrades to a new version, it performs internal data file upgrades on startup. If a Youtarr migration runs before that process completes, the combination of a database engine upgrade and an ALTER TABLE happening back-to-back can corrupt tables or cause data loss. This is a MariaDB/InnoDB limitation that affects any application running migrations during a database version change.
+
+**Solution**:
+Restart Youtarr. In most cases the table corruption is transient and the health check will recover automatically on restart. The error in the logs may look severe, but the database typically self-heals once MariaDB finishes its internal upgrade. Job/download history may be lost, but channels, videos, and settings are unaffected.
+
+**Prevention**: Never update your database server and Youtarr at the same time. Update MariaDB first, confirm it is fully running (check its logs for "ready for connections"), then update Youtarr. See the [External Database Guide](platforms/external-db.md) for details.
+
 ### UTF-8 Character Errors
 
 **Problem**: Errors like `Incorrect string value: '\\xF0\\x9F\\xA7\\xA1'` when channel names or video titles contain emojis.

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -13,6 +13,7 @@ This guide provides step-by-step instructions for common tasks in Youtarr. After
 - [Re-download Missing Videos](#re-download-missing-videos)
 - [Organize Channels with Multi-Library Support](#organize-channels-with-multi-library-support)
 - [Browse and Filter Channel Videos](#browse-and-filter-channel-videos)
+- [Preview and Play Videos](#preview-and-play-videos)
 - [External Access with API Keys](#external-access-with-api-keys)
 - [Content Ratings](#content-ratings)
 
@@ -343,6 +344,27 @@ Mark specific videos to exclude them from automatic channel downloads.
    - Ignored videos are tracked in `config/complete.list`
    - They won't appear in download recommendations
    - You can still manually download them if you change your mind
+
+## Preview and Play Videos
+
+Click any thumbnail on the Videos page or a channel page to open a video detail modal with extended metadata and in-browser playback.
+
+1. **Open the modal**
+   - Click the thumbnail of any video in the Videos page, a channel's video list, or the channel page's grid/list/table views
+   - On mobile, the modal opens fullscreen with a back arrow; on desktop it opens as a centered dialog
+
+2. **Extended metadata**
+   - Description, tags, view count, likes, resolution, fps, file sizes, and related file paths
+   - For downloaded videos, data is served from the cached `.info.json`
+   - For videos not yet downloaded, Youtarr fetches metadata on demand via yt-dlp (this can take a few seconds on the first open)
+
+3. **In-browser playback**
+   - Downloaded videos stream directly from Youtarr through the built-in player; no media server required
+   - Playback is authenticated via your existing session
+
+4. **Actions from the modal**
+   - Download, protect, delete, ignore, and rate actions are all available inside the modal
+   - Changes sync back to the source page when the modal closes
 
 ## Common tasks
 

--- a/docs/platforms/external-db.md
+++ b/docs/platforms/external-db.md
@@ -11,6 +11,16 @@ Youtarr supports running against an existing MariaDB or MySQL instance. This gui
 
 > **Tip:** Keep the database and Youtarr container on the same Docker network or ensure routing/firewall rules allow traffic from Youtarr to the DB host/port.
 
+## Important: Updating Your Database Separately from Youtarr
+
+> **Warning:** If you manage your own MariaDB/MySQL instance, **never update your database server and Youtarr at the same time.** Update them one at a time with a full restart in between.
+>
+> When MariaDB upgrades to a new version, it performs internal data file upgrades on startup. If a Youtarr migration (which may alter tables) runs while the database is still completing its own upgrade, the combination can corrupt tables and cause data loss. This is a MariaDB/InnoDB limitation, not a Youtarr bug.
+>
+> **Safe update order:**
+> 1. Update your MariaDB/MySQL container and let it fully start (check its logs for "ready for connections")
+> 2. Then update and start Youtarr
+
 ## 1. Prepare the External Database
 
 Run the following SQL on your target database host (adjust usernames/passwords as needed to match your `.env`):

--- a/docs/platforms/unraid.md
+++ b/docs/platforms/unraid.md
@@ -27,6 +27,8 @@ See [docs/platforms/external-db.md](external-db.md) for reference
 
 **NOTE**: Your MariaDB instance *must* be up and running before Youtarr starts!
 
+> **Warning: Do not update MariaDB and Youtarr at the same time.** If you update the MariaDB Official container and Youtarr together, MariaDB may still be upgrading its internal data files when Youtarr's migrations run, which can corrupt tables and cause data loss. Always update MariaDB first, confirm it's fully running (check its logs for "ready for connections"), then update Youtarr. See the [External Database Guide](external-db.md) for more details.
+
 ### Install and setup Youtarr
 
 The Unraid template for Youtarr `https://github.com/DialmasterOrg/unraid-templates/blob/main/Youtarr/Youtarr.xml`

--- a/migrations/20260408204301-add-video-protected-field.js
+++ b/migrations/20260408204301-add-video-protected-field.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { addColumnIfMissing, removeColumnIfExists } = require('../helpers');
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await addColumnIfMissing(queryInterface, 'Videos', 'protected', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  down: async (queryInterface) => {
+    await removeColumnIfExists(queryInterface, 'Videos', 'protected');
+  },
+};

--- a/migrations/20260408204301-add-video-protected-field.js
+++ b/migrations/20260408204301-add-video-protected-field.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { addColumnIfMissing, removeColumnIfExists } = require('../helpers');
+const { addColumnIfMissing, removeColumnIfExists } = require('./helpers');
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {

--- a/migrations/20260411232445-add-hidden-tabs-to-channels.js
+++ b/migrations/20260411232445-add-hidden-tabs-to-channels.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { addColumnIfMissing, removeColumnIfExists } = require('./helpers');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add hidden_tabs column to store user-selected tabs that should be hidden
+    // from the UI even when YouTube reports them as available. Comma-separated
+    // list of tab types ('videos', 'shorts', 'streams'). Null means nothing hidden.
+    await addColumnIfMissing(queryInterface, 'channels', 'hidden_tabs', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+      defaultValue: null
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await removeColumnIfExists(queryInterface, 'channels', 'hidden_tabs');
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,9 +2301,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/scripts/reset-server-data.sh
+++ b/scripts/reset-server-data.sh
@@ -8,12 +8,20 @@ cat <<'WARN'
 ##########################################################################
 
 This script will permanently remove all Youtarr server state, including:
-  • MariaDB data volume (./database/)
+  • MariaDB data (bind mount ./database/ AND Docker named volumes)
   • Download archive list (config/complete.list)
   • Job metadata caches (jobs/info/*)
   • Downloaded thumbnails and posters (server/images/*)
 
-Actual media files stored in your Plex/YouTube output directory are NOT touched.
+Docker named volumes removed if present:
+  - youtarr_youtarr-db-data-dev  (used by docker-compose.dev.yml)
+  - youtarr_youtarr-db-data      (used by docker-compose.arm.yml)
+
+Works whether Youtarr is running or stopped. Any running Youtarr
+containers will be force-stopped so their volumes can be removed.
+
+Actual media files in your Plex/YouTube output directory are NOT touched.
+External databases (docker-compose.external-db.yml) are NOT touched.
 
 ##########################################################################
 WARN
@@ -28,9 +36,38 @@ fi
 
 echo "Resetting Youtarr server data..."
 
+# Known Youtarr container and volume names across compose flows
+# (production, dev, and ARM). We operate on names directly instead of via
+# `docker compose down` so the script works even when required env vars
+# (e.g. YOUTUBE_OUTPUT_DIR) or compose files are missing.
+YOUTARR_CONTAINERS=(youtarr-dev youtarr youtarr-db-dev youtarr-db)
+YOUTARR_VOLUMES=(youtarr_youtarr-db-data-dev youtarr_youtarr-db-data)
+
+if command -v docker &>/dev/null && docker info &>/dev/null; then
+  # Named volumes can't be removed while a container is using them, so
+  # force-remove any known Youtarr containers first. `docker rm -f` works
+  # on both running and stopped containers.
+  for container in "${YOUTARR_CONTAINERS[@]}"; do
+    if docker ps -a --format '{{.Names}}' | grep -qx "$container"; then
+      echo "  Removing container: $container"
+      docker rm -f "$container" >/dev/null 2>&1 || true
+    fi
+  done
+
+  for vol in "${YOUTARR_VOLUMES[@]}"; do
+    if docker volume inspect "$vol" &>/dev/null; then
+      echo "  Removing Docker volume: $vol"
+      docker volume rm "$vol" >/dev/null
+    fi
+  done
+else
+  echo "  Docker not available - skipping container/volume cleanup."
+fi
+
 # Ensure glob patterns that match nothing simply expand to nothing
 shopt -s nullglob
 
+# Bind-mounted MariaDB data directory (used by the default docker-compose.yml flow)
 sudo rm -rf ./database/
 sudo rm -f ./config/complete.list
 sudo rm -f ./jobs/info/*

--- a/server/__tests__/server.additional-routes.test.js
+++ b/server/__tests__/server.additional-routes.test.js
@@ -248,6 +248,10 @@ const createServerModule = ({
         jest.doMock('../modules/downloadModule', () => downloadModuleMock);
         jest.doMock('../modules/jobModule', () => jobModuleMock);
         jest.doMock('../modules/videosModule', () => videosModuleMock);
+        jest.doMock('../modules/videoMetadataModule', () => ({
+          getVideoMetadata: jest.fn().mockResolvedValue(null),
+          getVideoStreamInfo: jest.fn().mockResolvedValue(null)
+        }));
         jest.doMock('../modules/channelSettingsModule', () => ({
           getChannelSettings: jest.fn(),
           updateChannelSettings: jest.fn(),

--- a/server/__tests__/server.apikeys.test.js
+++ b/server/__tests__/server.apikeys.test.js
@@ -261,6 +261,10 @@ const createServerModule = ({
           getRunningJobs: jest.fn(() => [])
         }));
         jest.doMock('../modules/videosModule', () => ({}));
+        jest.doMock('../modules/videoMetadataModule', () => ({
+          getVideoMetadata: jest.fn().mockResolvedValue(null),
+          getVideoStreamInfo: jest.fn().mockResolvedValue(null)
+        }));
         jest.doMock('../modules/channelSettingsModule', () => ({
           getChannelSettings: jest.fn(),
           updateChannelSettings: jest.fn(),

--- a/server/__tests__/server.auth-sessions.test.js
+++ b/server/__tests__/server.auth-sessions.test.js
@@ -215,6 +215,10 @@ const createServerModule = ({
           getRunningJobs: jest.fn(() => [])
         }));
         jest.doMock('../modules/videosModule', () => ({}));
+        jest.doMock('../modules/videoMetadataModule', () => ({
+          getVideoMetadata: jest.fn().mockResolvedValue(null),
+          getVideoStreamInfo: jest.fn().mockResolvedValue(null)
+        }));
         jest.doMock('../modules/channelSettingsModule', () => ({
           getChannelSettings: jest.fn(),
           updateChannelSettings: jest.fn(),

--- a/server/__tests__/server.core.test.js
+++ b/server/__tests__/server.core.test.js
@@ -479,7 +479,8 @@ describe('server initialization', () => {
       dateTo: '2024-12-31',
       sortBy: 'title',
       sortOrder: 'asc',
-      channelFilter: 'channel123'
+      channelFilter: 'channel123',
+      protectedFilter: false,
     });
 
     expect(res.statusCode).toBe(200);
@@ -573,7 +574,8 @@ describe('server initialization', () => {
       dateTo: null,
       sortBy: 'added',
       sortOrder: 'desc',
-      channelFilter: ''
+      channelFilter: '',
+      protectedFilter: false,
     });
 
     expect(res.statusCode).toBe(200);

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -831,7 +831,8 @@ describe('server routes - channels', () => {
         null, // default minDuration
         null, // default maxDuration
         null, // default dateFrom
-        null  // default dateTo
+        null, // default dateTo
+        false // default protectedFilter
       );
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
@@ -897,7 +898,8 @@ describe('server routes - channels', () => {
         null, // default minDuration
         null, // default maxDuration
         null, // default dateFrom
-        null  // default dateTo
+        null, // default dateTo
+        false // default protectedFilter
       );
       expect(res.statusCode).toBe(200);
     });
@@ -936,7 +938,8 @@ describe('server routes - channels', () => {
         null, // default minDuration
         null, // default maxDuration
         null, // default dateFrom
-        null  // default dateTo
+        null, // default dateTo
+        false // default protectedFilter
       );
       expect(res.statusCode).toBe(200);
     });

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -190,7 +190,13 @@ const createServerModule = ({
           }),
           deleteChannel: jest.fn().mockResolvedValue({ success: true }),
           getChannelAvailableTabs: jest.fn().mockResolvedValue({ availableTabs: ['videos', 'shorts', 'streams']}),
-          updateAutoDownloadForTab: jest.fn().mockResolvedValue()
+          updateAutoDownloadForTab: jest.fn().mockResolvedValue(),
+          redetectChannelTabs: jest.fn().mockResolvedValue({
+            availableTabs: ['videos', 'shorts', 'streams'],
+            detectedTabs: ['videos', 'shorts', 'streams'],
+            hiddenTabs: [],
+            autoDownloadEnabledTabs: 'video'
+          })
         };
 
         const plexModuleMock = {
@@ -801,6 +807,72 @@ describe('server routes - channels', () => {
         error: 'Failed to update auto download setting',
         message: 'Database error'
       });
+    });
+  });
+
+  describe('POST /api/channels/:channelId/tabs/redetect', () => {
+    test('forces re-detection and returns the refreshed tabs', async () => {
+      const { app, channelModuleMock } = await createServerModule();
+      channelModuleMock.redetectChannelTabs.mockResolvedValueOnce({
+        availableTabs: ['videos', 'streams'],
+        detectedTabs: ['videos', 'shorts', 'streams'],
+        hiddenTabs: ['shorts'],
+        autoDownloadEnabledTabs: 'video'
+      });
+
+      const handlers = findRouteHandlers(app, 'post', '/api/channels/:channelId/tabs/redetect');
+      expect(handlers.length).toBeGreaterThan(0);
+      const redetectHandler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({ params: { channelId: 'channel-1' } });
+      const res = createMockResponse();
+
+      await redetectHandler(req, res);
+
+      expect(channelModuleMock.redetectChannelTabs).toHaveBeenCalledWith('channel-1');
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({
+        availableTabs: ['videos', 'streams'],
+        detectedTabs: ['videos', 'shorts', 'streams'],
+        hiddenTabs: ['shorts'],
+        autoDownloadEnabledTabs: 'video'
+      });
+    });
+
+    test('returns 404 when channel is not found', async () => {
+      const { app, channelModuleMock } = await createServerModule();
+      channelModuleMock.redetectChannelTabs.mockRejectedValueOnce(
+        new Error('Channel not found in database')
+      );
+
+      const handlers = findRouteHandlers(app, 'post', '/api/channels/:channelId/tabs/redetect');
+      const redetectHandler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({ params: { channelId: 'missing' } });
+      const res = createMockResponse();
+
+      await redetectHandler(req, res);
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toEqual({ error: 'Channel not found in database' });
+    });
+
+    test('returns 500 on unexpected error', async () => {
+      const { app, channelModuleMock } = await createServerModule();
+      channelModuleMock.redetectChannelTabs.mockRejectedValueOnce(
+        new Error('yt-dlp crashed')
+      );
+
+      const handlers = findRouteHandlers(app, 'post', '/api/channels/:channelId/tabs/redetect');
+      const redetectHandler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({ params: { channelId: 'channel-1' } });
+      const res = createMockResponse();
+
+      await redetectHandler(req, res);
+
+      expect(res.statusCode).toBe(500);
+      expect(res.body).toEqual({ error: 'Failed to re-detect available tabs' });
     });
   });
 

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -336,6 +336,10 @@ const createServerModule = ({
         jest.doMock('../modules/videoDeletionModule', () => videoDeletionModuleMock);
         jest.doMock('../modules/videoValidationModule', () => videoValidationModuleMock);
         jest.doMock('../modules/channelSettingsModule', () => channelSettingsModuleMock);
+        jest.doMock('../modules/videoMetadataModule', () => ({
+          getVideoMetadata: jest.fn().mockResolvedValue(null),
+          getVideoStreamInfo: jest.fn().mockResolvedValue(null)
+        }));
         jest.doMock('../modules/archiveModule', () => ({
           getAutoRemovalDryRun: jest.fn().mockResolvedValue({ videos: [], totalSize: 0 })
         }));

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -1215,7 +1215,8 @@ describe('server routes - videos', () => {
         dateTo: null,
         sortBy: 'added',
         sortOrder: 'desc',
-        channelFilter: ''
+        channelFilter: '',
+        protectedFilter: false,
       });
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
@@ -1262,7 +1263,8 @@ describe('server routes - videos', () => {
         dateTo: '2024-12-31',
         sortBy: 'title',
         sortOrder: 'asc',
-        channelFilter: 'channel123'
+        channelFilter: 'channel123',
+        protectedFilter: false,
       });
       expect(res.statusCode).toBe(200);
     });

--- a/server/models/channel.js
+++ b/server/models/channel.js
@@ -51,6 +51,11 @@ Channel.init(
       allowNull: true,
       defaultValue: null,
     },
+    hidden_tabs: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      defaultValue: null,
+    },
     auto_download_enabled_tabs: {
       type: DataTypes.TEXT,
       allowNull: false,

--- a/server/models/video.js
+++ b/server/models/video.js
@@ -101,6 +101,11 @@ Video.init(
       allowNull: true,
       comment: 'Source of the rating',
     },
+    protected: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
   },
   {
     sequelize,

--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -2837,6 +2837,278 @@ describe('ChannelModule', () => {
         expect(mockChannel.save).toHaveBeenCalled();
       });
     });
+
+    describe('hidden_tabs filtering', () => {
+      describe('computeEffectiveTabs', () => {
+        test('returns detected tabs when nothing hidden', () => {
+          const result = ChannelModule.computeEffectiveTabs('videos,shorts,streams', null);
+          expect(result).toEqual(['videos', 'shorts', 'streams']);
+        });
+
+        test('filters out hidden tabs', () => {
+          const result = ChannelModule.computeEffectiveTabs('videos,shorts,streams', 'shorts');
+          expect(result).toEqual(['videos', 'streams']);
+        });
+
+        test('filters multiple hidden tabs', () => {
+          const result = ChannelModule.computeEffectiveTabs('videos,shorts,streams', 'shorts,streams');
+          expect(result).toEqual(['videos']);
+        });
+
+        test('returns empty array when all detected are hidden', () => {
+          const result = ChannelModule.computeEffectiveTabs('videos,shorts', 'videos,shorts');
+          expect(result).toEqual([]);
+        });
+
+        test('returns empty array when available_tabs is null', () => {
+          const result = ChannelModule.computeEffectiveTabs(null, null);
+          expect(result).toEqual([]);
+        });
+
+        test('ignores hidden entries that are not in detected set', () => {
+          const result = ChannelModule.computeEffectiveTabs('videos', 'shorts,streams');
+          expect(result).toEqual(['videos']);
+        });
+
+        test('trims whitespace in both lists', () => {
+          const result = ChannelModule.computeEffectiveTabs(' videos , shorts ', ' shorts ');
+          expect(result).toEqual(['videos']);
+        });
+      });
+
+      describe('mapChannelToResponse with hidden_tabs', () => {
+        test('returns effective available_tabs excluding hidden tabs', () => {
+          const channel = {
+            channel_id: 'UC123',
+            uploader: 'Test',
+            uploader_id: 'UC123',
+            title: 'Test',
+            description: 'Test',
+            url: 'https://youtube.com/@test',
+            auto_download_enabled_tabs: 'video',
+            available_tabs: 'videos,shorts,streams',
+            hidden_tabs: 'shorts'
+          };
+
+          const result = ChannelModule.mapChannelToResponse(channel);
+
+          expect(result.available_tabs).toBe('videos,streams');
+        });
+
+        test('leaves available_tabs unchanged when hidden_tabs is null', () => {
+          const channel = {
+            channel_id: 'UC123',
+            uploader: 'Test',
+            uploader_id: 'UC123',
+            title: 'Test',
+            description: 'Test',
+            url: 'https://youtube.com/@test',
+            auto_download_enabled_tabs: 'video',
+            available_tabs: 'videos,shorts',
+            hidden_tabs: null
+          };
+
+          const result = ChannelModule.mapChannelToResponse(channel);
+
+          expect(result.available_tabs).toBe('videos,shorts');
+        });
+
+        test('returns null available_tabs when all detected are hidden', () => {
+          const channel = {
+            channel_id: 'UC123',
+            uploader: 'Test',
+            uploader_id: 'UC123',
+            title: 'Test',
+            description: 'Test',
+            url: 'https://youtube.com/@test',
+            auto_download_enabled_tabs: 'video',
+            available_tabs: 'videos',
+            hidden_tabs: 'videos'
+          };
+
+          const result = ChannelModule.mapChannelToResponse(channel);
+
+          expect(result.available_tabs).toBeNull();
+        });
+      });
+
+      describe('mapChannelListEntry with hidden_tabs', () => {
+        test('returns effective available_tabs excluding hidden tabs', () => {
+          const channel = {
+            url: 'https://youtube.com/@test',
+            uploader: 'Test',
+            channel_id: 'UC123',
+            auto_download_enabled_tabs: 'video',
+            available_tabs: 'videos,shorts,streams',
+            hidden_tabs: 'shorts,streams'
+          };
+
+          const result = ChannelModule.mapChannelListEntry(channel);
+
+          expect(result.available_tabs).toBe('videos');
+        });
+      });
+
+      describe('buildChannelVideosResponse with hidden_tabs', () => {
+        test('returns effective availableTabs excluding hidden tabs', () => {
+          const channel = {
+            ...mockChannelData,
+            available_tabs: 'videos,shorts,streams',
+            hidden_tabs: 'shorts'
+          };
+
+          const result = ChannelModule.buildChannelVideosResponse([mockVideoData], channel, 'cache', null, false, 'video');
+
+          expect(result.availableTabs).toEqual(['videos', 'streams']);
+        });
+      });
+
+      describe('getChannelAvailableTabs with hidden_tabs', () => {
+        test('returns effective tabs (detected minus hidden)', async () => {
+          const mockChannel = {
+            ...mockChannelData,
+            available_tabs: 'videos,shorts,streams',
+            hidden_tabs: 'shorts'
+          };
+          Channel.findOne.mockResolvedValue(mockChannel);
+
+          const result = await ChannelModule.getChannelAvailableTabs('UC123');
+
+          expect(result).toEqual({ availableTabs: ['videos', 'streams'] });
+        });
+      });
+    });
+
+    describe('redetectChannelTabs', () => {
+      test('probes tabs via yt-dlp even when available_tabs is cached', async () => {
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: 'shorts', // Pretend RSS era gave us only shorts
+          hidden_tabs: null,
+          auto_download_enabled_tabs: 'short'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn()
+          .mockImplementation(async (chId, tabType) => {
+            if (tabType === 'videos') return true;
+            if (tabType === 'shorts') return true;
+            if (tabType === 'streams') return true;
+            return false;
+          });
+
+        const result = await ChannelModule.redetectChannelTabs('UC123');
+
+        expect(ChannelModule.checkTabExistsViaYtdlp).toHaveBeenCalledWith('UC123', 'videos');
+        expect(ChannelModule.checkTabExistsViaYtdlp).toHaveBeenCalledWith('UC123', 'shorts');
+        expect(ChannelModule.checkTabExistsViaYtdlp).toHaveBeenCalledWith('UC123', 'streams');
+        expect(Channel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            available_tabs: 'videos,shorts,streams'
+          }),
+          { where: { channel_id: 'UC123' } }
+        );
+        expect(result.availableTabs).toEqual(['videos', 'shorts', 'streams']);
+        expect(result.detectedTabs).toEqual(['videos', 'shorts', 'streams']);
+      });
+
+      test('preserves hidden_tabs when re-detecting', async () => {
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: 'videos',
+          hidden_tabs: 'shorts',
+          auto_download_enabled_tabs: 'video'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn()
+          .mockImplementation(async (chId, tabType) => {
+            return tabType === 'videos' || tabType === 'shorts';
+          });
+
+        const result = await ChannelModule.redetectChannelTabs('UC123');
+
+        // The update call should NOT overwrite hidden_tabs
+        const updateCall = Channel.update.mock.calls[0][0];
+        expect(updateCall).not.toHaveProperty('hidden_tabs');
+
+        // Effective available_tabs = detected - hidden = [videos, shorts] - [shorts] = [videos]
+        expect(result.availableTabs).toEqual(['videos']);
+        // detectedTabs shows the raw detection
+        expect(result.detectedTabs).toEqual(['videos', 'shorts']);
+        expect(result.hiddenTabs).toEqual(['shorts']);
+      });
+
+      test('drops auto_download_enabled_tabs entries that are no longer detected', async () => {
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: 'videos,shorts,streams',
+          hidden_tabs: null,
+          auto_download_enabled_tabs: 'video,short,livestream'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        // Shorts no longer exists
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn()
+          .mockImplementation(async (chId, tabType) => {
+            return tabType === 'videos' || tabType === 'streams';
+          });
+
+        await ChannelModule.redetectChannelTabs('UC123');
+
+        const updateCall = Channel.update.mock.calls[0][0];
+        expect(updateCall.auto_download_enabled_tabs.split(',').sort())
+          .toEqual(['livestream', 'video'].sort());
+      });
+
+      test('drops auto_download_enabled_tabs entries that are hidden', async () => {
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: 'videos',
+          hidden_tabs: 'shorts',
+          auto_download_enabled_tabs: 'video,short'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn()
+          .mockImplementation(async (chId, tabType) => {
+            return tabType === 'videos' || tabType === 'shorts';
+          });
+
+        await ChannelModule.redetectChannelTabs('UC123');
+
+        const updateCall = Channel.update.mock.calls[0][0];
+        // short should have been stripped because shorts is in hidden_tabs
+        expect(updateCall.auto_download_enabled_tabs.split(',')).toEqual(['video']);
+      });
+
+      test('throws error when channel not found', async () => {
+        Channel.findOne.mockResolvedValue(null);
+        await expect(ChannelModule.redetectChannelTabs('UC999'))
+          .rejects.toThrow('Channel not found in database');
+      });
+
+      test('falls back to videos tab when all yt-dlp probes fail', async () => {
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: 'shorts',
+          hidden_tabs: null,
+          auto_download_enabled_tabs: 'short'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn().mockResolvedValue(false);
+
+        const result = await ChannelModule.redetectChannelTabs('UC123');
+
+        expect(result.detectedTabs).toEqual(['videos']);
+      });
+    });
   });
 
   describe('resolveChannelFolderName', () => {

--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -956,7 +956,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: ['video1', 'video2', 'video3']
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
         expect(result[0].added).toBe(true);
         expect(result[0].removed).toBe(false);
@@ -985,7 +985,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: ['video1', 'video2']
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
         expect(result[0].added).toBe(true);
         expect(result[0].removed).toBe(false);
@@ -1042,7 +1042,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: ['video1', 'video2']
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
         expect(result[0].added).toBe(true);
         expect(result[0].removed).toBe(false);
@@ -1071,7 +1071,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: ['video1', 'video2', 'video3']
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
 
         // Video1 - not downloaded
@@ -1099,7 +1099,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: []
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
         expect(result).toEqual([]);
       });
@@ -1205,7 +1205,7 @@ describe('ChannelModule', () => {
           where: {
             youtubeId: ['video1', 'video2']
           },
-          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source']
+          attributes: ['id', 'youtubeId', 'removed', 'fileSize', 'filePath', 'audioFilePath', 'audioFileSize', 'normalized_rating', 'rating_source', 'protected']
         });
         expect(result[0].added).toBe(true);
         expect(result[0].removed).toBe(false);

--- a/server/modules/__tests__/channelSettingsModule.test.js
+++ b/server/modules/__tests__/channelSettingsModule.test.js
@@ -588,7 +588,7 @@ describe('ChannelSettingsModule', () => {
       Channel.findOne.mockResolvedValue(channel);
 
       const result = await channelSettingsModule.getChannelSettings('UC123456');
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         channel_id: 'UC123456',
         uploader: 'Test Channel',
         sub_folder: 'Music',
@@ -604,6 +604,32 @@ describe('ChannelSettingsModule', () => {
       await expect(
         channelSettingsModule.getChannelSettings('UC999999')
       ).rejects.toThrow('Channel not found');
+    });
+
+    test('includes detected_tabs, hidden_tabs, and effective available_tabs', async () => {
+      const channel = {
+        ...mockChannel,
+        available_tabs: 'videos,shorts,streams',
+        hidden_tabs: 'shorts'
+      };
+      Channel.findOne.mockResolvedValue(channel);
+
+      const result = await channelSettingsModule.getChannelSettings('UC123456');
+
+      expect(result.detected_tabs).toEqual(['videos', 'shorts', 'streams']);
+      expect(result.hidden_tabs).toEqual(['shorts']);
+      expect(result.available_tabs).toEqual(['videos', 'streams']);
+    });
+
+    test('returns empty arrays for detected_tabs/hidden_tabs when channel has no tab data', async () => {
+      const channel = { ...mockChannel };
+      Channel.findOne.mockResolvedValue(channel);
+
+      const result = await channelSettingsModule.getChannelSettings('UC123456');
+
+      expect(result.detected_tabs).toEqual([]);
+      expect(result.hidden_tabs).toEqual([]);
+      expect(result.available_tabs).toEqual([]);
     });
   });
 
@@ -743,6 +769,108 @@ describe('ChannelSettingsModule', () => {
       ).rejects.toThrow('Failed to move channel folder');
 
       expect(channel.update).toHaveBeenCalledWith({ sub_folder: null });
+    });
+
+    describe('hidden_tabs', () => {
+      test('persists hidden_tabs as comma-separated string', async () => {
+        const channel = {
+          ...mockChannel,
+          available_tabs: 'videos,shorts,streams',
+          hidden_tabs: null,
+          auto_download_enabled_tabs: 'video',
+          update: jest.fn().mockImplementation(function (data) {
+            Object.assign(this, data);
+            return Promise.resolve(this);
+          })
+        };
+        Channel.findOne.mockResolvedValue(channel);
+
+        const result = await channelSettingsModule.updateChannelSettings('UC123456', {
+          hidden_tabs: ['shorts']
+        });
+
+        expect(channel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ hidden_tabs: 'shorts' })
+        );
+        expect(result.settings.hidden_tabs).toEqual(['shorts']);
+        expect(result.settings.available_tabs).toEqual(['videos', 'streams']);
+      });
+
+      test('clears hidden_tabs when passed an empty array', async () => {
+        const channel = {
+          ...mockChannel,
+          available_tabs: 'videos,shorts',
+          hidden_tabs: 'shorts',
+          auto_download_enabled_tabs: 'video',
+          update: jest.fn().mockImplementation(function (data) {
+            Object.assign(this, data);
+            return Promise.resolve(this);
+          })
+        };
+        Channel.findOne.mockResolvedValue(channel);
+
+        await channelSettingsModule.updateChannelSettings('UC123456', {
+          hidden_tabs: []
+        });
+
+        expect(channel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ hidden_tabs: null })
+        );
+      });
+
+      test('rejects invalid tab type values', async () => {
+        const channel = {
+          ...mockChannel,
+          available_tabs: 'videos,shorts',
+          update: jest.fn()
+        };
+        Channel.findOne.mockResolvedValue(channel);
+
+        await expect(
+          channelSettingsModule.updateChannelSettings('UC123456', {
+            hidden_tabs: ['bogus']
+          })
+        ).rejects.toThrow('Invalid hidden_tabs');
+      });
+
+      test('rejects hiding every detected tab', async () => {
+        const channel = {
+          ...mockChannel,
+          available_tabs: 'videos,shorts',
+          update: jest.fn()
+        };
+        Channel.findOne.mockResolvedValue(channel);
+
+        await expect(
+          channelSettingsModule.updateChannelSettings('UC123456', {
+            hidden_tabs: ['videos', 'shorts']
+          })
+        ).rejects.toThrow('At least one tab must remain visible');
+      });
+
+      test('strips auto_download_enabled_tabs entries that map to a hidden tab', async () => {
+        const channel = {
+          ...mockChannel,
+          available_tabs: 'videos,shorts',
+          hidden_tabs: null,
+          auto_download_enabled_tabs: 'video,short',
+          update: jest.fn().mockImplementation(function (data) {
+            Object.assign(this, data);
+            return Promise.resolve(this);
+          })
+        };
+        Channel.findOne.mockResolvedValue(channel);
+
+        await channelSettingsModule.updateChannelSettings('UC123456', {
+          hidden_tabs: ['shorts']
+        });
+
+        const updateCall = channel.update.mock.calls.find(
+          (call) => 'auto_download_enabled_tabs' in (call[0] || {})
+        );
+        expect(updateCall).toBeDefined();
+        expect(updateCall[0].auto_download_enabled_tabs).toBe('video');
+      });
     });
   });
 

--- a/server/modules/__tests__/channelSettingsModule.test.js
+++ b/server/modules/__tests__/channelSettingsModule.test.js
@@ -446,6 +446,54 @@ describe('ChannelSettingsModule', () => {
       const result = await channelSettingsModule.getAllSubFolders();
       expect(result).toEqual(['__Alpha', '__Beta', '__Zulu']);
     });
+
+    test('should include the configured global default subfolder when no channels exist', async () => {
+      Channel.findAll.mockResolvedValue([]);
+      const configModule = require('../configModule');
+      configModule.getDefaultSubfolder.mockReturnValue('Adults');
+
+      const result = await channelSettingsModule.getAllSubFolders();
+
+      expect(result).toEqual(['__Adults']);
+    });
+
+    test('should include the global default subfolder alongside explicit channel subfolders', async () => {
+      Channel.findAll.mockResolvedValue([
+        { sub_folder: 'Kids' },
+        { sub_folder: 'Music' }
+      ]);
+      const configModule = require('../configModule');
+      configModule.getDefaultSubfolder.mockReturnValue('Adults');
+
+      const result = await channelSettingsModule.getAllSubFolders();
+
+      expect(result).toEqual(['__Adults', '__Kids', '__Music']);
+    });
+
+    test('should deduplicate when the global default matches an explicit channel subfolder', async () => {
+      Channel.findAll.mockResolvedValue([
+        { sub_folder: 'Music' },
+        { sub_folder: 'Adults' }
+      ]);
+      const configModule = require('../configModule');
+      configModule.getDefaultSubfolder.mockReturnValue('Adults');
+
+      const result = await channelSettingsModule.getAllSubFolders();
+
+      expect(result).toEqual(['__Adults', '__Music']);
+    });
+
+    test('should not add anything when the global default subfolder is null', async () => {
+      Channel.findAll.mockResolvedValue([
+        { sub_folder: 'Music' }
+      ]);
+      const configModule = require('../configModule');
+      configModule.getDefaultSubfolder.mockReturnValue(null);
+
+      const result = await channelSettingsModule.getAllSubFolders();
+
+      expect(result).toEqual(['__Music']);
+    });
   });
 
   describe('previewTitleFilter', () => {

--- a/server/modules/__tests__/channelSettingsModule.test.js
+++ b/server/modules/__tests__/channelSettingsModule.test.js
@@ -41,7 +41,9 @@ jest.mock('../jobModule', () => ({
 }));
 
 jest.mock('../plexModule', () => ({
-  refreshLibrary: jest.fn().mockResolvedValue(true)
+  refreshLibrary: jest.fn().mockResolvedValue(true),
+  refreshLibraryForSubfolder: jest.fn().mockResolvedValue(true),
+  refreshLibrariesForSubfolders: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe('ChannelSettingsModule', () => {
@@ -824,7 +826,7 @@ describe('ChannelSettingsModule', () => {
       });
     });
 
-    test('should trigger Plex library refresh asynchronously', async () => {
+    test('should trigger Plex library refresh for both old and new subfolders asynchronously', async () => {
       fs.existsSync
         .mockReturnValueOnce(true)
         .mockReturnValueOnce(false);
@@ -834,14 +836,14 @@ describe('ChannelSettingsModule', () => {
       // Plex refresh is called via setImmediate, so we need to flush the queue
       await new Promise(resolve => setImmediate(resolve));
 
-      expect(plexModule.refreshLibrary).toHaveBeenCalled();
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledWith([null, 'Music']);
     });
 
     test('should not fail if Plex refresh fails', async () => {
       fs.existsSync
         .mockReturnValueOnce(true)
         .mockReturnValueOnce(false);
-      plexModule.refreshLibrary.mockRejectedValue(new Error('Plex error'));
+      plexModule.refreshLibrariesForSubfolders.mockRejectedValue(new Error('Plex error'));
 
       const result = await channelSettingsModule.moveChannelFolder(channel, null, 'Music');
 
@@ -851,7 +853,7 @@ describe('ChannelSettingsModule', () => {
       await new Promise(resolve => setImmediate(resolve));
 
       expect(logger.error).toHaveBeenCalledWith(
-        expect.objectContaining({ err: 'Plex error' }),
+        expect.objectContaining({ err: expect.any(Error) }),
         'Could not refresh Plex library'
       );
     });

--- a/server/modules/__tests__/downloadModule.test.js
+++ b/server/modules/__tests__/downloadModule.test.js
@@ -323,7 +323,7 @@ describe('DownloadModule', () => {
 
       await downloadModule.doChannelDownloads();
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('Using grouped downloads: 2 group(s) with resolved settings');
+      expect(logger.info).toHaveBeenCalledWith({ groupCount: 2 }, 'Using grouped downloads with resolved settings');
       expect(spy).toHaveBeenCalledWith({}, groups, false);
     });
 
@@ -588,7 +588,7 @@ describe('DownloadModule', () => {
 
       await downloadModule.doGroupedChannelDownloads({}, groups);
 
-      expect(consoleLogSpy).toHaveBeenCalledWith('Processing 2 channel download groups in a single job');
+      expect(logger.info).toHaveBeenCalledWith({ groupCount: 2 }, 'Processing channel download groups in a single job');
       expect(jobModuleMock.addOrUpdateJob).toHaveBeenCalledTimes(1);
       expect(jobModuleMock.addOrUpdateJob).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -666,17 +666,30 @@ describe('DownloadModule', () => {
       });
     });
 
-    it('should refresh Plex and start next job after all groups complete', async () => {
+    it('should refresh Plex libraries for each group subfolder after all groups complete', async () => {
       const groups = [
         { quality: '1080', subFolder: null, channels: [{ channel_id: 'UC1' }] }
       ];
       const plexModuleMock = require('../plexModule');
-      plexModuleMock.refreshLibrary = jest.fn().mockReturnValue(Promise.resolve());
+      plexModuleMock.refreshLibrariesForSubfolders = jest.fn().mockReturnValue(Promise.resolve());
 
       await downloadModule.doGroupedChannelDownloads({}, groups);
 
-      expect(plexModuleMock.refreshLibrary).toHaveBeenCalled();
+      expect(plexModuleMock.refreshLibrariesForSubfolders).toHaveBeenCalledWith([null]);
       expect(jobModuleMock.startNextJob).toHaveBeenCalled();
+    });
+
+    it('should pass all group subfolders to refreshLibrariesForSubfolders', async () => {
+      const groups = [
+        { quality: '1080', subFolder: 'kids', channels: [{ channel_id: 'UC1' }] },
+        { quality: '720', subFolder: 'music', channels: [{ channel_id: 'UC2' }] },
+      ];
+      const plexModuleMock = require('../plexModule');
+      plexModuleMock.refreshLibrariesForSubfolders = jest.fn().mockReturnValue(Promise.resolve());
+
+      await downloadModule.doGroupedChannelDownloads({}, groups);
+
+      expect(plexModuleMock.refreshLibrariesForSubfolders).toHaveBeenCalledWith(['kids', 'music']);
     });
 
     it('should stop processing groups if job is terminated', async () => {
@@ -686,7 +699,7 @@ describe('DownloadModule', () => {
         { quality: '480', subFolder: null, channels: [{ channel_id: 'UC3' }] }
       ];
       const plexModuleMock = require('../plexModule');
-      plexModuleMock.refreshLibrary = jest.fn().mockReturnValue(Promise.resolve());
+      plexModuleMock.refreshLibrariesForSubfolders = jest.fn().mockReturnValue(Promise.resolve());
 
       // Mock executeGroupDownload to simulate the first group completing
       const executeSpy = jest.spyOn(downloadModule, 'executeGroupDownload').mockResolvedValue();
@@ -701,7 +714,7 @@ describe('DownloadModule', () => {
 
       // Should only execute first group, then stop when it detects termination
       expect(executeSpy).toHaveBeenCalledTimes(1);
-      expect(plexModuleMock.refreshLibrary).not.toHaveBeenCalled();
+      expect(plexModuleMock.refreshLibrariesForSubfolders).not.toHaveBeenCalled();
       expect(jobModuleMock.startNextJob).not.toHaveBeenCalled();
     });
   });

--- a/server/modules/__tests__/plexModule.test.js
+++ b/server/modules/__tests__/plexModule.test.js
@@ -153,7 +153,8 @@ describe('plexModule', () => {
       const result = await plexModule.refreshLibrary();
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://127.0.0.1:32400/library/sections/1/refresh?X-Plex-Token=existing-token'
+        'http://127.0.0.1:32400/library/sections/1/refresh?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
       expect(result).toBe(mockResponse);
       expect(logger.info).toHaveBeenCalledWith(
@@ -172,7 +173,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibrary('5');
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://127.0.0.1:32400/library/sections/5/refresh?X-Plex-Token=existing-token'
+        'http://127.0.0.1:32400/library/sections/5/refresh?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
     });
 
@@ -252,7 +254,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibrary('42');
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://127.0.0.1:32400/library/sections/42/refresh?X-Plex-Token=existing-token'
+        'http://127.0.0.1:32400/library/sections/42/refresh?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
     });
 
@@ -263,7 +266,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibrary();
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://env-plex:8080/library/sections/1/refresh?X-Plex-Token=existing-token'
+        'http://env-plex:8080/library/sections/1/refresh?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
     });
   });
@@ -325,7 +329,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibraryForSubfolder('kids');
 
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/library/sections/2/refresh')
+        expect.stringContaining('/library/sections/2/refresh'),
+        { timeout: 10000 }
       );
     });
 
@@ -336,7 +341,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibraryForSubfolder('unknown');
 
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/library/sections/1/refresh')
+        expect.stringContaining('/library/sections/1/refresh'),
+        { timeout: 10000 }
       );
     });
 
@@ -347,7 +353,8 @@ describe('plexModule', () => {
       await plexModule.refreshLibraryForSubfolder(null);
 
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/library/sections/1/refresh')
+        expect.stringContaining('/library/sections/1/refresh'),
+        { timeout: 10000 }
       );
     });
   });
@@ -375,10 +382,11 @@ describe('plexModule', () => {
 
       await plexModule.refreshLibrariesForSubfolders(['kids', 'cartoons']);
 
-      // Both resolve to library '2' — only one HTTP call should be made
+      // Both resolve to library '2' - only one HTTP call should be made
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/library/sections/2/refresh')
+        expect.stringContaining('/library/sections/2/refresh'),
+        { timeout: 10000 }
       );
     });
 
@@ -391,7 +399,8 @@ describe('plexModule', () => {
       // All three map to the global ID '1': deduplicated to one call
       expect(axios.get).toHaveBeenCalledTimes(1);
       expect(axios.get).toHaveBeenCalledWith(
-        expect.stringContaining('/library/sections/1/refresh')
+        expect.stringContaining('/library/sections/1/refresh'),
+        { timeout: 10000 }
       );
     });
 
@@ -451,7 +460,8 @@ describe('plexModule', () => {
       const result = await plexModule.getLibraries();
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://127.0.0.1:32400/library/sections?X-Plex-Token=existing-token'
+        'http://127.0.0.1:32400/library/sections?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
       expect(result).toEqual([
         {
@@ -481,7 +491,8 @@ describe('plexModule', () => {
       const result = await plexModule.getLibraries();
 
       expect(axios.get).toHaveBeenCalledWith(
-        'https://127.0.0.1:32400/library/sections?X-Plex-Token=existing-token'
+        'https://127.0.0.1:32400/library/sections?X-Plex-Token=existing-token',
+        { timeout: 10000 }
       );
       expect(result).toEqual([
         {
@@ -541,7 +552,8 @@ describe('plexModule', () => {
         'Attempting to fetch Plex libraries via URL: http://192.168.1.10:8080'
       );
       expect(axios.get).toHaveBeenCalledWith(
-        'http://192.168.1.10:8080/library/sections?X-Plex-Token=token'
+        'http://192.168.1.10:8080/library/sections?X-Plex-Token=token',
+        { timeout: 10000 }
       );
       expect(result).toEqual([
         {
@@ -595,7 +607,8 @@ describe('plexModule', () => {
       await plexModule.getLibrariesWithParams(null, 'token', null);
 
       expect(axios.get).toHaveBeenCalledWith(
-        'http://env-plex:9999/library/sections?X-Plex-Token=token'
+        'http://env-plex:9999/library/sections?X-Plex-Token=token',
+        { timeout: 10000 }
       );
     });
 
@@ -634,7 +647,8 @@ describe('plexModule', () => {
         'Attempting to fetch Plex libraries via URL: https://192.168.1.10:8080'
       );
       expect(axios.get).toHaveBeenCalledWith(
-        'https://192.168.1.10:8080/library/sections?X-Plex-Token=token'
+        'https://192.168.1.10:8080/library/sections?X-Plex-Token=token',
+        { timeout: 10000 }
       );
       expect(result).toHaveLength(1);
     });
@@ -660,7 +674,8 @@ describe('plexModule', () => {
         'Attempting to fetch Plex libraries via URL: http://192.168.1.10:8080'
       );
       expect(axios.get).toHaveBeenCalledWith(
-        'http://192.168.1.10:8080/library/sections?X-Plex-Token=token'
+        'http://192.168.1.10:8080/library/sections?X-Plex-Token=token',
+        { timeout: 10000 }
       );
       expect(result).toHaveLength(1);
     });
@@ -687,7 +702,8 @@ describe('plexModule', () => {
         'Attempting to fetch Plex libraries via URL: https://192.168.1.10:8080'
       );
       expect(axios.get).toHaveBeenCalledWith(
-        'https://192.168.1.10:8080/library/sections?X-Plex-Token=token'
+        'https://192.168.1.10:8080/library/sections?X-Plex-Token=token',
+        { timeout: 10000 }
       );
       expect(result).toHaveLength(1);
     });

--- a/server/modules/__tests__/plexModule.test.js
+++ b/server/modules/__tests__/plexModule.test.js
@@ -146,7 +146,7 @@ describe('plexModule', () => {
   });
 
   describe('refreshLibrary', () => {
-    test('successfully refreshes library', async () => {
+    test('successfully refreshes library using global config ID', async () => {
       const mockResponse = { status: 200, data: 'success' };
       axios.get.mockResolvedValue(mockResponse);
 
@@ -156,10 +156,23 @@ describe('plexModule', () => {
         'http://127.0.0.1:32400/library/sections/1/refresh?X-Plex-Token=existing-token'
       );
       expect(result).toBe(mockResponse);
-      expect(logger.info).toHaveBeenCalledWith('Refreshing Plex library');
+      expect(logger.info).toHaveBeenCalledWith(
+        { libraryId: '1' },
+        'Refreshing Plex library'
+      );
       expect(logger.info).toHaveBeenCalledWith(
         { libraryId: '1' },
         'Plex library refresh initiated successfully'
+      );
+    });
+
+    test('uses explicit libraryId argument when provided', async () => {
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibrary('5');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'http://127.0.0.1:32400/library/sections/5/refresh?X-Plex-Token=existing-token'
       );
     });
 
@@ -215,6 +228,34 @@ describe('plexModule', () => {
       expect(logger.error).toHaveBeenCalledWith({ err: error }, 'Failed to refresh Plex library');
     });
 
+    test('skips refresh when libraryId is non-numeric', async () => {
+      const result = await plexModule.refreshLibrary('../../admin');
+
+      expect(axios.get).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        { libraryId: '../../admin' },
+        'Skipping Plex refresh - invalid non-numeric library ID'
+      );
+    });
+
+    test('skips refresh when libraryId contains letters', async () => {
+      const result = await plexModule.refreshLibrary('abc');
+
+      expect(axios.get).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    test('allows valid numeric libraryId', async () => {
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibrary('42');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'http://127.0.0.1:32400/library/sections/42/refresh?X-Plex-Token=existing-token'
+      );
+    });
+
     test('uses PLEX_URL from environment when available', async () => {
       process.env.PLEX_URL = 'http://env-plex:8080';
       axios.get.mockResolvedValue({ status: 200 });
@@ -224,6 +265,157 @@ describe('plexModule', () => {
       expect(axios.get).toHaveBeenCalledWith(
         'http://env-plex:8080/library/sections/1/refresh?X-Plex-Token=existing-token'
       );
+    });
+  });
+
+  describe('getLibraryIdForSubfolder', () => {
+    test('returns matching libraryId when a mapping exists for the subfolder', () => {
+      config.plexSubfolderLibraryMappings = [
+        { subfolder: 'kids', libraryId: '2' },
+        { subfolder: 'music', libraryId: '3' },
+      ];
+
+      expect(plexModule.getLibraryIdForSubfolder('kids')).toBe('2');
+      expect(plexModule.getLibraryIdForSubfolder('music')).toBe('3');
+    });
+
+    test('returns global plexYoutubeLibraryId when no mapping matches', () => {
+      config.plexSubfolderLibraryMappings = [{ subfolder: 'kids', libraryId: '2' }];
+
+      expect(plexModule.getLibraryIdForSubfolder('unknown')).toBe('1');
+    });
+
+    test('returns mapping for root (null) subfolder', () => {
+      config.plexSubfolderLibraryMappings = [{ subfolder: null, libraryId: '4' }];
+
+      expect(plexModule.getLibraryIdForSubfolder(null)).toBe('4');
+    });
+
+    test('falls back to global ID when mappings array is empty', () => {
+      config.plexSubfolderLibraryMappings = [];
+
+      expect(plexModule.getLibraryIdForSubfolder('anything')).toBe('1');
+    });
+
+    test('falls back to global ID when plexSubfolderLibraryMappings is undefined', () => {
+      delete config.plexSubfolderLibraryMappings;
+
+      expect(plexModule.getLibraryIdForSubfolder('kids')).toBe('1');
+    });
+  });
+
+  describe('refreshLibraryForSubfolder', () => {
+    test('refreshes the library mapped to the given subfolder', async () => {
+      config.plexSubfolderLibraryMappings = [{ subfolder: 'kids', libraryId: '2' }];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibraryForSubfolder('kids');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/library/sections/2/refresh')
+      );
+    });
+
+    test('falls back to global library when no mapping for subfolder', async () => {
+      config.plexSubfolderLibraryMappings = [];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibraryForSubfolder('unknown');
+
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/library/sections/1/refresh')
+      );
+    });
+
+    test('uses global library for null (root) subfolder when no root mapping', async () => {
+      config.plexSubfolderLibraryMappings = [];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibraryForSubfolder(null);
+
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/library/sections/1/refresh')
+      );
+    });
+  });
+
+  describe('refreshLibrariesForSubfolders', () => {
+    test('refreshes each distinct library once', async () => {
+      config.plexSubfolderLibraryMappings = [
+        { subfolder: 'kids', libraryId: '2' },
+        { subfolder: 'music', libraryId: '3' },
+      ];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibrariesForSubfolders(['kids', 'music', null]);
+
+      // kids -> 2, music -> 3, null -> 1 (fallback): 3 distinct IDs → 3 calls
+      expect(axios.get).toHaveBeenCalledTimes(3);
+    });
+
+    test('deduplicates when two different subfolders map to the same library ID', async () => {
+      config.plexSubfolderLibraryMappings = [
+        { subfolder: 'kids', libraryId: '2' },
+        { subfolder: 'cartoons', libraryId: '2' }, // same target library as kids
+      ];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibrariesForSubfolders(['kids', 'cartoons']);
+
+      // Both resolve to library '2' — only one HTTP call should be made
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/library/sections/2/refresh')
+      );
+    });
+
+    test('refreshes global fallback library when all subfolders are unmapped', async () => {
+      config.plexSubfolderLibraryMappings = [];
+      axios.get.mockResolvedValue({ status: 200 });
+
+      await plexModule.refreshLibrariesForSubfolders([null, 'foo', 'bar']);
+
+      // All three map to the global ID '1': deduplicated to one call
+      expect(axios.get).toHaveBeenCalledTimes(1);
+      expect(axios.get).toHaveBeenCalledWith(
+        expect.stringContaining('/library/sections/1/refresh')
+      );
+    });
+
+    test('handles empty subfolders array without making any calls', async () => {
+      await plexModule.refreshLibrariesForSubfolders([]);
+
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    test('continues refreshing remaining libraries when one fails', async () => {
+      config.plexSubfolderLibraryMappings = [
+        { subfolder: 'kids', libraryId: '2' },
+        { subfolder: 'music', libraryId: '3' },
+      ];
+      // Library '2' fails; library '3' must still be called and the promise must resolve
+      axios.get
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({ status: 200 });
+
+      await expect(
+        plexModule.refreshLibrariesForSubfolders(['kids', 'music'])
+      ).resolves.toBeUndefined();
+
+      expect(axios.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('refreshLibraryForSubfolder - error handling', () => {
+    test('propagates rejection when refreshLibrary throws unexpectedly', async () => {
+      config.plexSubfolderLibraryMappings = [{ subfolder: 'kids', libraryId: '2' }];
+      // Force the axios call inside refreshLibrary to throw synchronously after try/catch
+      // by making getBaseUrl produce a value but axios.get throwing past the catch
+      // In practice refreshLibrary catches all errors and returns null, so this confirms
+      // that the method resolves (does not throw) even when the underlying call fails.
+      axios.get.mockRejectedValue(new Error('Unexpected'));
+
+      await expect(plexModule.refreshLibraryForSubfolder('kids')).resolves.toBeNull();
     });
   });
 

--- a/server/modules/__tests__/plexModule.test.js
+++ b/server/modules/__tests__/plexModule.test.js
@@ -302,6 +302,19 @@ describe('plexModule', () => {
 
       expect(plexModule.getLibraryIdForSubfolder('kids')).toBe('1');
     });
+
+    test('skips null and non-object entries in mappings array without throwing', () => {
+      config.plexSubfolderLibraryMappings = [
+        null,
+        undefined,
+        'bad-string',
+        42,
+        { subfolder: 'kids', libraryId: '2' },
+      ];
+
+      expect(plexModule.getLibraryIdForSubfolder('kids')).toBe('2');
+      expect(plexModule.getLibraryIdForSubfolder('unknown')).toBe('1');
+    });
   });
 
   describe('refreshLibraryForSubfolder', () => {
@@ -407,7 +420,7 @@ describe('plexModule', () => {
   });
 
   describe('refreshLibraryForSubfolder - error handling', () => {
-    test('propagates rejection when refreshLibrary throws unexpectedly', async () => {
+    test('resolves to null when the underlying refresh fails', async () => {
       config.plexSubfolderLibraryMappings = [{ subfolder: 'kids', libraryId: '2' }];
       // Force the axios call inside refreshLibrary to throw synchronously after try/catch
       // by making getBaseUrl produce a value but axios.get throwing past the catch

--- a/server/modules/__tests__/videoDeletionModule.test.js
+++ b/server/modules/__tests__/videoDeletionModule.test.js
@@ -871,6 +871,15 @@ describe('VideoDeletionModule', () => {
         'Error getting videos older than threshold'
       );
     });
+
+    test('should exclude protected videos from results', async () => {
+      mockSequelize.query.mockResolvedValue([]);
+
+      await VideoDeletionModule.getVideosOlderThanThreshold(30);
+
+      const queryString = mockSequelize.query.mock.calls[0][0];
+      expect(queryString).toContain('Videos.protected = 0');
+    });
   });
 
   describe('getOldestVideos', () => {
@@ -982,6 +991,15 @@ describe('VideoDeletionModule', () => {
         expect.objectContaining({ err: expect.any(Error) }),
         'Error getting oldest videos'
       );
+    });
+
+    test('should exclude protected videos from results', async () => {
+      mockSequelize.query.mockResolvedValue([]);
+
+      await VideoDeletionModule.getOldestVideos(10);
+
+      const queryString = mockSequelize.query.mock.calls[0][0];
+      expect(queryString).toContain('Videos.protected = 0');
     });
   });
 

--- a/server/modules/__tests__/videoMetadataModule.test.js
+++ b/server/modules/__tests__/videoMetadataModule.test.js
@@ -350,6 +350,56 @@ describe('VideoMetadataModule', () => {
 
       expect(result).toEqual([360, 480, 1440, 2160]);
     });
+
+    test('uses format_note tier for non-16:9 videos (actual height differs from tier)', () => {
+      // 2:1 aspect video: actual heights are half the width, but tier labels match standard buckets
+      const formats = [
+        { height: 320, format_note: '360p', vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 428, format_note: '480p', vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 640, format_note: '720p', vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 960, format_note: '1080p', vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([360, 480, 720, 1080]);
+    });
+
+    test('format_note with framerate suffix still extracts base tier', () => {
+      const formats = [
+        { height: 1080, format_note: '1080p60', vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 720, format_note: '720p60', vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([720, 1080]);
+    });
+  });
+
+  describe('_extractTierFromFormatNote', () => {
+    test('parses plain tier like "1080p"', () => {
+      expect(videoMetadataModule._extractTierFromFormatNote('1080p')).toBe(1080);
+    });
+
+    test('parses tier with framerate like "1080p60"', () => {
+      expect(videoMetadataModule._extractTierFromFormatNote('1080p60')).toBe(1080);
+    });
+
+    test('parses tier with audio suffix like "1080p+medium"', () => {
+      expect(videoMetadataModule._extractTierFromFormatNote('1080p+medium')).toBe(1080);
+    });
+
+    test('returns null for null, undefined, or empty input', () => {
+      expect(videoMetadataModule._extractTierFromFormatNote(null)).toBeNull();
+      expect(videoMetadataModule._extractTierFromFormatNote(undefined)).toBeNull();
+      expect(videoMetadataModule._extractTierFromFormatNote('')).toBeNull();
+    });
+
+    test('returns null when string does not start with a tier', () => {
+      expect(videoMetadataModule._extractTierFromFormatNote('medium')).toBeNull();
+      expect(videoMetadataModule._extractTierFromFormatNote('high quality')).toBeNull();
+    });
   });
 
   describe('_getVideoRelatedFiles', () => {

--- a/server/modules/__tests__/videoMetadataModule.test.js
+++ b/server/modules/__tests__/videoMetadataModule.test.js
@@ -1,0 +1,521 @@
+/* eslint-env jest */
+
+describe('VideoMetadataModule', () => {
+  let videoMetadataModule;
+  let mockFs;
+  let mockVideo;
+  let mockLogger;
+  let mockConfigModule;
+  let mockYtDlpRunner;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    mockFs = {
+      access: jest.fn(),
+      readFile: jest.fn(),
+      writeFile: jest.fn(),
+      mkdir: jest.fn(),
+      stat: jest.fn(),
+      readdir: jest.fn(),
+    };
+
+    mockVideo = {
+      findOne: jest.fn(),
+      findAll: jest.fn(),
+      findByPk: jest.fn(),
+      count: jest.fn(),
+      update: jest.fn(),
+    };
+
+    mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      trace: jest.fn(),
+      fatal: jest.fn(),
+    };
+
+    mockConfigModule = {
+      directoryPath: '/test/data',
+      getJobsPath: jest.fn().mockReturnValue('/test/jobs'),
+    };
+
+    mockYtDlpRunner = {
+      fetchMetadata: jest.fn(),
+    };
+
+    jest.doMock('fs', () => ({ promises: mockFs }));
+    jest.doMock('../../models', () => ({ Video: mockVideo }));
+    jest.doMock('../configModule', () => mockConfigModule);
+    jest.doMock('../../logger', () => mockLogger);
+    jest.doMock('../ytDlpRunner', () => mockYtDlpRunner);
+
+    videoMetadataModule = require('../videoMetadataModule');
+  });
+
+  describe('getVideoMetadata', () => {
+    test('returns curated metadata from cached .info.json file', async () => {
+      const rawInfoJson = {
+        description: 'A great video',
+        view_count: 12345,
+        like_count: 100,
+        comment_count: 50,
+        tags: ['test', 'video'],
+        categories: ['Entertainment'],
+        upload_date: '20240315',
+        resolution: '1920x1080',
+        height: 1080,
+        width: 1920,
+        aspect_ratio: 1.78,
+        fps: 30,
+        language: 'en',
+        is_live: false,
+        was_live: false,
+        availability: 'public',
+        channel_follower_count: 5000,
+        age_limit: 0,
+        webpage_url: 'https://www.youtube.com/watch?v=abc123',
+        // These bulk fields should NOT appear in output
+        formats: [{ format_id: '137' }],
+        automatic_captions: { en: [] },
+        thumbnails: [{ url: 'http://example.com/thumb.jpg' }],
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'abc123',
+        originalDate: '20240315',
+        update: jest.fn(),
+      });
+
+      const result = await videoMetadataModule.getVideoMetadata('abc123');
+
+      expect(result.description).toBe('A great video');
+      expect(result.viewCount).toBe(12345);
+      expect(result.likeCount).toBe(100);
+      expect(result.commentCount).toBe(50);
+      expect(result.tags).toEqual(['test', 'video']);
+      expect(result.categories).toEqual(['Entertainment']);
+      expect(result.uploadDate).toBe('20240315');
+      expect(result.resolution).toBe('1920x1080');
+      expect(result.fps).toBe(30);
+      expect(result.aspectRatio).toBe(1.78);
+      expect(result.language).toBe('en');
+      expect(result.isLive).toBe(false);
+      expect(result.wasLive).toBe(false);
+      expect(result.availability).toBe('public');
+      expect(result.channelFollowerCount).toBe(5000);
+      expect(result.ageLimit).toBe(0);
+      expect(result.webpageUrl).toBe('https://www.youtube.com/watch?v=abc123');
+
+      // Bulk arrays should NOT be in result
+      expect(result.formats).toBeUndefined();
+      expect(result.automatic_captions).toBeUndefined();
+      expect(result.thumbnails).toBeUndefined();
+    });
+
+    test('fetches from yt-dlp when cached file does not exist', async () => {
+      const ytdlpData = {
+        description: 'Fetched description',
+        view_count: 999,
+        like_count: 10,
+        upload_date: '20240101',
+        resolution: '1280x720',
+        height: 720,
+        width: 1280,
+        aspect_ratio: 1.78,
+      };
+
+      // fs.access rejects (file not found)
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockYtDlpRunner.fetchMetadata.mockResolvedValue(ytdlpData);
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockFs.writeFile.mockResolvedValue(undefined);
+      mockVideo.findOne.mockResolvedValue(null);
+
+      const result = await videoMetadataModule.getVideoMetadata('xyz789');
+
+      expect(mockYtDlpRunner.fetchMetadata).toHaveBeenCalledWith(
+        'https://www.youtube.com/watch?v=xyz789',
+        60000
+      );
+      expect(result.description).toBe('Fetched description');
+      expect(result.viewCount).toBe(999);
+      expect(result.resolution).toBe('1280x720');
+
+      // Should have cached the result
+      expect(mockFs.mkdir).toHaveBeenCalledWith(
+        expect.stringContaining('info'),
+        { recursive: true }
+      );
+      expect(mockFs.writeFile).toHaveBeenCalled();
+    });
+
+    test('returns all-null metadata when yt-dlp also fails', async () => {
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockYtDlpRunner.fetchMetadata.mockRejectedValue(new Error('yt-dlp failed'));
+
+      const result = await videoMetadataModule.getVideoMetadata('fail123');
+
+      expect(result.description).toBeNull();
+      expect(result.viewCount).toBeNull();
+      expect(result.resolution).toBeNull();
+      expect(result.webpageUrl).toBeNull();
+    });
+
+    test('backfills originalDate when DB record has no date', async () => {
+      const rawInfoJson = {
+        upload_date: '20240515',
+        description: 'test',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+
+      const mockVideoRecord = {
+        youtubeId: 'backfill1',
+        originalDate: null,
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+      mockVideo.findOne.mockResolvedValue(mockVideoRecord);
+
+      await videoMetadataModule.getVideoMetadata('backfill1');
+
+      expect(mockVideoRecord.update).toHaveBeenCalledWith({ originalDate: '20240515' });
+    });
+
+    test('backfills originalDate when DB record has different date', async () => {
+      const rawInfoJson = {
+        upload_date: '20240515',
+        description: 'test',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+
+      const mockVideoRecord = {
+        youtubeId: 'backfill2',
+        originalDate: '20240514',
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+      mockVideo.findOne.mockResolvedValue(mockVideoRecord);
+
+      await videoMetadataModule.getVideoMetadata('backfill2');
+
+      expect(mockVideoRecord.update).toHaveBeenCalledWith({ originalDate: '20240515' });
+    });
+
+    test('does not backfill when dates match', async () => {
+      const rawInfoJson = {
+        upload_date: '20240515',
+        description: 'test',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+
+      const mockVideoRecord = {
+        youtubeId: 'nobackfill',
+        originalDate: '20240515',
+        update: jest.fn(),
+      };
+      mockVideo.findOne.mockResolvedValue(mockVideoRecord);
+
+      await videoMetadataModule.getVideoMetadata('nobackfill');
+
+      expect(mockVideoRecord.update).not.toHaveBeenCalled();
+    });
+
+    test('handles missing optional fields gracefully', async () => {
+      const rawInfoJson = {
+        description: 'minimal video',
+        // Most fields are missing
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+
+      const result = await videoMetadataModule.getVideoMetadata('minimal1');
+
+      expect(result.description).toBe('minimal video');
+      expect(result.viewCount).toBeNull();
+      expect(result.likeCount).toBeNull();
+      expect(result.resolution).toBeNull();
+      expect(result.aspectRatio).toBeNull();
+      expect(result.fps).toBeNull();
+      expect(result.language).toBeNull();
+    });
+
+    test('caching failure does not prevent metadata return', async () => {
+      const ytdlpData = {
+        description: 'Should still return',
+        view_count: 42,
+      };
+
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockYtDlpRunner.fetchMetadata.mockResolvedValue(ytdlpData);
+      mockFs.mkdir.mockRejectedValue(new Error('Permission denied'));
+
+      const result = await videoMetadataModule.getVideoMetadata('cachefail1');
+
+      expect(result.description).toBe('Should still return');
+      expect(result.viewCount).toBe(42);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ youtubeId: 'cachefail1' }),
+        'Failed to cache .info.json'
+      );
+    });
+  });
+
+  describe('_extractAvailableResolutions', () => {
+    test('extracts supported resolutions from formats with video+audio streams', () => {
+      const formats = [
+        { height: 360, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 720, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 1080, vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([360, 720, 1080]);
+    });
+
+    test('excludes audio-only streams (vcodec is none)', () => {
+      const formats = [
+        { height: 720, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: null, vcodec: 'none', acodec: 'mp4a' },
+        { height: 0, vcodec: 'none', acodec: 'opus' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([720]);
+    });
+
+    test('deduplicates heights', () => {
+      const formats = [
+        { height: 1080, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 1080, vcodec: 'vp9', acodec: 'opus' },
+        { height: 1080, vcodec: 'av01', acodec: 'mp4a' },
+        { height: 720, vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([720, 1080]);
+    });
+
+    test('returns null for empty array', () => {
+      const result = videoMetadataModule._extractAvailableResolutions([]);
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null for null input', () => {
+      const result = videoMetadataModule._extractAvailableResolutions(null);
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null for undefined input', () => {
+      const result = videoMetadataModule._extractAvailableResolutions(undefined);
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when no formats have supported heights', () => {
+      const formats = [
+        { height: 144, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 240, vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toBeNull();
+    });
+
+    test('returns sorted resolutions', () => {
+      const formats = [
+        { height: 2160, vcodec: 'vp9', acodec: 'opus' },
+        { height: 360, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 1440, vcodec: 'vp9', acodec: 'opus' },
+        { height: 480, vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([360, 480, 1440, 2160]);
+    });
+  });
+
+  describe('_getVideoRelatedFiles', () => {
+    test('returns related files with correct categorization', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'rel123',
+        filePath: '/data/channel/My Video [rel123].mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'My Video [rel123].mp4',
+        'My Video [rel123].jpg',
+        'My Video [rel123].nfo',
+        'My Video [rel123].info.json',
+        'Other Video [other1].mp4',
+      ]);
+
+      mockFs.stat
+        .mockResolvedValueOnce({ size: 50000 })   // .jpg
+        .mockResolvedValueOnce({ size: 1200 })     // .nfo
+        .mockResolvedValueOnce({ size: 85000 });   // .info.json
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('rel123');
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({ fileName: 'My Video [rel123].jpg', fileSize: 50000, type: 'Thumbnail' });
+      expect(result[1]).toEqual({ fileName: 'My Video [rel123].nfo', fileSize: 1200, type: 'NFO Metadata' });
+      expect(result[2]).toEqual({ fileName: 'My Video [rel123].info.json', fileSize: 85000, type: 'Info JSON' });
+    });
+
+    test('does not include filePath in results', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'nopath1',
+        filePath: '/data/channel/Video [nopath1].mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'Video [nopath1].mp4',
+        'Video [nopath1].jpg',
+      ]);
+
+      mockFs.stat.mockResolvedValueOnce({ size: 1000 });
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('nopath1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].filePath).toBeUndefined();
+      expect(result[0].fileName).toBe('Video [nopath1].jpg');
+    });
+
+    test('excludes main video and audio files', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'excl1',
+        filePath: '/data/channel/Video [excl1].mp4',
+        audioFilePath: '/data/channel/Video [excl1].mp3',
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'Video [excl1].mp4',
+        'Video [excl1].mp3',
+        'Video [excl1].jpg',
+      ]);
+
+      mockFs.stat.mockResolvedValueOnce({ size: 2000 });
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('excl1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('Video [excl1].jpg');
+    });
+
+    test('returns null when video not found in database', async () => {
+      mockVideo.findOne.mockResolvedValue(null);
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('missing1');
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when video has no filePath', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'nofp1',
+        filePath: null,
+      });
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('nofp1');
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when directory does not exist', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'nodir1',
+        filePath: '/data/missing-channel/Video [nodir1].mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockRejectedValue(new Error('ENOENT: no such file or directory'));
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('nodir1');
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when no matching related files exist', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'nomatch1',
+        filePath: '/data/channel/Video [nomatch1].mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'Video [nomatch1].mp4',
+        'Other Video [other1].jpg',
+        'unrelated-file.txt',
+      ]);
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('nomatch1');
+
+      expect(result).toBeNull();
+    });
+
+    test('matches files using " - youtubeId" pattern', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'dash1',
+        filePath: '/data/channel/Video - dash1.mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'Video - dash1.mp4',
+        'Video - dash1.srt',
+      ]);
+
+      mockFs.stat.mockResolvedValueOnce({ size: 500 });
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('dash1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ fileName: 'Video - dash1.srt', fileSize: 500, type: 'Subtitles' });
+    });
+
+    test('handles stat failure for individual files gracefully', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'statfail1',
+        filePath: '/data/channel/Video [statfail1].mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'Video [statfail1].mp4',
+        'Video [statfail1].jpg',
+        'Video [statfail1].nfo',
+      ]);
+
+      // First stat call fails, second succeeds
+      mockFs.stat
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockResolvedValueOnce({ size: 800 });
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('statfail1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('Video [statfail1].nfo');
+    });
+  });
+});

--- a/server/modules/__tests__/videosModule.test.js
+++ b/server/modules/__tests__/videosModule.test.js
@@ -830,6 +830,43 @@ describe('VideosModule', () => {
     });
   });
 
+  describe('setVideoProtection', () => {
+    test('sets protected to true for existing video', async () => {
+      const mockVideoRecord = {
+        id: 1,
+        protected: false,
+        update: jest.fn().mockResolvedValue(),
+      };
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+
+      const result = await VideosModule.setVideoProtection(1, true);
+
+      expect(mockVideo.findByPk).toHaveBeenCalledWith(1);
+      expect(mockVideoRecord.update).toHaveBeenCalledWith({ protected: true });
+      expect(result).toEqual({ id: 1, protected: true });
+    });
+
+    test('sets protected to false for existing video', async () => {
+      const mockVideoRecord = {
+        id: 1,
+        protected: true,
+        update: jest.fn().mockResolvedValue(),
+      };
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+
+      const result = await VideosModule.setVideoProtection(1, false);
+
+      expect(mockVideoRecord.update).toHaveBeenCalledWith({ protected: false });
+      expect(result).toEqual({ id: 1, protected: false });
+    });
+
+    test('throws error when video not found', async () => {
+      mockVideo.findByPk.mockResolvedValue(null);
+
+      await expect(VideosModule.setVideoProtection(999, true)).rejects.toThrow('Video not found');
+    });
+  });
+
   describe('bulkUpdateVideoRatings', () => {
     test('clears metadata when null rating is applied and tracks missing videos', async () => {
       const existingId = 101;

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -1439,7 +1439,7 @@ class ChannelModule {
    * @param {string|null} dateTo - Filter videos to this date (ISO string, default null)
    * @returns {Promise<Array>} - Array of video objects with download status
    */
-  async fetchNewestVideosFromDb(channelId, limit = 50, offset = 0, excludeDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', checkFiles = false, mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null) {
+  async fetchNewestVideosFromDb(channelId, limit = 50, offset = 0, excludeDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', checkFiles = false, mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = false) {
     // First get all videos to enrich with download status
     const allChannelVideos = await ChannelVideo.findAll({
       where: {
@@ -1469,6 +1469,11 @@ class ChannelModule {
 
     // Apply duration and date filters
     filteredVideos = this._applyDurationAndDateFilters(filteredVideos, minDuration, maxDuration, dateFrom, dateTo);
+
+    // Apply protected filter
+    if (protectedFilter) {
+      filteredVideos = filteredVideos.filter(video => video.protected);
+    }
 
     // Apply sorting
     filteredVideos.sort((a, b) => {
@@ -1546,9 +1551,9 @@ class ChannelModule {
    * @param {string|null} dateTo - Filter videos to this date (ISO string, default null)
    * @returns {Promise<Object>} - Object with totalCount and oldestVideoDate
    */
-  async getChannelVideoStats(channelId, excludeDownloaded = false, searchQuery = '', mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null) {
+  async getChannelVideoStats(channelId, excludeDownloaded = false, searchQuery = '', mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = false) {
     // If we have search or filter, we need to get all videos
-    if (excludeDownloaded || searchQuery || minDuration !== null || maxDuration !== null || dateFrom || dateTo) {
+    if (excludeDownloaded || searchQuery || minDuration !== null || maxDuration !== null || dateFrom || dateTo || protectedFilter) {
       // Need to filter by download status and/or search
       const allChannelVideos = await ChannelVideo.findAll({
         where: {
@@ -1577,6 +1582,11 @@ class ChannelModule {
 
       // Apply duration and date filters
       filteredVideos = this._applyDurationAndDateFilters(filteredVideos, minDuration, maxDuration, dateFrom, dateTo);
+
+      // Apply protected filter
+      if (protectedFilter) {
+        filteredVideos = filteredVideos.filter(video => video.protected);
+      }
 
       return {
         totalCount: filteredVideos.length,
@@ -2085,7 +2095,7 @@ class ChannelModule {
    * @param {string|null} dateTo - Filter videos to this date (ISO string, default null)
    * @returns {Promise<Object>} - Response object with videos and metadata
    */
-  async getChannelVideos(channelId, page = 1, pageSize = 50, hideDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', tabType = TAB_TYPES.VIDEOS, minDuration = null, maxDuration = null, dateFrom = null, dateTo = null) {
+  async getChannelVideos(channelId, page = 1, pageSize = 50, hideDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', tabType = TAB_TYPES.VIDEOS, minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = false) {
     const channel = await Channel.findOne({
       where: { channel_id: channelId },
     });
@@ -2145,7 +2155,7 @@ class ChannelModule {
 
       // Now fetch the requested page of videos with file checking enabled
       const offset = (page - 1) * pageSize;
-      const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo);
+      const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter);
 
       // Check if videos still exist on YouTube and mark as removed if they don't
       const videoValidationModule = require('./videoValidationModule');
@@ -2215,15 +2225,15 @@ class ChannelModule {
       }
 
       // Get stats for the response
-      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo);
+      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter);
 
       return this.buildChannelVideosResponse(paginatedVideos, channel, 'cache', stats, autoDownloadsEnabled, mediaType);
 
     } catch (error) {
       logger.error({ err: error, channelId }, 'Error fetching channel videos');
       const offset = (page - 1) * pageSize;
-      const cachedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo);
-      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo);
+      const cachedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter);
+      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter);
       return this.buildChannelVideosResponse(cachedVideos, channel, 'cache', stats, autoDownloadsEnabled, mediaType);
     }
   }

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -1296,7 +1296,8 @@ class ChannelModule {
         'audioFilePath',
         'audioFileSize',
         'normalized_rating',
-        'rating_source'
+        'rating_source',
+        'protected'
       ]
     });
 
@@ -1313,7 +1314,8 @@ class ChannelModule {
         filePath: v.filePath,
         audioFilePath: v.audioFilePath,
         audioFileSize: v.audioFileSize,
-        normalized_rating: v.normalized_rating
+        normalized_rating: v.normalized_rating,
+        protected: v.protected
       });
 
       // Collect videos that need file checking (only if checkFiles is true and have any file path)
@@ -1358,6 +1360,8 @@ class ChannelModule {
         if (status.normalized_rating) {
           plainVideoObject.normalized_rating = status.normalized_rating;
         }
+        plainVideoObject.id = status.id;
+        plainVideoObject.protected = status.protected;
       } else {
         // Video never downloaded
         plainVideoObject.added = false;
@@ -1366,6 +1370,7 @@ class ChannelModule {
         plainVideoObject.filePath = null;
         plainVideoObject.audioFilePath = null;
         plainVideoObject.audioFileSize = null;
+        plainVideoObject.protected = false;
       }
 
       // Replace thumbnail with template format (unless video is removed from YouTube)

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -20,17 +20,7 @@ const { spawn, execSync } = require('child_process');
 
 const SUB_FOLDER_DEFAULT_KEY = '__default__';
 
-const TAB_TYPES = {
-  VIDEOS: 'videos',
-  SHORTS: 'shorts',
-  LIVE: 'streams',
-};
-
-const MEDIA_TAB_TYPE_MAP = {
-  'videos': 'video',
-  'shorts': 'short',
-  'streams': 'livestream',
-};
+const { TAB_TYPES, MEDIA_TAB_TYPE_MAP, parseTabCsv } = require('./tabsUtils');
 
 // Maximum number of videos to load when user clicks "Load More"
 // Limit set here because some channels have tens or hundreds of thousands of videos...
@@ -68,6 +58,33 @@ class ChannelModule {
       logger.error({ err: error, channelId: channel?.channel_id, mediaType }, 'Error parsing lastFetchedByTab');
       return null;
     }
+  }
+
+  /**
+   * Compute the "effective" available tabs for a channel by removing any
+   * user-hidden tabs from the detected list.
+   * @param {string|null} availableTabsCsv - Comma-separated list of detected tab types
+   * @param {string|null} hiddenTabsCsv - Comma-separated list of user-hidden tab types
+   * @returns {string[]} - Effective (detected minus hidden) tab types
+   */
+  computeEffectiveTabs(availableTabsCsv, hiddenTabsCsv) {
+    if (!availableTabsCsv) return [];
+
+    const detected = availableTabsCsv
+      .split(',')
+      .map((tab) => tab.trim())
+      .filter((tab) => tab.length > 0);
+
+    if (!hiddenTabsCsv) return detected;
+
+    const hidden = new Set(
+      hiddenTabsCsv
+        .split(',')
+        .map((tab) => tab.trim())
+        .filter((tab) => tab.length > 0)
+    );
+
+    return detected.filter((tab) => !hidden.has(tab));
   }
 
   /**
@@ -286,6 +303,7 @@ class ChannelModule {
    * @returns {Object} - Formatted channel response
    */
   mapChannelToResponse(channel) {
+    const effectiveTabs = this.computeEffectiveTabs(channel.available_tabs, channel.hidden_tabs);
     const out = {
       id: channel.channel_id,
       uploader: channel.uploader,
@@ -294,7 +312,7 @@ class ChannelModule {
       description: channel.description,
       url: channel.url,
       auto_download_enabled_tabs: channel.auto_download_enabled_tabs ?? 'video',
-      available_tabs: channel.available_tabs || null,
+      available_tabs: effectiveTabs.length > 0 ? effectiveTabs.join(',') : null,
       sub_folder: channel.sub_folder || null,
       video_quality: channel.video_quality || null,
       audio_format: channel.audio_format || null,
@@ -316,12 +334,13 @@ class ChannelModule {
    * @returns {Object} - Simplified channel representation
    */
   mapChannelListEntry(channel) {
+    const effectiveTabs = this.computeEffectiveTabs(channel.available_tabs, channel.hidden_tabs);
     const out = {
       url: channel.url,
       uploader: channel.uploader || '',
       channel_id: channel.channel_id || '',
       auto_download_enabled_tabs: channel.auto_download_enabled_tabs ?? 'video',
-      available_tabs: channel.available_tabs || null,
+      available_tabs: effectiveTabs.length > 0 ? effectiveTabs.join(',') : null,
       sub_folder: channel.sub_folder || null,
       video_quality: channel.video_quality || null,
       min_duration: channel.min_duration || null,
@@ -1817,8 +1836,10 @@ class ChannelModule {
    * @returns {Object} - Formatted response
    */
   buildChannelVideosResponse(videos, channel, dataSource = 'cache', stats = null, autoDownloadsEnabled = false, mediaType = 'video') {
-    // Parse available tabs if present
-    const availableTabs = channel && channel.available_tabs ? channel.available_tabs.split(',') : [];
+    // Parse available tabs if present (filters out user-hidden tabs)
+    const availableTabs = channel
+      ? this.computeEffectiveTabs(channel.available_tabs, channel.hidden_tabs)
+      : [];
 
     // Get the last fetched timestamp for this specific tab
     const lastFetched = channel ? this.getLastFetchedForTab(channel, mediaType) : null;
@@ -1896,9 +1917,46 @@ class ChannelModule {
   }
 
   /**
+   * Probe yt-dlp for each known tab type in parallel and return the list
+   * of detected tabs. Falls back to [TAB_TYPES.VIDEOS] if all probes fail
+   * so the channel stays usable. Shared by detectAndSaveChannelTabs and
+   * redetectChannelTabs to avoid drift between the two probe paths.
+   * @param {string} channelId - Channel ID to probe
+   * @returns {Promise<string[]>} - Detected tab types
+   * @private
+   */
+  async _probeTabsViaYtdlp(channelId) {
+    const tabTypesToTest = [TAB_TYPES.VIDEOS, TAB_TYPES.SHORTS, TAB_TYPES.LIVE];
+    const tabChecks = await Promise.all(
+      tabTypesToTest.map(async (tabType) => {
+        const exists = await this.checkTabExistsViaYtdlp(channelId, tabType);
+        if (exists) {
+          logger.info({ channelId, tabType }, 'Tab exists for channel');
+        } else {
+          logger.debug({ channelId, tabType }, 'Tab not available for channel');
+        }
+        return { tabType, exists };
+      })
+    );
+
+    const detected = tabChecks
+      .filter((result) => result.exists)
+      .map((result) => result.tabType);
+
+    if (detected.length === 0) {
+      logger.warn({ channelId }, 'All tab probes failed, defaulting to videos tab');
+      return [TAB_TYPES.VIDEOS];
+    }
+
+    return detected;
+  }
+
+  /**
    * Detect and save available tabs for a channel.
-   * Uses RSS feed checks for fast detection instead of yt-dlp.
-   * Uses activeFetches map to prevent concurrent detection for the same channel.
+   * Probes each tab type in parallel via yt-dlp. Short-circuits if
+   * the channel already has cached tabs (use redetectChannelTabs to
+   * force a fresh probe). Uses activeFetches map to prevent
+   * concurrent detection for the same channel.
    * @param {string} channelId - Channel ID to detect tabs for
    * @returns {Promise<{availableTabs: string[], autoDownloadEnabledTabs: string}|null>} - Detected tabs or null if skipped/failed
    */
@@ -1929,30 +1987,9 @@ class ChannelModule {
 
       logger.info({ channelId, channelTitle: channel.title }, 'Starting tab detection for channel (via yt-dlp)');
 
-      // Check all tabs in parallel using yt-dlp probing
-      const tabTypesToTest = [TAB_TYPES.VIDEOS, TAB_TYPES.SHORTS, TAB_TYPES.LIVE];
-      const tabChecks = await Promise.all(
-        tabTypesToTest.map(async (tabType) => {
-          const exists = await this.checkTabExistsViaYtdlp(channelId, tabType);
-          if (exists) {
-            logger.info({ channelId, tabType }, 'Tab exists for channel');
-          } else {
-            logger.debug({ channelId, tabType }, 'Tab not available for channel');
-          }
-          return { tabType, exists };
-        })
-      );
-
-      let availableTabs = tabChecks
-        .filter(result => result.exists)
-        .map(result => result.tabType);
-
-      // Fallback: if all RSS checks failed (e.g., network timeout), assume "videos" tab exists
-      // This prevents channels from being added with no tabs, which would make them unusable
-      if (availableTabs.length === 0) {
-        logger.warn({ channelId }, 'All tab checks failed, defaulting to videos tab');
-        availableTabs = [TAB_TYPES.VIDEOS];
-      }
+      // Probe every tab type in parallel via yt-dlp. Helper handles the
+      // fallback-to-videos behavior if all probes fail.
+      const availableTabs = await this._probeTabsViaYtdlp(channelId);
 
       // Determine auto_download_enabled_tabs: preserve existing user choice if set,
       // otherwise pick a smart default based on available tabs
@@ -1999,10 +2036,107 @@ class ChannelModule {
   }
 
   /**
+   * Force a fresh yt-dlp probe of a channel's tabs, bypassing any cached
+   * available_tabs value. Preserves the user's hidden_tabs selection and
+   * rewrites auto_download_enabled_tabs to drop any tabs that are no
+   * longer detected or are currently hidden.
+   *
+   * Concurrent calls for the same channel collapse to a single yt-dlp
+   * burst via the activeFetches map: a second caller receives the
+   * existing in-flight promise instead of spawning its own probe. This
+   * bounds at most one probe burst per channel in flight at any time.
+   *
+   * Use this when a channel's cached available_tabs is known to be stale
+   * (e.g. the RSS-era detection wrote a wrong value) and the user wants
+   * to re-run detection from the UI.
+   *
+   * @param {string} channelId - Channel ID to re-detect
+   * @returns {Promise<{availableTabs: string[], detectedTabs: string[], hiddenTabs: string[], autoDownloadEnabledTabs: string}>}
+   */
+  async redetectChannelTabs(channelId) {
+    const fetchKey = `redetect-tabs-${channelId}`;
+    const existing = this.activeFetches.get(fetchKey);
+    if (existing && existing.promise) {
+      logger.debug({ channelId }, 'redetectChannelTabs already running, awaiting in-flight probe');
+      return existing.promise;
+    }
+
+    const promise = this._redetectChannelTabsInner(channelId);
+    this.activeFetches.set(fetchKey, {
+      startTime: new Date().toISOString(),
+      type: 'tabRedetection',
+      promise,
+    });
+
+    try {
+      return await promise;
+    } finally {
+      this.activeFetches.delete(fetchKey);
+    }
+  }
+
+  /**
+   * Inner implementation of the redetect flow. Always executes a yt-dlp
+   * probe and database update. Do not call directly; go through
+   * redetectChannelTabs so the concurrency guard applies.
+   * @param {string} channelId - Channel ID to re-detect
+   * @returns {Promise<{availableTabs: string[], detectedTabs: string[], hiddenTabs: string[], autoDownloadEnabledTabs: string}>}
+   * @private
+   */
+  async _redetectChannelTabsInner(channelId) {
+    const channel = await Channel.findOne({ where: { channel_id: channelId } });
+    if (!channel) {
+      throw new Error('Channel not found in database');
+    }
+
+    logger.info({ channelId, channelTitle: channel.title }, 'Forcing tab re-detection for channel (via yt-dlp)');
+
+    const detectedTabs = await this._probeTabsViaYtdlp(channelId);
+    const hiddenTabs = parseTabCsv(channel.hidden_tabs);
+
+    // Compute effective tabs (what the user actually sees)
+    const effectiveTabs = this.computeEffectiveTabs(detectedTabs.join(','), channel.hidden_tabs);
+
+    // Rewrite auto_download_enabled_tabs: keep only entries whose
+    // corresponding tabType is both detected AND not hidden.
+    const validMediaTypes = new Set(effectiveTabs.map((tabType) => MEDIA_TAB_TYPE_MAP[tabType]).filter(Boolean));
+    const existingAutoTabs = parseTabCsv(channel.auto_download_enabled_tabs);
+    const filteredAutoTabs = existingAutoTabs.filter((mt) => validMediaTypes.has(mt));
+    const newAutoDownloadEnabledTabs = filteredAutoTabs.join(',');
+
+    await Channel.update(
+      {
+        available_tabs: detectedTabs.join(','),
+        auto_download_enabled_tabs: newAutoDownloadEnabledTabs
+      },
+      { where: { channel_id: channelId } }
+    );
+
+    logger.info(
+      { channelId, detectedTabs, hiddenTabs, effectiveTabs, autoDownloadEnabledTabs: newAutoDownloadEnabledTabs },
+      'Tab re-detection completed'
+    );
+
+    MessageEmitter.emitMessage('broadcast', null, 'channel', 'channelTabsDetected', {
+      channelId,
+      availableTabs: effectiveTabs,
+      autoDownloadEnabledTabs: newAutoDownloadEnabledTabs
+    });
+
+    return {
+      availableTabs: effectiveTabs,
+      detectedTabs,
+      hiddenTabs,
+      autoDownloadEnabledTabs: newAutoDownloadEnabledTabs
+    };
+  }
+
+  /**
    * Get available tabs for a channel.
-   * Returns cached result if available, otherwise detects tabs via RSS feeds.
+   * Returns cached result if available (filtered through hidden_tabs),
+   * otherwise detects tabs now via yt-dlp probing.
    * @param {string} channelId - Channel ID to get tabs for
-   * @returns {Promise<Object>} - Object with availableTabs array
+   * @returns {Promise<Object>} - Object with availableTabs array (effective set)
    */
   async getChannelAvailableTabs(channelId) {
     const channel = await Channel.findOne({
@@ -2013,18 +2147,20 @@ class ChannelModule {
       throw new Error('Channel not found in database');
     }
 
-    // Fast path: return cached tabs
+    // Fast path: return cached tabs (filtered through hidden_tabs)
     if (channel.available_tabs) {
       return {
-        availableTabs: channel.available_tabs.split(','),
+        availableTabs: this.computeEffectiveTabs(channel.available_tabs, channel.hidden_tabs),
       };
     }
 
-    // No tabs cached - detect them now (fast via RSS feeds)
+    // No tabs cached - detect them now via yt-dlp probing
     const result = await this.detectAndSaveChannelTabs(channelId);
+    const detectedTabs = result?.availableTabs || [];
+    const hiddenTabsCsv = channel.hidden_tabs || null;
 
     return {
-      availableTabs: result?.availableTabs || [],
+      availableTabs: this.computeEffectiveTabs(detectedTabs.join(','), hiddenTabsCsv),
     };
   }
 

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -6,6 +6,8 @@ const plexModule = require('./plexModule');
 const { Op } = require('sequelize');
 const logger = require('../logger');
 const ratingMapper = require('./ratingMapper');
+
+const { MEDIA_TAB_TYPE_MAP, VALID_TAB_TYPES, parseTabCsv } = require('./tabsUtils');
 const {
   GLOBAL_DEFAULT_SENTINEL,
   ROOT_SENTINEL,
@@ -517,6 +519,10 @@ class ChannelSettingsModule {
       throw new Error('Channel not found');
     }
 
+    const detectedTabs = parseTabCsv(channel.available_tabs);
+    const hiddenTabsSet = new Set(parseTabCsv(channel.hidden_tabs));
+    const availableTabs = detectedTabs.filter((tab) => !hiddenTabsSet.has(tab));
+
     return {
       channel_id: channel.channel_id,
       uploader: channel.uploader,
@@ -528,7 +534,51 @@ class ChannelSettingsModule {
       audio_format: channel.audio_format,
       default_rating: channel.default_rating,
       skip_video_folder: channel.skip_video_folder,
+      detected_tabs: detectedTabs,
+      hidden_tabs: Array.from(hiddenTabsSet),
+      available_tabs: availableTabs,
     };
+  }
+
+  /**
+   * Validate a hidden_tabs array from a user request.
+   * @param {any} hiddenTabs - The value provided in the update payload
+   * @param {string|null} detectedTabsCsv - The channel's current available_tabs (detected)
+   * @returns {{ valid: boolean, error?: string, normalized?: string[] }}
+   */
+  validateHiddenTabs(hiddenTabs, detectedTabsCsv) {
+    if (hiddenTabs === null || hiddenTabs === undefined) {
+      return { valid: true, normalized: [] };
+    }
+    if (!Array.isArray(hiddenTabs)) {
+      return { valid: false, error: 'Invalid hidden_tabs: must be an array of tab types' };
+    }
+
+    const normalized = [];
+    for (const entry of hiddenTabs) {
+      if (typeof entry !== 'string' || !VALID_TAB_TYPES.has(entry)) {
+        return {
+          valid: false,
+          error: `Invalid hidden_tabs entry: ${entry}. Allowed values: videos, shorts, streams`
+        };
+      }
+      if (!normalized.includes(entry)) {
+        normalized.push(entry);
+      }
+    }
+
+    const detected = parseTabCsv(detectedTabsCsv);
+    if (detected.length > 0) {
+      const remaining = detected.filter((tab) => !normalized.includes(tab));
+      if (remaining.length === 0) {
+        return {
+          valid: false,
+          error: 'At least one tab must remain visible'
+        };
+      }
+    }
+
+    return { valid: true, normalized };
   }
 
   /**
@@ -624,6 +674,16 @@ class ChannelSettingsModule {
       }
     }
 
+    // Validate hidden_tabs if provided
+    let normalizedHiddenTabs = null;
+    if (settings.hidden_tabs !== undefined) {
+      const validation = this.validateHiddenTabs(settings.hidden_tabs, channel.available_tabs);
+      if (!validation.valid) {
+        throw new Error(validation.error);
+      }
+      normalizedHiddenTabs = validation.normalized;
+    }
+
     // Store old subfolder for potential move
     const oldSubFolder = channel.sub_folder;
     const newSubFolder = settings.sub_folder !== undefined ?
@@ -663,6 +723,25 @@ class ChannelSettingsModule {
     if (settings.skip_video_folder !== undefined) {
       updateData.skip_video_folder = settings.skip_video_folder;
     }
+    if (normalizedHiddenTabs !== null) {
+      updateData.hidden_tabs = normalizedHiddenTabs.length > 0
+        ? normalizedHiddenTabs.join(',')
+        : null;
+
+      // When a tab is hidden, strip its corresponding media type from
+      // auto_download_enabled_tabs so we don't auto-download something the
+      // user has hidden from view.
+      const hiddenMediaTypes = new Set(
+        normalizedHiddenTabs
+          .map((tabType) => MEDIA_TAB_TYPE_MAP[tabType])
+          .filter(Boolean)
+      );
+      const currentAuto = parseTabCsv(channel.auto_download_enabled_tabs);
+      const filteredAuto = currentAuto.filter((mt) => !hiddenMediaTypes.has(mt));
+      if (filteredAuto.length !== currentAuto.length) {
+        updateData.auto_download_enabled_tabs = filteredAuto.join(',');
+      }
+    }
 
     // Update database FIRST to ensure changes are persisted before slow file operations
     // This prevents issues where HTTP requests timeout during file operations
@@ -698,6 +777,11 @@ class ChannelSettingsModule {
       }
     }
 
+    const detectedTabsAfter = parseTabCsv(updatedChannel.available_tabs);
+    const hiddenTabsAfter = parseTabCsv(updatedChannel.hidden_tabs);
+    const hiddenSetAfter = new Set(hiddenTabsAfter);
+    const availableTabsAfter = detectedTabsAfter.filter((tab) => !hiddenSetAfter.has(tab));
+
     return {
       settings: {
         channel_id: updatedChannel.channel_id,
@@ -710,6 +794,9 @@ class ChannelSettingsModule {
         audio_format: updatedChannel.audio_format,
         default_rating: updatedChannel.default_rating,
         skip_video_folder: updatedChannel.skip_video_folder,
+        detected_tabs: detectedTabsAfter,
+        hidden_tabs: hiddenTabsAfter,
+        available_tabs: availableTabsAfter,
       },
       folderMoved: subFolderChanged,
       moveResult

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -373,7 +373,16 @@ class ChannelSettingsModule {
 
   /**
    * Get all unique subfolders currently in use
-   * @returns {Promise<Array<string>>} - Array of unique subfolder names
+   *
+   * Includes:
+   * - Every explicit sub_folder value set on a channel (excluding the
+   *   ##USE_GLOBAL_DEFAULT## sentinel which is not a real folder name)
+   * - The configured global defaultSubfolder, if set. Channels on
+   *   ##USE_GLOBAL_DEFAULT## (and fresh installs with no channels at all)
+   *   still produce files under __{defaultSubfolder}/..., so the caller
+   *   must be able to see and map that folder.
+   *
+   * @returns {Promise<Array<string>>} - Array of unique subfolder names (with __ prefix)
    */
   async getAllSubFolders() {
     const channels = await Channel.findAll({
@@ -388,14 +397,22 @@ class ChannelSettingsModule {
       }
     });
 
-    const uniqueSubFolders = [...new Set(
+    const uniqueSubFolders = new Set(
       channels
         .map(ch => ch.sub_folder ? ch.sub_folder.trim() : null)
         .filter(folder => folder && folder !== GLOBAL_DEFAULT_SENTINEL)
-    )];
+    );
+
+    // Include the configured global default subfolder so the UI can map it
+    // even when no channels reference it explicitly. configModule already
+    // normalizes whitespace and returns null for empty values.
+    const globalDefault = configModule.getDefaultSubfolder();
+    if (globalDefault) {
+      uniqueSubFolders.add(globalDefault);
+    }
 
     // Add __ prefix for display (matches filesystem names)
-    return uniqueSubFolders.map(folder => buildSubfolderSegment(folder)).sort();
+    return [...uniqueSubFolders].map(folder => buildSubfolderSegment(folder)).sort();
   }
 
   /**

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const Channel = require('../models/channel');
 const configModule = require('./configModule');
+const plexModule = require('./plexModule');
 const { Op } = require('sequelize');
 const logger = require('../logger');
 const ratingMapper = require('./ratingMapper');
@@ -763,11 +764,13 @@ class ChannelSettingsModule {
       // Don't await this to prevent timeout issues from blocking the operation
       setImmediate(async () => {
         try {
-          const plexModule = require('./plexModule');
-          await plexModule.refreshLibrary();
-          logger.info('Plex library refresh completed after folder move');
+          await plexModule.refreshLibrariesForSubfolders([effectiveOldSubFolder, effectiveNewSubFolder]);
+          logger.info(
+            { oldSubfolder: effectiveOldSubFolder, newSubfolder: effectiveNewSubFolder },
+            'Plex library refresh completed after folder move (source and destination libraries notified)'
+          );
         } catch (plexError) {
-          logger.error({ err: plexError.message }, 'Could not refresh Plex library');
+          logger.error({ err: plexError }, 'Could not refresh Plex library');
           // Don't fail the whole operation if Plex refresh fails
         }
       });
@@ -780,7 +783,7 @@ class ChannelSettingsModule {
         newPath
       };
     } catch (error) {
-      logger.error({ err: error.message }, 'Error moving channel folder');
+      logger.error({ err: error }, 'Error moving channel folder');
       throw new Error(`Failed to move channel folder: ${error.message}`);
     }
   }

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -770,8 +770,8 @@ class ChannelSettingsModule {
             'Plex library refresh completed after folder move (source and destination libraries notified)'
           );
         } catch (plexError) {
+          // Defensive: refreshLibrary currently swallows errors internally
           logger.error({ err: plexError }, 'Could not refresh Plex library');
-          // Don't fail the whole operation if Plex refresh fails
         }
       });
       logger.info('Plex library refresh initiated asynchronously');

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -38,7 +38,7 @@ jest.mock('../../configModule', () => ({
 
 jest.mock('../../plexModule', () => ({
   refreshLibrary: jest.fn().mockResolvedValue(),
-  refreshLibraryForSubfolder: jest.fn().mockResolvedValue(),
+  refreshLibrariesForSubfolders: jest.fn().mockResolvedValue(),
 }));
 
 jest.mock('../../jobModule', () => ({
@@ -83,21 +83,25 @@ jest.mock('../../../models/channel', () => ({
 }));
 
 // Mock filesystem module
-jest.mock('../../filesystem', () => ({
-  isMainVideoFile: jest.fn(),
-  isVideoDirectory: jest.fn(),
-  isChannelDirectory: jest.fn(),
-  isDirectoryEmpty: jest.fn(),
-  cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false),
-  ROOT_SENTINEL: '##ROOT##',
-  GLOBAL_DEFAULT_SENTINEL: '##USE_GLOBAL_DEFAULT##',
-  resolveEffectiveSubfolder: jest.fn((subfolder) => {
-    if (subfolder === '##ROOT##') return null;
-    if (subfolder === '##USE_GLOBAL_DEFAULT##') return null;
-    if (subfolder && subfolder.trim() !== '') return subfolder.trim();
-    return null;
-  }),
-}));
+jest.mock('../../filesystem', () => {
+  const actualPathBuilder = jest.requireActual('../../filesystem/pathBuilder');
+  return {
+    isMainVideoFile: jest.fn(),
+    isVideoDirectory: jest.fn(),
+    isChannelDirectory: jest.fn(),
+    isDirectoryEmpty: jest.fn(),
+    cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false),
+    ROOT_SENTINEL: '##ROOT##',
+    GLOBAL_DEFAULT_SENTINEL: '##USE_GLOBAL_DEFAULT##',
+    resolveEffectiveSubfolder: jest.fn((subfolder) => {
+      if (subfolder === '##ROOT##') return null;
+      if (subfolder === '##USE_GLOBAL_DEFAULT##') return null;
+      if (subfolder && subfolder.trim() !== '') return subfolder.trim();
+      return null;
+    }),
+    extractSubfolderFromAbsPath: jest.fn(actualPathBuilder.extractSubfolderFromAbsPath),
+  };
+});
 
 const DownloadExecutor = require('../downloadExecutor');
 const filesystem = require('../../filesystem');
@@ -805,27 +809,114 @@ describe('DownloadExecutor', () => {
       expect(archiveModule.addVideoToArchive).toHaveBeenCalledWith('abc123XYZ_d');
     });
 
-    it('should trigger Plex library refresh for the subfolder on completion', async () => {
-      setTimeout(() => {
-        mockProcess.emit('exit', 0, null);
-      }, 10);
+    it('should refresh the Plex library for the subfolder extracted from the downloaded video path', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'abc123XYZ_d',
+          filePath: '/mock/output/__Adults/The Daily Show/The Daily Show - Video - abc123XYZ_d/The Daily Show - Video [abc123XYZ_d].mp4',
+          fileSize: '1024'
+        }
+      ]);
 
-      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, 'kids');
-
-      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith('kids');
-    });
-
-    it('should trigger Plex library refresh with null subfolder when none provided', async () => {
       setTimeout(() => {
         mockProcess.emit('exit', 0, null);
       }, 10);
 
       await executor.doDownload(mockArgs, mockJobId, mockJobType);
 
-      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledTimes(1);
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledWith(['Adults']);
+    });
+
+    it('should refresh with null when the downloaded video is in the root directory', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'abc123XYZ_d',
+          filePath: '/mock/output/ChannelName/ChannelName - Video - abc123XYZ_d/ChannelName - Video [abc123XYZ_d].mp4',
+          fileSize: '1024'
+        }
+      ]);
+
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledTimes(1);
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledWith([null]);
+    });
+
+    it('should refresh every distinct library once when videos span multiple subfolders', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'adults_vid1',
+          filePath: '/mock/output/__Adults/The Daily Show/vid1 - adults_vid1/vid1 [adults_vid1].mp4',
+          fileSize: '1024'
+        },
+        {
+          youtubeId: 'adults_vid2',
+          filePath: '/mock/output/__Adults/The Daily Show/vid2 - adults_vid2/vid2 [adults_vid2].mp4',
+          fileSize: '1024'
+        },
+        {
+          youtubeId: 'kids_vid1',
+          filePath: '/mock/output/__Kids/Sesame Street/vid3 - kids_vid1/vid3 [kids_vid1].mp4',
+          fileSize: '1024'
+        }
+      ]);
+
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledTimes(1);
+      const call = plexModule.refreshLibrariesForSubfolders.mock.calls[0][0];
+      expect(call).toHaveLength(2);
+      expect(new Set(call)).toEqual(new Set(['Adults', 'Kids']));
+    });
+
+    it('should fall back to audioFilePath when filePath is not set (audio-only download)', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'abc123XYZ_d',
+          filePath: null,
+          audioFilePath: '/mock/output/__Podcasts/Podcast Channel/Podcast - abc123XYZ_d/Podcast [abc123XYZ_d].mp3',
+          audioFileSize: '512'
+        }
+      ]);
+
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(plexModule.refreshLibrariesForSubfolders).toHaveBeenCalledWith(['Podcasts']);
+    });
+
+    it('should NOT trigger Plex refresh when no videos were downloaded', async () => {
+      // Default mock returns [] - no videos
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(plexModule.refreshLibrariesForSubfolders).not.toHaveBeenCalled();
     });
 
     it('should NOT trigger Plex refresh when skipJobTransition is true', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'abc123XYZ_d',
+          filePath: '/mock/output/__Adults/Channel/video - abc123XYZ_d/video [abc123XYZ_d].mp4',
+          fileSize: '1024'
+        }
+      ]);
+
       setTimeout(() => {
         mockProcess.emit('exit', 0, null);
       }, 10);
@@ -833,27 +924,7 @@ describe('DownloadExecutor', () => {
       // skipJobTransition=true (7th positional arg)
       await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, true, 'kids');
 
-      expect(plexModule.refreshLibraryForSubfolder).not.toHaveBeenCalled();
-    });
-
-    it('should normalize ##ROOT## sentinel to null before Plex refresh', async () => {
-      setTimeout(() => {
-        mockProcess.emit('exit', 0, null);
-      }, 10);
-
-      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, '##ROOT##');
-
-      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
-    });
-
-    it('should normalize ##USE_GLOBAL_DEFAULT## sentinel before Plex refresh', async () => {
-      setTimeout(() => {
-        mockProcess.emit('exit', 0, null);
-      }, 10);
-
-      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, '##USE_GLOBAL_DEFAULT##');
-
-      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
+      expect(plexModule.refreshLibrariesForSubfolders).not.toHaveBeenCalled();
     });
 
     it('should start next job after completion', async () => {

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -37,7 +37,8 @@ jest.mock('../../configModule', () => ({
 }));
 
 jest.mock('../../plexModule', () => ({
-  refreshLibrary: jest.fn().mockResolvedValue()
+  refreshLibrary: jest.fn().mockResolvedValue(),
+  refreshLibraryForSubfolder: jest.fn().mockResolvedValue(),
 }));
 
 jest.mock('../../jobModule', () => ({
@@ -796,14 +797,35 @@ describe('DownloadExecutor', () => {
       expect(archiveModule.addVideoToArchive).toHaveBeenCalledWith('abc123XYZ_d');
     });
 
-    it('should trigger Plex library refresh on completion', async () => {
+    it('should trigger Plex library refresh for the subfolder on completion', async () => {
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, 'kids');
+
+      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith('kids');
+    });
+
+    it('should trigger Plex library refresh with null subfolder when none provided', async () => {
       setTimeout(() => {
         mockProcess.emit('exit', 0, null);
       }, 10);
 
       await executor.doDownload(mockArgs, mockJobId, mockJobType);
 
-      expect(plexModule.refreshLibrary).toHaveBeenCalled();
+      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
+    });
+
+    it('should NOT trigger Plex refresh when skipJobTransition is true', async () => {
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      // skipJobTransition=true (7th positional arg)
+      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, true, 'kids');
+
+      expect(plexModule.refreshLibraryForSubfolder).not.toHaveBeenCalled();
     });
 
     it('should start next job after completion', async () => {

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -92,6 +92,7 @@ jest.mock('../../filesystem', () => ({
   ROOT_SENTINEL: '##ROOT##',
   GLOBAL_DEFAULT_SENTINEL: '##USE_GLOBAL_DEFAULT##',
   resolveEffectiveSubfolder: jest.fn((subfolder) => {
+    if (subfolder === '##ROOT##') return null;
     if (subfolder === '##USE_GLOBAL_DEFAULT##') return null;
     if (subfolder && subfolder.trim() !== '') return subfolder.trim();
     return null;

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -88,7 +88,14 @@ jest.mock('../../filesystem', () => ({
   isVideoDirectory: jest.fn(),
   isChannelDirectory: jest.fn(),
   isDirectoryEmpty: jest.fn(),
-  cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false)
+  cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false),
+  ROOT_SENTINEL: '##ROOT##',
+  GLOBAL_DEFAULT_SENTINEL: '##USE_GLOBAL_DEFAULT##',
+  resolveEffectiveSubfolder: jest.fn((subfolder) => {
+    if (subfolder === '##USE_GLOBAL_DEFAULT##') return null;
+    if (subfolder && subfolder.trim() !== '') return subfolder.trim();
+    return null;
+  }),
 }));
 
 const DownloadExecutor = require('../downloadExecutor');
@@ -826,6 +833,26 @@ describe('DownloadExecutor', () => {
       await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, true, 'kids');
 
       expect(plexModule.refreshLibraryForSubfolder).not.toHaveBeenCalled();
+    });
+
+    it('should normalize ##ROOT## sentinel to null before Plex refresh', async () => {
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, '##ROOT##');
+
+      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
+    });
+
+    it('should normalize ##USE_GLOBAL_DEFAULT## sentinel before Plex refresh', async () => {
+      setTimeout(() => {
+        mockProcess.emit('exit', 0, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType, 0, null, false, false, '##USE_GLOBAL_DEFAULT##');
+
+      expect(plexModule.refreshLibraryForSubfolder).toHaveBeenCalledWith(null);
     });
 
     it('should start next job after completion', async () => {

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -1390,7 +1390,11 @@ class DownloadExecutor {
 
         // Only refresh Plex and start next job if not processing multiple groups
         if (!skipJobTransition) {
-          plexModule.refreshLibraryForSubfolder(subfolderOverride).catch(err => {
+          // Normalize sentinel values before Plex lookup: ##ROOT## → null, ##USE_GLOBAL_DEFAULT## → resolved default
+          const resolvedSubfolder = subfolderOverride === filesystem.ROOT_SENTINEL
+            ? null
+            : filesystem.resolveEffectiveSubfolder(subfolderOverride, configModule.getConfig().defaultSubfolder || null);
+          plexModule.refreshLibraryForSubfolder(resolvedSubfolder).catch(err => {
             logger.error({ err }, 'Failed to refresh Plex library');
           });
           jobModule.startNextJob().catch(err => {

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -1390,7 +1390,7 @@ class DownloadExecutor {
 
         // Only refresh Plex and start next job if not processing multiple groups
         if (!skipJobTransition) {
-          plexModule.refreshLibrary().catch(err => {
+          plexModule.refreshLibraryForSubfolder(subfolderOverride).catch(err => {
             logger.error({ err }, 'Failed to refresh Plex library');
           });
           jobModule.startNextJob().catch(err => {

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -1390,11 +1390,26 @@ class DownloadExecutor {
 
         // Only refresh Plex and start next job if not processing multiple groups
         if (!skipJobTransition) {
-          const resolvedSubfolder = filesystem.resolveEffectiveSubfolder(subfolderOverride, configModule.getConfig().defaultSubfolder || null);
-          // Defensive: refreshLibrary currently swallows errors internally
-          plexModule.refreshLibraryForSubfolder(resolvedSubfolder).catch(err => {
-            logger.error({ err }, 'Failed to refresh Plex library');
-          });
+          // Derive the set of subfolders from where each video actually ended up
+          // on disk. This mirrors reality (the post-processor may have placed
+          // each video under its channel-specific sub_folder) instead of relying
+          // on the job-level subfolderOverride, which is null for typical
+          // manual URL and non-grouped channel downloads.
+          const baseDir = configModule.directoryPath;
+          const subfoldersInUse = new Set();
+          for (const video of (videoData || [])) {
+            const mediaPath = video.filePath || video.audioFilePath;
+            if (!mediaPath) continue;
+            subfoldersInUse.add(filesystem.extractSubfolderFromAbsPath(mediaPath, baseDir));
+          }
+
+          if (subfoldersInUse.size > 0) {
+            // Defensive: refreshLibrary currently swallows errors internally
+            plexModule.refreshLibrariesForSubfolders([...subfoldersInUse]).catch(err => {
+              logger.error({ err }, 'Failed to refresh Plex libraries');
+            });
+          }
+
           jobModule.startNextJob().catch(err => {
             logger.error({ err }, 'Failed to start next job');
           });

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -1390,10 +1390,8 @@ class DownloadExecutor {
 
         // Only refresh Plex and start next job if not processing multiple groups
         if (!skipJobTransition) {
-          // Normalize sentinel values before Plex lookup: ##ROOT## → null, ##USE_GLOBAL_DEFAULT## → resolved default
-          const resolvedSubfolder = subfolderOverride === filesystem.ROOT_SENTINEL
-            ? null
-            : filesystem.resolveEffectiveSubfolder(subfolderOverride, configModule.getConfig().defaultSubfolder || null);
+          const resolvedSubfolder = filesystem.resolveEffectiveSubfolder(subfolderOverride, configModule.getConfig().defaultSubfolder || null);
+          // Defensive: refreshLibrary currently swallows errors internally
           plexModule.refreshLibraryForSubfolder(resolvedSubfolder).catch(err => {
             logger.error({ err }, 'Failed to refresh Plex library');
           });

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -1,5 +1,6 @@
 const configModule = require('./configModule');
 const jobModule = require('./jobModule');
+const plexModule = require('./plexModule');
 const DownloadExecutor = require('./download/downloadExecutor');
 const YtdlpCommandBuilder = require('./download/ytdlpCommandBuilder');
 const tempPathManager = require('./download/tempPathManager');
@@ -106,7 +107,7 @@ class DownloadModule {
         groups.some((g) => g.filterConfig && g.filterConfig.hasGroupingCriteria && g.filterConfig.hasGroupingCriteria());
 
       if (needsGrouping) {
-        console.log(`Using grouped downloads: ${groups.length} group(s) with resolved settings`);
+        logger.info({ groupCount: groups.length }, 'Using grouped downloads with resolved settings');
         return await this.doGroupedChannelDownloads(jobData, groups, isNextJob);
       }
 
@@ -187,7 +188,7 @@ class DownloadModule {
   }
 
   async doGroupedChannelDownloads(jobData, groups, isNextJob = false) {
-    console.log(`Processing ${groups.length} channel download groups in a single job`);
+    logger.info({ groupCount: groups.length }, 'Processing channel download groups in a single job');
 
     // Create ONE job for all groups
     const jobType = `Channel Downloads - ${groups.length} group(s)`;
@@ -227,7 +228,7 @@ class DownloadModule {
       const groupDesc = `Group ${i + 1}/${groups.length} (${group.quality}p${group.subFolder ? `, ${group.subFolder}` : ''})`;
       const groupJobType = `Channel Downloads - ${groupDesc}`;
 
-      console.log(`Processing ${groupJobType} with ${group.channels.length} channels`);
+      logger.info({ groupJobType, channelCount: group.channels.length }, 'Processing download group');
 
       // Update job type to show current group
       await jobModule.updateJob(jobId, {
@@ -237,7 +238,7 @@ class DownloadModule {
       try {
         // Execute this group's download (without starting next job)
         await this.executeGroupDownload(group, jobId, groupJobType, jobData, true);
-        console.log(`Completed ${groupJobType}`);
+        logger.info({ groupJobType }, 'Completed download group');
       } catch (err) {
         logger.error({ err, group: groupDesc }, 'Error processing download group');
         await jobModule.updateJob(jobId, {
@@ -319,10 +320,12 @@ class DownloadModule {
       }
     }
 
-    // Refresh Plex library once after all groups
-    const plexModule = require('./plexModule');
-    plexModule.refreshLibrary().catch(err => {
-      logger.error({ err }, 'Failed to refresh Plex library');
+    // Refresh each distinct Plex library mapped to the downloaded subfolders.
+    // Pre-condition: g.subFolder must already be a resolved effective subfolder
+    // (clean name, no __ prefix, no ##USE_GLOBAL_DEFAULT## sentinel) as produced
+    // by channelDownloadGrouper. null means root (no subfolder).
+    plexModule.refreshLibrariesForSubfolders(groups.map(g => g.subFolder ?? null)).catch(err => {
+      logger.error({ err }, 'Failed to refresh Plex libraries after grouped download');
     });
 
     // Now start the next job in the queue
@@ -376,7 +379,7 @@ class DownloadModule {
       // Check if we have any URLs to download
       if (urls.length === 0) {
         logger.warn({ jobType }, 'Skipping group - no enabled tabs for any channels in this group');
-        console.log(`Skipping ${jobType} - no enabled tabs for any channels`);
+        logger.info({ jobType }, 'Skipping group - no enabled tabs for any channels');
         return; // Skip this group, continue with next group in sequence
       }
 

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -324,6 +324,7 @@ class DownloadModule {
     // Pre-condition: g.subFolder must already be a resolved effective subfolder
     // (clean name, no __ prefix, no ##USE_GLOBAL_DEFAULT## sentinel) as produced
     // by channelDownloadGrouper. null means root (no subfolder).
+    // Defensive: refreshLibrary currently swallows errors internally
     plexModule.refreshLibrariesForSubfolders(groups.map(g => g.subFolder ?? null)).catch(err => {
       logger.error({ err }, 'Failed to refresh Plex libraries after grouped download');
     });

--- a/server/modules/filesystem/__tests__/pathBuilder.test.js
+++ b/server/modules/filesystem/__tests__/pathBuilder.test.js
@@ -10,7 +10,8 @@ const {
   buildThumbnailTemplate,
   extractYoutubeIdFromPath,
   isValidYoutubeId,
-  calculateRelocatedPath
+  calculateRelocatedPath,
+  extractSubfolderFromAbsPath
 } = require('../pathBuilder');
 const { GLOBAL_DEFAULT_SENTINEL, ROOT_SENTINEL } = require('../constants');
 
@@ -240,6 +241,72 @@ describe('filesystem/pathBuilder', () => {
 
     it('should return null for null original', () => {
       expect(calculateRelocatedPath('/a', '/b', null)).toBeNull();
+    });
+  });
+
+  describe('extractSubfolderFromAbsPath', () => {
+    const baseDir = '/usr/src/app/data';
+
+    it('should return the subfolder name for a path inside a subfolder directory', () => {
+      const filePath = '/usr/src/app/data/__Adults/The Daily Show/The Daily Show - Video - abc12345678/The Daily Show - Video [abc12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBe('Adults');
+    });
+
+    it('should return null for a path directly under the base directory (root)', () => {
+      const filePath = '/usr/src/app/data/ChannelName/ChannelName - Video - abc12345678/ChannelName - Video [abc12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBeNull();
+    });
+
+    it('should handle subfolder names with spaces and special characters', () => {
+      const filePath = '/usr/src/app/data/__Kids Shows/Channel/Video - id12345678/Video [id12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBe('Kids Shows');
+    });
+
+    it('should work with audio (mp3) file paths', () => {
+      const filePath = '/usr/src/app/data/__Podcasts/Channel/Video - id12345678/Video [id12345678].mp3';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBe('Podcasts');
+    });
+
+    it('should tolerate a trailing slash on the base directory', () => {
+      const filePath = '/usr/src/app/data/__Adults/Channel/Video - id12345678/Video [id12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, '/usr/src/app/data/')).toBe('Adults');
+    });
+
+    it('should return the subfolder for a flat-mode (skip_video_folder) layout with subfolder', () => {
+      // Flat mode: no per-video directory - video file lives directly in the channel dir
+      const filePath = '/usr/src/app/data/__Adults/Channel/Channel - Video [id12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBe('Adults');
+    });
+
+    it('should return null for a flat-mode (skip_video_folder) layout without subfolder', () => {
+      // Flat mode at root: channel dir directly under baseDir, file directly in channel dir
+      const filePath = '/usr/src/app/data/Channel/Channel - Video [id12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBeNull();
+    });
+
+    it('should return null when filePath is not under baseDir', () => {
+      expect(extractSubfolderFromAbsPath('/other/path/video.mp4', baseDir)).toBeNull();
+    });
+
+    it('should return null for null filePath', () => {
+      expect(extractSubfolderFromAbsPath(null, baseDir)).toBeNull();
+    });
+
+    it('should return null for undefined filePath', () => {
+      expect(extractSubfolderFromAbsPath(undefined, baseDir)).toBeNull();
+    });
+
+    it('should return null for empty filePath', () => {
+      expect(extractSubfolderFromAbsPath('', baseDir)).toBeNull();
+    });
+
+    it('should return null when baseDir is missing', () => {
+      expect(extractSubfolderFromAbsPath('/usr/src/app/data/__Adults/Channel/file.mp4', null)).toBeNull();
+    });
+
+    it('should return empty string for a bare __ subfolder segment', () => {
+      const filePath = '/usr/src/app/data/__/Channel/Video/Video [abc12345678].mp4';
+      expect(extractSubfolderFromAbsPath(filePath, baseDir)).toBe('');
     });
   });
 });

--- a/server/modules/filesystem/__tests__/pathBuilder.test.js
+++ b/server/modules/filesystem/__tests__/pathBuilder.test.js
@@ -12,7 +12,7 @@ const {
   isValidYoutubeId,
   calculateRelocatedPath
 } = require('../pathBuilder');
-const { GLOBAL_DEFAULT_SENTINEL } = require('../constants');
+const { GLOBAL_DEFAULT_SENTINEL, ROOT_SENTINEL } = require('../constants');
 
 describe('filesystem/pathBuilder', () => {
   describe('buildSubfolderSegment', () => {
@@ -69,6 +69,11 @@ describe('filesystem/pathBuilder', () => {
   });
 
   describe('resolveEffectiveSubfolder', () => {
+    it('should return null for ROOT_SENTINEL regardless of global default', () => {
+      expect(resolveEffectiveSubfolder(ROOT_SENTINEL, 'default')).toBeNull();
+      expect(resolveEffectiveSubfolder(ROOT_SENTINEL, null)).toBeNull();
+    });
+
     it('should return global default for GLOBAL_DEFAULT_SENTINEL', () => {
       expect(resolveEffectiveSubfolder(GLOBAL_DEFAULT_SENTINEL, 'default')).toBe('default');
     });

--- a/server/modules/filesystem/pathBuilder.js
+++ b/server/modules/filesystem/pathBuilder.js
@@ -7,6 +7,7 @@ const path = require('path');
 const {
   SUBFOLDER_PREFIX,
   GLOBAL_DEFAULT_SENTINEL,
+  ROOT_SENTINEL,
   CHANNEL_TEMPLATE,
   VIDEO_FOLDER_TEMPLATE,
   VIDEO_FILE_TEMPLATE,
@@ -53,7 +54,8 @@ function extractSubfolderName(dirName) {
 
 /**
  * Resolve the effective subfolder for a channel
- * Handles the three-state logic:
+ * Handles four-state logic:
+ * - ROOT_SENTINEL -> null (explicit root override, e.g. manual downloads)
  * - GLOBAL_DEFAULT_SENTINEL -> use global default
  * - non-empty string -> use that subfolder
  * - null/empty -> null (download to root, backwards compatible)
@@ -63,6 +65,11 @@ function extractSubfolderName(dirName) {
  * @returns {string|null} - The actual subfolder to use (without __ prefix), or null for root
  */
 function resolveEffectiveSubfolder(channelSubFolder, globalDefault = null) {
+  // Explicit "download to root" override
+  if (channelSubFolder === ROOT_SENTINEL) {
+    return null;
+  }
+
   // Explicit "use global default" setting
   if (channelSubFolder === GLOBAL_DEFAULT_SENTINEL) {
     return globalDefault || null;

--- a/server/modules/filesystem/pathBuilder.js
+++ b/server/modules/filesystem/pathBuilder.js
@@ -204,6 +204,45 @@ function calculateRelocatedPath(oldBasePath, newBasePath, originalPath) {
   return newBasePath + relativePath;
 }
 
+/**
+ * Extract the effective subfolder from an absolute media file path
+ * Given a video or audio file path produced by the post-processor, return the
+ * subfolder name (without the __ prefix) that contains it, or null if the file
+ * is directly under the base directory (root, no subfolder).
+ *
+ * This is used to determine which Plex library to refresh for a downloaded
+ * video, based on where the file actually ended up on disk rather than
+ * re-running subfolder resolution logic.
+ *
+ * @param {string} filePath - Absolute path to the downloaded media file
+ * @param {string} baseDir - The base output directory (configModule.directoryPath)
+ * @returns {string|null} - The subfolder name (without __ prefix), or null for root
+ */
+function extractSubfolderFromAbsPath(filePath, baseDir) {
+  if (!filePath || !baseDir) {
+    return null;
+  }
+
+  const relativePath = path.relative(baseDir, filePath);
+
+  // path.relative returns a path starting with '..' when filePath is not under baseDir
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null;
+  }
+
+  const firstSegment = relativePath.split(path.sep)[0];
+  if (!firstSegment) {
+    return null;
+  }
+
+  if (isSubfolderDirectory(firstSegment)) {
+    return extractSubfolderName(firstSegment);
+  }
+
+  // First segment is the channel directory, meaning the file is in root (no subfolder)
+  return null;
+}
+
 module.exports = {
   buildSubfolderSegment,
   isSubfolderDirectory,
@@ -216,5 +255,6 @@ module.exports = {
   buildThumbnailTemplate,
   extractYoutubeIdFromPath,
   isValidYoutubeId,
-  calculateRelocatedPath
+  calculateRelocatedPath,
+  extractSubfolderFromAbsPath
 };

--- a/server/modules/plexModule.js
+++ b/server/modules/plexModule.js
@@ -30,22 +30,72 @@ class PlexModule {
     return `${protocol}://${ip}:${port}`;
   }
 
-  async refreshLibrary() {
-    logger.info('Refreshing Plex library');
-    // Example GET http://[plexIP]:[plexPort]/library/sections/[plexYoutubeLibraryId]/refresh?X-Plex-Token=[plexApiKey]
+  /**
+   * Get the Plex library ID that should be refreshed for a given resolved subfolder.
+   * Falls back to the global plexYoutubeLibraryId when no specific mapping is found.
+   * @param {string|null} subfolder - Resolved subfolder name (no __ prefix, null = root)
+   * @returns {string} Library ID to refresh
+   */
+  getLibraryIdForSubfolder(subfolder) {
+    const config = configModule.getConfig();
+    const raw = config.plexSubfolderLibraryMappings;
+    const mappings = Array.isArray(raw) ? raw : [];
+
+    const normalizedSubfolder = subfolder || null;
+    const match = mappings.find((m) => (m.subfolder || null) === normalizedSubfolder);
+    return (match && match.libraryId) || config.plexYoutubeLibraryId || '';
+  }
+
+  /**
+   * Refresh the Plex library associated with the given resolved subfolder.
+   * Falls back to the global library when no specific mapping exists.
+   * @param {string|null} subfolder - Resolved subfolder name (no __ prefix, null = root)
+   * @returns {Promise<Object|null>}
+   */
+  async refreshLibraryForSubfolder(subfolder) {
+    const libraryId = this.getLibraryIdForSubfolder(subfolder);
+    return this.refreshLibrary(libraryId);
+  }
+
+  /**
+   * Refresh all distinct Plex libraries mapped to the provided subfolders.
+   * Deduplicates library IDs so each library is only refreshed once.
+   * @param {Array<string|null>} subfolders - Array of resolved subfolder names
+   * @returns {Promise<void>}
+   */
+  async refreshLibrariesForSubfolders(subfolders) {
+    const libraryIds = new Set(subfolders.map((sf) => this.getLibraryIdForSubfolder(sf)));
+    await Promise.all(
+      [...libraryIds].map((libraryId) =>
+        this.refreshLibrary(libraryId).catch((err) => {
+          logger.error({ err, libraryId }, 'Failed to refresh Plex library for subfolder');
+        })
+      )
+    );
+  }
+
+  async refreshLibrary(libraryId) {
+    const config = configModule.getConfig();
+    const resolvedLibraryId = libraryId || config.plexYoutubeLibraryId;
+    logger.info({ libraryId: resolvedLibraryId }, 'Refreshing Plex library');
     try {
-      const config = configModule.getConfig();
       const baseUrl = this.getBaseUrl(config.plexIP, config, config.plexPort, config.plexViaHttps);
 
-      if (!baseUrl || !config.plexYoutubeLibraryId || !config.plexApiKey) {
+      if (!baseUrl || !resolvedLibraryId || !config.plexApiKey) {
         logger.warn('Skipping Plex refresh - missing server details or credentials');
         return null;
       }
 
+      // Plex library IDs are always numeric; reject anything else to prevent path traversal
+      if (!/^\d+$/.test(String(resolvedLibraryId))) {
+        logger.warn({ libraryId: resolvedLibraryId }, 'Skipping Plex refresh - invalid non-numeric library ID');
+        return null;
+      }
+
       const response = await axios.get(
-        `${baseUrl}/library/sections/${config.plexYoutubeLibraryId}/refresh?X-Plex-Token=${config.plexApiKey}`
+        `${baseUrl}/library/sections/${encodeURIComponent(resolvedLibraryId)}/refresh?X-Plex-Token=${config.plexApiKey}`
       );
-      logger.info({ libraryId: config.plexYoutubeLibraryId }, 'Plex library refresh initiated successfully');
+      logger.info({ libraryId: resolvedLibraryId }, 'Plex library refresh initiated successfully');
       return response;
     } catch (error) {
       logger.error({ err: error }, 'Failed to refresh Plex library');

--- a/server/modules/plexModule.js
+++ b/server/modules/plexModule.js
@@ -67,7 +67,7 @@ class PlexModule {
    */
   async refreshLibrariesForSubfolders(subfolders) {
     const libraryIds = new Set(subfolders.map((sf) => this.getLibraryIdForSubfolder(sf)));
-    await Promise.all(
+    await Promise.allSettled(
       [...libraryIds].map((libraryId) =>
         this.refreshLibrary(libraryId)
       )

--- a/server/modules/plexModule.js
+++ b/server/modules/plexModule.js
@@ -2,6 +2,14 @@ const axios = require('axios');
 const configModule = require('./configModule');
 const logger = require('../logger');
 
+// Plex HTTP request timeout in milliseconds.
+// Any call to the local Plex server should complete within a few seconds on
+// a healthy LAN; anything longer almost certainly means Plex is unreachable.
+// Without this timeout, axios inherits the OS-level TCP retry timeouts which
+// can hang for 60+ seconds, leaving the Configuration UI stuck on "Testing..."
+// while the user waits for the initial connectivity check to resolve.
+const PLEX_REQUEST_TIMEOUT_MS = 10000;
+
 class PlexModule {
   constructor() {}
 
@@ -92,7 +100,8 @@ class PlexModule {
 
       logger.info({ libraryId: resolvedLibraryId }, 'Refreshing Plex library');
       const response = await axios.get(
-        `${baseUrl}/library/sections/${encodeURIComponent(resolvedLibraryId)}/refresh?X-Plex-Token=${config.plexApiKey}`
+        `${baseUrl}/library/sections/${encodeURIComponent(resolvedLibraryId)}/refresh?X-Plex-Token=${config.plexApiKey}`,
+        { timeout: PLEX_REQUEST_TIMEOUT_MS }
       );
       logger.info({ libraryId: resolvedLibraryId }, 'Plex library refresh initiated successfully');
       return response;
@@ -100,6 +109,8 @@ class PlexModule {
       logger.error({ err: error }, 'Failed to refresh Plex library');
       if (error.code === 'ECONNREFUSED') {
         logger.warn('Could not connect to Plex server - continuing without refresh');
+      } else if (error.code === 'ECONNABORTED') {
+        logger.warn('Plex request timed out - continuing without refresh');
       }
       // Return null or empty response to indicate failure, but don't throw
       return null;
@@ -129,7 +140,8 @@ class PlexModule {
       logger.info(`Attempting to fetch Plex libraries via URL: ${baseUrl}`);
 
       const response = await axios.get(
-        `${baseUrl}/library/sections?X-Plex-Token=${plexApiKey}`
+        `${baseUrl}/library/sections?X-Plex-Token=${plexApiKey}`,
+        { timeout: PLEX_REQUEST_TIMEOUT_MS }
       );
 
       const libraries = response.data.MediaContainer.Directory.map(
@@ -149,6 +161,8 @@ class PlexModule {
       logger.error({ err: error }, 'Failed to get Plex libraries');
       if (error.code === 'ECONNREFUSED') {
         logger.warn('Could not connect to Plex server - returning empty library list');
+      } else if (error.code === 'ECONNABORTED') {
+        logger.warn('Plex request timed out - returning empty library list');
       }
       // Return empty array instead of throwing to prevent frontend crashes
       return [];

--- a/server/modules/plexModule.js
+++ b/server/modules/plexModule.js
@@ -42,7 +42,9 @@ class PlexModule {
     const mappings = Array.isArray(raw) ? raw : [];
 
     const normalizedSubfolder = subfolder || null;
-    const match = mappings.find((m) => (m.subfolder || null) === normalizedSubfolder);
+    const match = mappings
+      .filter((m) => m && typeof m === 'object')
+      .find((m) => (m.subfolder || null) === normalizedSubfolder);
     return (match && match.libraryId) || config.plexYoutubeLibraryId || '';
   }
 
@@ -67,9 +69,7 @@ class PlexModule {
     const libraryIds = new Set(subfolders.map((sf) => this.getLibraryIdForSubfolder(sf)));
     await Promise.all(
       [...libraryIds].map((libraryId) =>
-        this.refreshLibrary(libraryId).catch((err) => {
-          logger.error({ err, libraryId }, 'Failed to refresh Plex library for subfolder');
-        })
+        this.refreshLibrary(libraryId)
       )
     );
   }
@@ -77,7 +77,6 @@ class PlexModule {
   async refreshLibrary(libraryId) {
     const config = configModule.getConfig();
     const resolvedLibraryId = libraryId || config.plexYoutubeLibraryId;
-    logger.info({ libraryId: resolvedLibraryId }, 'Refreshing Plex library');
     try {
       const baseUrl = this.getBaseUrl(config.plexIP, config, config.plexPort, config.plexViaHttps);
 
@@ -86,12 +85,12 @@ class PlexModule {
         return null;
       }
 
-      // Plex library IDs are always numeric; reject anything else to prevent path traversal
       if (!/^\d+$/.test(String(resolvedLibraryId))) {
         logger.warn({ libraryId: resolvedLibraryId }, 'Skipping Plex refresh - invalid non-numeric library ID');
         return null;
       }
 
+      logger.info({ libraryId: resolvedLibraryId }, 'Refreshing Plex library');
       const response = await axios.get(
         `${baseUrl}/library/sections/${encodeURIComponent(resolvedLibraryId)}/refresh?X-Plex-Token=${config.plexApiKey}`
       );

--- a/server/modules/tabsUtils.js
+++ b/server/modules/tabsUtils.js
@@ -1,0 +1,36 @@
+/**
+ * Shared tab-type constants and helpers used by channelModule and
+ * channelSettingsModule. Both modules originally duplicated these
+ * definitions; this module is the single source of truth.
+ */
+
+const TAB_TYPES = Object.freeze({
+  VIDEOS: 'videos',
+  SHORTS: 'shorts',
+  LIVE: 'streams',
+});
+
+const MEDIA_TAB_TYPE_MAP = Object.freeze({
+  videos: 'video',
+  shorts: 'short',
+  streams: 'livestream',
+});
+
+const VALID_TAB_TYPES = new Set(Object.values(TAB_TYPES));
+
+/**
+ * Parse a comma-separated tab CSV string into a trimmed, non-empty array.
+ * @param {string|null|undefined} csv
+ * @returns {string[]}
+ */
+function parseTabCsv(csv) {
+  if (!csv) return [];
+  return csv.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+}
+
+module.exports = {
+  TAB_TYPES,
+  MEDIA_TAB_TYPE_MAP,
+  VALID_TAB_TYPES,
+  parseTabCsv,
+};

--- a/server/modules/videoDeletionModule.js
+++ b/server/modules/videoDeletionModule.js
@@ -290,6 +290,7 @@ class VideoDeletionModule {
         LEFT JOIN JobVideos ON Videos.id = JobVideos.video_id
         LEFT JOIN Jobs ON Jobs.id = JobVideos.job_id
         WHERE Videos.removed = 0
+          AND Videos.protected = 0
           AND COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, '%Y%m%d')) IS NOT NULL
           AND COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, '%Y%m%d')) < DATE_SUB(NOW(), INTERVAL :ageInDays DAY)
         ORDER BY timeCreated ASC
@@ -334,6 +335,7 @@ class VideoDeletionModule {
         LEFT JOIN JobVideos ON Videos.id = JobVideos.video_id
         LEFT JOIN Jobs ON Jobs.id = JobVideos.job_id
         WHERE Videos.removed = 0
+          AND Videos.protected = 0
           AND COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, '%Y%m%d')) IS NOT NULL
 ${excludeClause}        ORDER BY timeCreated ASC
         LIMIT :limit

--- a/server/modules/videoMetadataModule.js
+++ b/server/modules/videoMetadataModule.js
@@ -28,6 +28,7 @@ const NULL_METADATA = {
   webpageUrl: null,
   relatedFiles: null,
   availableResolutions: null,
+  downloadedTier: null,
 };
 
 const YTDLP_FETCH_TIMEOUT_MS = 60000;
@@ -118,6 +119,11 @@ class VideoMetadataModule {
       // Extract available resolutions from the formats array
       const availableResolutions = this._extractAvailableResolutions(rawData.formats);
 
+      // Extract downloaded tier from top-level format_note (e.g. "1080p+medium" -> 1080).
+      // This is the YouTube quality tier, which differs from the actual pixel height
+      // for non-16:9 aspect ratios (e.g. a 2:1 video's "1080p" tier has 960 actual height).
+      const downloadedTier = this._extractTierFromFormatNote(rawData.format_note);
+
       return {
         description: rawData.description ?? null,
         viewCount: rawData.view_count ?? null,
@@ -140,6 +146,7 @@ class VideoMetadataModule {
         webpageUrl: rawData.webpage_url ?? null,
         relatedFiles,
         availableResolutions,
+        downloadedTier,
       };
     } catch (err) {
       logger.error({ err, youtubeId }, 'Unexpected error in getVideoMetadata');
@@ -206,21 +213,44 @@ class VideoMetadataModule {
   /**
    * Extract available download resolutions from the yt-dlp formats array.
    * Only returns resolutions we support downloading (360p-2160p).
+   *
+   * Prefers format_note (e.g. "1080p") over raw height because for non-16:9
+   * aspect ratios the actual pixel height differs from the quality tier label
+   * (e.g. a 2:1 video's "1080p" format has 960 actual height, not 1080).
+   * Falls back to height when format_note isn't present or parseable.
    */
   _extractAvailableResolutions(formats) {
     if (!Array.isArray(formats) || formats.length === 0) return null;
 
-    const availableHeights = new Set();
+    const availableTiers = new Set();
 
     for (const fmt of formats) {
-      if (fmt.height && fmt.vcodec && fmt.vcodec !== 'none' && SUPPORTED_HEIGHTS.includes(fmt.height)) {
-        availableHeights.add(fmt.height);
+      if (!fmt.vcodec || fmt.vcodec === 'none') continue;
+
+      let tier = this._extractTierFromFormatNote(fmt.format_note);
+      if (tier === null && fmt.height) {
+        tier = fmt.height;
+      }
+
+      if (tier !== null && SUPPORTED_HEIGHTS.includes(tier)) {
+        availableTiers.add(tier);
       }
     }
 
-    if (availableHeights.size === 0) return null;
+    if (availableTiers.size === 0) return null;
 
-    return [...availableHeights].sort((a, b) => a - b);
+    return [...availableTiers].sort((a, b) => a - b);
+  }
+
+  /**
+   * Parse a YouTube quality tier from a yt-dlp format_note string.
+   * Examples: "1080p" -> 1080, "1080p60" -> 1080, "1080p+medium" -> 1080.
+   * Returns null if the string isn't present or doesn't start with a tier.
+   */
+  _extractTierFromFormatNote(formatNote) {
+    if (!formatNote || typeof formatNote !== 'string') return null;
+    const match = formatNote.match(/^(\d+)p/);
+    return match ? parseInt(match[1], 10) : null;
   }
 
   _categorizeFileExtension(ext) {

--- a/server/modules/videoMetadataModule.js
+++ b/server/modules/videoMetadataModule.js
@@ -1,0 +1,281 @@
+const { Video } = require('../models');
+const fsSync = require('fs');
+const fs = require('fs').promises;
+const path = require('path');
+const configModule = require('./configModule');
+const ytDlpRunner = require('./ytDlpRunner');
+const logger = require('../logger');
+
+const NULL_METADATA = {
+  description: null,
+  viewCount: null,
+  likeCount: null,
+  commentCount: null,
+  tags: null,
+  categories: null,
+  uploadDate: null,
+  resolution: null,
+  width: null,
+  height: null,
+  fps: null,
+  aspectRatio: null,
+  language: null,
+  isLive: null,
+  wasLive: null,
+  availability: null,
+  channelFollowerCount: null,
+  ageLimit: null,
+  webpageUrl: null,
+  relatedFiles: null,
+  availableResolutions: null,
+};
+
+const YTDLP_FETCH_TIMEOUT_MS = 60000;
+
+const SUPPORTED_HEIGHTS = [360, 480, 720, 1080, 1440, 2160];
+
+const FILE_EXTENSION_CATEGORIES = {
+  '.jpg': 'Thumbnail', '.jpeg': 'Thumbnail', '.png': 'Thumbnail', '.webp': 'Thumbnail',
+  '.nfo': 'NFO Metadata',
+  '.srt': 'Subtitles', '.vtt': 'Subtitles', '.ass': 'Subtitles',
+  '.info.json': 'Info JSON',
+  '.json': 'Info JSON',
+};
+
+class VideoMetadataModule {
+  constructor() {}
+
+  /**
+   * Get extended video metadata from cached .info.json or by fetching via yt-dlp.
+   * Returns a curated subset of fields. Silently backfills originalDate when
+   * the .info.json has a more accurate upload_date than the existing DB record.
+   * @param {string} youtubeId - YouTube video ID
+   * @returns {Promise<Object>} Curated metadata object (all null on failure)
+   */
+  async getVideoMetadata(youtubeId) {
+    try {
+      const infoDir = path.join(configModule.getJobsPath(), 'info');
+      const infoPath = path.join(infoDir, `${youtubeId}.info.json`);
+
+      let rawData = null;
+
+      // Try reading cached .info.json from disk
+      try {
+        await fs.access(infoPath);
+        const content = await fs.readFile(infoPath, 'utf8');
+        rawData = JSON.parse(content);
+      } catch {
+        // Not cached - fetch via yt-dlp
+        logger.debug({ youtubeId }, 'No cached .info.json, fetching via yt-dlp');
+        try {
+          rawData = await ytDlpRunner.fetchMetadata(
+            `https://www.youtube.com/watch?v=${youtubeId}`,
+            YTDLP_FETCH_TIMEOUT_MS
+          );
+
+          // Cache the result for future requests
+          try {
+            await fs.mkdir(infoDir, { recursive: true });
+            await fs.writeFile(infoPath, JSON.stringify(rawData, null, 2), 'utf8');
+            logger.debug({ youtubeId }, 'Cached .info.json from yt-dlp fetch');
+          } catch (cacheErr) {
+            logger.warn({ err: cacheErr, youtubeId }, 'Failed to cache .info.json');
+          }
+        } catch (fetchErr) {
+          logger.warn({ err: fetchErr, youtubeId }, 'Failed to fetch metadata via yt-dlp');
+          return NULL_METADATA;
+        }
+      }
+
+      if (!rawData) {
+        return NULL_METADATA;
+      }
+
+      // Silently backfill originalDate if yt-dlp has a more accurate value
+      if (rawData.upload_date) {
+        try {
+          const video = await Video.findOne({ where: { youtubeId } });
+          if (video) {
+            const dbDate = video.originalDate;
+            const ytDate = rawData.upload_date; // YYYYMMDD format
+            // Backfill if DB has no date, or if yt-dlp date is different (more accurate)
+            if (!dbDate || dbDate !== ytDate) {
+              await video.update({ originalDate: ytDate });
+              logger.debug({ youtubeId, oldDate: dbDate, newDate: ytDate }, 'Backfilled originalDate from metadata');
+            }
+          }
+        } catch (backfillErr) {
+          logger.warn({ err: backfillErr, youtubeId }, 'Failed to backfill originalDate');
+        }
+      }
+
+      // Use the numeric aspect_ratio from yt-dlp (e.g. 1.78 for 16:9)
+      const aspectRatio = rawData.aspect_ratio ?? null;
+
+      // Collect related files on disk (thumbnail, subtitles, nfo, etc.)
+      const relatedFiles = await this._getVideoRelatedFiles(youtubeId);
+
+      // Extract available resolutions from the formats array
+      const availableResolutions = this._extractAvailableResolutions(rawData.formats);
+
+      return {
+        description: rawData.description ?? null,
+        viewCount: rawData.view_count ?? null,
+        likeCount: rawData.like_count ?? null,
+        commentCount: rawData.comment_count ?? null,
+        tags: rawData.tags ?? null,
+        categories: rawData.categories ?? null,
+        uploadDate: rawData.upload_date ?? null,
+        resolution: rawData.resolution ?? null,
+        width: rawData.width ?? null,
+        height: rawData.height ?? null,
+        fps: rawData.fps ?? null,
+        aspectRatio,
+        language: rawData.language ?? null,
+        isLive: rawData.is_live ?? null,
+        wasLive: rawData.was_live ?? null,
+        availability: rawData.availability ?? null,
+        channelFollowerCount: rawData.channel_follower_count ?? null,
+        ageLimit: rawData.age_limit ?? null,
+        webpageUrl: rawData.webpage_url ?? null,
+        relatedFiles,
+        availableResolutions,
+      };
+    } catch (err) {
+      logger.error({ err, youtubeId }, 'Unexpected error in getVideoMetadata');
+      return NULL_METADATA;
+    }
+  }
+
+  /**
+   * Find all related files for a video on disk (thumbnail, subtitles, nfo, etc.).
+   * Uses the same YouTube ID matching pattern as videoDeletionModule:
+   * files containing [youtubeId] or " - youtubeId" in the name.
+   * Excludes the main video and audio files (those are shown separately).
+   * Returns only fileName, fileSize, and type - internal paths are stripped.
+   */
+  async _getVideoRelatedFiles(youtubeId) {
+    try {
+      const video = await Video.findOne({ where: { youtubeId } });
+      if (!video || !video.filePath) return null;
+
+      const videoDir = path.dirname(video.filePath);
+
+      let files;
+      try {
+        files = await fs.readdir(videoDir);
+      } catch {
+        return null;
+      }
+
+      // Filter to files belonging to this video
+      const matchingFiles = files.filter(
+        file => file.includes(`[${youtubeId}]`) || file.includes(` - ${youtubeId}`)
+      );
+
+      // Get file stats and categorize
+      const result = [];
+      const mainVideoBase = video.filePath ? path.basename(video.filePath) : null;
+      const mainAudioBase = video.audioFilePath ? path.basename(video.audioFilePath) : null;
+
+      for (const fileName of matchingFiles) {
+        // Skip the main video and audio files (shown separately in the Files section)
+        if (fileName === mainVideoBase || fileName === mainAudioBase) continue;
+
+        const fullPath = path.join(videoDir, fileName);
+        try {
+          const stat = await fs.stat(fullPath);
+          const ext = path.extname(fileName).toLowerCase();
+          result.push({
+            fileName,
+            fileSize: stat.size,
+            type: this._categorizeFileExtension(ext),
+          });
+        } catch {
+          // File may have been removed between readdir and stat
+        }
+      }
+
+      return result.length > 0 ? result : null;
+    } catch (err) {
+      logger.warn({ err, youtubeId }, 'Failed to list related video files');
+      return null;
+    }
+  }
+
+  /**
+   * Extract available download resolutions from the yt-dlp formats array.
+   * Only returns resolutions we support downloading (360p-2160p).
+   */
+  _extractAvailableResolutions(formats) {
+    if (!Array.isArray(formats) || formats.length === 0) return null;
+
+    const availableHeights = new Set();
+
+    for (const fmt of formats) {
+      if (fmt.height && fmt.vcodec && fmt.vcodec !== 'none' && SUPPORTED_HEIGHTS.includes(fmt.height)) {
+        availableHeights.add(fmt.height);
+      }
+    }
+
+    if (availableHeights.size === 0) return null;
+
+    return [...availableHeights].sort((a, b) => a - b);
+  }
+
+  _categorizeFileExtension(ext) {
+    return FILE_EXTENSION_CATEGORIES[ext] || 'Other';
+  }
+
+  /**
+   * Resolve stream info for a video file (video or audio).
+   * Looks up the video in the database, checks the file exists on disk,
+   * and returns the path, content type, and file size.
+   * @param {string} youtubeId - YouTube video ID
+   * @param {string} type - 'video' or 'audio'
+   * @returns {Promise<{filePath: string, contentType: string, fileSize: number}|null>}
+   *   Returns null if video not found; throws with a message property for specific error cases.
+   */
+  async getVideoStreamInfo(youtubeId, type) {
+    const MIME_TYPES = {
+      '.mp4': 'video/mp4',
+      '.webm': 'video/webm',
+      '.mkv': 'video/x-matroska',
+      '.mp3': 'audio/mpeg',
+      '.m4a': 'audio/mp4',
+      '.ogg': 'audio/ogg',
+    };
+    const DEFAULT_MIME_TYPE = 'application/octet-stream';
+
+    const video = await Video.findOne({ where: { youtubeId } });
+
+    if (!video) {
+      return { error: 'not_found', message: 'Video not found' };
+    }
+
+    const filePath = type === 'audio' ? video.audioFilePath : video.filePath;
+
+    if (!filePath) {
+      return { error: 'no_file', message: `No ${type} file available for this video` };
+    }
+
+    // Verify file exists on disk
+    try {
+      fsSync.accessSync(filePath, fsSync.constants.R_OK);
+    } catch {
+      return { error: 'file_missing', message: 'File not found on disk' };
+    }
+
+    const stat = fsSync.statSync(filePath);
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] || DEFAULT_MIME_TYPE;
+
+    return {
+      filePath,
+      contentType,
+      fileSize: stat.size,
+    };
+  }
+}
+
+module.exports = new VideoMetadataModule();

--- a/server/modules/videoMetadataModule.js
+++ b/server/modules/videoMetadataModule.js
@@ -1,5 +1,4 @@
 const { Video } = require('../models');
-const fsSync = require('fs');
 const fs = require('fs').promises;
 const path = require('path');
 const configModule = require('./configModule');
@@ -39,9 +38,19 @@ const FILE_EXTENSION_CATEGORIES = {
   '.jpg': 'Thumbnail', '.jpeg': 'Thumbnail', '.png': 'Thumbnail', '.webp': 'Thumbnail',
   '.nfo': 'NFO Metadata',
   '.srt': 'Subtitles', '.vtt': 'Subtitles', '.ass': 'Subtitles',
-  '.info.json': 'Info JSON',
   '.json': 'Info JSON',
 };
+
+const STREAM_MIME_TYPES = {
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mkv': 'video/x-matroska',
+  '.mp3': 'audio/mpeg',
+  '.m4a': 'audio/mp4',
+  '.ogg': 'audio/ogg',
+};
+
+const DEFAULT_STREAM_MIME_TYPE = 'application/octet-stream';
 
 class VideoMetadataModule {
   constructor() {}
@@ -267,16 +276,6 @@ class VideoMetadataModule {
    *   Returns null if video not found; throws with a message property for specific error cases.
    */
   async getVideoStreamInfo(youtubeId, type) {
-    const MIME_TYPES = {
-      '.mp4': 'video/mp4',
-      '.webm': 'video/webm',
-      '.mkv': 'video/x-matroska',
-      '.mp3': 'audio/mpeg',
-      '.m4a': 'audio/mp4',
-      '.ogg': 'audio/ogg',
-    };
-    const DEFAULT_MIME_TYPE = 'application/octet-stream';
-
     const video = await Video.findOne({ where: { youtubeId } });
 
     if (!video) {
@@ -290,15 +289,16 @@ class VideoMetadataModule {
     }
 
     // Verify file exists on disk
+    let stat;
     try {
-      fsSync.accessSync(filePath, fsSync.constants.R_OK);
+      await fs.access(filePath);
+      stat = await fs.stat(filePath);
     } catch {
       return { error: 'file_missing', message: 'File not found on disk' };
     }
 
-    const stat = fsSync.statSync(filePath);
     const ext = path.extname(filePath).toLowerCase();
-    const contentType = MIME_TYPES[ext] || DEFAULT_MIME_TYPE;
+    const contentType = STREAM_MIME_TYPES[ext] || DEFAULT_STREAM_MIME_TYPE;
 
     return {
       filePath,

--- a/server/modules/videosModule.js
+++ b/server/modules/videosModule.js
@@ -18,7 +18,8 @@ class VideosModule {
       dateTo = null,
       sortBy = 'added',
       sortOrder = 'desc',
-      channelFilter = ''
+      channelFilter = '',
+      protectedFilter = false,
     } = options;
 
     try {
@@ -46,6 +47,10 @@ class VideosModule {
       if (dateTo) {
         whereConditions.push('Videos.originalDate <= :dateTo');
         replacements.dateTo = dateTo.replace(/-/g, '');
+      }
+
+      if (protectedFilter) {
+        whereConditions.push('Videos.protected = 1');
       }
 
       const whereClause = whereConditions.length > 0 ? `WHERE ${whereConditions.join(' AND ')}` : '';
@@ -95,6 +100,7 @@ class VideosModule {
           Videos.media_type,
           Videos.normalized_rating,
           Videos.rating_source,
+          Videos.protected,
           COALESCE(Videos.last_downloaded_at, Jobs.timeCreated, STR_TO_DATE(Videos.originalDate, '%Y%m%d')) AS timeCreated
         FROM Videos
         LEFT JOIN JobVideos ON Videos.id = JobVideos.video_id

--- a/server/modules/videosModule.js
+++ b/server/modules/videosModule.js
@@ -631,6 +631,15 @@ class VideosModule {
       throw err;
     }
   }
+
+  async setVideoProtection(id, protectedState) {
+    const video = await Video.findByPk(id);
+    if (!video) {
+      throw new Error('Video not found');
+    }
+    await video.update({ protected: protectedState });
+    return { id: video.id, protected: protectedState };
+  }
 }
 
 module.exports = new VideosModule();

--- a/server/routes/__tests__/videoDetail.test.js
+++ b/server/routes/__tests__/videoDetail.test.js
@@ -1,0 +1,501 @@
+/* eslint-env jest */
+const express = require('express');
+const createVideoDetailRoutes = require('../videoDetail');
+const { findRouteHandler, findRouteHandlers } = require('../../__tests__/testUtils');
+
+// Mock fs (synchronous methods used by stream endpoint)
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    accessSync: jest.fn(),
+    statSync: jest.fn(),
+    createReadStream: jest.fn(),
+    constants: actual.constants,
+  };
+});
+
+const fs = require('fs');
+
+describe('GET /api/videos/:youtubeId/metadata', () => {
+  const loggerMock = {
+    info: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const createResponse = () => {
+    const res = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    return res;
+  };
+
+  const getHandler = (videoMetadataModuleMock) => {
+    const router = createVideoDetailRoutes({
+      verifyToken: (req, res, next) => next(),
+      videoMetadataModule: videoMetadataModuleMock,
+    });
+
+    const app = express();
+    app.use(router);
+
+    return findRouteHandler(app, 'get', '/api/videos/:youtubeId/metadata');
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns metadata from videoMetadataModule', async () => {
+    const mockMetadata = {
+      description: 'Test video',
+      viewCount: 1000,
+      likeCount: 50,
+      resolution: '1080p',
+    };
+
+    const videoMetadataModuleMock = {
+      getVideoMetadata: jest.fn().mockResolvedValue(mockMetadata),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'abc123' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(videoMetadataModuleMock.getVideoMetadata).toHaveBeenCalledWith('abc123');
+    expect(res.json).toHaveBeenCalledWith(mockMetadata);
+  });
+
+  test('returns 400 for missing youtubeId', async () => {
+    const videoMetadataModuleMock = {
+      getVideoMetadata: jest.fn(),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: '' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid YouTube ID' });
+    expect(videoMetadataModuleMock.getVideoMetadata).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 for overly long youtubeId', async () => {
+    const videoMetadataModuleMock = {
+      getVideoMetadata: jest.fn(),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'a'.repeat(21) },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid YouTube ID' });
+  });
+
+  test('returns 400 for youtubeId with path traversal characters', async () => {
+    const videoMetadataModuleMock = {
+      getVideoMetadata: jest.fn(),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: '../../etc/passwd' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid YouTube ID' });
+    expect(videoMetadataModuleMock.getVideoMetadata).not.toHaveBeenCalled();
+  });
+
+  test('returns 500 when module throws', async () => {
+    const videoMetadataModuleMock = {
+      getVideoMetadata: jest.fn().mockRejectedValue(new Error('boom')),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'abc123' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Failed to retrieve video metadata' });
+  });
+});
+
+describe('GET /api/videos/:youtubeId/stream', () => {
+  const loggerMock = {
+    info: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const createResponse = () => {
+    const res = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    res.set = jest.fn(() => res);
+    res.end = jest.fn(() => res);
+    res.destroy = jest.fn();
+    return res;
+  };
+
+  const getHandler = (videoMetadataModuleMock) => {
+    const router = createVideoDetailRoutes({
+      verifyToken: (req, res, next) => next(),
+      videoMetadataModule: videoMetadataModuleMock || {
+        getVideoStreamInfo: jest.fn().mockResolvedValue({ error: 'not_found', message: 'Video not found' }),
+      },
+    });
+
+    const app = express();
+    app.use(router);
+
+    return findRouteHandler(app, 'get', '/api/videos/:youtubeId/stream');
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns 400 for invalid youtubeId', async () => {
+    const handler = getHandler();
+    const req = {
+      params: { youtubeId: '' },
+      query: {},
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid YouTube ID' });
+  });
+
+  test('returns 400 for invalid type parameter', async () => {
+    const handler = getHandler();
+    const req = {
+      params: { youtubeId: 'abc123' },
+      query: { type: 'invalid' },
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Invalid type parameter. Must be "video" or "audio"',
+    });
+  });
+
+  test('returns 404 when video record not found', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({ error: 'not_found', message: 'Video not found' }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'notfound1' },
+      query: {},
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Video not found' });
+  });
+
+  test('returns 404 when video has no filePath', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({ error: 'no_file', message: 'No video file available for this video' }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'nofile1' },
+      query: {},
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'No video file available for this video' });
+  });
+
+  test('returns 404 when audio requested but no audioFilePath', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({ error: 'no_file', message: 'No audio file available for this video' }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'noaudio1' },
+      query: { type: 'audio' },
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'No audio file available for this video' });
+  });
+
+  test('returns 404 when file does not exist on disk', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({ error: 'file_missing', message: 'File not found on disk' }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'diskfail1' },
+      query: {},
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'File not found on disk' });
+  });
+
+  test('streams full file without Range header and includes Cache-Control headers', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({
+        filePath: '/data/channel/video [abc123].mp4',
+        contentType: 'video/mp4',
+        fileSize: 5000,
+      }),
+    };
+
+    const mockStream = { on: jest.fn().mockReturnThis(), pipe: jest.fn() };
+    fs.createReadStream.mockReturnValue(mockStream);
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'abc123' },
+      query: {},
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.set).toHaveBeenCalledWith({
+      'Content-Length': 5000,
+      'Content-Type': 'video/mp4',
+      'Accept-Ranges': 'bytes',
+      'Cache-Control': 'no-store',
+      'Pragma': 'no-cache',
+    });
+    expect(fs.createReadStream).toHaveBeenCalledWith('/data/channel/video [abc123].mp4');
+    expect(mockStream.pipe).toHaveBeenCalledWith(res);
+  });
+
+  test('streams partial content with Range header and includes Cache-Control headers', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({
+        filePath: '/data/channel/video [range1].mp4',
+        contentType: 'video/mp4',
+        fileSize: 10000,
+      }),
+    };
+
+    const mockStream = { on: jest.fn().mockReturnThis(), pipe: jest.fn() };
+    fs.createReadStream.mockReturnValue(mockStream);
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'range1' },
+      query: {},
+      headers: { range: 'bytes=0-999' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(206);
+    expect(res.set).toHaveBeenCalledWith({
+      'Content-Range': 'bytes 0-999/10000',
+      'Accept-Ranges': 'bytes',
+      'Content-Length': 1000,
+      'Content-Type': 'video/mp4',
+      'Cache-Control': 'no-store',
+      'Pragma': 'no-cache',
+    });
+    expect(fs.createReadStream).toHaveBeenCalledWith(
+      '/data/channel/video [range1].mp4',
+      { start: 0, end: 999 }
+    );
+  });
+
+  test('returns 416 for out-of-range request', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({
+        filePath: '/data/channel/video [outofrange1].mp4',
+        contentType: 'video/mp4',
+        fileSize: 5000,
+      }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'outofrange1' },
+      query: {},
+      headers: { range: 'bytes=6000-7000' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(416);
+    expect(res.set).toHaveBeenCalledWith('Content-Range', 'bytes */5000');
+  });
+
+  test('returns 416 for malformed Range header with non-numeric values', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({
+        filePath: '/data/channel/video [malrange].mp4',
+        contentType: 'video/mp4',
+        fileSize: 5000,
+      }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'malrange1234' },
+      query: {},
+      headers: { range: 'bytes=abc-def' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(416);
+    expect(res.set).toHaveBeenCalledWith('Content-Range', 'bytes */5000');
+    expect(fs.createReadStream).not.toHaveBeenCalled();
+  });
+
+  test('streams audio file when type=audio', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({
+        filePath: '/data/channel/video [audio1].mp3',
+        contentType: 'audio/mpeg',
+        fileSize: 3000,
+      }),
+    };
+
+    const mockStream = { on: jest.fn().mockReturnThis(), pipe: jest.fn() };
+    fs.createReadStream.mockReturnValue(mockStream);
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'audio1' },
+      query: { type: 'audio' },
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(videoMetadataModuleMock.getVideoStreamInfo).toHaveBeenCalledWith('audio1', 'audio');
+    expect(res.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'Content-Type': 'audio/mpeg',
+      })
+    );
+    expect(fs.createReadStream).toHaveBeenCalledWith('/data/channel/video [audio1].mp3');
+  });
+
+  test('queryTokenToHeader copies query token to header', () => {
+    const router = createVideoDetailRoutes({
+      verifyToken: (req, res, next) => next(),
+      videoMetadataModule: {},
+    });
+
+    const app = express();
+    app.use(router);
+
+    // Find all handlers for the stream endpoint (includes queryTokenToHeader middleware)
+    const handlers = findRouteHandlers(app, 'get', '/api/videos/:youtubeId/stream');
+
+    // The first handler in the chain should be queryTokenToHeader
+    const queryTokenMiddleware = handlers[0];
+
+    const req = {
+      query: { token: 'my-secret-token' },
+      headers: {},
+    };
+
+    const next = jest.fn();
+    queryTokenMiddleware(req, {}, next);
+
+    expect(req.headers['x-access-token']).toBe('my-secret-token');
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('queryTokenToHeader does not override existing header', () => {
+    const router = createVideoDetailRoutes({
+      verifyToken: (req, res, next) => next(),
+      videoMetadataModule: {},
+    });
+
+    const app = express();
+    app.use(router);
+
+    const handlers = findRouteHandlers(app, 'get', '/api/videos/:youtubeId/stream');
+    const queryTokenMiddleware = handlers[0];
+
+    const req = {
+      query: { token: 'query-token' },
+      headers: { 'x-access-token': 'header-token' },
+    };
+
+    const next = jest.fn();
+    queryTokenMiddleware(req, {}, next);
+
+    // Should keep the existing header, not override it
+    expect(req.headers['x-access-token']).toBe('header-token');
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/server/routes/__tests__/videos.routes.test.js
+++ b/server/routes/__tests__/videos.routes.test.js
@@ -74,3 +74,149 @@ describe('POST /api/videos/rating', () => {
     }));
   });
 });
+
+describe('PATCH /api/videos/:id/protected', () => {
+  const loggerMock = {
+    info: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const createResponse = () => {
+    const res = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    return res;
+  };
+
+  const getHandler = (videosModuleMock) => {
+    const router = createVideoRoutes({
+      verifyToken: (req, res, next) => next(),
+      videosModule: videosModuleMock,
+      downloadModule: {}
+    });
+
+    const app = express();
+    app.use(router);
+
+    return findRouteHandler(app, 'patch', '/api/videos/:id/protected');
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('toggles protection on for a video', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn().mockResolvedValue({ id: 1, protected: true })
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '1' },
+      body: { protected: true },
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(videosModuleMock.setVideoProtection).toHaveBeenCalledWith(1, true);
+    expect(res.json).toHaveBeenCalledWith({ id: 1, protected: true });
+  });
+
+  test('toggles protection off for a video', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn().mockResolvedValue({ id: 1, protected: false })
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '1' },
+      body: { protected: false },
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(videosModuleMock.setVideoProtection).toHaveBeenCalledWith(1, false);
+    expect(res.json).toHaveBeenCalledWith({ id: 1, protected: false });
+  });
+
+  test('returns 400 when protected field is missing', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn()
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '1' },
+      body: {},
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'protected field (boolean) is required' });
+    expect(videosModuleMock.setVideoProtection).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 when protected is not a boolean', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn()
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '1' },
+      body: { protected: 'yes' },
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'protected field (boolean) is required' });
+  });
+
+  test('returns 404 when video not found', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn().mockRejectedValue(new Error('Video not found'))
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '999' },
+      body: { protected: true },
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Video not found' });
+  });
+
+  test('returns 500 on unexpected error', async () => {
+    const videosModuleMock = {
+      setVideoProtection: jest.fn().mockRejectedValue(new Error('Database connection lost'))
+    };
+
+    const handler = getHandler(videosModuleMock);
+    const req = {
+      params: { id: '1' },
+      body: { protected: true },
+      log: loggerMock
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Database connection lost' });
+  });
+});

--- a/server/routes/__tests__/videos.routes.test.js
+++ b/server/routes/__tests__/videos.routes.test.js
@@ -217,6 +217,6 @@ describe('PATCH /api/videos/:id/protected', () => {
     await handler(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({ error: 'Database connection lost' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Failed to update protection status' });
   });
 });

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -638,7 +638,8 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
     const maxDuration = (parsedMaxDuration !== null && !isNaN(parsedMaxDuration)) ? parsedMaxDuration : null;
     const dateFrom = req.query.dateFrom || null;
     const dateTo = req.query.dateTo || null;
-    const result = await channelModule.getChannelVideos(channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, minDuration, maxDuration, dateFrom, dateTo);
+    const protectedFilter = req.query.protectedFilter === 'true';
+    const result = await channelModule.getChannelVideos(channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter);
 
     if (Array.isArray(result)) {
       res.status(200).json({

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -394,6 +394,73 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
 
   /**
    * @swagger
+   * /api/channels/{channelId}/tabs/redetect:
+   *   post:
+   *     summary: Force re-detection of a channel's available tabs
+   *     description: >
+   *       Bypasses the cached `available_tabs` value and re-probes the
+   *       channel's tabs via yt-dlp. Preserves `hidden_tabs` and
+   *       rewrites `auto_download_enabled_tabs` to drop entries whose
+   *       tab is no longer detected or is currently hidden. Use this
+   *       when a channel's cached tab list is known to be wrong.
+   *     tags: [Channels]
+   *     parameters:
+   *       - in: path
+   *         name: channelId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: YouTube channel ID
+   *     responses:
+   *       200:
+   *         description: Tabs re-detected successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 availableTabs:
+   *                   type: array
+   *                   description: Effective tabs (detected minus hidden)
+   *                   items:
+   *                     type: string
+   *                     enum: [videos, shorts, streams]
+   *                 detectedTabs:
+   *                   type: array
+   *                   description: Raw tabs found by yt-dlp
+   *                   items:
+   *                     type: string
+   *                     enum: [videos, shorts, streams]
+   *                 hiddenTabs:
+   *                   type: array
+   *                   items:
+   *                     type: string
+   *                     enum: [videos, shorts, streams]
+   *                 autoDownloadEnabledTabs:
+   *                   type: string
+   *       404:
+   *         description: Channel not found
+   *       500:
+   *         description: Failed to re-detect tabs
+   */
+  router.post('/api/channels/:channelId/tabs/redetect', verifyToken, async (req, res) => {
+    const { channelId } = req.params;
+    req.log.info({ channelId }, 'Forcing re-detection of available tabs for channel');
+
+    try {
+      const result = await channelModule.redetectChannelTabs(channelId);
+      res.status(200).json(result);
+    } catch (error) {
+      if (error.message === 'Channel not found in database') {
+        return res.status(404).json({ error: 'Channel not found in database' });
+      }
+      req.log.error({ err: error, channelId }, 'Failed to re-detect available tabs');
+      res.status(500).json({ error: 'Failed to re-detect available tabs' });
+    }
+  });
+
+  /**
+   * @swagger
    * /api/channels/{channelId}/settings:
    *   get:
    *     summary: Get channel settings

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -9,6 +9,7 @@ const createPlexRoutes = require('./plex');
 const createApiKeyRoutes = require('./apikeys');
 const createSubscriptionRoutes = require('./subscriptions');
 const createVideoDetailRoutes = require('./videoDetail');
+const videoMetadataModule = require('../modules/videoMetadataModule');
 
 /**
  * Registers all route modules with the Express app
@@ -16,7 +17,6 @@ const createVideoDetailRoutes = require('./videoDetail');
  * @param {Object} deps - Dependencies to inject into route modules
  */
 function registerRoutes(app, deps) {
-  const videoMetadataModule = require('../modules/videoMetadataModule');
   const {
     verifyToken,
     loginLimiter,

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -8,6 +8,7 @@ const createJobRoutes = require('./jobs');
 const createPlexRoutes = require('./plex');
 const createApiKeyRoutes = require('./apikeys');
 const createSubscriptionRoutes = require('./subscriptions');
+const createVideoDetailRoutes = require('./videoDetail');
 
 /**
  * Registers all route modules with the Express app
@@ -15,6 +16,7 @@ const createSubscriptionRoutes = require('./subscriptions');
  * @param {Object} deps - Dependencies to inject into route modules
  */
 function registerRoutes(app, deps) {
+  const videoMetadataModule = require('../modules/videoMetadataModule');
   const {
     verifyToken,
     loginLimiter,
@@ -62,6 +64,9 @@ function registerRoutes(app, deps) {
 
   // Subscription import routes
   app.use(createSubscriptionRoutes({ verifyToken, subscriptionImportModule }));
+
+  // Video detail routes (metadata and streaming)
+  app.use(createVideoDetailRoutes({ verifyToken, videoMetadataModule }));
 }
 
 module.exports = { registerRoutes };

--- a/server/routes/videoDetail.js
+++ b/server/routes/videoDetail.js
@@ -1,0 +1,204 @@
+const express = require('express');
+const fs = require('fs');
+
+/**
+ * Creates video detail routes for metadata and streaming
+ * @param {Object} deps - Dependencies
+ * @param {Function} deps.verifyToken - Token verification middleware
+ * @param {Object} deps.videoMetadataModule - Video metadata module
+ * @returns {express.Router}
+ */
+function createVideoDetailRoutes({ verifyToken, videoMetadataModule }) {
+  const router = express.Router();
+
+  /**
+   * Middleware to support token via query parameter.
+   * HTML <video> elements cannot set custom headers, so the frontend
+   * passes the auth token as ?token=... in the src URL.
+   * This copies it to the x-access-token header before verifyToken runs.
+   */
+  const queryTokenToHeader = (req, res, next) => {
+    if (req.query.token && !req.headers['x-access-token']) {
+      req.headers['x-access-token'] = req.query.token;
+    }
+    next();
+  };
+
+  /**
+   * @swagger
+   * /api/videos/{youtubeId}/metadata:
+   *   get:
+   *     summary: Get extended video metadata
+   *     description: Returns curated metadata from the cached .info.json file, or fetches it via yt-dlp if not cached.
+   *     tags: [Videos]
+   *     parameters:
+   *       - in: path
+   *         name: youtubeId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: YouTube video ID
+   *     responses:
+   *       200:
+   *         description: Video metadata
+   *       400:
+   *         description: Invalid YouTube ID
+   *       500:
+   *         description: Internal server error
+   */
+  router.get('/api/videos/:youtubeId/metadata', verifyToken, async (req, res) => {
+    const { youtubeId } = req.params;
+
+    if (!youtubeId || !/^[A-Za-z0-9_-]{6,20}$/.test(youtubeId)) {
+      return res.status(400).json({ error: 'Invalid YouTube ID' });
+    }
+
+    try {
+      const metadata = await videoMetadataModule.getVideoMetadata(youtubeId);
+      res.json(metadata);
+    } catch (err) {
+      req.log.error({ err, youtubeId }, 'Failed to get video metadata');
+      res.status(500).json({ error: 'Failed to retrieve video metadata' });
+    }
+  });
+
+  /**
+   * @swagger
+   * /api/videos/{youtubeId}/stream:
+   *   get:
+   *     summary: Stream a downloaded video file
+   *     description: Serves the downloaded video or audio file with HTTP Range support for seeking. Auth token must be passed as a query parameter since <video> elements cannot set custom headers.
+   *     tags: [Videos]
+   *     parameters:
+   *       - in: path
+   *         name: youtubeId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: YouTube video ID
+   *       - in: query
+   *         name: type
+   *         schema:
+   *           type: string
+   *           enum: [video, audio]
+   *           default: video
+   *         description: Whether to stream the video or audio file
+   *       - in: query
+   *         name: token
+   *         schema:
+   *           type: string
+   *         description: Authentication token (required for video element src)
+   *     responses:
+   *       200:
+   *         description: Full file response
+   *       206:
+   *         description: Partial content (range request)
+   *       400:
+   *         description: Invalid YouTube ID
+   *       404:
+   *         description: Video or file not found
+   *       416:
+   *         description: Range not satisfiable
+   *       500:
+   *         description: Internal server error
+   */
+  router.get('/api/videos/:youtubeId/stream', queryTokenToHeader, verifyToken, async (req, res) => {
+    const { youtubeId } = req.params;
+    const type = req.query.type || 'video';
+
+    if (!youtubeId || !/^[A-Za-z0-9_-]{6,20}$/.test(youtubeId)) {
+      return res.status(400).json({ error: 'Invalid YouTube ID' });
+    }
+
+    if (type !== 'video' && type !== 'audio') {
+      return res.status(400).json({ error: 'Invalid type parameter. Must be "video" or "audio"' });
+    }
+
+    try {
+      const streamInfo = await videoMetadataModule.getVideoStreamInfo(youtubeId, type);
+
+      if (streamInfo.error === 'not_found') {
+        return res.status(404).json({ error: streamInfo.message });
+      }
+      if (streamInfo.error === 'no_file') {
+        return res.status(404).json({ error: streamInfo.message });
+      }
+      if (streamInfo.error === 'file_missing') {
+        return res.status(404).json({ error: streamInfo.message });
+      }
+
+      const { filePath, contentType, fileSize } = streamInfo;
+      const range = req.headers.range;
+
+      // Prevent caching of token-bearing stream URLs
+      const cacheHeaders = {
+        'Cache-Control': 'no-store',
+        'Pragma': 'no-cache',
+      };
+
+      if (range) {
+        // Parse Range header
+        const parts = range.replace(/bytes=/, '').split('-');
+        const start = parseInt(parts[0], 10);
+        const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
+
+        if (isNaN(start) || isNaN(end) || start < 0) {
+          res.status(416).set('Content-Range', `bytes */${fileSize}`);
+          return res.end();
+        }
+
+        if (start >= fileSize || end >= fileSize || start > end) {
+          res.status(416).set('Content-Range', `bytes */${fileSize}`);
+          return res.end();
+        }
+
+        const chunkSize = end - start + 1;
+
+        res.status(206).set({
+          'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+          'Accept-Ranges': 'bytes',
+          'Content-Length': chunkSize,
+          'Content-Type': contentType,
+          ...cacheHeaders,
+        });
+
+        const stream = fs.createReadStream(filePath, { start, end });
+        stream.on('error', (err) => {
+          req.log.error({ err, youtubeId }, 'Stream read error');
+          if (!res.headersSent) {
+            res.status(500).json({ error: 'Error reading file' });
+          } else {
+            res.destroy();
+          }
+        });
+        stream.pipe(res);
+      } else {
+        // No range - serve entire file
+        res.set({
+          'Content-Length': fileSize,
+          'Content-Type': contentType,
+          'Accept-Ranges': 'bytes',
+          ...cacheHeaders,
+        });
+
+        const stream = fs.createReadStream(filePath);
+        stream.on('error', (err) => {
+          req.log.error({ err, youtubeId }, 'Stream read error');
+          if (!res.headersSent) {
+            res.status(500).json({ error: 'Error reading file' });
+          } else {
+            res.destroy();
+          }
+        });
+        stream.pipe(res);
+      }
+    } catch (err) {
+      req.log.error({ err, youtubeId }, 'Failed to stream video');
+      res.status(500).json({ error: 'Failed to stream video' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createVideoDetailRoutes;

--- a/server/routes/videoDetail.js
+++ b/server/routes/videoDetail.js
@@ -1,5 +1,18 @@
 const express = require('express');
 const fs = require('fs');
+const rateLimit = require('express-rate-limit');
+
+// Metadata endpoint rate limiter. The endpoint may spawn yt-dlp on cache miss
+// (up to 60s per call), so we cap concurrent abuse. The limit is generous
+// enough for a user rapidly clicking through a video list.
+const metadataLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60, // 60 requests per minute per IP
+  message: { error: 'Too many metadata requests, please try again shortly' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { trustProxy: false },
+});
 
 /**
  * Creates video detail routes for metadata and streaming
@@ -46,7 +59,7 @@ function createVideoDetailRoutes({ verifyToken, videoMetadataModule }) {
    *       500:
    *         description: Internal server error
    */
-  router.get('/api/videos/:youtubeId/metadata', verifyToken, async (req, res) => {
+  router.get('/api/videos/:youtubeId/metadata', metadataLimiter, verifyToken, async (req, res) => {
     const { youtubeId } = req.params;
 
     if (!youtubeId || !/^[A-Za-z0-9_-]{6,20}$/.test(youtubeId)) {

--- a/server/routes/videos.js
+++ b/server/routes/videos.js
@@ -111,7 +111,7 @@ module.exports = function createVideoRoutes({ verifyToken, videosModule, downloa
     req.log.info('Getting videos');
 
     try {
-      const { page, limit, search, dateFrom, dateTo, sortBy, sortOrder, channelFilter } = req.query;
+      const { page, limit, search, dateFrom, dateTo, sortBy, sortOrder, channelFilter, protectedFilter } = req.query;
 
       const options = {
         page: parseInt(page) || 1,
@@ -121,7 +121,8 @@ module.exports = function createVideoRoutes({ verifyToken, videosModule, downloa
         dateTo: dateTo || null,
         sortBy: sortBy || 'added',
         sortOrder: sortOrder || 'desc',
-        channelFilter: channelFilter || ''
+        channelFilter: channelFilter || '',
+        protectedFilter: protectedFilter === 'true',
       };
 
       const result = await videosModule.getVideosPaginated(options);

--- a/server/routes/videos.js
+++ b/server/routes/videos.js
@@ -265,7 +265,7 @@ module.exports = function createVideoRoutes({ verifyToken, videosModule, downloa
         return res.status(404).json({ error: 'Video not found' });
       }
       req.log.error({ err: error }, 'Failed to update video protection status');
-      res.status(500).json({ error: error.message });
+      res.status(500).json({ error: 'Failed to update protection status' });
     }
   });
 

--- a/server/routes/videos.js
+++ b/server/routes/videos.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const router = express.Router();
 const rateLimit = require('express-rate-limit');
 
 // Video validation rate limiter
@@ -44,6 +43,8 @@ const apiKeyDownloadLimiter = rateLimit({
  * @returns {express.Router}
  */
 module.exports = function createVideoRoutes({ verifyToken, videosModule, downloadModule }) {
+  const router = express.Router();
+
   /**
    * @swagger
    * /getVideos:
@@ -209,6 +210,61 @@ module.exports = function createVideoRoutes({ verifyToken, videosModule, downloa
         success: false,
         error: error.message
       });
+    }
+  });
+
+  /**
+   * @swagger
+   * /api/videos/{id}/protected:
+   *   patch:
+   *     summary: Toggle video protection
+   *     description: Set whether a video is protected from automatic deletion.
+   *     tags: [Videos]
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: integer
+   *         description: Video database ID
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - protected
+   *             properties:
+   *               protected:
+   *                 type: boolean
+   *     responses:
+   *       200:
+   *         description: Protection status updated
+   *       400:
+   *         description: Invalid request
+   *       404:
+   *         description: Video not found
+   *       500:
+   *         description: Failed to update protection status
+   */
+  router.patch('/api/videos/:id/protected', verifyToken, async (req, res) => {
+    try {
+      const { id } = req.params;
+      const { protected: protectedState } = req.body;
+
+      if (typeof protectedState !== 'boolean') {
+        return res.status(400).json({ error: 'protected field (boolean) is required' });
+      }
+
+      const result = await videosModule.setVideoProtection(parseInt(id, 10), protectedState);
+      res.json(result);
+    } catch (error) {
+      if (error.message === 'Video not found') {
+        return res.status(404).json({ error: 'Video not found' });
+      }
+      req.log.error({ err: error }, 'Failed to update video protection status');
+      res.status(500).json({ error: error.message });
     }
   });
 

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,20 @@ const { setupSwagger } = require('./swagger');
 const app = express();
 app.set('trust proxy', true); // Trust proxy headers for correct IP detection
 
+// Strip auth tokens from URLs before logging. The video streaming endpoint
+// passes the auth token as ?token=... because <video src> cannot set headers,
+// and pino-http otherwise logs the full URL.
+function redactUrl(url) {
+  if (typeof url !== 'string' || !url.includes('token=')) return url;
+  return url.replace(/([?&])token=[^&]*/g, '$1token=[REDACTED]');
+}
+
+function redactQuery(query) {
+  if (!query || typeof query !== 'object') return query;
+  if (!('token' in query)) return query;
+  return { ...query, token: '[REDACTED]' };
+}
+
 // Setup HTTP request logging with pino-http
 // This must come after trust proxy but before other middleware
 app.use(pinoHttp({
@@ -44,9 +58,9 @@ app.use(pinoHttp({
     req: (req) => ({
       id: req.id,
       method: req.method,
-      url: req.url,
+      url: redactUrl(req.url),
       // Only include query/params if they exist
-      ...(Object.keys(req.query || {}).length > 0 && { query: req.query }),
+      ...(Object.keys(req.query || {}).length > 0 && { query: redactQuery(req.query) }),
       ...(Object.keys(req.params || {}).length > 0 && { params: req.params }),
       remoteAddress: req.remoteAddress,
     }),
@@ -56,10 +70,10 @@ app.use(pinoHttp({
   },
   // Customize the success message to be more concise
   customSuccessMessage: (req, res) => {
-    return `${req.method} ${req.url} ${res.statusCode}`;
+    return `${req.method} ${redactUrl(req.url)} ${res.statusCode}`;
   },
   customErrorMessage: (req, res, err) => {
-    return `${req.method} ${req.url} ${res.statusCode} - ${err?.message || 'Error'}`;
+    return `${req.method} ${redactUrl(req.url)} ${res.statusCode} - ${err?.message || 'Error'}`;
   },
 }));
 


### PR DESCRIPTION
## Features

**Video detail modal with in-app playback**
Click any thumbnail on the Videos page or a channel page to open a detail modal with extended metadata (description, tags, view count, likes, resolution, fps, file sizes, related files) and in-browser playback of downloaded videos - no media server required. Metadata is served from the cached .info.json when available, or fetched on demand via yt-dlp. All existing actions (protect, delete, ignore, rate, download) work from inside the modal and sync back to the source page on close. Mobile opens fullscreen with a back arrow; desktop opens as a centered dialog.

**Per-subfolder Plex library mappings**
You can now point different YouTube subfolders at different Plex libraries. Configure the mappings in the Plex Integration section of the Configuration page, and Youtarr will refresh the matching library after each download instead of always refreshing the global one. Useful if you split your channels across libraries like Kids, Music, or Tech.

**Video protection**
Individual videos can be marked as protected with a shield icon. Protected videos are skipped by the auto-removal feature, so you can pin the ones you want to keep regardless of retention rules. A new filter chip shows all protected videos at a glance on the Videos page and on each channel's page.

**Manual tab override for channels**
You can now choose which YouTube tabs (Videos, Shorts, Live) a channel uses. The channel settings dialog has a new tab editor with a "Refresh from YouTube" button that forces yt-dlp to re-detect the channel's tabs, bypassing the cached list. This is the workaround for channels where the old tab detection went stale and started showing tabs that no longer exist (or hiding ones that do).

**Selectable page size on channel pages**
The channel page now has a "per page" dropdown (8, 16, 32, 64, 128) next to the pagination controls. The selection is persisted to localStorage so it sticks across sessions. Replaces the old hardcoded 16-desktop / 8-mobile split with a single user-chosen value.

## Fixes

- Patched axios (SSRF) and vite (path traversal) dependency vulnerabilities.
- The `reset-server-data` script now also clears the dev and ARM database volumes so it actually resets everything.
- Documentation refreshed for the dev workflow, Docker Compose file variants, and several config field clarifications.