### PR TITLE
feat(channels): add selectable page size for channel videos (#288)

### DIFF
--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -20,6 +20,8 @@ import {
   Pagination,
   Tabs,
   Tab,
+  Select,
+  MenuItem,
 } from '@mui/material';
 
 import DownloadIcon from '@mui/icons-material/Download';
@@ -46,6 +48,7 @@ import { useChannelVideos } from './hooks/useChannelVideos';
 import { useRefreshChannelVideos } from './hooks/useRefreshChannelVideos';
 import { useChannelFetchStatus } from './hooks/useChannelFetchStatus';
 import { useChannelVideoFilters } from './hooks/useChannelVideoFilters';
+import { useChannelVideosPageSize, ALLOWED_PAGE_SIZES, type PageSize } from './hooks/useChannelVideosPageSize';
 import ChannelVideosFilters from './components/ChannelVideosFilters';
 import { useConfig } from '../../hooks/useConfig';
 import { useTriggerDownloads } from '../../hooks/useTriggerDownloads';
@@ -88,7 +91,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   const [tabAutoDownloadStatus, setTabAutoDownloadStatus] = useState<Record<string, boolean>>({});
 
   // Data states
-  const pageSize = isMobile ? 8 : 16;
+  const [pageSize, setPageSize] = useChannelVideosPageSize();
   const [page, setPage] = useState(1);
   const [checkedBoxes, setCheckedBoxes] = useState<string[]>([]);
   const [hideDownloaded, setHideDownloaded] = useState(false);
@@ -693,6 +696,11 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
     setPage(value);
   };
 
+  const handlePageSizeChange = (newSize: PageSize) => {
+    setPageSize(newSize);
+    setPage(1);
+  };
+
   const handleViewModeChange = (event: React.MouseEvent<HTMLElement>, newMode: ViewMode | null) => {
     if (newMode !== null) {
       setViewMode(newMode);
@@ -953,17 +961,68 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
           </Box>
         )}
 
-        {/* Pagination - directly under tabs */}
-        {totalPages > 1 && (
-          <Box sx={{ display: 'flex', justifyContent: 'center', py: 2, px: 2, borderBottom: '1px solid', borderColor: 'divider' }}>
-            <Pagination
-              count={totalPages}
-              page={page}
-              onChange={handlePageChange}
-              color="primary"
-              size={isMobile ? 'small' : 'medium'}
-              siblingCount={isMobile ? 0 : 1}
-            />
+        {/* Pagination and page size selector */}
+        {!videosLoading && totalCount > 0 && (
+          <Box sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 1,
+            py: 1.5,
+            px: 2,
+            borderBottom: '1px solid',
+            borderColor: 'divider',
+            position: 'relative',
+            minHeight: 48,
+          }}>
+            {totalPages > 1 && (
+              <Pagination
+                count={totalPages}
+                page={page}
+                onChange={handlePageChange}
+                color="primary"
+                size={isMobile ? 'small' : 'medium'}
+                siblingCount={isMobile ? 0 : 1}
+              />
+            )}
+            <Box sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              position: { sm: 'absolute' },
+              right: { sm: 16 },
+            }}>
+              {!isMobile && (
+                <Typography variant="body2" color="text.secondary">
+                  Per page:
+                </Typography>
+              )}
+              <Select
+                size="small"
+                value={pageSize}
+                onChange={(e) => {
+                  const val = Number(e.target.value);
+                  if ((ALLOWED_PAGE_SIZES as readonly number[]).includes(val)) {
+                    handlePageSizeChange(val as PageSize);
+                  }
+                }}
+                aria-label="videos per page"
+                sx={{
+                  minWidth: 64,
+                  '& .MuiSelect-select': {
+                    py: 0.5,
+                    fontSize: '0.875rem',
+                  },
+                }}
+              >
+                {ALLOWED_PAGE_SIZES.map((size) => (
+                  <MenuItem key={size} value={size}>
+                    {size}
+                  </MenuItem>
+                ))}
+              </Select>
+            </Box>
           </Box>
         )}
 

--- a/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -174,6 +174,7 @@ describe('ChannelVideos Component', () => {
     mockFetch.mockReset();
     (useMediaQuery as jest.Mock).mockReturnValue(false);
     mockNavigate.mockClear();
+    localStorage.removeItem('youtarr.channelVideos.pageSize');
 
     // Default mock responses
     useChannelVideos.mockReturnValue({
@@ -434,6 +435,180 @@ describe('ChannelVideos Component', () => {
     });
   });
 
+  describe('Page Size Selector', () => {
+    test('renders page size selector when videos exist', () => {
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      expect(screen.getByLabelText('videos per page')).toBeInTheDocument();
+    });
+
+    test('does not render page size selector when no videos', () => {
+      useChannelVideos.mockReturnValue({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      expect(screen.queryByLabelText('videos per page')).not.toBeInTheDocument();
+    });
+
+    test('does not render page size selector while loading', () => {
+      useChannelVideos.mockReturnValue({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: true,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      expect(screen.queryByLabelText('videos per page')).not.toBeInTheDocument();
+    });
+
+    test('selector shows default value of 16', () => {
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      const select = screen.getByLabelText('videos per page');
+      expect(select).toHaveTextContent('16');
+    });
+
+    test('selector reads stored value from localStorage', () => {
+      localStorage.setItem('youtarr.channelVideos.pageSize', '32');
+
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      expect(useChannelVideos).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageSize: 32,
+        })
+      );
+    });
+
+    test('changing page size updates fetch params and writes to localStorage', async () => {
+      const user = userEvent.setup();
+
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 48, // enough for multiple pages at size 16
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      // Navigate to page 2 first so we can verify page resets to 1
+      await waitFor(() => {
+        expect(screen.getAllByRole('navigation').length).toBeGreaterThan(0);
+      });
+      const page2Buttons = screen.getAllByRole('button', { name: 'Go to page 2' });
+      await user.click(page2Buttons[0]);
+
+      expect(useChannelVideos).toHaveBeenLastCalledWith(
+        expect.objectContaining({ page: 2 })
+      );
+
+      // Open the MUI Select dropdown by clicking its displayed value text.
+      // MUI Select (non-native) opens on mouseDown on the inner trigger div.
+      // The "Per page:" label precedes the Select, and the Select displays "16".
+      // Use within() on the labeled container to find the trigger by its text content.
+      const selectContainer = screen.getByLabelText('videos per page');
+      const trigger = within(selectContainer).getByText('16');
+      fireEvent.mouseDown(trigger);
+
+      // Choose 32
+      const option = await screen.findByRole('option', { name: '32' });
+      await user.click(option);
+
+      expect(localStorage.getItem('youtarr.channelVideos.pageSize')).toBe('32');
+      expect(useChannelVideos).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          pageSize: 32,
+          page: 1,
+        })
+      );
+    });
+
+    test('renders selector without pagination buttons when only one page', () => {
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 3,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      // Selector should be present
+      expect(screen.getByLabelText('videos per page')).toBeInTheDocument();
+
+      // Only 1 page total (3 videos < 16 per page), so no page 2 button should exist
+      expect(screen.queryByRole('button', { name: 'Go to page 2' })).not.toBeInTheDocument();
+    });
+
+    test('renders both selector and pagination when multiple pages', () => {
+      useChannelVideos.mockReturnValue({
+        videos: mockVideos,
+        totalCount: 32,
+        oldestVideoDate: '2023-01-01',
+        videoFailed: false,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+
+      // Both should be present
+      expect(screen.getByLabelText('videos per page')).toBeInTheDocument();
+      expect(screen.getAllByRole('navigation').length).toBeGreaterThan(0);
+    });
+  });
+
   describe('Error Handling', () => {
     test('handles tab fetch error gracefully', async () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -679,12 +854,12 @@ describe('ChannelVideos Component', () => {
       (useMediaQuery as jest.Mock).mockReturnValue(true);
     });
 
-    test('uses mobile page size', () => {
+    test('uses same page size on mobile as desktop (unified setting)', () => {
       renderChannelVideos();
 
       expect(useChannelVideos).toHaveBeenCalledWith(
         expect.objectContaining({
-          pageSize: 8, // Mobile page size
+          pageSize: 16,
         })
       );
     });

--- a/client/src/components/ChannelPage/hooks/__tests__/useChannelVideosPageSize.test.ts
+++ b/client/src/components/ChannelPage/hooks/__tests__/useChannelVideosPageSize.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, act } from '@testing-library/react';
+import { useChannelVideosPageSize, ALLOWED_PAGE_SIZES } from '../useChannelVideosPageSize';
+
+const STORAGE_KEY = 'youtarr.channelVideos.pageSize';
+
+describe('useChannelVideosPageSize', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('returns default 16 when localStorage is empty', () => {
+    const { result } = renderHook(() => useChannelVideosPageSize());
+    expect(result.current[0]).toBe(16);
+  });
+
+  test('returns stored value when localStorage holds a valid page size', () => {
+    localStorage.setItem(STORAGE_KEY, '32');
+    const { result } = renderHook(() => useChannelVideosPageSize());
+    expect(result.current[0]).toBe(32);
+  });
+
+  test.each([8, 16, 32, 64, 128])('accepts valid page size %i', (size) => {
+    localStorage.setItem(STORAGE_KEY, String(size));
+    const { result } = renderHook(() => useChannelVideosPageSize());
+    expect(result.current[0]).toBe(size);
+  });
+
+  test.each(['foo', '7', '256', '', 'NaN', '0', '-1', '16.5'])(
+    'returns default 16 for invalid localStorage value "%s"',
+    (badValue) => {
+      localStorage.setItem(STORAGE_KEY, badValue);
+      const { result } = renderHook(() => useChannelVideosPageSize());
+      expect(result.current[0]).toBe(16);
+    }
+  );
+
+  test('setPageSize writes to localStorage and updates state', () => {
+    const { result } = renderHook(() => useChannelVideosPageSize());
+    expect(result.current[0]).toBe(16);
+
+    act(() => {
+      result.current[1](64);
+    });
+
+    expect(result.current[0]).toBe(64);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('64');
+  });
+
+  test('handles localStorage.setItem throwing without crashing', () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => useChannelVideosPageSize());
+
+    act(() => {
+      result.current[1](32);
+    });
+
+    // State still updates even though localStorage write failed
+    expect(result.current[0]).toBe(32);
+
+    setItemSpy.mockRestore();
+  });
+
+  test('handles localStorage.getItem throwing without crashing', () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+
+    const { result } = renderHook(() => useChannelVideosPageSize());
+    expect(result.current[0]).toBe(16);
+
+    getItemSpy.mockRestore();
+  });
+
+});

--- a/client/src/components/ChannelPage/hooks/useChannelVideosPageSize.ts
+++ b/client/src/components/ChannelPage/hooks/useChannelVideosPageSize.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'youtarr.channelVideos.pageSize';
+const ALLOWED_PAGE_SIZES = [8, 16, 32, 64, 128] as const;
+const DEFAULT_PAGE_SIZE = 16;
+
+type PageSize = (typeof ALLOWED_PAGE_SIZES)[number];
+
+function readStoredPageSize(): PageSize {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === null) return DEFAULT_PAGE_SIZE;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) return DEFAULT_PAGE_SIZE;
+    if (!(ALLOWED_PAGE_SIZES as readonly number[]).includes(parsed)) return DEFAULT_PAGE_SIZE;
+    return parsed as PageSize;
+  } catch {
+    return DEFAULT_PAGE_SIZE;
+  }
+}
+
+export function useChannelVideosPageSize(): [PageSize, (next: PageSize) => void] {
+  const [pageSize, setPageSizeState] = useState<PageSize>(readStoredPageSize);
+
+  const setPageSize = useCallback((next: PageSize) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(next));
+    } catch {
+      // localStorage may be unavailable (private mode, quota); keep in-memory value
+    }
+    setPageSizeState(next);
+  }, []);
+
+  return [pageSize, setPageSize];
+}
+
+export { ALLOWED_PAGE_SIZES, DEFAULT_PAGE_SIZE };
+export type { PageSize };


### PR DESCRIPTION
- Replace hardcoded page size (16 desktop / 8 mobile) with a user-selectable dropdown persisted to localStorage
- Add useChannelVideosPageSize hook with allowlist validation (8, 16, 32, 64, 128) and localStorage error resilience
- Show page size selector alongside pagination controls, positioned right-aligned on desktop
- Reset to page 1 when page size changes to avoid empty pages
- Add tests for the new hook and page size selector behavior, including a page-reset test that navigates away from page 1 before asserting the reset

<img width="1476" height="1145" alt="image" src="https://github.com/user-attachments/assets/acebd4f3-4425-4716-a9d3-15202da1ea76" />
