### PR TITLE
feat(videos): add video detail modal with in-app playback (#522)

### DIFF
--- a/client/src/components/ChannelPage.tsx
+++ b/client/src/components/ChannelPage.tsx
@@ -360,6 +360,7 @@ function ChannelPage({ token }: ChannelPageProps) {
         token={token}
         channelAutoDownloadTabs={channel?.auto_download_enabled_tabs}
         channelId={channel_id || undefined}
+        channelName={channel?.uploader || ''}
         channelVideoQuality={channel?.video_quality || null}
         channelAudioFormat={channel?.audio_format || null}
         channelAvailableTabs={channel?.available_tabs ?? null}

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -1205,7 +1205,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
 
       {modalVideo && (
         <VideoModal
-          open={modalVideo !== null}
+          open
           onClose={() => setModalVideo(null)}
           video={channelVideoToModalData(modalVideo, channelName, channelId)}
           token={token}

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -52,11 +52,15 @@ import { useChannelVideosPageSize, ALLOWED_PAGE_SIZES, type PageSize } from './h
 import ChannelVideosFilters from './components/ChannelVideosFilters';
 import { useConfig } from '../../hooks/useConfig';
 import { useTriggerDownloads } from '../../hooks/useTriggerDownloads';
+import VideoModal from '../shared/VideoModal';
+import { VideoModalData } from '../shared/VideoModal/types';
+import { ChannelVideo } from '../../types/ChannelVideo';
 
 interface ChannelVideosProps {
   token: string | null;
   channelAutoDownloadTabs?: string;
   channelId?: string;
+  channelName?: string;
   channelVideoQuality?: string | null;
   channelAudioFormat?: string | null;
   /**
@@ -72,7 +76,33 @@ type ViewMode = 'table' | 'grid' | 'list';
 type SortBy = 'date' | 'title' | 'duration' | 'size';
 type SortOrder = 'asc' | 'desc';
 
-function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelId, channelVideoQuality, channelAudioFormat, channelAvailableTabs }: ChannelVideosProps) {
+function channelVideoToModalData(video: ChannelVideo, channelName: string, channelId: string | undefined): VideoModalData {
+  const status = getVideoStatus(video);
+  return {
+    youtubeId: video.youtube_id,
+    title: video.title,
+    channelName,
+    thumbnailUrl: video.thumbnail,
+    duration: video.duration,
+    publishedAt: video.publishedAt || null,
+    addedAt: null,
+    mediaType: video.media_type || 'video',
+    status,
+    isDownloaded: video.added && !video.removed,
+    filePath: video.filePath || null,
+    fileSize: video.fileSize || null,
+    audioFilePath: video.audioFilePath || null,
+    audioFileSize: video.audioFileSize || null,
+    isProtected: video.protected || false,
+    isIgnored: video.ignored || false,
+    normalizedRating: video.normalized_rating || null,
+    ratingSource: video.rating_source || null,
+    databaseId: video.id || null,
+    channelId: channelId || null,
+  };
+}
+
+function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelId, channelName = '', channelVideoQuality, channelAudioFormat, channelAvailableTabs }: ChannelVideosProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -103,6 +133,9 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
   const [selectedForDeletion, setSelectedForDeletion] = useState<string[]>([]);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Modal state
+  const [modalVideo, setModalVideo] = useState<ChannelVideo | null>(null);
 
   // Local state to track ignore status changes without refetching
   const [localIgnoreStatus, setLocalIgnoreStatus] = useState<Record<string, boolean>>({});
@@ -1074,6 +1107,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onToggleIgnore={toggleIgnore}
                       onToggleProtection={handleToggleProtection}
                       onMobileTooltip={setMobileTooltip}
+                      onVideoClick={setModalVideo}
                     />
                   ))}
                 </Grid>
@@ -1092,6 +1126,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                       onToggleIgnore={toggleIgnore}
                       onToggleProtection={handleToggleProtection}
                       onMobileTooltip={setMobileTooltip}
+                      onVideoClick={setModalVideo}
                     />
                   ))}
                 </Box>
@@ -1112,6 +1147,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
                   onToggleIgnore={toggleIgnore}
                   onToggleProtection={handleToggleProtection}
                   onMobileTooltip={setMobileTooltip}
+                  onVideoClick={setModalVideo}
                 />
               )}
 
@@ -1166,6 +1202,31 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
         onSuccessMessageClose={() => setSuccessMessage(null)}
         onErrorMessageClose={() => setErrorMessage(null)}
       />
+
+      {modalVideo && (
+        <VideoModal
+          open={modalVideo !== null}
+          onClose={() => setModalVideo(null)}
+          video={channelVideoToModalData(modalVideo, channelName, channelId)}
+          token={token}
+          onVideoDeleted={() => {
+            setModalVideo(null);
+            refetchVideos();
+          }}
+          onProtectionChanged={(youtubeId, isProtected) => {
+            setLocalProtectedStatus(prev => ({ ...prev, [youtubeId]: isProtected }));
+          }}
+          onIgnoreChanged={(youtubeId, isIgnored) => {
+            setLocalIgnoreStatus(prev => ({ ...prev, [youtubeId]: isIgnored }));
+          }}
+          onDownloadQueued={() => {
+            setModalVideo(null);
+          }}
+          onRatingChanged={() => {
+            refetchVideos();
+          }}
+        />
+      )}
     </>
   );
 }

--- a/client/src/components/ChannelPage/VideoCard.tsx
+++ b/client/src/components/ChannelPage/VideoCard.tsx
@@ -23,6 +23,7 @@ import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
 import RatingBadge from '../shared/RatingBadge';
 import ProtectionShieldButton from '../shared/ProtectionShieldButton';
+import ThumbnailClickOverlay from '../shared/ThumbnailClickOverlay';
 
 interface VideoCardProps {
   video: ChannelVideo;
@@ -36,6 +37,7 @@ interface VideoCardProps {
   onToggleIgnore: (youtubeId: string) => void;
   onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
+  onVideoClick?: (video: ChannelVideo) => void;
 }
 
 function VideoCard({
@@ -50,6 +52,7 @@ function VideoCard({
   onToggleIgnore,
   onToggleProtection,
   onMobileTooltip,
+  onVideoClick,
 }: VideoCardProps) {
   const theme = useTheme();
   const status = getVideoStatus(video);
@@ -104,6 +107,16 @@ function VideoCard({
               }}
               loading="lazy"
             />
+
+            {/* Center hotspot for opening video modal */}
+            {onVideoClick && (
+              <ThumbnailClickOverlay
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  onVideoClick(video);
+                }}
+              />
+            )}
 
             {/* YouTube Removed Banner */}
             {video.youtube_removed ? (
@@ -266,6 +279,10 @@ function VideoCard({
           <Box sx={{ p: isMobile ? 1.5 : 2, flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
             <Typography
               variant="body2"
+              onClick={onVideoClick ? (e: React.MouseEvent) => {
+                e.stopPropagation();
+                onVideoClick(video);
+              } : undefined}
               sx={{
                 mb: 1,
                 overflow: 'hidden',
@@ -275,6 +292,8 @@ function VideoCard({
                 WebkitBoxOrient: 'vertical',
                 lineHeight: 1.3,
                 minHeight: '2.6em',
+                cursor: onVideoClick ? 'pointer' : 'default',
+                '&:hover': onVideoClick ? { textDecoration: 'underline' } : {},
               }}
               title={decodeHtml(video.title)}
             >

--- a/client/src/components/ChannelPage/VideoListItem.tsx
+++ b/client/src/components/ChannelPage/VideoListItem.tsx
@@ -23,6 +23,7 @@ import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
 import RatingBadge from '../shared/RatingBadge';
 import ProtectionShieldButton from '../shared/ProtectionShieldButton';
+import ThumbnailClickOverlay from '../shared/ThumbnailClickOverlay';
 
 interface VideoListItemProps {
   video: ChannelVideo;
@@ -33,6 +34,7 @@ interface VideoListItemProps {
   onToggleIgnore: (youtubeId: string) => void;
   onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
+  onVideoClick?: (video: ChannelVideo) => void;
 }
 
 function VideoListItem({
@@ -44,6 +46,7 @@ function VideoListItem({
   onToggleIgnore,
   onToggleProtection,
   onMobileTooltip,
+  onVideoClick,
 }: VideoListItemProps) {
   const theme = useTheme();
   const status = getVideoStatus(video);
@@ -92,6 +95,16 @@ function VideoListItem({
             }}
             loading="lazy"
           />
+
+          {/* Center hotspot for opening video modal */}
+          {onVideoClick && (
+            <ThumbnailClickOverlay
+              onClick={(e: React.MouseEvent) => {
+                e.stopPropagation();
+                onVideoClick(video);
+              }}
+            />
+          )}
 
           {/* YouTube Removed Banner */}
           {video.youtube_removed ? (
@@ -244,6 +257,10 @@ function VideoListItem({
           {/* Title */}
           <Typography
             variant="body2"
+            onClick={onVideoClick ? (e: React.MouseEvent) => {
+              e.stopPropagation();
+              onVideoClick(video);
+            } : undefined}
             sx={{
               mb: 0.5,
               overflow: 'hidden',
@@ -253,6 +270,8 @@ function VideoListItem({
               WebkitBoxOrient: 'vertical',
               lineHeight: 1.3,
               fontSize: '0.875rem',
+              cursor: onVideoClick ? 'pointer' : 'default',
+              '&:hover': onVideoClick ? { textDecoration: 'underline' } : {},
             }}
             title={decodeHtml(video.title)}
           >

--- a/client/src/components/ChannelPage/VideoTableView.tsx
+++ b/client/src/components/ChannelPage/VideoTableView.tsx
@@ -25,6 +25,7 @@ import { decodeHtml } from '../../utils/formatters';
 import { getVideoStatus, getStatusColor, getStatusIcon, getStatusLabel, getMediaTypeInfo } from '../../utils/videoStatus';
 import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
+import ThumbnailClickOverlay from '../shared/ThumbnailClickOverlay';
 
 type SortBy = 'date' | 'title' | 'duration' | 'size';
 type SortOrder = 'asc' | 'desc';
@@ -43,6 +44,7 @@ interface VideoTableViewProps {
   onToggleIgnore: (youtubeId: string) => void;
   onToggleProtection: (youtubeId: string) => void;
   onMobileTooltip?: (message: string) => void;
+  onVideoClick?: (video: ChannelVideo) => void;
 }
 
 function VideoTableView({
@@ -59,6 +61,7 @@ function VideoTableView({
   onToggleIgnore,
   onToggleProtection,
   onMobileTooltip,
+  onVideoClick,
 }: VideoTableViewProps) {
   return (
     <TableContainer>
@@ -209,6 +212,15 @@ function VideoTableView({
                       }}
                       loading="lazy"
                     />
+                    {/* Center hotspot for opening video modal */}
+                    {onVideoClick && (
+                      <ThumbnailClickOverlay
+                        onClick={(e: React.MouseEvent) => {
+                          e.stopPropagation();
+                          onVideoClick(video);
+                        }}
+                      />
+                    )}
                     {video.youtube_removed && (
                       <Box
                         sx={{
@@ -232,7 +244,18 @@ function VideoTableView({
                   </Box>
                 </TableCell>
                 <TableCell>
-                  <Typography variant="body2" sx={{ mb: 0.5 }}>
+                  <Typography
+                    variant="body2"
+                    onClick={onVideoClick ? (e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      onVideoClick(video);
+                    } : undefined}
+                    sx={{
+                      mb: 0.5,
+                      cursor: onVideoClick ? 'pointer' : 'default',
+                      '&:hover': onVideoClick ? { textDecoration: 'underline' } : {},
+                    }}
+                  >
                     {decodeHtml(video.title)}
                   </Typography>
                 </TableCell>

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -54,6 +54,34 @@ import RatingBadge from './shared/RatingBadge';
 import ChangeRatingDialog from './shared/ChangeRatingDialog';
 import VideoActionsDropdown from './shared/VideoActionsDropdown';
 import ProtectionShieldButton from './shared/ProtectionShieldButton';
+import VideoModal from './shared/VideoModal';
+import ThumbnailClickOverlay from './shared/ThumbnailClickOverlay';
+import { VideoModalData } from './shared/VideoModal/types';
+
+function videoDataToModalData(video: VideoData): VideoModalData {
+  return {
+    youtubeId: video.youtubeId,
+    title: video.youTubeVideoName,
+    channelName: video.youTubeChannelName,
+    thumbnailUrl: `/images/videothumb-${video.youtubeId}.jpg`,
+    duration: video.duration,
+    publishedAt: video.originalDate || null,
+    addedAt: video.timeCreated || null,
+    mediaType: video.media_type || 'video',
+    status: video.removed ? 'missing' : 'downloaded',
+    isDownloaded: !video.removed,
+    filePath: video.filePath || null,
+    fileSize: video.fileSize ? Number(video.fileSize) : null,
+    audioFilePath: video.audioFilePath || null,
+    audioFileSize: video.audioFileSize ? Number(video.audioFileSize) : null,
+    isProtected: video.protected || false,
+    isIgnored: false,
+    normalizedRating: video.normalized_rating || null,
+    ratingSource: video.rating_source || null,
+    databaseId: video.id,
+    channelId: video.channel_id || null,
+  };
+}
 
 interface VideosPageProps {
   token: string | null;
@@ -91,6 +119,7 @@ function VideosPage({ token }: VideosPageProps) {
   const { deleteVideos, loading: deleteLoading } = useVideoDeletion();
   const { toggleProtection, successMessage: protectionSuccess, error: protectionError, clearMessages: clearProtectionMessages } = useVideoProtection(token);
   const [protectedFilter, setProtectedFilter] = useState(false);
+  const [modalVideo, setModalVideo] = useState<VideoData | null>(null);
 
   const videosPerPage = isMobile ? 6 : 12;
 
@@ -645,6 +674,13 @@ function VideosPage({ token }: VideosPageProps) {
                                   }
                                 />
                               )}
+                              {/* Center hotspot for opening video modal */}
+                              <ThumbnailClickOverlay
+                                onClick={(e: React.MouseEvent) => {
+                                  e.stopPropagation();
+                                  setModalVideo(video);
+                                }}
+                              />
                               {video.youtube_removed ? (
                                 <Box
                                   style={{
@@ -724,7 +760,12 @@ function VideosPage({ token }: VideosPageProps) {
                               />
                               )}
                             </Box>
-                            <Typography variant='subtitle1' textAlign='center'>
+                            <Typography
+                              variant='subtitle1'
+                              textAlign='center'
+                              onClick={() => setModalVideo(video)}
+                              sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                            >
                               {video.youTubeVideoName}
                               {video.duration && (
                                 <Typography
@@ -874,6 +915,13 @@ function VideosPage({ token }: VideosPageProps) {
                                   }
                                 />
                               )}
+                              {/* Center hotspot for opening video modal */}
+                              <ThumbnailClickOverlay
+                                onClick={(e: React.MouseEvent) => {
+                                  e.stopPropagation();
+                                  setModalVideo(video);
+                                }}
+                              />
                               {video.youtube_removed ? (
                                 <Box
                                   style={{
@@ -942,7 +990,11 @@ function VideosPage({ token }: VideosPageProps) {
                             })()}
                           </TableCell>
                           <TableCell style={{ fontSize: 'medium' }}>
-                            <Typography variant='subtitle1'>
+                            <Typography
+                              variant='subtitle1'
+                              onClick={() => setModalVideo(video)}
+                              sx={{ cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+                            >
                               {video.youTubeVideoName}
                             </Typography>
                             {video.duration && (
@@ -1118,6 +1170,35 @@ function VideosPage({ token }: VideosPageProps) {
           {protectionError}
         </Alert>
       </Snackbar>
+
+      {modalVideo && (
+        <VideoModal
+          open={modalVideo !== null}
+          onClose={() => setModalVideo(null)}
+          video={videoDataToModalData(modalVideo)}
+          token={token}
+          onVideoDeleted={() => {
+            setModalVideo(null);
+            fetchVideos();
+          }}
+          onProtectionChanged={(youtubeId, isProtected) => {
+            setVideos((prev: VideoData[]) =>
+              prev.map((v: VideoData) =>
+                v.youtubeId === youtubeId ? { ...v, protected: isProtected } : v
+              )
+            );
+          }}
+          onRatingChanged={(youtubeId, rating) => {
+            setVideos((prev: VideoData[]) =>
+              prev.map((v: VideoData) =>
+                v.youtubeId === youtubeId
+                  ? { ...v, normalized_rating: rating, rating_source: rating ? 'Manual Override' : null }
+                  : v
+              )
+            );
+          }}
+        />
+      )}
     </Card>
   );
 }

--- a/client/src/components/VideosPage.tsx
+++ b/client/src/components/VideosPage.tsx
@@ -1173,7 +1173,7 @@ function VideosPage({ token }: VideosPageProps) {
 
       {modalVideo && (
         <VideoModal
-          open={modalVideo !== null}
+          open
           onClose={() => setModalVideo(null)}
           video={videoDataToModalData(modalVideo)}
           token={token}

--- a/client/src/components/shared/ThumbnailClickOverlay.tsx
+++ b/client/src/components/shared/ThumbnailClickOverlay.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box, SxProps, Theme } from '@mui/material';
+
+interface ThumbnailClickOverlayProps {
+  onClick: (e: React.MouseEvent) => void;
+  sx?: SxProps<Theme>;
+}
+
+const ThumbnailClickOverlay: React.FC<ThumbnailClickOverlayProps> = ({ onClick, sx }) => (
+  <Box
+    onClick={onClick}
+    sx={{
+      position: 'absolute',
+      top: '25%',
+      left: '25%',
+      width: '50%',
+      height: '50%',
+      cursor: 'pointer',
+      zIndex: 1,
+      ...sx as object,
+    }}
+  />
+);
+
+export default ThumbnailClickOverlay;

--- a/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
+++ b/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
@@ -1,0 +1,424 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { VideoModalData } from '../types';
+
+// Mock axios
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  delete: jest.fn(),
+  patch: jest.fn(),
+}));
+
+const axios = require('axios');
+
+// Mock useVideoMetadata - uses a ref object so resetMocks doesn't clear the return value
+const videoMetadataReturn = {
+  metadata: null as null,
+  loading: false,
+  error: null as string | null,
+};
+jest.mock('../hooks/useVideoMetadata', () => ({
+  useVideoMetadata: () => videoMetadataReturn,
+}));
+
+// Mock useVideoProtection - use plain object refs to survive resetMocks
+const mockToggleProtection = jest.fn();
+const protectionReturn = {
+  get toggleProtection() { return mockToggleProtection; },
+  loading: false,
+  error: null as string | null,
+  successMessage: null as string | null,
+  clearMessages: () => {},
+};
+jest.mock('../../useVideoProtection', () => ({
+  useVideoProtection: () => protectionReturn,
+}));
+
+// Mock useVideoDeletion
+const mockDeleteVideosByYoutubeIds = jest.fn();
+const deletionReturn = {
+  deleteVideos: () => Promise.resolve({ success: true, deleted: [], failed: [] }),
+  get deleteVideosByYoutubeIds() { return mockDeleteVideosByYoutubeIds; },
+  loading: false,
+  error: null as string | null,
+};
+jest.mock('../../useVideoDeletion', () => ({
+  useVideoDeletion: () => deletionReturn,
+}));
+
+// Mock sub-components that don't need full rendering
+jest.mock('../components/VideoPlayer', () => ({
+  __esModule: true,
+  default: function MockVideoPlayer() {
+    const React = require('react');
+    return React.createElement('div', { 'data-testid': 'video-player' }, 'VideoPlayer');
+  },
+}));
+
+jest.mock('../components/VideoMetadata', () => ({
+  __esModule: true,
+  default: function MockVideoMetadata() {
+    const React = require('react');
+    return React.createElement('div', { 'data-testid': 'video-metadata' }, 'VideoMetadata');
+  },
+}));
+
+jest.mock('../components/VideoTechnical', () => ({
+  __esModule: true,
+  default: function MockVideoTechnical() {
+    const React = require('react');
+    return React.createElement('div', { 'data-testid': 'video-technical' }, 'VideoTechnical');
+  },
+}));
+
+jest.mock('../../DeleteVideosDialog', () => ({
+  __esModule: true,
+  default: function MockDeleteDialog(props: { open: boolean; onConfirm: () => void; onClose: () => void }) {
+    const React = require('react');
+    if (!props.open) return null;
+    return React.createElement('div', { 'data-testid': 'delete-dialog' },
+      React.createElement('button', { 'data-testid': 'confirm-delete', onClick: props.onConfirm }, 'Confirm Delete'),
+      React.createElement('button', { 'data-testid': 'cancel-delete', onClick: props.onClose }, 'Cancel')
+    );
+  },
+}));
+
+jest.mock('../../../DownloadManager/ManualDownload/DownloadSettingsDialog', () => ({
+  __esModule: true,
+  default: function MockDownloadDialog(props: { open: boolean; onConfirm: () => void; onClose: () => void }) {
+    const React = require('react');
+    if (!props.open) return null;
+    return React.createElement('div', { 'data-testid': 'download-dialog' },
+      React.createElement('button', { 'data-testid': 'confirm-download', onClick: props.onConfirm }, 'Confirm Download'),
+    );
+  },
+}));
+
+jest.mock('../../ChangeRatingDialog', () => ({
+  __esModule: true,
+  default: function MockRatingDialog(props: { open: boolean; onApply: (rating: string | null) => Promise<void>; onClose: () => void }) {
+    const React = require('react');
+    if (!props.open) return null;
+    return React.createElement('div', { 'data-testid': 'rating-dialog' },
+      React.createElement('button', {
+        'data-testid': 'apply-rating',
+        onClick: () => props.onApply('PG-13'),
+      }, 'Apply PG-13'),
+      React.createElement('button', {
+        'data-testid': 'clear-rating',
+        onClick: () => props.onApply(null),
+      }, 'Clear Rating'),
+    );
+  },
+}));
+
+jest.mock('../../RatingBadge', () => ({
+  __esModule: true,
+  default: function MockRatingBadge(props: { rating: string | null }) {
+    const React = require('react');
+    return props.rating
+      ? React.createElement('span', { 'data-testid': 'rating-badge' }, props.rating)
+      : null;
+  },
+}));
+
+import VideoModal from '../index';
+
+const theme = createTheme();
+
+const baseVideo: VideoModalData = {
+  youtubeId: 'test123',
+  title: 'Test Video Title',
+  channelName: 'Test Channel',
+  thumbnailUrl: 'https://example.com/thumb.jpg',
+  duration: 120,
+  publishedAt: '2024-01-15',
+  addedAt: '2024-01-16',
+  mediaType: 'video',
+  status: 'downloaded',
+  isDownloaded: true,
+  filePath: '/videos/test.mp4',
+  fileSize: 1024000,
+  audioFilePath: null,
+  audioFileSize: null,
+  isProtected: false,
+  isIgnored: false,
+  normalizedRating: null,
+  ratingSource: null,
+  databaseId: 42,
+  channelId: 'UC123',
+};
+
+const neverDownloadedVideo: VideoModalData = {
+  ...baseVideo,
+  status: 'never_downloaded',
+  isDownloaded: false,
+  filePath: null,
+  fileSize: null,
+};
+
+function renderModal(props: Partial<React.ComponentProps<typeof VideoModal>> = {}) {
+  const defaultProps = {
+    open: true,
+    onClose: jest.fn(),
+    video: baseVideo,
+    token: 'test-token',
+  };
+
+  return render(
+    <ThemeProvider theme={theme}>
+      <VideoModal {...defaultProps} {...props} />
+    </ThemeProvider>
+  );
+}
+
+describe('VideoModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    protectionReturn.error = null;
+  });
+
+  test('renders video title when open', () => {
+    renderModal();
+    expect(screen.getByText('Test Video Title')).toBeInTheDocument();
+  });
+
+  test('renders status chip', () => {
+    renderModal();
+    expect(screen.getByText('Downloaded')).toBeInTheDocument();
+  });
+
+  test('renders rating badge when rating exists', () => {
+    renderModal({
+      video: { ...baseVideo, normalizedRating: 'PG-13', ratingSource: 'manual' },
+    });
+    expect(screen.getByTestId('rating-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('rating-badge')).toHaveTextContent('PG-13');
+  });
+
+  test('renders delete button for downloaded videos', () => {
+    renderModal();
+    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+  });
+
+  test('renders ignore button for non-downloaded videos', () => {
+    renderModal({ video: neverDownloadedVideo });
+    expect(screen.getByRole('button', { name: /ignore/i })).toBeInTheDocument();
+  });
+
+  test('calls onClose when close button clicked', async () => {
+    const onClose = jest.fn();
+    renderModal({ onClose });
+
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    await userEvent.click(closeButton);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not render when closed', () => {
+    renderModal({ open: false });
+    expect(screen.queryByText('Test Video Title')).not.toBeInTheDocument();
+  });
+
+  describe('handleProtectionToggle', () => {
+    test('calls toggleProtection and fires onProtectionChanged on success', async () => {
+      const onProtectionChanged = jest.fn();
+      mockToggleProtection.mockResolvedValueOnce(true);
+
+      renderModal({ onProtectionChanged });
+
+      const protectButton = screen.getByRole('button', { name: /protect from auto-deletion/i });
+      await userEvent.click(protectButton);
+
+      await waitFor(() => {
+        expect(mockToggleProtection).toHaveBeenCalledWith(42, false);
+      });
+
+      await waitFor(() => {
+        expect(onProtectionChanged).toHaveBeenCalledWith('test123', true);
+      });
+
+      expect(screen.getByText('Video protected from auto-deletion')).toBeInTheDocument();
+    });
+
+    test('shows error snackbar and reverts on protection failure', async () => {
+      protectionReturn.error = 'Server error';
+      mockToggleProtection.mockResolvedValueOnce(undefined);
+
+      renderModal();
+
+      const protectButton = screen.getByRole('button', { name: /protect from auto-deletion/i });
+      await userEvent.click(protectButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Server error')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('handleDeleteConfirm', () => {
+    test('calls deleteVideosByYoutubeIds and fires onVideoDeleted on success', async () => {
+      const onVideoDeleted = jest.fn();
+      const onClose = jest.fn();
+      mockDeleteVideosByYoutubeIds.mockResolvedValueOnce({
+        success: true,
+        deleted: ['test123'],
+        failed: [],
+      });
+
+      renderModal({ onVideoDeleted, onClose });
+
+      // Click the Delete button to open the dialog
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await userEvent.click(deleteButton);
+
+      // Confirm the deletion in the dialog
+      const confirmButton = screen.getByTestId('confirm-delete');
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        expect(mockDeleteVideosByYoutubeIds).toHaveBeenCalledWith(['test123'], 'test-token');
+      });
+
+      await waitFor(() => {
+        expect(onVideoDeleted).toHaveBeenCalledWith('test123');
+      });
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    test('shows error snackbar on deletion failure', async () => {
+      mockDeleteVideosByYoutubeIds.mockResolvedValueOnce({
+        success: false,
+        deleted: [],
+        failed: [{ youtubeId: 'test123', error: 'Permission denied' }],
+      });
+
+      renderModal();
+
+      const deleteButton = screen.getByRole('button', { name: /delete/i });
+      await userEvent.click(deleteButton);
+
+      const confirmButton = screen.getByTestId('confirm-delete');
+      await userEvent.click(confirmButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Permission denied')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('handleIgnoreToggle', () => {
+    test('calls ignore API and fires onIgnoreChanged on success', async () => {
+      const onIgnoreChanged = jest.fn();
+      axios.post.mockResolvedValueOnce({ data: { success: true } });
+
+      renderModal({ video: neverDownloadedVideo, onIgnoreChanged });
+
+      const ignoreButton = screen.getByRole('button', { name: /ignore/i });
+      await userEvent.click(ignoreButton);
+
+      await waitFor(() => {
+        expect(axios.post).toHaveBeenCalledWith(
+          '/api/channels/videos/test123/ignore',
+          { ignored: true },
+          { headers: { 'x-access-token': 'test-token' } }
+        );
+      });
+
+      await waitFor(() => {
+        expect(onIgnoreChanged).toHaveBeenCalledWith('test123', true);
+      });
+
+      expect(screen.getByText('Video ignored')).toBeInTheDocument();
+    });
+
+    test('shows error snackbar on ignore API failure', async () => {
+      axios.post.mockRejectedValueOnce({
+        response: { data: { error: 'Network error' } },
+      });
+
+      renderModal({ video: neverDownloadedVideo });
+
+      const ignoreButton = screen.getByRole('button', { name: /ignore/i });
+      await userEvent.click(ignoreButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Network error')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('handleRatingApply', () => {
+    test('calls rating API and fires onRatingChanged on success', async () => {
+      const onRatingChanged = jest.fn();
+      axios.post.mockResolvedValueOnce({ data: { success: true } });
+
+      renderModal({ onRatingChanged });
+
+      // Click the Rate button to open the rating dialog
+      const rateButton = screen.getByRole('button', { name: /rate/i });
+      await userEvent.click(rateButton);
+
+      // Apply a rating
+      const applyButton = screen.getByTestId('apply-rating');
+      await userEvent.click(applyButton);
+
+      await waitFor(() => {
+        expect(axios.post).toHaveBeenCalledWith(
+          '/api/videos/rating',
+          { videoIds: [42], rating: 'PG-13' },
+          { headers: { 'x-access-token': 'test-token' } }
+        );
+      });
+
+      await waitFor(() => {
+        expect(onRatingChanged).toHaveBeenCalledWith('test123', 'PG-13');
+      });
+
+      expect(screen.getByText('Rating updated')).toBeInTheDocument();
+    });
+
+    test('shows error snackbar on rating API failure', async () => {
+      axios.post.mockRejectedValueOnce({
+        response: { data: { error: 'Rating update failed' } },
+      });
+
+      renderModal();
+
+      const rateButton = screen.getByRole('button', { name: /rate/i });
+      await userEvent.click(rateButton);
+
+      const applyButton = screen.getByTestId('apply-rating');
+      await userEvent.click(applyButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Rating update failed')).toBeInTheDocument();
+      });
+    });
+
+    test('shows error snackbar when video has no databaseId', async () => {
+      const videoWithoutDbId = { ...baseVideo, databaseId: null };
+      axios.post.mockResolvedValueOnce({ data: { success: true } });
+
+      renderModal({ video: videoWithoutDbId });
+
+      const rateButton = screen.getByRole('button', { name: /rate/i });
+      await userEvent.click(rateButton);
+
+      const applyButton = screen.getByTestId('apply-rating');
+      await userEvent.click(applyButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('Cannot update rating: video not in database')).toBeInTheDocument();
+      });
+
+      // Should not have called the API
+      expect(axios.post).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
+++ b/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
@@ -191,12 +191,13 @@ describe('VideoModal', () => {
     expect(screen.getByText('Downloaded')).toBeInTheDocument();
   });
 
-  test('renders rating badge when rating exists', () => {
+  test('renders rating in action button when rating exists', () => {
     renderModal({
       video: { ...baseVideo, normalizedRating: 'PG-13', ratingSource: 'manual' },
     });
-    expect(screen.getByTestId('rating-badge')).toBeInTheDocument();
-    expect(screen.getByTestId('rating-badge')).toHaveTextContent('PG-13');
+    const ratingButton = screen.getByRole('button', { name: /change rating/i });
+    expect(ratingButton).toBeInTheDocument();
+    expect(ratingButton).toHaveTextContent('PG-13');
   });
 
   test('renders delete button for downloaded videos', () => {
@@ -361,7 +362,7 @@ describe('VideoModal', () => {
       renderModal({ onRatingChanged });
 
       // Click the Rate button to open the rating dialog
-      const rateButton = screen.getByRole('button', { name: /rate/i });
+      const rateButton = screen.getByRole('button', { name: /change rating/i });
       await userEvent.click(rateButton);
 
       // Apply a rating
@@ -390,7 +391,7 @@ describe('VideoModal', () => {
 
       renderModal();
 
-      const rateButton = screen.getByRole('button', { name: /rate/i });
+      const rateButton = screen.getByRole('button', { name: /change rating/i });
       await userEvent.click(rateButton);
 
       const applyButton = screen.getByTestId('apply-rating');
@@ -407,7 +408,7 @@ describe('VideoModal', () => {
 
       renderModal({ video: videoWithoutDbId });
 
-      const rateButton = screen.getByRole('button', { name: /rate/i });
+      const rateButton = screen.getByRole('button', { name: /change rating/i });
       await userEvent.click(rateButton);
 
       const applyButton = screen.getByTestId('apply-rating');

--- a/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
+++ b/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
@@ -49,6 +49,23 @@ jest.mock('../../useVideoDeletion', () => ({
   useVideoDeletion: () => deletionReturn,
 }));
 
+// Mock useTriggerDownloads
+const mockTriggerDownloads = jest.fn();
+jest.mock('../../../../hooks/useTriggerDownloads', () => ({
+  useTriggerDownloads: () => ({
+    get triggerDownloads() { return mockTriggerDownloads; },
+    loading: false,
+    error: null,
+  }),
+}));
+
+// Mock react-router-dom useNavigate
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
 // Mock sub-components that don't need full rendering
 jest.mock('../components/VideoPlayer', () => ({
   __esModule: true,
@@ -88,11 +105,11 @@ jest.mock('../../DeleteVideosDialog', () => ({
 
 jest.mock('../../../DownloadManager/ManualDownload/DownloadSettingsDialog', () => ({
   __esModule: true,
-  default: function MockDownloadDialog(props: { open: boolean; onConfirm: () => void; onClose: () => void }) {
+  default: function MockDownloadDialog(props: { open: boolean; onConfirm: (settings: null) => void; onClose: () => void }) {
     const React = require('react');
     if (!props.open) return null;
     return React.createElement('div', { 'data-testid': 'download-dialog' },
-      React.createElement('button', { 'data-testid': 'confirm-download', onClick: props.onConfirm }, 'Confirm Download'),
+      React.createElement('button', { 'data-testid': 'confirm-download', onClick: () => props.onConfirm(null) }, 'Confirm Download'),
     );
   },
 }));
@@ -125,6 +142,7 @@ jest.mock('../../RatingBadge', () => ({
   },
 }));
 
+import { MemoryRouter } from 'react-router-dom';
 import VideoModal from '../index';
 
 const theme = createTheme();
@@ -169,9 +187,11 @@ function renderModal(props: Partial<React.ComponentProps<typeof VideoModal>> = {
   };
 
   return render(
-    <ThemeProvider theme={theme}>
-      <VideoModal {...defaultProps} {...props} />
-    </ThemeProvider>
+    <MemoryRouter>
+      <ThemeProvider theme={theme}>
+        <VideoModal {...defaultProps} {...props} />
+      </ThemeProvider>
+    </MemoryRouter>
   );
 }
 
@@ -179,6 +199,7 @@ describe('VideoModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     protectionReturn.error = null;
+    mockTriggerDownloads.mockResolvedValue(true);
   });
 
   test('renders video title when open', () => {

--- a/client/src/components/shared/VideoModal/components/VideoActions.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoActions.tsx
@@ -1,28 +1,55 @@
 import React from 'react';
-import { Box, Button } from '@mui/material';
+import { Box, Button, Chip, IconButton, Tooltip } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import StarIcon from '@mui/icons-material/Star';
+import StarOutlineIcon from '@mui/icons-material/StarOutline';
 import BlockIcon from '@mui/icons-material/Block';
 import VisibilityIcon from '@mui/icons-material/Visibility';
-import ProtectionShieldButton from '../../ProtectionShieldButton';
+import ShieldIcon from '@mui/icons-material/Shield';
+import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import { VideoModalData } from '../types';
+import { VideoStatus } from '../../../../utils/videoStatus';
+
+interface StatusChipInfo {
+  label: string;
+  color: 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+}
+
+interface MediaTypeChipInfo {
+  label: string;
+  color: 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning';
+  icon: React.ReactElement;
+}
 
 interface VideoActionsProps {
   video: VideoModalData;
+  statusChip: StatusChipInfo;
+  mediaTypeChip: MediaTypeChipInfo | null;
   onDelete: () => void;
   onProtectionToggle: () => void;
   onIgnoreToggle: () => void;
   onRatingChange: () => void;
   protectionLoading: boolean;
+  isMobile: boolean;
 }
+
+const PILL_SX = {
+  textTransform: 'none',
+  borderRadius: 5,
+  px: 1.5,
+  minHeight: 32,
+} as const;
 
 function VideoActions({
   video,
+  statusChip,
+  mediaTypeChip,
   onDelete,
   onProtectionToggle,
   onIgnoreToggle,
   onRatingChange,
   protectionLoading,
+  isMobile,
 }: VideoActionsProps) {
   const isDownloadedAndPresent = video.isDownloaded && video.status !== 'missing';
   const showProtect = isDownloadedAndPresent;
@@ -36,55 +63,111 @@ function VideoActions({
         display: 'flex',
         flexWrap: 'wrap',
         alignItems: 'center',
-        gap: 1,
+        gap: 0.75,
+        py: 0.5,
       }}
     >
+      {/* Status indicators (filled chips - not clickable) */}
+      <Chip
+        label={statusChip.label}
+        color={statusChip.color}
+        size="small"
+      />
+      {mediaTypeChip && (
+        <Chip
+          label={mediaTypeChip.label}
+          color={mediaTypeChip.color}
+          size="small"
+          icon={mediaTypeChip.icon}
+        />
+      )}
+
+      {/* Separator between status and actions */}
+      <Box
+        sx={{
+          width: '1px',
+          height: 20,
+          bgcolor: 'divider',
+          mx: 0.25,
+        }}
+      />
+
+      {/* Action buttons (outlined pills - clickable) */}
       {showProtect && (
-        <ProtectionShieldButton
-          isProtected={video.isProtected}
+        <Button
+          size="small"
+          variant={video.isProtected ? 'contained' : 'outlined'}
+          color={video.isProtected ? 'primary' : 'inherit'}
+          startIcon={video.isProtected ? <ShieldIcon /> : <ShieldOutlinedIcon />}
           onClick={(e: React.MouseEvent) => {
             e.stopPropagation();
             if (!protectionLoading) {
               onProtectionToggle();
             }
           }}
-          variant="inline"
-          size="small"
-        />
+          disabled={protectionLoading}
+          aria-label={video.isProtected ? 'Remove protection' : 'Protect from auto-deletion'}
+          sx={PILL_SX}
+        >
+          {video.isProtected ? 'Protected' : 'Protect'}
+        </Button>
       )}
 
       {showRating && (
         <Button
           size="small"
-          startIcon={<StarIcon />}
+          variant="outlined"
+          color={video.normalizedRating ? 'warning' : 'inherit'}
+          startIcon={video.normalizedRating ? <StarIcon /> : <StarOutlineIcon />}
           onClick={onRatingChange}
-          sx={{ textTransform: 'none' }}
+          aria-label="Change rating"
+          sx={PILL_SX}
         >
-          {video.normalizedRating ? `${video.normalizedRating}` : 'Rate'}
+          {video.normalizedRating || 'Rate'}
         </Button>
       )}
 
       {showIgnore && (
         <Button
           size="small"
+          variant="outlined"
+          color="inherit"
           startIcon={video.isIgnored ? <VisibilityIcon /> : <BlockIcon />}
           onClick={onIgnoreToggle}
-          sx={{ textTransform: 'none' }}
+          aria-label={video.isIgnored ? 'Unignore' : 'Ignore'}
+          sx={PILL_SX}
         >
           {video.isIgnored ? 'Unignore' : 'Ignore'}
         </Button>
       )}
 
+      <Box sx={{ flex: 1 }} />
+
       {showDelete && (
-        <Button
-          size="small"
-          startIcon={<DeleteIcon />}
-          onClick={onDelete}
-          color="error"
-          sx={{ textTransform: 'none' }}
-        >
-          Delete
-        </Button>
+        isMobile ? (
+          <Tooltip title="Delete video">
+            <IconButton
+              size="small"
+              color="error"
+              onClick={onDelete}
+              aria-label="Delete video"
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        ) : (
+          <Button
+            size="small"
+            variant="outlined"
+            color="error"
+            startIcon={<DeleteIcon />}
+            onClick={onDelete}
+            aria-label="Delete video"
+            sx={PILL_SX}
+          >
+            Delete
+          </Button>
+        )
       )}
     </Box>
   );

--- a/client/src/components/shared/VideoModal/components/VideoActions.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoActions.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Box, Button } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import StarIcon from '@mui/icons-material/Star';
+import BlockIcon from '@mui/icons-material/Block';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import ProtectionShieldButton from '../../ProtectionShieldButton';
+import { VideoModalData } from '../types';
+
+interface VideoActionsProps {
+  video: VideoModalData;
+  onDelete: () => void;
+  onProtectionToggle: () => void;
+  onIgnoreToggle: () => void;
+  onRatingChange: () => void;
+  protectionLoading: boolean;
+}
+
+function VideoActions({
+  video,
+  onDelete,
+  onProtectionToggle,
+  onIgnoreToggle,
+  onRatingChange,
+  protectionLoading,
+}: VideoActionsProps) {
+  const isDownloadedAndPresent = video.isDownloaded && video.status !== 'missing';
+  const showProtect = isDownloadedAndPresent;
+  const showRating = isDownloadedAndPresent;
+  const showIgnore = !video.isDownloaded || video.isIgnored;
+  const showDelete = video.isDownloaded || video.status === 'missing';
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: 1,
+      }}
+    >
+      {showProtect && (
+        <ProtectionShieldButton
+          isProtected={video.isProtected}
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            if (!protectionLoading) {
+              onProtectionToggle();
+            }
+          }}
+          variant="inline"
+          size="small"
+        />
+      )}
+
+      {showRating && (
+        <Button
+          size="small"
+          startIcon={<StarIcon />}
+          onClick={onRatingChange}
+          sx={{ textTransform: 'none' }}
+        >
+          {video.normalizedRating ? `${video.normalizedRating}` : 'Rate'}
+        </Button>
+      )}
+
+      {showIgnore && (
+        <Button
+          size="small"
+          startIcon={video.isIgnored ? <VisibilityIcon /> : <BlockIcon />}
+          onClick={onIgnoreToggle}
+          sx={{ textTransform: 'none' }}
+        >
+          {video.isIgnored ? 'Unignore' : 'Ignore'}
+        </Button>
+      )}
+
+      {showDelete && (
+        <Button
+          size="small"
+          startIcon={<DeleteIcon />}
+          onClick={onDelete}
+          color="error"
+          sx={{ textTransform: 'none' }}
+        >
+          Delete
+        </Button>
+      )}
+    </Box>
+  );
+}
+
+export default VideoActions;

--- a/client/src/components/shared/VideoModal/components/VideoMetadata.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoMetadata.tsx
@@ -1,0 +1,250 @@
+import React, { useState, useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  Chip,
+  Link,
+  Skeleton,
+  Collapse,
+  Button,
+} from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import ThumbUpIcon from '@mui/icons-material/ThumbUp';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import { VideoModalData, VideoExtendedMetadata } from '../types';
+import { YOUTUBE_URL_BASE } from '../constants';
+
+interface VideoMetadataProps {
+  video: VideoModalData;
+  metadata: VideoExtendedMetadata | null;
+  loading: boolean;
+}
+
+const DESCRIPTION_PREVIEW_LENGTH = 300;
+const VISIBLE_TAGS_COUNT = 6;
+
+function formatCount(count: number): string {
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+  }
+  if (count >= 1_000) {
+    return `${(count / 1_000).toFixed(1).replace(/\.0$/, '')}K`;
+  }
+  return count.toLocaleString();
+}
+
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  }
+  return `${minutes}:${String(secs).padStart(2, '0')}`;
+}
+
+function parseDate(dateStr: string): Date | null {
+  // Handle YYYYMMDD format from yt-dlp
+  if (/^\d{8}$/.test(dateStr)) {
+    const year = parseInt(dateStr.substring(0, 4), 10);
+    const month = parseInt(dateStr.substring(4, 6), 10) - 1;
+    const day = parseInt(dateStr.substring(6, 8), 10);
+    return new Date(year, month, day);
+  }
+  // Handle ISO strings and other formats
+  const parsed = new Date(dateStr);
+  return isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function formatDate(dateStr: string | null): string | null {
+  if (!dateStr) return null;
+  const date = parseDate(dateStr);
+  if (!date) return null;
+  return date.toLocaleDateString();
+}
+
+function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const [tagsExpanded, setTagsExpanded] = useState(false);
+
+  const publishDate = useMemo(
+    () => formatDate(metadata?.uploadDate ?? video.publishedAt),
+    [metadata?.uploadDate, video.publishedAt]
+  );
+
+  const description = metadata?.description ?? null;
+  const needsTruncation = description !== null && description.length > DESCRIPTION_PREVIEW_LENGTH;
+
+  const allTags = useMemo(() => {
+    const tags = metadata?.tags ?? [];
+    const categories = metadata?.categories ?? [];
+    const combined = [...new Set([...categories, ...tags])];
+    return combined;
+  }, [metadata?.tags, metadata?.categories]);
+
+  const visibleTags = tagsExpanded ? allTags : allTags.slice(0, VISIBLE_TAGS_COUNT);
+  const hiddenTagsCount = allTags.length - VISIBLE_TAGS_COUNT;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {/* Stats row */}
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1.5 }}>
+        <Typography variant="body2" sx={{ fontWeight: 600, color: 'text.primary' }}>
+          {video.channelName}
+        </Typography>
+
+        {publishDate && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <CalendarTodayIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            <Typography variant="body2" color="text.secondary">
+              {publishDate}
+            </Typography>
+          </Box>
+        )}
+
+        {video.duration !== null && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+            <AccessTimeIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            <Typography variant="body2" color="text.secondary">
+              {formatDuration(video.duration)}
+            </Typography>
+          </Box>
+        )}
+
+        {loading ? (
+          <>
+            <Skeleton width={60} height={20} />
+            <Skeleton width={60} height={20} />
+            <Skeleton width={60} height={20} />
+          </>
+        ) : (
+          <>
+            {metadata?.viewCount !== null && metadata?.viewCount !== undefined && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <VisibilityIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <Typography variant="body2" color="text.secondary">
+                  {formatCount(metadata.viewCount)}
+                </Typography>
+              </Box>
+            )}
+
+            {metadata?.likeCount !== null && metadata?.likeCount !== undefined && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <ThumbUpIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <Typography variant="body2" color="text.secondary">
+                  {formatCount(metadata.likeCount)}
+                </Typography>
+              </Box>
+            )}
+
+            {metadata?.commentCount !== null && metadata?.commentCount !== undefined && (
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <ChatBubbleOutlineIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <Typography variant="body2" color="text.secondary">
+                  {formatCount(metadata.commentCount)}
+                </Typography>
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+
+      {/* Tags / Categories */}
+      {loading ? (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" width={70} height={24} />
+          ))}
+        </Box>
+      ) : allTags.length > 0 ? (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', alignItems: 'center' }}>
+          {visibleTags.map((tag) => (
+            <Chip key={tag} label={tag} size="small" variant="outlined" />
+          ))}
+          {hiddenTagsCount > 0 && !tagsExpanded && (
+            <Chip
+              label={`+${hiddenTagsCount} more`}
+              size="small"
+              onClick={() => setTagsExpanded(true)}
+              sx={{ cursor: 'pointer' }}
+            />
+          )}
+          {tagsExpanded && allTags.length > VISIBLE_TAGS_COUNT && (
+            <Chip
+              label="Show less"
+              size="small"
+              onClick={() => setTagsExpanded(false)}
+              sx={{ cursor: 'pointer' }}
+            />
+          )}
+        </Box>
+      ) : null}
+
+      {/* Description */}
+      {loading ? (
+        <Box>
+          <Skeleton width="100%" height={20} />
+          <Skeleton width="100%" height={20} />
+          <Skeleton width="80%" height={20} />
+        </Box>
+      ) : description ? (
+        <Box>
+          <Collapse in={descriptionExpanded} collapsedSize={60}>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+            >
+              {descriptionExpanded
+                ? description
+                : needsTruncation
+                  ? `${description.substring(0, DESCRIPTION_PREVIEW_LENGTH)}...`
+                  : description}
+            </Typography>
+          </Collapse>
+          {needsTruncation && (
+            <Button
+              size="small"
+              onClick={() => setDescriptionExpanded(!descriptionExpanded)}
+              endIcon={descriptionExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+              sx={{ textTransform: 'none', mt: 0.5, p: 0, minWidth: 0 }}
+            >
+              {descriptionExpanded ? 'Show less' : 'Show more'}
+            </Button>
+          )}
+        </Box>
+      ) : null}
+
+      {/* Footer: YouTube ID and link */}
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          pt: 1,
+          borderTop: 1,
+          borderColor: 'divider',
+        }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          ID: {video.youtubeId}
+        </Typography>
+        <Link
+          href={`${YOUTUBE_URL_BASE}${video.youtubeId}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          underline="hover"
+          variant="caption"
+        >
+          Open on YouTube
+        </Link>
+      </Box>
+    </Box>
+  );
+}
+
+export default VideoMetadata;

--- a/client/src/components/shared/VideoModal/components/VideoMetadata.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoMetadata.tsx
@@ -91,24 +91,31 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      {/* Stats row */}
-      <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1.5 }}>
+      {/* Channel and date */}
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1 }}>
         <Typography variant="body2" sx={{ fontWeight: 600, color: 'text.primary' }}>
           {video.channelName}
         </Typography>
-
         {publishDate && (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <CalendarTodayIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
-            <Typography variant="body2" color="text.secondary">
-              {publishDate}
+          <>
+            <Typography variant="body2" color="text.disabled" sx={{ lineHeight: 1 }}>
+              ·
             </Typography>
-          </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              <CalendarTodayIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
+              <Typography variant="body2" color="text.secondary">
+                {publishDate}
+              </Typography>
+            </Box>
+          </>
         )}
+      </Box>
 
+      {/* Stats row */}
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1.5 }}>
         {video.duration !== null && (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <AccessTimeIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+            <AccessTimeIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
             <Typography variant="body2" color="text.secondary">
               {formatDuration(video.duration)}
             </Typography>
@@ -119,13 +126,12 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
           <>
             <Skeleton width={60} height={20} />
             <Skeleton width={60} height={20} />
-            <Skeleton width={60} height={20} />
           </>
         ) : (
           <>
             {metadata?.viewCount !== null && metadata?.viewCount !== undefined && (
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <VisibilityIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <VisibilityIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
                 <Typography variant="body2" color="text.secondary">
                   {formatCount(metadata.viewCount)}
                 </Typography>
@@ -134,7 +140,7 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
 
             {metadata?.likeCount !== null && metadata?.likeCount !== undefined && (
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <ThumbUpIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <ThumbUpIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
                 <Typography variant="body2" color="text.secondary">
                   {formatCount(metadata.likeCount)}
                 </Typography>
@@ -143,7 +149,7 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
 
             {metadata?.commentCount !== null && metadata?.commentCount !== undefined && (
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                <ChatBubbleOutlineIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                <ChatBubbleOutlineIcon sx={{ fontSize: 18, color: 'text.secondary' }} />
                 <Typography variant="body2" color="text.secondary">
                   {formatCount(metadata.commentCount)}
                 </Typography>
@@ -169,8 +175,9 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
             <Chip
               label={`+${hiddenTagsCount} more`}
               size="small"
+              color="primary"
               onClick={() => setTagsExpanded(true)}
-              sx={{ cursor: 'pointer' }}
+              sx={{ cursor: 'pointer', fontWeight: 500 }}
             />
           )}
           {tagsExpanded && allTags.length > VISIBLE_TAGS_COUNT && (
@@ -193,25 +200,37 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
         </Box>
       ) : description ? (
         <Box>
-          <Collapse in={descriptionExpanded} collapsedSize={60}>
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-            >
-              {descriptionExpanded
-                ? description
-                : needsTruncation
-                  ? `${description.substring(0, DESCRIPTION_PREVIEW_LENGTH)}...`
-                  : description}
-            </Typography>
-          </Collapse>
+          <Box sx={{ position: 'relative' }}>
+            <Collapse in={descriptionExpanded} collapsedSize={72}>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+              >
+                {description}
+              </Typography>
+            </Collapse>
+            {!descriptionExpanded && needsTruncation && (
+              <Box
+                sx={{
+                  position: 'absolute',
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  height: 36,
+                  background: (theme) =>
+                    `linear-gradient(to bottom, transparent, ${theme.palette.background.paper})`,
+                  pointerEvents: 'none',
+                }}
+              />
+            )}
+          </Box>
           {needsTruncation && (
             <Button
               size="small"
               onClick={() => setDescriptionExpanded(!descriptionExpanded)}
               endIcon={descriptionExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-              sx={{ textTransform: 'none', mt: 0.5, p: 0, minWidth: 0 }}
+              sx={{ textTransform: 'none', mt: 0.5, fontWeight: 500 }}
             >
               {descriptionExpanded ? 'Show less' : 'Show more'}
             </Button>
@@ -230,9 +249,25 @@ function VideoMetadata({ video, metadata, loading }: VideoMetadataProps) {
           borderColor: 'divider',
         }}
       >
-        <Typography variant="caption" color="text.secondary">
-          ID: {video.youtubeId}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+          <Typography variant="caption" color="text.secondary">
+            YouTube ID
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{
+              fontFamily: 'monospace',
+              bgcolor: 'action.hover',
+              color: 'text.primary',
+              px: 0.75,
+              py: 0.25,
+              borderRadius: 0.5,
+              fontSize: '0.7rem',
+            }}
+          >
+            {video.youtubeId}
+          </Typography>
+        </Box>
         <Link
           href={`${YOUTUBE_URL_BASE}${video.youtubeId}`}
           target="_blank"

--- a/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
@@ -1,0 +1,245 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import {
+  Box,
+  Typography,
+  Button,
+  IconButton,
+  Tooltip,
+  Link,
+} from '@mui/material';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import CloudOffIcon from '@mui/icons-material/CloudOff';
+import DownloadIcon from '@mui/icons-material/Download';
+import BlockIcon from '@mui/icons-material/Block';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import StopIcon from '@mui/icons-material/Stop';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import { VideoModalData } from '../types';
+import { YOUTUBE_URL_BASE } from '../constants';
+
+interface VideoPlayerProps {
+  video: VideoModalData;
+  token: string | null;
+  onDownloadClick: () => void;
+  isMobile: boolean;
+}
+
+// Fixed player heights as percentage of viewport.
+// The dialog is ~85vh. These heights leave room for title + metadata below.
+const PLAYER_HEIGHT_DESKTOP = '50vh';
+const PLAYER_HEIGHT_MOBILE = '25vh';
+
+function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerProps) {
+  const [playbackStarted, setPlaybackStarted] = useState(false);
+  const [streamError, setStreamError] = useState(false);
+
+  useEffect(() => {
+    setPlaybackStarted(false);
+    setStreamError(false);
+  }, [video.youtubeId]);
+
+  const canStream = video.isDownloaded && video.status !== 'missing';
+  const streamUrl = token
+    ? `/api/videos/${video.youtubeId}/stream?token=${encodeURIComponent(token)}`
+    : null;
+
+  const handlePlay = useCallback(() => {
+    setPlaybackStarted(true);
+  }, []);
+
+  const handleStreamError = useCallback(() => {
+    setStreamError(true);
+    setPlaybackStarted(false);
+  }, []);
+
+  const handleStop = useCallback(() => {
+    setPlaybackStarted(false);
+  }, []);
+
+  const youtubeUrl = `${YOUTUBE_URL_BASE}${video.youtubeId}`;
+  const isPlaying = canStream && playbackStarted && streamUrl && !streamError;
+  const playerHeight = isMobile ? PLAYER_HEIGHT_MOBILE : PLAYER_HEIGHT_DESKTOP;
+
+  // Two different sizing strategies:
+  // - Thumbnail: natural flow (width: 100%, height: auto) so it fills
+  //   the width with no black bars, capped by maxHeight.
+  // - Video playback: fixed height container with absolute positioning,
+  //   because <video> elements don't respect maxHeight in flex layouts.
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: '100%',
+        // When playing, use fixed height for the video element.
+        // When showing thumbnail, let the image determine the height naturally.
+        ...(isPlaying && { height: playerHeight, bgcolor: 'black' }),
+        overflow: 'hidden',
+        borderRadius: 1,
+      }}
+    >
+      {/* Video element - absolutely positioned when playing */}
+      {isPlaying && (
+        <Box
+          component="video"
+          data-testid="video-stream-element"
+          src={streamUrl}
+          controls
+          autoPlay
+          onError={handleStreamError}
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'contain',
+          }}
+        />
+      )}
+
+      {/* Thumbnail - scales to the largest size that fits both width and height
+          constraints while preserving aspect ratio. No cropping, no black bars. */}
+      {!isPlaying && (
+        <Box
+          component="img"
+          src={video.thumbnailUrl}
+          alt={video.title}
+          sx={{
+            display: 'block',
+            maxWidth: '100%',
+            maxHeight: playerHeight,
+            width: 'auto',
+            height: 'auto',
+            mx: 'auto',
+          }}
+        />
+      )}
+
+      {/* Overlay content - shown when not playing */}
+      {!isPlaying && (
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            bgcolor: 'rgba(0,0,0,0.4)',
+            gap: 1,
+          }}
+        >
+          {streamError ? (
+            <>
+              <CloudOffIcon sx={{ fontSize: 48, color: 'common.white' }} />
+              <Typography variant="body2" sx={{ color: 'common.white' }}>
+                Unable to stream video
+              </Typography>
+              <Link
+                href={youtubeUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                underline="hover"
+                variant="body2"
+                sx={{ color: 'primary.light' }}
+              >
+                Open on YouTube
+              </Link>
+            </>
+          ) : canStream ? (
+            <IconButton
+              onClick={handlePlay}
+              aria-label="Play video"
+              sx={{
+                bgcolor: 'rgba(0,0,0,0.6)',
+                color: 'common.white',
+                '&:hover': { bgcolor: 'rgba(0,0,0,0.8)' },
+                width: 64,
+                height: 64,
+              }}
+            >
+              <PlayArrowIcon sx={{ fontSize: 40 }} />
+            </IconButton>
+          ) : video.status === 'ignored' ? (
+            <>
+              <BlockIcon sx={{ fontSize: 48, color: 'common.white' }} />
+              <Typography variant="body1" sx={{ color: 'common.white', fontWeight: 500 }}>
+                Ignored
+              </Typography>
+            </>
+          ) : video.status === 'missing' ? (
+            <>
+              <WarningAmberIcon sx={{ fontSize: 48, color: 'warning.light' }} />
+              <Typography variant="body1" sx={{ color: 'common.white', fontWeight: 500 }}>
+                File Missing
+              </Typography>
+              <Button
+                variant="contained"
+                startIcon={<DownloadIcon />}
+                onClick={onDownloadClick}
+                size="small"
+                sx={{ textTransform: 'none', mt: 1 }}
+              >
+                Re-download Video
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="contained"
+              startIcon={<DownloadIcon />}
+              onClick={onDownloadClick}
+              size="small"
+              sx={{ textTransform: 'none' }}
+            >
+              Download Video
+            </Button>
+          )}
+        </Box>
+      )}
+
+      {/* Stop button - shown during playback */}
+      {isPlaying && (
+        <Tooltip title="Stop playback">
+          <IconButton
+            size="small"
+            onClick={handleStop}
+            aria-label="Stop playback"
+            sx={{
+              position: 'absolute',
+              top: 8,
+              left: 8,
+              color: 'common.white',
+              bgcolor: 'rgba(0,0,0,0.5)',
+              '&:hover': { bgcolor: 'rgba(0,0,0,0.7)' },
+              zIndex: 2,
+            }}
+          >
+            <StopIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
+
+      {/* Playback info tooltip - shown when video can stream */}
+      {canStream && !streamError && (
+        <Tooltip title="Video is served directly without transcoding. Playback may buffer on slow connections.">
+          <IconButton
+            size="small"
+            sx={{
+              position: 'absolute',
+              top: 8,
+              right: 8,
+              color: 'common.white',
+              bgcolor: 'rgba(0,0,0,0.5)',
+              '&:hover': { bgcolor: 'rgba(0,0,0,0.7)' },
+              zIndex: 2,
+            }}
+          >
+            <InfoOutlinedIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      )}
+    </Box>
+  );
+}
+
+export default VideoPlayer;

--- a/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
@@ -14,6 +14,7 @@ import BlockIcon from '@mui/icons-material/Block';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import StopIcon from '@mui/icons-material/Stop';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import LockIcon from '@mui/icons-material/Lock';
 import { VideoModalData } from '../types';
 import { YOUTUBE_URL_BASE } from '../constants';
 
@@ -187,6 +188,16 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
               >
                 Re-download Video
               </Button>
+            </>
+          ) : video.status === 'members_only' ? (
+            <>
+              <LockIcon sx={{ fontSize: 48, color: 'common.white' }} />
+              <Typography variant="body1" sx={{ color: 'common.white', fontWeight: 500 }}>
+                Members Only
+              </Typography>
+              <Typography variant="body2" sx={{ color: 'common.white', opacity: 0.85, textAlign: 'center', px: 2 }}>
+                Youtarr cannot download this video or fetch its metadata
+              </Typography>
             </>
           ) : (
             <Button

--- a/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
@@ -70,9 +70,10 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
       sx={{
         position: 'relative',
         width: '100%',
-        // When playing, use fixed height for the video element.
-        // When showing thumbnail, let the image determine the height naturally.
-        ...(isPlaying && { height: playerHeight, bgcolor: 'black' }),
+        bgcolor: 'black',
+        border: 1,
+        borderColor: 'divider',
+        ...(isPlaying && { height: playerHeight }),
         overflow: 'hidden',
         borderRadius: 1,
       }}
@@ -125,7 +126,7 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
             flexDirection: 'column',
             alignItems: 'center',
             justifyContent: 'center',
-            bgcolor: 'rgba(0,0,0,0.4)',
+            background: 'linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.5) 100%)',
             gap: 1,
           }}
         >
@@ -151,14 +152,18 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
               onClick={handlePlay}
               aria-label="Play video"
               sx={{
-                bgcolor: 'rgba(0,0,0,0.6)',
+                bgcolor: 'rgba(0,0,0,0.7)',
                 color: 'common.white',
-                '&:hover': { bgcolor: 'rgba(0,0,0,0.8)' },
-                width: 64,
-                height: 64,
+                '&:hover': {
+                  bgcolor: 'rgba(0,0,0,0.85)',
+                  transform: 'scale(1.1)',
+                },
+                transition: 'transform 0.2s ease, background-color 0.2s ease',
+                width: 72,
+                height: 72,
               }}
             >
-              <PlayArrowIcon sx={{ fontSize: 40 }} />
+              <PlayArrowIcon sx={{ fontSize: 48 }} />
             </IconButton>
           ) : video.status === 'ignored' ? (
             <>

--- a/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
@@ -6,6 +6,7 @@ import {
   IconButton,
   Tooltip,
   Link,
+  ClickAwayListener,
 } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
@@ -33,10 +34,12 @@ const PLAYER_HEIGHT_MOBILE = '25vh';
 function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerProps) {
   const [playbackStarted, setPlaybackStarted] = useState(false);
   const [streamError, setStreamError] = useState(false);
+  const [infoTooltipOpen, setInfoTooltipOpen] = useState(false);
 
   useEffect(() => {
     setPlaybackStarted(false);
     setStreamError(false);
+    setInfoTooltipOpen(false);
   }, [video.youtubeId]);
 
   const canStream = video.isDownloaded && video.status !== 'missing';
@@ -235,24 +238,35 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
         </Tooltip>
       )}
 
-      {/* Playback info tooltip - shown when video can stream */}
+      {/* Playback info tooltip - shown when video can stream.
+          Controlled open state so a tap works on touch devices (hover doesn't exist on mobile).
+          ClickAwayListener dismisses the tooltip when tapping elsewhere. */}
       {canStream && !streamError && (
-        <Tooltip title="Video is served directly without transcoding. Playback may buffer on slow connections.">
-          <IconButton
-            size="small"
-            sx={{
-              position: 'absolute',
-              top: 8,
-              right: 8,
-              color: 'common.white',
-              bgcolor: 'rgba(0,0,0,0.5)',
-              '&:hover': { bgcolor: 'rgba(0,0,0,0.7)' },
-              zIndex: 2,
-            }}
+        <ClickAwayListener onClickAway={() => setInfoTooltipOpen(false)}>
+          <Tooltip
+            open={infoTooltipOpen}
+            onOpen={() => setInfoTooltipOpen(true)}
+            onClose={() => setInfoTooltipOpen(false)}
+            title="Video is served directly without transcoding. Playback may buffer on slow connections."
           >
-            <InfoOutlinedIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
+            <IconButton
+              size="small"
+              onClick={() => setInfoTooltipOpen((prev) => !prev)}
+              aria-label="Playback info"
+              sx={{
+                position: 'absolute',
+                top: 8,
+                right: 8,
+                color: 'common.white',
+                bgcolor: 'rgba(0,0,0,0.5)',
+                '&:hover': { bgcolor: 'rgba(0,0,0,0.7)' },
+                zIndex: 2,
+              }}
+            >
+              <InfoOutlinedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </ClickAwayListener>
       )}
     </Box>
   );

--- a/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { Box, Typography, Skeleton, Card, CardContent, Tooltip, Chip } from '@mui/material';
+import { VideoModalData, VideoExtendedMetadata } from '../types';
+
+interface VideoTechnicalProps {
+  video: VideoModalData;
+  metadata: VideoExtendedMetadata | null;
+  loading: boolean;
+}
+
+const BYTES_PER_KB = 1024;
+const BYTES_PER_MB = 1024 * 1024;
+const BYTES_PER_GB = 1024 * 1024 * 1024;
+
+const INTERNAL_PATH_PREFIX = '/usr/src/app/data/';
+
+function formatFileSize(bytes: number): string {
+  if (bytes >= BYTES_PER_GB) {
+    return `${(bytes / BYTES_PER_GB).toFixed(2)} GB`;
+  }
+  if (bytes >= BYTES_PER_MB) {
+    return `${(bytes / BYTES_PER_MB).toFixed(1)} MB`;
+  }
+  if (bytes >= BYTES_PER_KB) {
+    return `${(bytes / BYTES_PER_KB).toFixed(1)} KB`;
+  }
+  return `${bytes} B`;
+}
+
+function stripInternalPath(filePath: string): string {
+  if (filePath.startsWith(INTERNAL_PATH_PREFIX)) {
+    return filePath.slice(INTERNAL_PATH_PREFIX.length);
+  }
+  return filePath;
+}
+
+function getOrientationLabel(ratio: number): string {
+  if (ratio > 1) return 'Landscape';
+  if (ratio < 1) return 'Portrait';
+  return 'Square';
+}
+
+function formatAddedDate(dateStr: string | null): string | null {
+  if (!dateStr) return null;
+  const date = new Date(dateStr);
+  return isNaN(date.getTime()) ? null : date.toLocaleDateString();
+}
+
+function formatResolutionLabel(height: number | null): string | null {
+  if (!height) return null;
+  return `${height}p`;
+}
+
+interface DetailRowProps {
+  label: string;
+  value: string;
+}
+
+function DetailRow({ label, value }: DetailRowProps) {
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', py: 0.5 }}>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="body2" color="text.primary" sx={{ fontWeight: 500 }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+interface FileRowProps {
+  label: string;
+  filePath: string;
+  fileSize: number | null;
+}
+
+function FileRow({ label, filePath, fileSize }: FileRowProps) {
+  const displayPath = stripInternalPath(filePath);
+  const sizeLabel = fileSize ? formatFileSize(fileSize) : 'Unknown size';
+
+  return (
+    <Box sx={{ py: 0.75 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Typography variant="body2" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography variant="body2" color="text.primary" sx={{ fontWeight: 500 }}>
+          {sizeLabel}
+        </Typography>
+      </Box>
+      <Tooltip title={displayPath} arrow placement="bottom-start" enterTouchDelay={0}>
+        <Typography
+          variant="caption"
+          color="text.disabled"
+          sx={{
+            display: 'block',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            maxWidth: '100%',
+            mt: 0.25,
+          }}
+        >
+          {displayPath}
+        </Typography>
+      </Tooltip>
+    </Box>
+  );
+}
+
+function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
+        <Box sx={{ flex: 1 }}>
+          <Skeleton variant="rounded" height={120} />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Skeleton variant="rounded" height={120} />
+        </Box>
+      </Box>
+    );
+  }
+
+  // Build technical details
+  const technicalDetails: DetailRowProps[] = [];
+  const availableResolutions = metadata?.availableResolutions ?? null;
+
+  // Download resolution - only for downloaded videos
+  if (video.isDownloaded && metadata?.height) {
+    const downloadRes = formatResolutionLabel(metadata.height);
+    if (downloadRes) {
+      technicalDetails.push({ label: 'Downloaded', value: downloadRes });
+    }
+  }
+
+  if (metadata?.fps !== null && metadata?.fps !== undefined) {
+    technicalDetails.push({ label: 'FPS', value: `${metadata.fps}` });
+  }
+  if (metadata?.aspectRatio !== null && metadata?.aspectRatio !== undefined && typeof metadata.aspectRatio === 'number') {
+    const orientation = getOrientationLabel(metadata.aspectRatio);
+    technicalDetails.push({
+      label: 'Aspect Ratio',
+      value: `${metadata.aspectRatio.toFixed(2)} (${orientation})`,
+    });
+  }
+  if (metadata?.language) {
+    technicalDetails.push({ label: 'Language', value: metadata.language });
+  }
+
+  // Build file info
+  const hasVideoFile = video.filePath !== null;
+  const hasAudioFile = video.audioFilePath !== null;
+  const relatedFiles = metadata?.relatedFiles ?? null;
+  const addedDate = formatAddedDate(video.addedAt);
+  const hasFileInfo = hasVideoFile || hasAudioFile || relatedFiles || addedDate;
+
+  const hasTechnical = technicalDetails.length > 0 || availableResolutions;
+
+  // Return null if nothing to show
+  if (!hasTechnical && !hasFileInfo) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
+      {hasTechnical && (
+        <Card variant="outlined" sx={{ flex: 1 }}>
+          <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
+            <Typography variant="subtitle2" color="text.primary" sx={{ mb: 1 }}>
+              Technical
+            </Typography>
+            {technicalDetails.map((detail) => (
+              <DetailRow key={detail.label} label={detail.label} value={detail.value} />
+            ))}
+            {availableResolutions && (
+              <Box sx={{ py: 0.5 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 0.75 }}>
+                  Available Resolutions
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                  {availableResolutions.map((h) => {
+                    const isDownloaded = video.isDownloaded && metadata?.height === h;
+                    return (
+                      <Chip
+                        key={h}
+                        label={`${h}p`}
+                        size="small"
+                        color={isDownloaded ? 'primary' : 'default'}
+                        variant={isDownloaded ? 'filled' : 'outlined'}
+                        sx={{ fontSize: '0.75rem', height: 24 }}
+                      />
+                    );
+                  })}
+                </Box>
+              </Box>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {hasFileInfo && (
+        <Card variant="outlined" sx={{ flex: 1 }}>
+          <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
+            <Typography variant="subtitle2" color="text.primary" sx={{ mb: 1 }}>
+              Files
+            </Typography>
+            {hasVideoFile && (
+              <FileRow
+                label="Video"
+                filePath={video.filePath!}
+                fileSize={video.fileSize}
+              />
+            )}
+            {hasAudioFile && (
+              <FileRow
+                label="Audio"
+                filePath={video.audioFilePath!}
+                fileSize={video.audioFileSize}
+              />
+            )}
+            {relatedFiles && relatedFiles.map((file) => (
+              <FileRow
+                key={file.fileName}
+                label={file.type}
+                filePath={file.fileName}
+                fileSize={file.fileSize}
+              />
+            ))}
+            {addedDate && (
+              <DetailRow label="Added" value={addedDate} />
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </Box>
+  );
+}
+
+export default VideoTechnical;

--- a/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography, Skeleton, Card, CardContent, Tooltip, Chip } from '@mui/material';
+import { Box, Typography, Skeleton, Card, CardContent, Tooltip, Chip, useTheme, useMediaQuery } from '@mui/material';
 import { VideoModalData, VideoExtendedMetadata } from '../types';
 
 interface VideoTechnicalProps {
@@ -110,6 +110,9 @@ function FileRow({ label, filePath, fileSize }: FileRowProps) {
 }
 
 function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
   if (loading) {
     return (
       <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
@@ -166,14 +169,36 @@ function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
   return (
     <Box sx={{ display: 'flex', gap: 2, flexDirection: { xs: 'column', sm: 'row' } }}>
       {hasTechnical && (
-        <Card variant="outlined" sx={{ flex: 1 }}>
+        <Card
+          variant="outlined"
+          sx={{
+            flex: 1,
+            ...(isMobile && {
+              border: 'none',
+              borderTop: 1,
+              borderColor: 'divider',
+              borderRadius: 0,
+            }),
+          }}
+        >
           <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
             <Typography variant="subtitle2" color="text.primary" sx={{ mb: 1 }}>
               Technical
             </Typography>
-            {technicalDetails.map((detail) => (
-              <DetailRow key={detail.label} label={detail.label} value={detail.value} />
-            ))}
+            <Box
+              sx={{
+                '& > div:nth-of-type(even)': {
+                  bgcolor: 'action.hover',
+                  borderRadius: 0.5,
+                  mx: -0.5,
+                  px: 0.5,
+                },
+              }}
+            >
+              {technicalDetails.map((detail) => (
+                <DetailRow key={detail.label} label={detail.label} value={detail.value} />
+              ))}
+            </Box>
             {availableResolutions && (
               <Box sx={{ py: 0.5 }}>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 0.75 }}>
@@ -201,36 +226,58 @@ function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
       )}
 
       {hasFileInfo && (
-        <Card variant="outlined" sx={{ flex: 1 }}>
+        <Card
+          variant="outlined"
+          sx={{
+            flex: 1,
+            ...(isMobile && {
+              border: 'none',
+              borderTop: 1,
+              borderColor: 'divider',
+              borderRadius: 0,
+            }),
+          }}
+        >
           <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
             <Typography variant="subtitle2" color="text.primary" sx={{ mb: 1 }}>
               Files
             </Typography>
-            {hasVideoFile && (
-              <FileRow
-                label="Video"
-                filePath={video.filePath!}
-                fileSize={video.fileSize}
-              />
-            )}
-            {hasAudioFile && (
-              <FileRow
-                label="Audio"
-                filePath={video.audioFilePath!}
-                fileSize={video.audioFileSize}
-              />
-            )}
-            {relatedFiles && relatedFiles.map((file) => (
-              <FileRow
-                key={file.fileName}
-                label={file.type}
-                filePath={file.fileName}
-                fileSize={file.fileSize}
-              />
-            ))}
-            {addedDate && (
-              <DetailRow label="Added" value={addedDate} />
-            )}
+            <Box
+              sx={{
+                '& > div:nth-of-type(even)': {
+                  bgcolor: 'action.hover',
+                  borderRadius: 0.5,
+                  mx: -0.5,
+                  px: 0.5,
+                },
+              }}
+            >
+              {hasVideoFile && (
+                <FileRow
+                  label="Video"
+                  filePath={video.filePath!}
+                  fileSize={video.fileSize}
+                />
+              )}
+              {hasAudioFile && (
+                <FileRow
+                  label="Audio"
+                  filePath={video.audioFilePath!}
+                  fileSize={video.audioFileSize}
+                />
+              )}
+              {relatedFiles && relatedFiles.map((file) => (
+                <FileRow
+                  key={file.fileName}
+                  label={file.type}
+                  filePath={file.fileName}
+                  fileSize={file.fileSize}
+                />
+              ))}
+              {addedDate && (
+                <DetailRow label="Added" value={addedDate} />
+              )}
+            </Box>
           </CardContent>
         </Card>
       )}

--- a/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoTechnical.tsx
@@ -51,6 +51,21 @@ function formatResolutionLabel(height: number | null): string | null {
   return `${height}p`;
 }
 
+function formatDownloadedResolution(
+  width: number | null,
+  height: number | null,
+  tier: number | null
+): string | null {
+  if (!height) return null;
+  const base = width ? `${width}x${height}` : `${height}p`;
+  // Show the tier label when it differs from the actual height (non-16:9 videos).
+  // For 16:9 videos the tier matches the height, so appending it would be redundant.
+  if (tier && tier !== height) {
+    return `${base} (${tier}p)`;
+  }
+  return base;
+}
+
 interface DetailRowProps {
   label: string;
   value: string;
@@ -132,7 +147,11 @@ function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
 
   // Download resolution - only for downloaded videos
   if (video.isDownloaded && metadata?.height) {
-    const downloadRes = formatResolutionLabel(metadata.height);
+    const downloadRes = formatDownloadedResolution(
+      metadata.width,
+      metadata.height,
+      metadata.downloadedTier
+    );
     if (downloadRes) {
       technicalDetails.push({ label: 'Downloaded', value: downloadRes });
     }
@@ -206,7 +225,10 @@ function VideoTechnical({ video, metadata, loading }: VideoTechnicalProps) {
                 </Typography>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
                   {availableResolutions.map((h) => {
-                    const isDownloaded = video.isDownloaded && metadata?.height === h;
+                    // Match by tier when available (handles non-16:9 videos correctly),
+                    // fall back to raw height for backward-compatible info.json files.
+                    const downloadedMarker = metadata?.downloadedTier ?? metadata?.height ?? null;
+                    const isDownloaded = video.isDownloaded && downloadedMarker === h;
                     return (
                       <Chip
                         key={h}

--- a/client/src/components/shared/VideoModal/components/__tests__/VideoPlayer.test.tsx
+++ b/client/src/components/shared/VideoModal/components/__tests__/VideoPlayer.test.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { VideoModalData } from '../../types';
+
+// Mock MUI icons to lightweight spans
+jest.mock('@mui/icons-material/PlayArrow', () => ({
+  __esModule: true,
+  default: function MockPlayArrowIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'PlayArrowIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/CloudOff', () => ({
+  __esModule: true,
+  default: function MockCloudOffIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'CloudOffIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/Download', () => ({
+  __esModule: true,
+  default: function MockDownloadIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'DownloadIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/Block', () => ({
+  __esModule: true,
+  default: function MockBlockIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'BlockIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/InfoOutlined', () => ({
+  __esModule: true,
+  default: function MockInfoOutlinedIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'InfoOutlinedIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/Stop', () => ({
+  __esModule: true,
+  default: function MockStopIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'StopIcon' });
+  },
+}));
+
+jest.mock('@mui/icons-material/WarningAmber', () => ({
+  __esModule: true,
+  default: function MockWarningAmberIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'WarningAmberIcon' });
+  },
+}));
+
+import VideoPlayer from '../VideoPlayer';
+
+const theme = createTheme();
+
+const downloadedVideo: VideoModalData = {
+  youtubeId: 'abc123',
+  title: 'Test Video',
+  channelName: 'Test Channel',
+  thumbnailUrl: 'https://example.com/thumb.jpg',
+  duration: 300,
+  publishedAt: '2024-06-01',
+  addedAt: '2024-06-02',
+  mediaType: 'video',
+  status: 'downloaded',
+  isDownloaded: true,
+  filePath: '/videos/test.mp4',
+  fileSize: 5242880,
+  audioFilePath: null,
+  audioFileSize: null,
+  isProtected: false,
+  isIgnored: false,
+  normalizedRating: null,
+  ratingSource: null,
+  databaseId: 1,
+  channelId: 'UC_test',
+};
+
+function renderPlayer(
+  videoOverride?: Partial<VideoModalData>,
+  propsOverride?: { token?: string | null; isMobile?: boolean }
+) {
+  const video = videoOverride
+    ? { ...downloadedVideo, ...videoOverride }
+    : downloadedVideo;
+
+  const defaultProps = {
+    video,
+    token: 'my-test-token',
+    onDownloadClick: jest.fn(),
+    isMobile: false,
+    ...propsOverride,
+  };
+
+  return {
+    ...render(
+      <ThemeProvider theme={theme}>
+        <VideoPlayer {...defaultProps} />
+      </ThemeProvider>
+    ),
+    onDownloadClick: defaultProps.onDownloadClick,
+  };
+}
+
+describe('VideoPlayer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders thumbnail with play overlay for a downloaded video', () => {
+    renderPlayer();
+
+    expect(screen.getByRole('img', { name: 'Test Video' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Play video' })).toBeInTheDocument();
+  });
+
+  test('renders "not downloaded" state with download button', () => {
+    renderPlayer({
+      status: 'never_downloaded',
+      isDownloaded: false,
+      filePath: null,
+      fileSize: null,
+    });
+
+    expect(screen.getByRole('button', { name: /download video/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Play video' })).not.toBeInTheDocument();
+  });
+
+  test('renders "ignored" state with block icon and label', () => {
+    renderPlayer({
+      status: 'ignored',
+      isDownloaded: false,
+      isIgnored: true,
+      filePath: null,
+      fileSize: null,
+    });
+
+    expect(screen.getByText('Ignored')).toBeInTheDocument();
+    expect(screen.getByTestId('BlockIcon')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Play video' })).not.toBeInTheDocument();
+  });
+
+  test('renders "missing file" state with warning and re-download button', () => {
+    renderPlayer({
+      status: 'missing',
+      isDownloaded: true,
+    });
+
+    expect(screen.getByText('File Missing')).toBeInTheDocument();
+    expect(screen.getByTestId('WarningAmberIcon')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /re-download video/i })).toBeInTheDocument();
+  });
+
+  test('clicking play enters playback mode with correct stream URL', async () => {
+    const user = userEvent.setup();
+    renderPlayer();
+
+    await user.click(screen.getByRole('button', { name: 'Play video' }));
+
+    // Playback mode: stop button visible, play button and thumbnail gone
+    expect(screen.getByRole('button', { name: 'Stop playback' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Play video' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'Test Video' })).not.toBeInTheDocument();
+
+    // Verify the stream URL includes the video ID and properly encoded token
+    const videoEl = screen.getByTestId('video-stream-element');
+    expect(videoEl).toHaveAttribute(
+      'src',
+      '/api/videos/abc123/stream?token=my-test-token'
+    );
+  });
+
+  test('stream error shows fallback UI with YouTube link', async () => {
+    const user = userEvent.setup();
+    renderPlayer();
+
+    // Start playback
+    await user.click(screen.getByRole('button', { name: 'Play video' }));
+
+    // Trigger error on the video element via its data-testid
+    const videoEl = screen.getByTestId('video-stream-element');
+    fireEvent.error(videoEl);
+
+    // Error fallback should appear
+    await waitFor(() => {
+      expect(screen.getByText('Unable to stream video')).toBeInTheDocument();
+    });
+
+    const youtubeLink = screen.getByRole('link', { name: 'Open on YouTube' });
+    expect(youtubeLink).toHaveAttribute(
+      'href',
+      'https://www.youtube.com/watch?v=abc123'
+    );
+  });
+
+  test('state resets when video.youtubeId changes', async () => {
+    const user = userEvent.setup();
+
+    const { rerender } = render(
+      <ThemeProvider theme={theme}>
+        <VideoPlayer
+          video={downloadedVideo}
+          token="my-test-token"
+          onDownloadClick={jest.fn()}
+          isMobile={false}
+        />
+      </ThemeProvider>
+    );
+
+    // Start playback
+    await user.click(screen.getByRole('button', { name: 'Play video' }));
+    expect(screen.getByRole('button', { name: 'Stop playback' })).toBeInTheDocument();
+
+    // Rerender with a different youtubeId
+    const newVideo: VideoModalData = {
+      ...downloadedVideo,
+      youtubeId: 'xyz789',
+      title: 'Different Video',
+    };
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <VideoPlayer
+          video={newVideo}
+          token="my-test-token"
+          onDownloadClick={jest.fn()}
+          isMobile={false}
+        />
+      </ThemeProvider>
+    );
+
+    // useEffect resets playbackStarted and streamError, so thumbnail + play button return
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Play video' })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: 'Stop playback' })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/shared/VideoModal/components/__tests__/VideoPlayer.test.tsx
+++ b/client/src/components/shared/VideoModal/components/__tests__/VideoPlayer.test.tsx
@@ -61,6 +61,14 @@ jest.mock('@mui/icons-material/WarningAmber', () => ({
   },
 }));
 
+jest.mock('@mui/icons-material/Lock', () => ({
+  __esModule: true,
+  default: function MockLockIcon() {
+    const React = require('react');
+    return React.createElement('span', { 'data-testid': 'LockIcon' });
+  },
+}));
+
 import VideoPlayer from '../VideoPlayer';
 
 const theme = createTheme();
@@ -161,6 +169,20 @@ describe('VideoPlayer', () => {
     expect(screen.getByText('File Missing')).toBeInTheDocument();
     expect(screen.getByTestId('WarningAmberIcon')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /re-download video/i })).toBeInTheDocument();
+  });
+
+  test('renders "members only" state with lock icon and no download button', () => {
+    renderPlayer({
+      status: 'members_only',
+      isDownloaded: false,
+      filePath: null,
+      fileSize: null,
+    });
+
+    expect(screen.getByText('Members Only')).toBeInTheDocument();
+    expect(screen.getByTestId('LockIcon')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /download video/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Play video' })).not.toBeInTheDocument();
   });
 
   test('clicking play enters playback mode with correct stream URL', async () => {

--- a/client/src/components/shared/VideoModal/constants.ts
+++ b/client/src/components/shared/VideoModal/constants.ts
@@ -1,0 +1,1 @@
+export const YOUTUBE_URL_BASE = 'https://www.youtube.com/watch?v=';

--- a/client/src/components/shared/VideoModal/hooks/__tests__/useVideoMetadata.test.ts
+++ b/client/src/components/shared/VideoModal/hooks/__tests__/useVideoMetadata.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+const axios = require('axios');
+
+import { useVideoMetadata } from '../useVideoMetadata';
+import { VideoExtendedMetadata } from '../../types';
+
+const mockMetadata: VideoExtendedMetadata = {
+  description: 'A test video description',
+  viewCount: 12345,
+  likeCount: 678,
+  commentCount: 90,
+  tags: ['tag1', 'tag2'],
+  categories: ['Entertainment'],
+  uploadDate: '2024-01-15',
+  resolution: '1920x1080',
+  width: 1920,
+  height: 1080,
+  fps: 30,
+  aspectRatio: 1.777,
+  language: 'en',
+  isLive: false,
+  wasLive: false,
+  availability: 'public',
+  channelFollowerCount: 50000,
+  ageLimit: 0,
+  webpageUrl: 'https://www.youtube.com/watch?v=testId123',
+  relatedFiles: null,
+  availableResolutions: null,
+};
+
+describe('useVideoMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches metadata when youtubeId and token are provided', async () => {
+    axios.get.mockResolvedValueOnce({ data: mockMetadata });
+
+    const { result } = renderHook(() =>
+      useVideoMetadata('testId123', 'test-token')
+    );
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.metadata).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.metadata).toEqual(mockMetadata);
+    expect(result.current.error).toBeNull();
+    expect(axios.get).toHaveBeenCalledWith(
+      '/api/videos/testId123/metadata',
+      { headers: { 'x-access-token': 'test-token' } }
+    );
+  });
+
+  test('does not fetch when youtubeId is empty', () => {
+    const { result } = renderHook(() =>
+      useVideoMetadata('', 'test-token')
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.metadata).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test('does not fetch when token is null', () => {
+    const { result } = renderHook(() =>
+      useVideoMetadata('testId123', null)
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.metadata).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test('handles fetch error gracefully and metadata stays null', async () => {
+    axios.get.mockRejectedValueOnce({
+      response: { data: { error: 'Video not found' } },
+    });
+
+    const { result } = renderHook(() =>
+      useVideoMetadata('badId', 'test-token')
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.metadata).toBeNull();
+    expect(result.current.error).toBe('Video not found');
+  });
+});

--- a/client/src/components/shared/VideoModal/hooks/__tests__/useVideoMetadata.test.ts
+++ b/client/src/components/shared/VideoModal/hooks/__tests__/useVideoMetadata.test.ts
@@ -31,6 +31,7 @@ const mockMetadata: VideoExtendedMetadata = {
   webpageUrl: 'https://www.youtube.com/watch?v=testId123',
   relatedFiles: null,
   availableResolutions: null,
+  downloadedTier: null,
 };
 
 describe('useVideoMetadata', () => {

--- a/client/src/components/shared/VideoModal/hooks/useVideoMetadata.ts
+++ b/client/src/components/shared/VideoModal/hooks/useVideoMetadata.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { VideoExtendedMetadata } from '../types';
+
+interface UseVideoMetadataReturn {
+  metadata: VideoExtendedMetadata | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export const useVideoMetadata = (
+  youtubeId: string,
+  token: string | null
+): UseVideoMetadataReturn => {
+  const [metadata, setMetadata] = useState<VideoExtendedMetadata | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!youtubeId || !token) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchMetadata = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await axios.get<VideoExtendedMetadata>(
+          `/api/videos/${youtubeId}/metadata`,
+          { headers: { 'x-access-token': token } }
+        );
+
+        if (!cancelled) {
+          setMetadata(response.data);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const errorMessage =
+            (err as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+            (err instanceof Error ? err.message : 'Failed to fetch video metadata');
+          setError(errorMessage);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchMetadata();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [youtubeId, token]);
+
+  return { metadata, loading, error };
+};

--- a/client/src/components/shared/VideoModal/hooks/useVideoModalActions.ts
+++ b/client/src/components/shared/VideoModal/hooks/useVideoModalActions.ts
@@ -1,0 +1,209 @@
+import { useState, useEffect, useCallback } from 'react';
+import axios from 'axios';
+import { VideoModalData } from '../types';
+import { useVideoProtection } from '../../useVideoProtection';
+import { useVideoDeletion } from '../../useVideoDeletion';
+
+interface SnackbarState {
+  open: boolean;
+  message: string;
+  severity: 'success' | 'error';
+}
+
+interface AxiosErrorShape {
+  response?: { data?: { error?: string } };
+}
+
+interface UseVideoModalActionsParams {
+  video: VideoModalData;
+  token: string | null;
+  onVideoDeleted?: (youtubeId: string) => void;
+  onProtectionChanged?: (youtubeId: string, isProtected: boolean) => void;
+  onIgnoreChanged?: (youtubeId: string, isIgnored: boolean) => void;
+  onDownloadQueued?: (youtubeId: string) => void;
+  onRatingChanged?: (youtubeId: string, rating: string | null) => void;
+  onClose: () => void;
+}
+
+interface UseVideoModalActionsReturn {
+  localVideo: VideoModalData;
+  snackbar: SnackbarState;
+  deleteDialogOpen: boolean;
+  downloadDialogOpen: boolean;
+  ratingDialogOpen: boolean;
+  protectionLoading: boolean;
+  setDeleteDialogOpen: (open: boolean) => void;
+  setDownloadDialogOpen: (open: boolean) => void;
+  setRatingDialogOpen: (open: boolean) => void;
+  handleProtectionToggle: () => Promise<void>;
+  handleDeleteConfirm: () => Promise<void>;
+  handleIgnoreToggle: () => Promise<void>;
+  handleDownloadConfirm: () => void;
+  handleRatingApply: (rating: string | null) => Promise<void>;
+  handleSnackbarClose: () => void;
+}
+
+function extractErrorMessage(err: unknown, fallback: string): string {
+  return (
+    (err as AxiosErrorShape)?.response?.data?.error ||
+    (err instanceof Error ? err.message : fallback)
+  );
+}
+
+export function useVideoModalActions({
+  video,
+  token,
+  onVideoDeleted,
+  onProtectionChanged,
+  onIgnoreChanged,
+  onDownloadQueued,
+  onRatingChanged,
+  onClose,
+}: UseVideoModalActionsParams): UseVideoModalActionsReturn {
+  const [localVideo, setLocalVideo] = useState<VideoModalData>(video);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
+  const [ratingDialogOpen, setRatingDialogOpen] = useState(false);
+  const [snackbar, setSnackbar] = useState<SnackbarState>({
+    open: false,
+    message: '',
+    severity: 'success',
+  });
+
+  const protection = useVideoProtection(token);
+  const deletion = useVideoDeletion();
+
+  // Reset local state when a different video is opened (not on every re-render).
+  // The video prop is a new object on each parent render, so we track by youtubeId.
+  useEffect(() => {
+    setLocalVideo(video);
+  }, [video.youtubeId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const showSnackbar = useCallback((message: string, severity: 'success' | 'error') => {
+    setSnackbar({ open: true, message, severity });
+  }, []);
+
+  const handleSnackbarClose = useCallback(() => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  const handleProtectionToggle = useCallback(async () => {
+    if (!localVideo.databaseId) return;
+
+    const newState = !localVideo.isProtected;
+
+    // Optimistic update
+    setLocalVideo((prev) => ({ ...prev, isProtected: newState }));
+
+    const result = await protection.toggleProtection(
+      localVideo.databaseId,
+      localVideo.isProtected
+    );
+
+    if (result !== undefined) {
+      setLocalVideo((prev) => ({ ...prev, isProtected: result }));
+      showSnackbar(
+        result ? 'Video protected from auto-deletion' : 'Video protection removed',
+        'success'
+      );
+      onProtectionChanged?.(localVideo.youtubeId, result);
+    } else {
+      setLocalVideo((prev) => ({ ...prev, isProtected: !newState }));
+      showSnackbar(protection.error || 'Failed to update protection', 'error');
+    }
+  }, [localVideo.databaseId, localVideo.isProtected, localVideo.youtubeId, protection, showSnackbar, onProtectionChanged]);
+
+  const handleDeleteConfirm = useCallback(async () => {
+    const result = await deletion.deleteVideosByYoutubeIds(
+      [localVideo.youtubeId],
+      token
+    );
+
+    if (result.success) {
+      showSnackbar('Video deleted successfully', 'success');
+      onVideoDeleted?.(localVideo.youtubeId);
+      setDeleteDialogOpen(false);
+      onClose();
+    } else {
+      const errorMsg = result.failed[0]?.error || 'Failed to delete video';
+      showSnackbar(errorMsg, 'error');
+      setDeleteDialogOpen(false);
+    }
+  }, [localVideo.youtubeId, token, deletion, showSnackbar, onVideoDeleted, onClose]);
+
+  const handleIgnoreToggle = useCallback(async () => {
+    const newIgnored = !localVideo.isIgnored;
+
+    try {
+      await axios.post(
+        `/api/channels/videos/${localVideo.youtubeId}/ignore`,
+        { ignored: newIgnored },
+        { headers: { 'x-access-token': token || '' } }
+      );
+
+      setLocalVideo((prev) => ({
+        ...prev,
+        isIgnored: newIgnored,
+        status: newIgnored ? 'ignored' : 'never_downloaded',
+      }));
+      showSnackbar(
+        newIgnored ? 'Video ignored' : 'Video unignored',
+        'success'
+      );
+      onIgnoreChanged?.(localVideo.youtubeId, newIgnored);
+    } catch (err: unknown) {
+      showSnackbar(extractErrorMessage(err, 'Failed to update ignore status'), 'error');
+    }
+  }, [localVideo.isIgnored, localVideo.youtubeId, token, showSnackbar, onIgnoreChanged]);
+
+  const handleDownloadConfirm = useCallback(() => {
+    setDownloadDialogOpen(false);
+    onDownloadQueued?.(localVideo.youtubeId);
+    showSnackbar('Video queued for download', 'success');
+  }, [localVideo.youtubeId, showSnackbar, onDownloadQueued]);
+
+  const handleRatingApply = useCallback(async (rating: string | null) => {
+    if (!localVideo.databaseId) {
+      showSnackbar('Cannot update rating: video not in database', 'error');
+      return;
+    }
+
+    try {
+      await axios.post(
+        '/api/videos/rating',
+        {
+          videoIds: [localVideo.databaseId],
+          rating,
+        },
+        { headers: { 'x-access-token': token || '' } }
+      );
+
+      setLocalVideo((prev) => ({
+        ...prev,
+        normalizedRating: rating,
+      }));
+      showSnackbar('Rating updated', 'success');
+      onRatingChanged?.(localVideo.youtubeId, rating);
+    } catch (err: unknown) {
+      showSnackbar(extractErrorMessage(err, 'Failed to update rating'), 'error');
+    }
+  }, [localVideo.databaseId, localVideo.youtubeId, token, showSnackbar, onRatingChanged]);
+
+  return {
+    localVideo,
+    snackbar,
+    deleteDialogOpen,
+    downloadDialogOpen,
+    ratingDialogOpen,
+    protectionLoading: protection.loading,
+    setDeleteDialogOpen,
+    setDownloadDialogOpen,
+    setRatingDialogOpen,
+    handleProtectionToggle,
+    handleDeleteConfirm,
+    handleIgnoreToggle,
+    handleDownloadConfirm,
+    handleRatingApply,
+    handleSnackbarClose,
+  };
+}

--- a/client/src/components/shared/VideoModal/hooks/useVideoModalActions.ts
+++ b/client/src/components/shared/VideoModal/hooks/useVideoModalActions.ts
@@ -1,8 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { VideoModalData } from '../types';
 import { useVideoProtection } from '../../useVideoProtection';
 import { useVideoDeletion } from '../../useVideoDeletion';
+import { useTriggerDownloads } from '../../../../hooks/useTriggerDownloads';
+import { DownloadSettings } from '../../../DownloadManager/ManualDownload/types';
 
 interface SnackbarState {
   open: boolean;
@@ -38,7 +41,7 @@ interface UseVideoModalActionsReturn {
   handleProtectionToggle: () => Promise<void>;
   handleDeleteConfirm: () => Promise<void>;
   handleIgnoreToggle: () => Promise<void>;
-  handleDownloadConfirm: () => void;
+  handleDownloadConfirm: (settings: DownloadSettings | null) => Promise<void>;
   handleRatingApply: (rating: string | null) => Promise<void>;
   handleSnackbarClose: () => void;
 }
@@ -70,8 +73,10 @@ export function useVideoModalActions({
     severity: 'success',
   });
 
+  const navigate = useNavigate();
   const protection = useVideoProtection(token);
   const deletion = useVideoDeletion();
+  const { triggerDownloads } = useTriggerDownloads(token);
 
   // Reset local state when a different video is opened (not on every re-render).
   // The video prop is a new object on each parent render, so we track by youtubeId.
@@ -156,11 +161,35 @@ export function useVideoModalActions({
     }
   }, [localVideo.isIgnored, localVideo.youtubeId, token, showSnackbar, onIgnoreChanged]);
 
-  const handleDownloadConfirm = useCallback(() => {
+  const handleDownloadConfirm = useCallback(async (settings: DownloadSettings | null) => {
     setDownloadDialogOpen(false);
-    onDownloadQueued?.(localVideo.youtubeId);
-    showSnackbar('Video queued for download', 'success');
-  }, [localVideo.youtubeId, showSnackbar, onDownloadQueued]);
+
+    const url = `https://www.youtube.com/watch?v=${localVideo.youtubeId}`;
+    const overrideSettings = settings
+      ? {
+          resolution: settings.resolution,
+          allowRedownload: settings.allowRedownload,
+          subfolder: settings.subfolder,
+          audioFormat: settings.audioFormat,
+          rating: settings.rating,
+          skipVideoFolder: settings.skipVideoFolder,
+        }
+      : undefined;
+
+    const success = await triggerDownloads({
+      urls: [url],
+      overrideSettings,
+      channelId: localVideo.channelId,
+    });
+
+    if (success) {
+      onDownloadQueued?.(localVideo.youtubeId);
+      onClose();
+      navigate('/downloads');
+    } else {
+      showSnackbar('Failed to queue download', 'error');
+    }
+  }, [localVideo.youtubeId, localVideo.channelId, triggerDownloads, showSnackbar, onDownloadQueued, onClose, navigate]);
 
   const handleRatingApply = useCallback(async (rating: string | null) => {
     if (!localVideo.databaseId) {

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -5,7 +5,6 @@ import {
   DialogContent,
   Box,
   Typography,
-  Chip,
   IconButton,
   Snackbar,
   Alert,
@@ -13,6 +12,7 @@ import {
   useTheme,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import VideoPlayer from './components/VideoPlayer';
 import VideoMetadata from './components/VideoMetadata';
 import VideoActions from './components/VideoActions';
@@ -23,7 +23,6 @@ import { VideoModalProps } from './types';
 import DeleteVideosDialog from '../DeleteVideosDialog';
 import ChangeRatingDialog from '../ChangeRatingDialog';
 import DownloadSettingsDialog from '../../DownloadManager/ManualDownload/DownloadSettingsDialog';
-import RatingBadge from '../RatingBadge';
 import { getStatusLabel, getStatusColor, getMediaTypeInfo } from '../../../utils/videoStatus';
 
 const SNACKBAR_AUTO_HIDE_MS = 4000;
@@ -85,15 +84,14 @@ function VideoModal({
         onClose={onClose}
         maxWidth="lg"
         fullWidth
+        fullScreen={isMobile}
         PaperProps={{
           sx: {
-            maxHeight: '92vh',
-            m: isMobile ? 0.5 : 1.5,
-            width: isMobile ? 'calc(100% - 8px)' : undefined,
+            ...(!isMobile && { maxHeight: '92vh', m: 1.5 }),
           },
         }}
       >
-        {/* Header bar */}
+        {/* Header bar - title + close */}
         <DialogTitle
           sx={{
             display: 'flex',
@@ -101,37 +99,48 @@ function VideoModal({
             gap: 1,
             py: 1.5,
             px: 2,
+            borderBottom: 1,
+            borderColor: 'divider',
           }}
         >
-          <Chip
-            label={getStatusLabel(localVideo.status)}
-            color={getStatusColor(localVideo.status)}
-            size="small"
-          />
-          {mediaTypeInfo && (
-            <Chip
-              label={mediaTypeInfo.label}
-              color={mediaTypeInfo.color}
+          {isMobile && (
+            <IconButton
+              onClick={onClose}
               size="small"
-              icon={mediaTypeInfo.icon}
-            />
+              aria-label="Close"
+              edge="start"
+              sx={{ mr: 0.5 }}
+            >
+              <ArrowBackIcon />
+            </IconButton>
           )}
-          {localVideo.normalizedRating && (
-            <RatingBadge
-              rating={localVideo.normalizedRating}
-              ratingSource={localVideo.ratingSource}
-              size="small"
-            />
-          )}
-          <Box sx={{ flex: 1 }} />
-          <IconButton
-            onClick={onClose}
-            size="small"
-            aria-label="Close"
-            edge="end"
+          <Typography
+            variant="h6"
+            component="span"
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              fontSize: isMobile ? '1rem' : '1.15rem',
+              fontWeight: 600,
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
+              overflow: 'hidden',
+              wordBreak: 'break-word',
+            }}
           >
-            <CloseIcon />
-          </IconButton>
+            {localVideo.title}
+          </Typography>
+          {!isMobile && (
+            <IconButton
+              onClick={onClose}
+              size="small"
+              aria-label="Close"
+              edge="end"
+            >
+              <CloseIcon />
+            </IconButton>
+          )}
         </DialogTitle>
 
         <DialogContent sx={{ p: isMobile ? 1.5 : 2 }}>
@@ -146,16 +155,16 @@ function VideoModal({
                 />
               </Box>
               <Box sx={{ minWidth: 0 }}>
-                <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
-                  {localVideo.title}
-                </Typography>
                 <VideoActions
                   video={localVideo}
+                  statusChip={{ label: getStatusLabel(localVideo.status), color: getStatusColor(localVideo.status) }}
+                  mediaTypeChip={mediaTypeInfo}
                   onDelete={() => setDeleteDialogOpen(true)}
                   onProtectionToggle={handleProtectionToggle}
                   onIgnoreToggle={handleIgnoreToggle}
                   onRatingChange={() => setRatingDialogOpen(true)}
                   protectionLoading={protectionLoading}
+                  isMobile={isMobile}
                 />
                 <Box sx={{ mt: 2 }}>
                   <VideoMetadata
@@ -179,17 +188,17 @@ function VideoModal({
                 onDownloadClick={() => setDownloadDialogOpen(true)}
                 isMobile={isMobile}
               />
-              <Box sx={{ mt: 2 }}>
-                <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
-                  {localVideo.title}
-                </Typography>
+              <Box sx={{ mt: 1.5 }}>
                 <VideoActions
                   video={localVideo}
+                  statusChip={{ label: getStatusLabel(localVideo.status), color: getStatusColor(localVideo.status) }}
+                  mediaTypeChip={mediaTypeInfo}
                   onDelete={() => setDeleteDialogOpen(true)}
                   onProtectionToggle={handleProtectionToggle}
                   onIgnoreToggle={handleIgnoreToggle}
                   onRatingChange={() => setRatingDialogOpen(true)}
                   protectionLoading={protectionLoading}
+                  isMobile={isMobile}
                 />
               </Box>
               <Box sx={{ mt: 2 }}>

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -69,8 +69,14 @@ function VideoModal({
     onClose,
   });
 
+  // Skip metadata fetch for members-only videos that we haven't downloaded -
+  // yt-dlp cannot access them and the error just spams the server logs. For
+  // already-downloaded members-only videos, the backend still serves cached
+  // .info.json so we let the fetch proceed.
+  const skipMetadataFetch = video.status === 'members_only' && !video.isDownloaded;
+  const shouldFetchMetadata = open && !skipMetadataFetch;
   const { metadata, loading: metadataLoading } = useVideoMetadata(
-    open ? video.youtubeId : '',
+    shouldFetchMetadata ? video.youtubeId : '',
     token
   );
 

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import {
   Dialog,
   DialogTitle,
@@ -83,11 +84,12 @@ function VideoModal({
   const { config } = useConfig(token);
 
   // Fetch channel-level download settings when modal opens
-  const [channelSettings, setChannelSettings] = useState<{
+  interface ChannelSettings {
     video_quality?: string | null;
     audio_format?: string | null;
     default_rating?: string | null;
-  }>({});
+  }
+  const [channelSettings, setChannelSettings] = useState<ChannelSettings>({});
 
   useEffect(() => {
     if (!open || !video.channelId || !token) {
@@ -97,14 +99,18 @@ function VideoModal({
     const controller = new AbortController();
     const fetchSettings = async () => {
       try {
-        const resp = await fetch(`/api/channels/${video.channelId}/settings`, {
-          headers: { 'x-access-token': token },
-          signal: controller.signal,
-        });
-        if (!resp.ok) return;
-        setChannelSettings(await resp.json());
-      } catch (err: unknown) {
-        if (err instanceof DOMException && err.name === 'AbortError') return;
+        const resp = await axios.get<ChannelSettings>(
+          `/api/channels/${video.channelId}/settings`,
+          {
+            headers: { 'x-access-token': token },
+            signal: controller.signal,
+          }
+        );
+        if (!controller.signal.aborted) {
+          setChannelSettings(resp.data);
+        }
+      } catch {
+        // Request failed or was aborted; leave channelSettings at its last value.
       }
     };
     fetchSettings();

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -1,0 +1,256 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Box,
+  Typography,
+  Chip,
+  IconButton,
+  Snackbar,
+  Alert,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import VideoPlayer from './components/VideoPlayer';
+import VideoMetadata from './components/VideoMetadata';
+import VideoActions from './components/VideoActions';
+import VideoTechnical from './components/VideoTechnical';
+import { useVideoMetadata } from './hooks/useVideoMetadata';
+import { useVideoModalActions } from './hooks/useVideoModalActions';
+import { VideoModalProps } from './types';
+import DeleteVideosDialog from '../DeleteVideosDialog';
+import ChangeRatingDialog from '../ChangeRatingDialog';
+import DownloadSettingsDialog from '../../DownloadManager/ManualDownload/DownloadSettingsDialog';
+import RatingBadge from '../RatingBadge';
+import { getStatusLabel, getStatusColor, getMediaTypeInfo } from '../../../utils/videoStatus';
+
+const SNACKBAR_AUTO_HIDE_MS = 4000;
+
+function VideoModal({
+  open,
+  onClose,
+  video,
+  token,
+  onVideoDeleted,
+  onProtectionChanged,
+  onIgnoreChanged,
+  onDownloadQueued,
+  onRatingChanged,
+}: VideoModalProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const {
+    localVideo,
+    snackbar,
+    deleteDialogOpen,
+    downloadDialogOpen,
+    ratingDialogOpen,
+    protectionLoading,
+    setDeleteDialogOpen,
+    setDownloadDialogOpen,
+    setRatingDialogOpen,
+    handleProtectionToggle,
+    handleDeleteConfirm,
+    handleIgnoreToggle,
+    handleDownloadConfirm,
+    handleRatingApply,
+    handleSnackbarClose,
+  } = useVideoModalActions({
+    video,
+    token,
+    onVideoDeleted,
+    onProtectionChanged,
+    onIgnoreChanged,
+    onDownloadQueued,
+    onRatingChanged,
+    onClose,
+  });
+
+  const { metadata, loading: metadataLoading } = useVideoMetadata(
+    open ? video.youtubeId : '',
+    token
+  );
+
+  const isShort = localVideo.mediaType === 'short';
+  const useSideBySide = isShort && !isMobile;
+  const mediaTypeInfo = getMediaTypeInfo(localVideo.mediaType);
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={onClose}
+        maxWidth="lg"
+        fullWidth
+        PaperProps={{
+          sx: {
+            maxHeight: '92vh',
+            m: isMobile ? 0.5 : 1.5,
+            width: isMobile ? 'calc(100% - 8px)' : undefined,
+          },
+        }}
+      >
+        {/* Header bar */}
+        <DialogTitle
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            py: 1.5,
+            px: 2,
+          }}
+        >
+          <Chip
+            label={getStatusLabel(localVideo.status)}
+            color={getStatusColor(localVideo.status)}
+            size="small"
+          />
+          {mediaTypeInfo && (
+            <Chip
+              label={mediaTypeInfo.label}
+              color={mediaTypeInfo.color}
+              size="small"
+              icon={mediaTypeInfo.icon}
+            />
+          )}
+          {localVideo.normalizedRating && (
+            <RatingBadge
+              rating={localVideo.normalizedRating}
+              ratingSource={localVideo.ratingSource}
+              size="small"
+            />
+          )}
+          <Box sx={{ flex: 1 }} />
+          <IconButton
+            onClick={onClose}
+            size="small"
+            aria-label="Close"
+            edge="end"
+          >
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+
+        <DialogContent sx={{ p: isMobile ? 1.5 : 2 }}>
+          {useSideBySide ? (
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Box sx={{ width: 300, flexShrink: 0 }}>
+                <VideoPlayer
+                  video={localVideo}
+                  token={token}
+                  onDownloadClick={() => setDownloadDialogOpen(true)}
+                  isMobile={isMobile}
+                />
+              </Box>
+              <Box sx={{ minWidth: 0 }}>
+                <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
+                  {localVideo.title}
+                </Typography>
+                <VideoActions
+                  video={localVideo}
+                  onDelete={() => setDeleteDialogOpen(true)}
+                  onProtectionToggle={handleProtectionToggle}
+                  onIgnoreToggle={handleIgnoreToggle}
+                  onRatingChange={() => setRatingDialogOpen(true)}
+                  protectionLoading={protectionLoading}
+                />
+                <Box sx={{ mt: 2 }}>
+                  <VideoMetadata
+                    video={localVideo}
+                    metadata={metadata}
+                    loading={metadataLoading}
+                  />
+                  <VideoTechnical
+                    video={localVideo}
+                    metadata={metadata}
+                    loading={metadataLoading}
+                  />
+                </Box>
+              </Box>
+            </Box>
+          ) : (
+            <>
+              <VideoPlayer
+                video={localVideo}
+                token={token}
+                onDownloadClick={() => setDownloadDialogOpen(true)}
+                isMobile={isMobile}
+              />
+              <Box sx={{ mt: 2 }}>
+                <Typography variant="h6" sx={{ mb: 1, wordBreak: 'break-word' }}>
+                  {localVideo.title}
+                </Typography>
+                <VideoActions
+                  video={localVideo}
+                  onDelete={() => setDeleteDialogOpen(true)}
+                  onProtectionToggle={handleProtectionToggle}
+                  onIgnoreToggle={handleIgnoreToggle}
+                  onRatingChange={() => setRatingDialogOpen(true)}
+                  protectionLoading={protectionLoading}
+                />
+              </Box>
+              <Box sx={{ mt: 2 }}>
+                <VideoMetadata
+                  video={localVideo}
+                  metadata={metadata}
+                  loading={metadataLoading}
+                />
+              </Box>
+              <Box sx={{ mt: 2 }}>
+                <VideoTechnical
+                  video={localVideo}
+                  metadata={metadata}
+                  loading={metadataLoading}
+                />
+              </Box>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <DeleteVideosDialog
+        open={deleteDialogOpen}
+        onClose={() => setDeleteDialogOpen(false)}
+        onConfirm={handleDeleteConfirm}
+        videoCount={1}
+      />
+
+      <DownloadSettingsDialog
+        open={downloadDialogOpen}
+        onClose={() => setDownloadDialogOpen(false)}
+        onConfirm={handleDownloadConfirm}
+        videoCount={1}
+        mode="manual"
+        token={token}
+      />
+
+      <ChangeRatingDialog
+        open={ratingDialogOpen}
+        onClose={() => setRatingDialogOpen(false)}
+        onApply={handleRatingApply}
+        selectedCount={1}
+      />
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={SNACKBAR_AUTO_HIDE_MS}
+        onClose={handleSnackbarClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={handleSnackbarClose}
+          severity={snackbar.severity}
+          variant="filled"
+          sx={{ width: '100%' }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}
+
+export default VideoModal;

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -24,6 +24,7 @@ import DeleteVideosDialog from '../DeleteVideosDialog';
 import ChangeRatingDialog from '../ChangeRatingDialog';
 import DownloadSettingsDialog from '../../DownloadManager/ManualDownload/DownloadSettingsDialog';
 import { getStatusLabel, getStatusColor, getMediaTypeInfo } from '../../../utils/videoStatus';
+import { useConfig } from '../../../hooks/useConfig';
 
 const SNACKBAR_AUTO_HIDE_MS = 4000;
 
@@ -72,6 +73,44 @@ function VideoModal({
     open ? video.youtubeId : '',
     token
   );
+
+  const { config } = useConfig(token);
+
+  // Fetch channel-level download settings when modal opens
+  const [channelSettings, setChannelSettings] = useState<{
+    video_quality?: string | null;
+    audio_format?: string | null;
+    default_rating?: string | null;
+  }>({});
+
+  useEffect(() => {
+    if (!open || !video.channelId || !token) {
+      setChannelSettings({});
+      return;
+    }
+    const controller = new AbortController();
+    const fetchSettings = async () => {
+      try {
+        const resp = await fetch(`/api/channels/${video.channelId}/settings`, {
+          headers: { 'x-access-token': token },
+          signal: controller.signal,
+        });
+        if (!resp.ok) return;
+        setChannelSettings(await resp.json());
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+      }
+    };
+    fetchSettings();
+    return () => { controller.abort(); };
+  }, [open, video.channelId, token]);
+
+  const hasChannelQualityOverride = Boolean(channelSettings.video_quality);
+  const defaultResolution = channelSettings.video_quality || config.preferredResolution || '1080';
+  const defaultResolutionSource: 'channel' | 'global' = hasChannelQualityOverride ? 'channel' : 'global';
+  const hasChannelAudioOverride = Boolean(channelSettings.audio_format);
+  const defaultAudioFormat = channelSettings.audio_format || null;
+  const defaultAudioFormatSource: 'channel' | 'global' = hasChannelAudioOverride ? 'channel' : 'global';
 
   const isShort = localVideo.mediaType === 'short';
   const useSideBySide = isShort && !isMobile;
@@ -234,6 +273,11 @@ function VideoModal({
         videoCount={1}
         mode="manual"
         token={token}
+        defaultResolution={defaultResolution}
+        defaultResolutionSource={defaultResolutionSource}
+        defaultAudioFormat={defaultAudioFormat}
+        defaultAudioFormatSource={defaultAudioFormatSource}
+        defaultRating={channelSettings.default_rating ?? null}
       />
 
       <ChangeRatingDialog

--- a/client/src/components/shared/VideoModal/types.ts
+++ b/client/src/components/shared/VideoModal/types.ts
@@ -57,6 +57,7 @@ export interface VideoExtendedMetadata {
   webpageUrl: string | null;
   relatedFiles: VideoRelatedFile[] | null;
   availableResolutions: number[] | null;
+  downloadedTier: number | null;
 }
 
 export interface VideoRelatedFile {

--- a/client/src/components/shared/VideoModal/types.ts
+++ b/client/src/components/shared/VideoModal/types.ts
@@ -1,0 +1,66 @@
+import { VideoStatus } from '../../../utils/videoStatus';
+
+export interface VideoModalData {
+  youtubeId: string;
+  title: string;
+  channelName: string;
+  thumbnailUrl: string;
+  duration: number | null;
+  publishedAt: string | null;
+  addedAt: string | null;
+  mediaType: string;
+  status: VideoStatus;
+  isDownloaded: boolean;
+  filePath: string | null;
+  fileSize: number | null;
+  audioFilePath: string | null;
+  audioFileSize: number | null;
+  isProtected: boolean;
+  isIgnored: boolean;
+  normalizedRating: string | null;
+  ratingSource: string | null;
+  databaseId: number | null;
+  channelId: string | null;
+}
+
+export interface VideoModalProps {
+  open: boolean;
+  onClose: () => void;
+  video: VideoModalData;
+  token: string | null;
+  onVideoDeleted?: (youtubeId: string) => void;
+  onProtectionChanged?: (youtubeId: string, isProtected: boolean) => void;
+  onIgnoreChanged?: (youtubeId: string, isIgnored: boolean) => void;
+  onDownloadQueued?: (youtubeId: string) => void;
+  onRatingChanged?: (youtubeId: string, rating: string | null) => void;
+}
+
+export interface VideoExtendedMetadata {
+  description: string | null;
+  viewCount: number | null;
+  likeCount: number | null;
+  commentCount: number | null;
+  tags: string[] | null;
+  categories: string[] | null;
+  uploadDate: string | null;
+  resolution: string | null;
+  width: number | null;
+  height: number | null;
+  fps: number | null;
+  aspectRatio: number | null;
+  language: string | null;
+  isLive: boolean | null;
+  wasLive: boolean | null;
+  availability: string | null;
+  channelFollowerCount: number | null;
+  ageLimit: number | null;
+  webpageUrl: string | null;
+  relatedFiles: VideoRelatedFile[] | null;
+  availableResolutions: number[] | null;
+}
+
+export interface VideoRelatedFile {
+  fileName: string;
+  fileSize: number;
+  type: string;
+}

--- a/server/__tests__/server.additional-routes.test.js
+++ b/server/__tests__/server.additional-routes.test.js
@@ -248,6 +248,10 @@ const createServerModule = ({
         jest.doMock('../modules/downloadModule', () => downloadModuleMock);
         jest.doMock('../modules/jobModule', () => jobModuleMock);
         jest.doMock('../modules/videosModule', () => videosModuleMock);
+        jest.doMock('../modules/videoMetadataModule', () => ({
+          getVideoMetadata: jest.fn().mockResolvedValue(null),
+          getVideoStreamInfo: jest.fn().mockResolvedValue(null)
+        }));
         jest.doMock('../modules/channelSettingsModule', () => ({
           getChannelSettings: jest.fn(),
           updateChannelSettings: jest.fn(),

--- a/server/__tests__/server.apikeys.test.js
+++ b/server/__tests__/server.apikeys.test.js
@@ -261,6 +261,10 @@ const createServerModule = ({
           getRunningJobs: jest.fn(() => [])
         }));
         jest.doMock('../modules/videosModule', () => ({}));
+        jest.doMock('../modules/videoMetadataModule', () => ({
+          getVideoMetadata: jest.fn().mockResolvedValue(null),
+          getVideoStreamInfo: jest.fn().mockResolvedValue(null)
+        }));
         jest.doMock('../modules/channelSettingsModule', () => ({
           getChannelSettings: jest.fn(),
           updateChannelSettings: jest.fn(),

--- a/server/__tests__/server.auth-sessions.test.js
+++ b/server/__tests__/server.auth-sessions.test.js
@@ -215,6 +215,10 @@ const createServerModule = ({
           getRunningJobs: jest.fn(() => [])
         }));
         jest.doMock('../modules/videosModule', () => ({}));
+        jest.doMock('../modules/videoMetadataModule', () => ({
+          getVideoMetadata: jest.fn().mockResolvedValue(null),
+          getVideoStreamInfo: jest.fn().mockResolvedValue(null)
+        }));
         jest.doMock('../modules/channelSettingsModule', () => ({
           getChannelSettings: jest.fn(),
           updateChannelSettings: jest.fn(),

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -336,6 +336,10 @@ const createServerModule = ({
         jest.doMock('../modules/videoDeletionModule', () => videoDeletionModuleMock);
         jest.doMock('../modules/videoValidationModule', () => videoValidationModuleMock);
         jest.doMock('../modules/channelSettingsModule', () => channelSettingsModuleMock);
+        jest.doMock('../modules/videoMetadataModule', () => ({
+          getVideoMetadata: jest.fn().mockResolvedValue(null),
+          getVideoStreamInfo: jest.fn().mockResolvedValue(null)
+        }));
         jest.doMock('../modules/archiveModule', () => ({
           getAutoRemovalDryRun: jest.fn().mockResolvedValue({ videos: [], totalSize: 0 })
         }));

--- a/server/modules/__tests__/videoMetadataModule.test.js
+++ b/server/modules/__tests__/videoMetadataModule.test.js
@@ -350,6 +350,56 @@ describe('VideoMetadataModule', () => {
 
       expect(result).toEqual([360, 480, 1440, 2160]);
     });
+
+    test('uses format_note tier for non-16:9 videos (actual height differs from tier)', () => {
+      // 2:1 aspect video: actual heights are half the width, but tier labels match standard buckets
+      const formats = [
+        { height: 320, format_note: '360p', vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 428, format_note: '480p', vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 640, format_note: '720p', vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 960, format_note: '1080p', vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([360, 480, 720, 1080]);
+    });
+
+    test('format_note with framerate suffix still extracts base tier', () => {
+      const formats = [
+        { height: 1080, format_note: '1080p60', vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 720, format_note: '720p60', vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([720, 1080]);
+    });
+  });
+
+  describe('_extractTierFromFormatNote', () => {
+    test('parses plain tier like "1080p"', () => {
+      expect(videoMetadataModule._extractTierFromFormatNote('1080p')).toBe(1080);
+    });
+
+    test('parses tier with framerate like "1080p60"', () => {
+      expect(videoMetadataModule._extractTierFromFormatNote('1080p60')).toBe(1080);
+    });
+
+    test('parses tier with audio suffix like "1080p+medium"', () => {
+      expect(videoMetadataModule._extractTierFromFormatNote('1080p+medium')).toBe(1080);
+    });
+
+    test('returns null for null, undefined, or empty input', () => {
+      expect(videoMetadataModule._extractTierFromFormatNote(null)).toBeNull();
+      expect(videoMetadataModule._extractTierFromFormatNote(undefined)).toBeNull();
+      expect(videoMetadataModule._extractTierFromFormatNote('')).toBeNull();
+    });
+
+    test('returns null when string does not start with a tier', () => {
+      expect(videoMetadataModule._extractTierFromFormatNote('medium')).toBeNull();
+      expect(videoMetadataModule._extractTierFromFormatNote('high quality')).toBeNull();
+    });
   });
 
   describe('_getVideoRelatedFiles', () => {

--- a/server/modules/__tests__/videoMetadataModule.test.js
+++ b/server/modules/__tests__/videoMetadataModule.test.js
@@ -1,0 +1,521 @@
+/* eslint-env jest */
+
+describe('VideoMetadataModule', () => {
+  let videoMetadataModule;
+  let mockFs;
+  let mockVideo;
+  let mockLogger;
+  let mockConfigModule;
+  let mockYtDlpRunner;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    mockFs = {
+      access: jest.fn(),
+      readFile: jest.fn(),
+      writeFile: jest.fn(),
+      mkdir: jest.fn(),
+      stat: jest.fn(),
+      readdir: jest.fn(),
+    };
+
+    mockVideo = {
+      findOne: jest.fn(),
+      findAll: jest.fn(),
+      findByPk: jest.fn(),
+      count: jest.fn(),
+      update: jest.fn(),
+    };
+
+    mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      trace: jest.fn(),
+      fatal: jest.fn(),
+    };
+
+    mockConfigModule = {
+      directoryPath: '/test/data',
+      getJobsPath: jest.fn().mockReturnValue('/test/jobs'),
+    };
+
+    mockYtDlpRunner = {
+      fetchMetadata: jest.fn(),
+    };
+
+    jest.doMock('fs', () => ({ promises: mockFs }));
+    jest.doMock('../../models', () => ({ Video: mockVideo }));
+    jest.doMock('../configModule', () => mockConfigModule);
+    jest.doMock('../../logger', () => mockLogger);
+    jest.doMock('../ytDlpRunner', () => mockYtDlpRunner);
+
+    videoMetadataModule = require('../videoMetadataModule');
+  });
+
+  describe('getVideoMetadata', () => {
+    test('returns curated metadata from cached .info.json file', async () => {
+      const rawInfoJson = {
+        description: 'A great video',
+        view_count: 12345,
+        like_count: 100,
+        comment_count: 50,
+        tags: ['test', 'video'],
+        categories: ['Entertainment'],
+        upload_date: '20240315',
+        resolution: '1920x1080',
+        height: 1080,
+        width: 1920,
+        aspect_ratio: 1.78,
+        fps: 30,
+        language: 'en',
+        is_live: false,
+        was_live: false,
+        availability: 'public',
+        channel_follower_count: 5000,
+        age_limit: 0,
+        webpage_url: 'https://www.youtube.com/watch?v=abc123',
+        // These bulk fields should NOT appear in output
+        formats: [{ format_id: '137' }],
+        automatic_captions: { en: [] },
+        thumbnails: [{ url: 'http://example.com/thumb.jpg' }],
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'abc123',
+        originalDate: '20240315',
+        update: jest.fn(),
+      });
+
+      const result = await videoMetadataModule.getVideoMetadata('abc123');
+
+      expect(result.description).toBe('A great video');
+      expect(result.viewCount).toBe(12345);
+      expect(result.likeCount).toBe(100);
+      expect(result.commentCount).toBe(50);
+      expect(result.tags).toEqual(['test', 'video']);
+      expect(result.categories).toEqual(['Entertainment']);
+      expect(result.uploadDate).toBe('20240315');
+      expect(result.resolution).toBe('1920x1080');
+      expect(result.fps).toBe(30);
+      expect(result.aspectRatio).toBe(1.78);
+      expect(result.language).toBe('en');
+      expect(result.isLive).toBe(false);
+      expect(result.wasLive).toBe(false);
+      expect(result.availability).toBe('public');
+      expect(result.channelFollowerCount).toBe(5000);
+      expect(result.ageLimit).toBe(0);
+      expect(result.webpageUrl).toBe('https://www.youtube.com/watch?v=abc123');
+
+      // Bulk arrays should NOT be in result
+      expect(result.formats).toBeUndefined();
+      expect(result.automatic_captions).toBeUndefined();
+      expect(result.thumbnails).toBeUndefined();
+    });
+
+    test('fetches from yt-dlp when cached file does not exist', async () => {
+      const ytdlpData = {
+        description: 'Fetched description',
+        view_count: 999,
+        like_count: 10,
+        upload_date: '20240101',
+        resolution: '1280x720',
+        height: 720,
+        width: 1280,
+        aspect_ratio: 1.78,
+      };
+
+      // fs.access rejects (file not found)
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockYtDlpRunner.fetchMetadata.mockResolvedValue(ytdlpData);
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockFs.writeFile.mockResolvedValue(undefined);
+      mockVideo.findOne.mockResolvedValue(null);
+
+      const result = await videoMetadataModule.getVideoMetadata('xyz789');
+
+      expect(mockYtDlpRunner.fetchMetadata).toHaveBeenCalledWith(
+        'https://www.youtube.com/watch?v=xyz789',
+        60000
+      );
+      expect(result.description).toBe('Fetched description');
+      expect(result.viewCount).toBe(999);
+      expect(result.resolution).toBe('1280x720');
+
+      // Should have cached the result
+      expect(mockFs.mkdir).toHaveBeenCalledWith(
+        expect.stringContaining('info'),
+        { recursive: true }
+      );
+      expect(mockFs.writeFile).toHaveBeenCalled();
+    });
+
+    test('returns all-null metadata when yt-dlp also fails', async () => {
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockYtDlpRunner.fetchMetadata.mockRejectedValue(new Error('yt-dlp failed'));
+
+      const result = await videoMetadataModule.getVideoMetadata('fail123');
+
+      expect(result.description).toBeNull();
+      expect(result.viewCount).toBeNull();
+      expect(result.resolution).toBeNull();
+      expect(result.webpageUrl).toBeNull();
+    });
+
+    test('backfills originalDate when DB record has no date', async () => {
+      const rawInfoJson = {
+        upload_date: '20240515',
+        description: 'test',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+
+      const mockVideoRecord = {
+        youtubeId: 'backfill1',
+        originalDate: null,
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+      mockVideo.findOne.mockResolvedValue(mockVideoRecord);
+
+      await videoMetadataModule.getVideoMetadata('backfill1');
+
+      expect(mockVideoRecord.update).toHaveBeenCalledWith({ originalDate: '20240515' });
+    });
+
+    test('backfills originalDate when DB record has different date', async () => {
+      const rawInfoJson = {
+        upload_date: '20240515',
+        description: 'test',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+
+      const mockVideoRecord = {
+        youtubeId: 'backfill2',
+        originalDate: '20240514',
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+      mockVideo.findOne.mockResolvedValue(mockVideoRecord);
+
+      await videoMetadataModule.getVideoMetadata('backfill2');
+
+      expect(mockVideoRecord.update).toHaveBeenCalledWith({ originalDate: '20240515' });
+    });
+
+    test('does not backfill when dates match', async () => {
+      const rawInfoJson = {
+        upload_date: '20240515',
+        description: 'test',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+
+      const mockVideoRecord = {
+        youtubeId: 'nobackfill',
+        originalDate: '20240515',
+        update: jest.fn(),
+      };
+      mockVideo.findOne.mockResolvedValue(mockVideoRecord);
+
+      await videoMetadataModule.getVideoMetadata('nobackfill');
+
+      expect(mockVideoRecord.update).not.toHaveBeenCalled();
+    });
+
+    test('handles missing optional fields gracefully', async () => {
+      const rawInfoJson = {
+        description: 'minimal video',
+        // Most fields are missing
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+
+      const result = await videoMetadataModule.getVideoMetadata('minimal1');
+
+      expect(result.description).toBe('minimal video');
+      expect(result.viewCount).toBeNull();
+      expect(result.likeCount).toBeNull();
+      expect(result.resolution).toBeNull();
+      expect(result.aspectRatio).toBeNull();
+      expect(result.fps).toBeNull();
+      expect(result.language).toBeNull();
+    });
+
+    test('caching failure does not prevent metadata return', async () => {
+      const ytdlpData = {
+        description: 'Should still return',
+        view_count: 42,
+      };
+
+      mockFs.access.mockRejectedValue(new Error('ENOENT'));
+      mockYtDlpRunner.fetchMetadata.mockResolvedValue(ytdlpData);
+      mockFs.mkdir.mockRejectedValue(new Error('Permission denied'));
+
+      const result = await videoMetadataModule.getVideoMetadata('cachefail1');
+
+      expect(result.description).toBe('Should still return');
+      expect(result.viewCount).toBe(42);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ youtubeId: 'cachefail1' }),
+        'Failed to cache .info.json'
+      );
+    });
+  });
+
+  describe('_extractAvailableResolutions', () => {
+    test('extracts supported resolutions from formats with video+audio streams', () => {
+      const formats = [
+        { height: 360, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 720, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 1080, vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([360, 720, 1080]);
+    });
+
+    test('excludes audio-only streams (vcodec is none)', () => {
+      const formats = [
+        { height: 720, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: null, vcodec: 'none', acodec: 'mp4a' },
+        { height: 0, vcodec: 'none', acodec: 'opus' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([720]);
+    });
+
+    test('deduplicates heights', () => {
+      const formats = [
+        { height: 1080, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 1080, vcodec: 'vp9', acodec: 'opus' },
+        { height: 1080, vcodec: 'av01', acodec: 'mp4a' },
+        { height: 720, vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([720, 1080]);
+    });
+
+    test('returns null for empty array', () => {
+      const result = videoMetadataModule._extractAvailableResolutions([]);
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null for null input', () => {
+      const result = videoMetadataModule._extractAvailableResolutions(null);
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null for undefined input', () => {
+      const result = videoMetadataModule._extractAvailableResolutions(undefined);
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when no formats have supported heights', () => {
+      const formats = [
+        { height: 144, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 240, vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toBeNull();
+    });
+
+    test('returns sorted resolutions', () => {
+      const formats = [
+        { height: 2160, vcodec: 'vp9', acodec: 'opus' },
+        { height: 360, vcodec: 'avc1', acodec: 'mp4a' },
+        { height: 1440, vcodec: 'vp9', acodec: 'opus' },
+        { height: 480, vcodec: 'avc1', acodec: 'mp4a' },
+      ];
+
+      const result = videoMetadataModule._extractAvailableResolutions(formats);
+
+      expect(result).toEqual([360, 480, 1440, 2160]);
+    });
+  });
+
+  describe('_getVideoRelatedFiles', () => {
+    test('returns related files with correct categorization', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'rel123',
+        filePath: '/data/channel/My Video [rel123].mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'My Video [rel123].mp4',
+        'My Video [rel123].jpg',
+        'My Video [rel123].nfo',
+        'My Video [rel123].info.json',
+        'Other Video [other1].mp4',
+      ]);
+
+      mockFs.stat
+        .mockResolvedValueOnce({ size: 50000 })   // .jpg
+        .mockResolvedValueOnce({ size: 1200 })     // .nfo
+        .mockResolvedValueOnce({ size: 85000 });   // .info.json
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('rel123');
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({ fileName: 'My Video [rel123].jpg', fileSize: 50000, type: 'Thumbnail' });
+      expect(result[1]).toEqual({ fileName: 'My Video [rel123].nfo', fileSize: 1200, type: 'NFO Metadata' });
+      expect(result[2]).toEqual({ fileName: 'My Video [rel123].info.json', fileSize: 85000, type: 'Info JSON' });
+    });
+
+    test('does not include filePath in results', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'nopath1',
+        filePath: '/data/channel/Video [nopath1].mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'Video [nopath1].mp4',
+        'Video [nopath1].jpg',
+      ]);
+
+      mockFs.stat.mockResolvedValueOnce({ size: 1000 });
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('nopath1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].filePath).toBeUndefined();
+      expect(result[0].fileName).toBe('Video [nopath1].jpg');
+    });
+
+    test('excludes main video and audio files', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'excl1',
+        filePath: '/data/channel/Video [excl1].mp4',
+        audioFilePath: '/data/channel/Video [excl1].mp3',
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'Video [excl1].mp4',
+        'Video [excl1].mp3',
+        'Video [excl1].jpg',
+      ]);
+
+      mockFs.stat.mockResolvedValueOnce({ size: 2000 });
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('excl1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('Video [excl1].jpg');
+    });
+
+    test('returns null when video not found in database', async () => {
+      mockVideo.findOne.mockResolvedValue(null);
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('missing1');
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when video has no filePath', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'nofp1',
+        filePath: null,
+      });
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('nofp1');
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when directory does not exist', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'nodir1',
+        filePath: '/data/missing-channel/Video [nodir1].mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockRejectedValue(new Error('ENOENT: no such file or directory'));
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('nodir1');
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when no matching related files exist', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'nomatch1',
+        filePath: '/data/channel/Video [nomatch1].mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'Video [nomatch1].mp4',
+        'Other Video [other1].jpg',
+        'unrelated-file.txt',
+      ]);
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('nomatch1');
+
+      expect(result).toBeNull();
+    });
+
+    test('matches files using " - youtubeId" pattern', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'dash1',
+        filePath: '/data/channel/Video - dash1.mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'Video - dash1.mp4',
+        'Video - dash1.srt',
+      ]);
+
+      mockFs.stat.mockResolvedValueOnce({ size: 500 });
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('dash1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ fileName: 'Video - dash1.srt', fileSize: 500, type: 'Subtitles' });
+    });
+
+    test('handles stat failure for individual files gracefully', async () => {
+      mockVideo.findOne.mockResolvedValue({
+        youtubeId: 'statfail1',
+        filePath: '/data/channel/Video [statfail1].mp4',
+        audioFilePath: null,
+      });
+
+      mockFs.readdir.mockResolvedValue([
+        'Video [statfail1].mp4',
+        'Video [statfail1].jpg',
+        'Video [statfail1].nfo',
+      ]);
+
+      // First stat call fails, second succeeds
+      mockFs.stat
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockResolvedValueOnce({ size: 800 });
+
+      const result = await videoMetadataModule._getVideoRelatedFiles('statfail1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('Video [statfail1].nfo');
+    });
+  });
+});

--- a/server/modules/videoMetadataModule.js
+++ b/server/modules/videoMetadataModule.js
@@ -28,6 +28,7 @@ const NULL_METADATA = {
   webpageUrl: null,
   relatedFiles: null,
   availableResolutions: null,
+  downloadedTier: null,
 };
 
 const YTDLP_FETCH_TIMEOUT_MS = 60000;
@@ -118,6 +119,11 @@ class VideoMetadataModule {
       // Extract available resolutions from the formats array
       const availableResolutions = this._extractAvailableResolutions(rawData.formats);
 
+      // Extract downloaded tier from top-level format_note (e.g. "1080p+medium" -> 1080).
+      // This is the YouTube quality tier, which differs from the actual pixel height
+      // for non-16:9 aspect ratios (e.g. a 2:1 video's "1080p" tier has 960 actual height).
+      const downloadedTier = this._extractTierFromFormatNote(rawData.format_note);
+
       return {
         description: rawData.description ?? null,
         viewCount: rawData.view_count ?? null,
@@ -140,6 +146,7 @@ class VideoMetadataModule {
         webpageUrl: rawData.webpage_url ?? null,
         relatedFiles,
         availableResolutions,
+        downloadedTier,
       };
     } catch (err) {
       logger.error({ err, youtubeId }, 'Unexpected error in getVideoMetadata');
@@ -206,21 +213,44 @@ class VideoMetadataModule {
   /**
    * Extract available download resolutions from the yt-dlp formats array.
    * Only returns resolutions we support downloading (360p-2160p).
+   *
+   * Prefers format_note (e.g. "1080p") over raw height because for non-16:9
+   * aspect ratios the actual pixel height differs from the quality tier label
+   * (e.g. a 2:1 video's "1080p" format has 960 actual height, not 1080).
+   * Falls back to height when format_note isn't present or parseable.
    */
   _extractAvailableResolutions(formats) {
     if (!Array.isArray(formats) || formats.length === 0) return null;
 
-    const availableHeights = new Set();
+    const availableTiers = new Set();
 
     for (const fmt of formats) {
-      if (fmt.height && fmt.vcodec && fmt.vcodec !== 'none' && SUPPORTED_HEIGHTS.includes(fmt.height)) {
-        availableHeights.add(fmt.height);
+      if (!fmt.vcodec || fmt.vcodec === 'none') continue;
+
+      let tier = this._extractTierFromFormatNote(fmt.format_note);
+      if (tier === null && fmt.height) {
+        tier = fmt.height;
+      }
+
+      if (tier !== null && SUPPORTED_HEIGHTS.includes(tier)) {
+        availableTiers.add(tier);
       }
     }
 
-    if (availableHeights.size === 0) return null;
+    if (availableTiers.size === 0) return null;
 
-    return [...availableHeights].sort((a, b) => a - b);
+    return [...availableTiers].sort((a, b) => a - b);
+  }
+
+  /**
+   * Parse a YouTube quality tier from a yt-dlp format_note string.
+   * Examples: "1080p" -> 1080, "1080p60" -> 1080, "1080p+medium" -> 1080.
+   * Returns null if the string isn't present or doesn't start with a tier.
+   */
+  _extractTierFromFormatNote(formatNote) {
+    if (!formatNote || typeof formatNote !== 'string') return null;
+    const match = formatNote.match(/^(\d+)p/);
+    return match ? parseInt(match[1], 10) : null;
   }
 
   _categorizeFileExtension(ext) {

--- a/server/modules/videoMetadataModule.js
+++ b/server/modules/videoMetadataModule.js
@@ -1,0 +1,281 @@
+const { Video } = require('../models');
+const fsSync = require('fs');
+const fs = require('fs').promises;
+const path = require('path');
+const configModule = require('./configModule');
+const ytDlpRunner = require('./ytDlpRunner');
+const logger = require('../logger');
+
+const NULL_METADATA = {
+  description: null,
+  viewCount: null,
+  likeCount: null,
+  commentCount: null,
+  tags: null,
+  categories: null,
+  uploadDate: null,
+  resolution: null,
+  width: null,
+  height: null,
+  fps: null,
+  aspectRatio: null,
+  language: null,
+  isLive: null,
+  wasLive: null,
+  availability: null,
+  channelFollowerCount: null,
+  ageLimit: null,
+  webpageUrl: null,
+  relatedFiles: null,
+  availableResolutions: null,
+};
+
+const YTDLP_FETCH_TIMEOUT_MS = 60000;
+
+const SUPPORTED_HEIGHTS = [360, 480, 720, 1080, 1440, 2160];
+
+const FILE_EXTENSION_CATEGORIES = {
+  '.jpg': 'Thumbnail', '.jpeg': 'Thumbnail', '.png': 'Thumbnail', '.webp': 'Thumbnail',
+  '.nfo': 'NFO Metadata',
+  '.srt': 'Subtitles', '.vtt': 'Subtitles', '.ass': 'Subtitles',
+  '.info.json': 'Info JSON',
+  '.json': 'Info JSON',
+};
+
+class VideoMetadataModule {
+  constructor() {}
+
+  /**
+   * Get extended video metadata from cached .info.json or by fetching via yt-dlp.
+   * Returns a curated subset of fields. Silently backfills originalDate when
+   * the .info.json has a more accurate upload_date than the existing DB record.
+   * @param {string} youtubeId - YouTube video ID
+   * @returns {Promise<Object>} Curated metadata object (all null on failure)
+   */
+  async getVideoMetadata(youtubeId) {
+    try {
+      const infoDir = path.join(configModule.getJobsPath(), 'info');
+      const infoPath = path.join(infoDir, `${youtubeId}.info.json`);
+
+      let rawData = null;
+
+      // Try reading cached .info.json from disk
+      try {
+        await fs.access(infoPath);
+        const content = await fs.readFile(infoPath, 'utf8');
+        rawData = JSON.parse(content);
+      } catch {
+        // Not cached - fetch via yt-dlp
+        logger.debug({ youtubeId }, 'No cached .info.json, fetching via yt-dlp');
+        try {
+          rawData = await ytDlpRunner.fetchMetadata(
+            `https://www.youtube.com/watch?v=${youtubeId}`,
+            YTDLP_FETCH_TIMEOUT_MS
+          );
+
+          // Cache the result for future requests
+          try {
+            await fs.mkdir(infoDir, { recursive: true });
+            await fs.writeFile(infoPath, JSON.stringify(rawData, null, 2), 'utf8');
+            logger.debug({ youtubeId }, 'Cached .info.json from yt-dlp fetch');
+          } catch (cacheErr) {
+            logger.warn({ err: cacheErr, youtubeId }, 'Failed to cache .info.json');
+          }
+        } catch (fetchErr) {
+          logger.warn({ err: fetchErr, youtubeId }, 'Failed to fetch metadata via yt-dlp');
+          return NULL_METADATA;
+        }
+      }
+
+      if (!rawData) {
+        return NULL_METADATA;
+      }
+
+      // Silently backfill originalDate if yt-dlp has a more accurate value
+      if (rawData.upload_date) {
+        try {
+          const video = await Video.findOne({ where: { youtubeId } });
+          if (video) {
+            const dbDate = video.originalDate;
+            const ytDate = rawData.upload_date; // YYYYMMDD format
+            // Backfill if DB has no date, or if yt-dlp date is different (more accurate)
+            if (!dbDate || dbDate !== ytDate) {
+              await video.update({ originalDate: ytDate });
+              logger.debug({ youtubeId, oldDate: dbDate, newDate: ytDate }, 'Backfilled originalDate from metadata');
+            }
+          }
+        } catch (backfillErr) {
+          logger.warn({ err: backfillErr, youtubeId }, 'Failed to backfill originalDate');
+        }
+      }
+
+      // Use the numeric aspect_ratio from yt-dlp (e.g. 1.78 for 16:9)
+      const aspectRatio = rawData.aspect_ratio ?? null;
+
+      // Collect related files on disk (thumbnail, subtitles, nfo, etc.)
+      const relatedFiles = await this._getVideoRelatedFiles(youtubeId);
+
+      // Extract available resolutions from the formats array
+      const availableResolutions = this._extractAvailableResolutions(rawData.formats);
+
+      return {
+        description: rawData.description ?? null,
+        viewCount: rawData.view_count ?? null,
+        likeCount: rawData.like_count ?? null,
+        commentCount: rawData.comment_count ?? null,
+        tags: rawData.tags ?? null,
+        categories: rawData.categories ?? null,
+        uploadDate: rawData.upload_date ?? null,
+        resolution: rawData.resolution ?? null,
+        width: rawData.width ?? null,
+        height: rawData.height ?? null,
+        fps: rawData.fps ?? null,
+        aspectRatio,
+        language: rawData.language ?? null,
+        isLive: rawData.is_live ?? null,
+        wasLive: rawData.was_live ?? null,
+        availability: rawData.availability ?? null,
+        channelFollowerCount: rawData.channel_follower_count ?? null,
+        ageLimit: rawData.age_limit ?? null,
+        webpageUrl: rawData.webpage_url ?? null,
+        relatedFiles,
+        availableResolutions,
+      };
+    } catch (err) {
+      logger.error({ err, youtubeId }, 'Unexpected error in getVideoMetadata');
+      return NULL_METADATA;
+    }
+  }
+
+  /**
+   * Find all related files for a video on disk (thumbnail, subtitles, nfo, etc.).
+   * Uses the same YouTube ID matching pattern as videoDeletionModule:
+   * files containing [youtubeId] or " - youtubeId" in the name.
+   * Excludes the main video and audio files (those are shown separately).
+   * Returns only fileName, fileSize, and type - internal paths are stripped.
+   */
+  async _getVideoRelatedFiles(youtubeId) {
+    try {
+      const video = await Video.findOne({ where: { youtubeId } });
+      if (!video || !video.filePath) return null;
+
+      const videoDir = path.dirname(video.filePath);
+
+      let files;
+      try {
+        files = await fs.readdir(videoDir);
+      } catch {
+        return null;
+      }
+
+      // Filter to files belonging to this video
+      const matchingFiles = files.filter(
+        file => file.includes(`[${youtubeId}]`) || file.includes(` - ${youtubeId}`)
+      );
+
+      // Get file stats and categorize
+      const result = [];
+      const mainVideoBase = video.filePath ? path.basename(video.filePath) : null;
+      const mainAudioBase = video.audioFilePath ? path.basename(video.audioFilePath) : null;
+
+      for (const fileName of matchingFiles) {
+        // Skip the main video and audio files (shown separately in the Files section)
+        if (fileName === mainVideoBase || fileName === mainAudioBase) continue;
+
+        const fullPath = path.join(videoDir, fileName);
+        try {
+          const stat = await fs.stat(fullPath);
+          const ext = path.extname(fileName).toLowerCase();
+          result.push({
+            fileName,
+            fileSize: stat.size,
+            type: this._categorizeFileExtension(ext),
+          });
+        } catch {
+          // File may have been removed between readdir and stat
+        }
+      }
+
+      return result.length > 0 ? result : null;
+    } catch (err) {
+      logger.warn({ err, youtubeId }, 'Failed to list related video files');
+      return null;
+    }
+  }
+
+  /**
+   * Extract available download resolutions from the yt-dlp formats array.
+   * Only returns resolutions we support downloading (360p-2160p).
+   */
+  _extractAvailableResolutions(formats) {
+    if (!Array.isArray(formats) || formats.length === 0) return null;
+
+    const availableHeights = new Set();
+
+    for (const fmt of formats) {
+      if (fmt.height && fmt.vcodec && fmt.vcodec !== 'none' && SUPPORTED_HEIGHTS.includes(fmt.height)) {
+        availableHeights.add(fmt.height);
+      }
+    }
+
+    if (availableHeights.size === 0) return null;
+
+    return [...availableHeights].sort((a, b) => a - b);
+  }
+
+  _categorizeFileExtension(ext) {
+    return FILE_EXTENSION_CATEGORIES[ext] || 'Other';
+  }
+
+  /**
+   * Resolve stream info for a video file (video or audio).
+   * Looks up the video in the database, checks the file exists on disk,
+   * and returns the path, content type, and file size.
+   * @param {string} youtubeId - YouTube video ID
+   * @param {string} type - 'video' or 'audio'
+   * @returns {Promise<{filePath: string, contentType: string, fileSize: number}|null>}
+   *   Returns null if video not found; throws with a message property for specific error cases.
+   */
+  async getVideoStreamInfo(youtubeId, type) {
+    const MIME_TYPES = {
+      '.mp4': 'video/mp4',
+      '.webm': 'video/webm',
+      '.mkv': 'video/x-matroska',
+      '.mp3': 'audio/mpeg',
+      '.m4a': 'audio/mp4',
+      '.ogg': 'audio/ogg',
+    };
+    const DEFAULT_MIME_TYPE = 'application/octet-stream';
+
+    const video = await Video.findOne({ where: { youtubeId } });
+
+    if (!video) {
+      return { error: 'not_found', message: 'Video not found' };
+    }
+
+    const filePath = type === 'audio' ? video.audioFilePath : video.filePath;
+
+    if (!filePath) {
+      return { error: 'no_file', message: `No ${type} file available for this video` };
+    }
+
+    // Verify file exists on disk
+    try {
+      fsSync.accessSync(filePath, fsSync.constants.R_OK);
+    } catch {
+      return { error: 'file_missing', message: 'File not found on disk' };
+    }
+
+    const stat = fsSync.statSync(filePath);
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] || DEFAULT_MIME_TYPE;
+
+    return {
+      filePath,
+      contentType,
+      fileSize: stat.size,
+    };
+  }
+}
+
+module.exports = new VideoMetadataModule();

--- a/server/modules/videoMetadataModule.js
+++ b/server/modules/videoMetadataModule.js
@@ -1,5 +1,4 @@
 const { Video } = require('../models');
-const fsSync = require('fs');
 const fs = require('fs').promises;
 const path = require('path');
 const configModule = require('./configModule');
@@ -39,9 +38,19 @@ const FILE_EXTENSION_CATEGORIES = {
   '.jpg': 'Thumbnail', '.jpeg': 'Thumbnail', '.png': 'Thumbnail', '.webp': 'Thumbnail',
   '.nfo': 'NFO Metadata',
   '.srt': 'Subtitles', '.vtt': 'Subtitles', '.ass': 'Subtitles',
-  '.info.json': 'Info JSON',
   '.json': 'Info JSON',
 };
+
+const STREAM_MIME_TYPES = {
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mkv': 'video/x-matroska',
+  '.mp3': 'audio/mpeg',
+  '.m4a': 'audio/mp4',
+  '.ogg': 'audio/ogg',
+};
+
+const DEFAULT_STREAM_MIME_TYPE = 'application/octet-stream';
 
 class VideoMetadataModule {
   constructor() {}
@@ -267,16 +276,6 @@ class VideoMetadataModule {
    *   Returns null if video not found; throws with a message property for specific error cases.
    */
   async getVideoStreamInfo(youtubeId, type) {
-    const MIME_TYPES = {
-      '.mp4': 'video/mp4',
-      '.webm': 'video/webm',
-      '.mkv': 'video/x-matroska',
-      '.mp3': 'audio/mpeg',
-      '.m4a': 'audio/mp4',
-      '.ogg': 'audio/ogg',
-    };
-    const DEFAULT_MIME_TYPE = 'application/octet-stream';
-
     const video = await Video.findOne({ where: { youtubeId } });
 
     if (!video) {
@@ -290,15 +289,16 @@ class VideoMetadataModule {
     }
 
     // Verify file exists on disk
+    let stat;
     try {
-      fsSync.accessSync(filePath, fsSync.constants.R_OK);
+      await fs.access(filePath);
+      stat = await fs.stat(filePath);
     } catch {
       return { error: 'file_missing', message: 'File not found on disk' };
     }
 
-    const stat = fsSync.statSync(filePath);
     const ext = path.extname(filePath).toLowerCase();
-    const contentType = MIME_TYPES[ext] || DEFAULT_MIME_TYPE;
+    const contentType = STREAM_MIME_TYPES[ext] || DEFAULT_STREAM_MIME_TYPE;
 
     return {
       filePath,

--- a/server/routes/__tests__/videoDetail.test.js
+++ b/server/routes/__tests__/videoDetail.test.js
@@ -1,0 +1,501 @@
+/* eslint-env jest */
+const express = require('express');
+const createVideoDetailRoutes = require('../videoDetail');
+const { findRouteHandler, findRouteHandlers } = require('../../__tests__/testUtils');
+
+// Mock fs (synchronous methods used by stream endpoint)
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    accessSync: jest.fn(),
+    statSync: jest.fn(),
+    createReadStream: jest.fn(),
+    constants: actual.constants,
+  };
+});
+
+const fs = require('fs');
+
+describe('GET /api/videos/:youtubeId/metadata', () => {
+  const loggerMock = {
+    info: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const createResponse = () => {
+    const res = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    return res;
+  };
+
+  const getHandler = (videoMetadataModuleMock) => {
+    const router = createVideoDetailRoutes({
+      verifyToken: (req, res, next) => next(),
+      videoMetadataModule: videoMetadataModuleMock,
+    });
+
+    const app = express();
+    app.use(router);
+
+    return findRouteHandler(app, 'get', '/api/videos/:youtubeId/metadata');
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns metadata from videoMetadataModule', async () => {
+    const mockMetadata = {
+      description: 'Test video',
+      viewCount: 1000,
+      likeCount: 50,
+      resolution: '1080p',
+    };
+
+    const videoMetadataModuleMock = {
+      getVideoMetadata: jest.fn().mockResolvedValue(mockMetadata),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'abc123' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(videoMetadataModuleMock.getVideoMetadata).toHaveBeenCalledWith('abc123');
+    expect(res.json).toHaveBeenCalledWith(mockMetadata);
+  });
+
+  test('returns 400 for missing youtubeId', async () => {
+    const videoMetadataModuleMock = {
+      getVideoMetadata: jest.fn(),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: '' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid YouTube ID' });
+    expect(videoMetadataModuleMock.getVideoMetadata).not.toHaveBeenCalled();
+  });
+
+  test('returns 400 for overly long youtubeId', async () => {
+    const videoMetadataModuleMock = {
+      getVideoMetadata: jest.fn(),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'a'.repeat(21) },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid YouTube ID' });
+  });
+
+  test('returns 400 for youtubeId with path traversal characters', async () => {
+    const videoMetadataModuleMock = {
+      getVideoMetadata: jest.fn(),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: '../../etc/passwd' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid YouTube ID' });
+    expect(videoMetadataModuleMock.getVideoMetadata).not.toHaveBeenCalled();
+  });
+
+  test('returns 500 when module throws', async () => {
+    const videoMetadataModuleMock = {
+      getVideoMetadata: jest.fn().mockRejectedValue(new Error('boom')),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'abc123' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Failed to retrieve video metadata' });
+  });
+});
+
+describe('GET /api/videos/:youtubeId/stream', () => {
+  const loggerMock = {
+    info: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const createResponse = () => {
+    const res = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    res.set = jest.fn(() => res);
+    res.end = jest.fn(() => res);
+    res.destroy = jest.fn();
+    return res;
+  };
+
+  const getHandler = (videoMetadataModuleMock) => {
+    const router = createVideoDetailRoutes({
+      verifyToken: (req, res, next) => next(),
+      videoMetadataModule: videoMetadataModuleMock || {
+        getVideoStreamInfo: jest.fn().mockResolvedValue({ error: 'not_found', message: 'Video not found' }),
+      },
+    });
+
+    const app = express();
+    app.use(router);
+
+    return findRouteHandler(app, 'get', '/api/videos/:youtubeId/stream');
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns 400 for invalid youtubeId', async () => {
+    const handler = getHandler();
+    const req = {
+      params: { youtubeId: '' },
+      query: {},
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid YouTube ID' });
+  });
+
+  test('returns 400 for invalid type parameter', async () => {
+    const handler = getHandler();
+    const req = {
+      params: { youtubeId: 'abc123' },
+      query: { type: 'invalid' },
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Invalid type parameter. Must be "video" or "audio"',
+    });
+  });
+
+  test('returns 404 when video record not found', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({ error: 'not_found', message: 'Video not found' }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'notfound1' },
+      query: {},
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Video not found' });
+  });
+
+  test('returns 404 when video has no filePath', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({ error: 'no_file', message: 'No video file available for this video' }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'nofile1' },
+      query: {},
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'No video file available for this video' });
+  });
+
+  test('returns 404 when audio requested but no audioFilePath', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({ error: 'no_file', message: 'No audio file available for this video' }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'noaudio1' },
+      query: { type: 'audio' },
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'No audio file available for this video' });
+  });
+
+  test('returns 404 when file does not exist on disk', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({ error: 'file_missing', message: 'File not found on disk' }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'diskfail1' },
+      query: {},
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: 'File not found on disk' });
+  });
+
+  test('streams full file without Range header and includes Cache-Control headers', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({
+        filePath: '/data/channel/video [abc123].mp4',
+        contentType: 'video/mp4',
+        fileSize: 5000,
+      }),
+    };
+
+    const mockStream = { on: jest.fn().mockReturnThis(), pipe: jest.fn() };
+    fs.createReadStream.mockReturnValue(mockStream);
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'abc123' },
+      query: {},
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.set).toHaveBeenCalledWith({
+      'Content-Length': 5000,
+      'Content-Type': 'video/mp4',
+      'Accept-Ranges': 'bytes',
+      'Cache-Control': 'no-store',
+      'Pragma': 'no-cache',
+    });
+    expect(fs.createReadStream).toHaveBeenCalledWith('/data/channel/video [abc123].mp4');
+    expect(mockStream.pipe).toHaveBeenCalledWith(res);
+  });
+
+  test('streams partial content with Range header and includes Cache-Control headers', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({
+        filePath: '/data/channel/video [range1].mp4',
+        contentType: 'video/mp4',
+        fileSize: 10000,
+      }),
+    };
+
+    const mockStream = { on: jest.fn().mockReturnThis(), pipe: jest.fn() };
+    fs.createReadStream.mockReturnValue(mockStream);
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'range1' },
+      query: {},
+      headers: { range: 'bytes=0-999' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(206);
+    expect(res.set).toHaveBeenCalledWith({
+      'Content-Range': 'bytes 0-999/10000',
+      'Accept-Ranges': 'bytes',
+      'Content-Length': 1000,
+      'Content-Type': 'video/mp4',
+      'Cache-Control': 'no-store',
+      'Pragma': 'no-cache',
+    });
+    expect(fs.createReadStream).toHaveBeenCalledWith(
+      '/data/channel/video [range1].mp4',
+      { start: 0, end: 999 }
+    );
+  });
+
+  test('returns 416 for out-of-range request', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({
+        filePath: '/data/channel/video [outofrange1].mp4',
+        contentType: 'video/mp4',
+        fileSize: 5000,
+      }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'outofrange1' },
+      query: {},
+      headers: { range: 'bytes=6000-7000' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(416);
+    expect(res.set).toHaveBeenCalledWith('Content-Range', 'bytes */5000');
+  });
+
+  test('returns 416 for malformed Range header with non-numeric values', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({
+        filePath: '/data/channel/video [malrange].mp4',
+        contentType: 'video/mp4',
+        fileSize: 5000,
+      }),
+    };
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'malrange1234' },
+      query: {},
+      headers: { range: 'bytes=abc-def' },
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(416);
+    expect(res.set).toHaveBeenCalledWith('Content-Range', 'bytes */5000');
+    expect(fs.createReadStream).not.toHaveBeenCalled();
+  });
+
+  test('streams audio file when type=audio', async () => {
+    const videoMetadataModuleMock = {
+      getVideoStreamInfo: jest.fn().mockResolvedValue({
+        filePath: '/data/channel/video [audio1].mp3',
+        contentType: 'audio/mpeg',
+        fileSize: 3000,
+      }),
+    };
+
+    const mockStream = { on: jest.fn().mockReturnThis(), pipe: jest.fn() };
+    fs.createReadStream.mockReturnValue(mockStream);
+
+    const handler = getHandler(videoMetadataModuleMock);
+    const req = {
+      params: { youtubeId: 'audio1' },
+      query: { type: 'audio' },
+      headers: {},
+      log: loggerMock,
+    };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(videoMetadataModuleMock.getVideoStreamInfo).toHaveBeenCalledWith('audio1', 'audio');
+    expect(res.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'Content-Type': 'audio/mpeg',
+      })
+    );
+    expect(fs.createReadStream).toHaveBeenCalledWith('/data/channel/video [audio1].mp3');
+  });
+
+  test('queryTokenToHeader copies query token to header', () => {
+    const router = createVideoDetailRoutes({
+      verifyToken: (req, res, next) => next(),
+      videoMetadataModule: {},
+    });
+
+    const app = express();
+    app.use(router);
+
+    // Find all handlers for the stream endpoint (includes queryTokenToHeader middleware)
+    const handlers = findRouteHandlers(app, 'get', '/api/videos/:youtubeId/stream');
+
+    // The first handler in the chain should be queryTokenToHeader
+    const queryTokenMiddleware = handlers[0];
+
+    const req = {
+      query: { token: 'my-secret-token' },
+      headers: {},
+    };
+
+    const next = jest.fn();
+    queryTokenMiddleware(req, {}, next);
+
+    expect(req.headers['x-access-token']).toBe('my-secret-token');
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('queryTokenToHeader does not override existing header', () => {
+    const router = createVideoDetailRoutes({
+      verifyToken: (req, res, next) => next(),
+      videoMetadataModule: {},
+    });
+
+    const app = express();
+    app.use(router);
+
+    const handlers = findRouteHandlers(app, 'get', '/api/videos/:youtubeId/stream');
+    const queryTokenMiddleware = handlers[0];
+
+    const req = {
+      query: { token: 'query-token' },
+      headers: { 'x-access-token': 'header-token' },
+    };
+
+    const next = jest.fn();
+    queryTokenMiddleware(req, {}, next);
+
+    // Should keep the existing header, not override it
+    expect(req.headers['x-access-token']).toBe('header-token');
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -9,6 +9,7 @@ const createPlexRoutes = require('./plex');
 const createApiKeyRoutes = require('./apikeys');
 const createSubscriptionRoutes = require('./subscriptions');
 const createVideoDetailRoutes = require('./videoDetail');
+const videoMetadataModule = require('../modules/videoMetadataModule');
 
 /**
  * Registers all route modules with the Express app
@@ -16,7 +17,6 @@ const createVideoDetailRoutes = require('./videoDetail');
  * @param {Object} deps - Dependencies to inject into route modules
  */
 function registerRoutes(app, deps) {
-  const videoMetadataModule = require('../modules/videoMetadataModule');
   const {
     verifyToken,
     loginLimiter,

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -8,6 +8,7 @@ const createJobRoutes = require('./jobs');
 const createPlexRoutes = require('./plex');
 const createApiKeyRoutes = require('./apikeys');
 const createSubscriptionRoutes = require('./subscriptions');
+const createVideoDetailRoutes = require('./videoDetail');
 
 /**
  * Registers all route modules with the Express app
@@ -15,6 +16,7 @@ const createSubscriptionRoutes = require('./subscriptions');
  * @param {Object} deps - Dependencies to inject into route modules
  */
 function registerRoutes(app, deps) {
+  const videoMetadataModule = require('../modules/videoMetadataModule');
   const {
     verifyToken,
     loginLimiter,
@@ -62,6 +64,9 @@ function registerRoutes(app, deps) {
 
   // Subscription import routes
   app.use(createSubscriptionRoutes({ verifyToken, subscriptionImportModule }));
+
+  // Video detail routes (metadata and streaming)
+  app.use(createVideoDetailRoutes({ verifyToken, videoMetadataModule }));
 }
 
 module.exports = { registerRoutes };

--- a/server/routes/videoDetail.js
+++ b/server/routes/videoDetail.js
@@ -1,0 +1,204 @@
+const express = require('express');
+const fs = require('fs');
+
+/**
+ * Creates video detail routes for metadata and streaming
+ * @param {Object} deps - Dependencies
+ * @param {Function} deps.verifyToken - Token verification middleware
+ * @param {Object} deps.videoMetadataModule - Video metadata module
+ * @returns {express.Router}
+ */
+function createVideoDetailRoutes({ verifyToken, videoMetadataModule }) {
+  const router = express.Router();
+
+  /**
+   * Middleware to support token via query parameter.
+   * HTML <video> elements cannot set custom headers, so the frontend
+   * passes the auth token as ?token=... in the src URL.
+   * This copies it to the x-access-token header before verifyToken runs.
+   */
+  const queryTokenToHeader = (req, res, next) => {
+    if (req.query.token && !req.headers['x-access-token']) {
+      req.headers['x-access-token'] = req.query.token;
+    }
+    next();
+  };
+
+  /**
+   * @swagger
+   * /api/videos/{youtubeId}/metadata:
+   *   get:
+   *     summary: Get extended video metadata
+   *     description: Returns curated metadata from the cached .info.json file, or fetches it via yt-dlp if not cached.
+   *     tags: [Videos]
+   *     parameters:
+   *       - in: path
+   *         name: youtubeId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: YouTube video ID
+   *     responses:
+   *       200:
+   *         description: Video metadata
+   *       400:
+   *         description: Invalid YouTube ID
+   *       500:
+   *         description: Internal server error
+   */
+  router.get('/api/videos/:youtubeId/metadata', verifyToken, async (req, res) => {
+    const { youtubeId } = req.params;
+
+    if (!youtubeId || !/^[A-Za-z0-9_-]{6,20}$/.test(youtubeId)) {
+      return res.status(400).json({ error: 'Invalid YouTube ID' });
+    }
+
+    try {
+      const metadata = await videoMetadataModule.getVideoMetadata(youtubeId);
+      res.json(metadata);
+    } catch (err) {
+      req.log.error({ err, youtubeId }, 'Failed to get video metadata');
+      res.status(500).json({ error: 'Failed to retrieve video metadata' });
+    }
+  });
+
+  /**
+   * @swagger
+   * /api/videos/{youtubeId}/stream:
+   *   get:
+   *     summary: Stream a downloaded video file
+   *     description: Serves the downloaded video or audio file with HTTP Range support for seeking. Auth token must be passed as a query parameter since <video> elements cannot set custom headers.
+   *     tags: [Videos]
+   *     parameters:
+   *       - in: path
+   *         name: youtubeId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: YouTube video ID
+   *       - in: query
+   *         name: type
+   *         schema:
+   *           type: string
+   *           enum: [video, audio]
+   *           default: video
+   *         description: Whether to stream the video or audio file
+   *       - in: query
+   *         name: token
+   *         schema:
+   *           type: string
+   *         description: Authentication token (required for video element src)
+   *     responses:
+   *       200:
+   *         description: Full file response
+   *       206:
+   *         description: Partial content (range request)
+   *       400:
+   *         description: Invalid YouTube ID
+   *       404:
+   *         description: Video or file not found
+   *       416:
+   *         description: Range not satisfiable
+   *       500:
+   *         description: Internal server error
+   */
+  router.get('/api/videos/:youtubeId/stream', queryTokenToHeader, verifyToken, async (req, res) => {
+    const { youtubeId } = req.params;
+    const type = req.query.type || 'video';
+
+    if (!youtubeId || !/^[A-Za-z0-9_-]{6,20}$/.test(youtubeId)) {
+      return res.status(400).json({ error: 'Invalid YouTube ID' });
+    }
+
+    if (type !== 'video' && type !== 'audio') {
+      return res.status(400).json({ error: 'Invalid type parameter. Must be "video" or "audio"' });
+    }
+
+    try {
+      const streamInfo = await videoMetadataModule.getVideoStreamInfo(youtubeId, type);
+
+      if (streamInfo.error === 'not_found') {
+        return res.status(404).json({ error: streamInfo.message });
+      }
+      if (streamInfo.error === 'no_file') {
+        return res.status(404).json({ error: streamInfo.message });
+      }
+      if (streamInfo.error === 'file_missing') {
+        return res.status(404).json({ error: streamInfo.message });
+      }
+
+      const { filePath, contentType, fileSize } = streamInfo;
+      const range = req.headers.range;
+
+      // Prevent caching of token-bearing stream URLs
+      const cacheHeaders = {
+        'Cache-Control': 'no-store',
+        'Pragma': 'no-cache',
+      };
+
+      if (range) {
+        // Parse Range header
+        const parts = range.replace(/bytes=/, '').split('-');
+        const start = parseInt(parts[0], 10);
+        const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1;
+
+        if (isNaN(start) || isNaN(end) || start < 0) {
+          res.status(416).set('Content-Range', `bytes */${fileSize}`);
+          return res.end();
+        }
+
+        if (start >= fileSize || end >= fileSize || start > end) {
+          res.status(416).set('Content-Range', `bytes */${fileSize}`);
+          return res.end();
+        }
+
+        const chunkSize = end - start + 1;
+
+        res.status(206).set({
+          'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+          'Accept-Ranges': 'bytes',
+          'Content-Length': chunkSize,
+          'Content-Type': contentType,
+          ...cacheHeaders,
+        });
+
+        const stream = fs.createReadStream(filePath, { start, end });
+        stream.on('error', (err) => {
+          req.log.error({ err, youtubeId }, 'Stream read error');
+          if (!res.headersSent) {
+            res.status(500).json({ error: 'Error reading file' });
+          } else {
+            res.destroy();
+          }
+        });
+        stream.pipe(res);
+      } else {
+        // No range - serve entire file
+        res.set({
+          'Content-Length': fileSize,
+          'Content-Type': contentType,
+          'Accept-Ranges': 'bytes',
+          ...cacheHeaders,
+        });
+
+        const stream = fs.createReadStream(filePath);
+        stream.on('error', (err) => {
+          req.log.error({ err, youtubeId }, 'Stream read error');
+          if (!res.headersSent) {
+            res.status(500).json({ error: 'Error reading file' });
+          } else {
+            res.destroy();
+          }
+        });
+        stream.pipe(res);
+      }
+    } catch (err) {
+      req.log.error({ err, youtubeId }, 'Failed to stream video');
+      res.status(500).json({ error: 'Failed to stream video' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createVideoDetailRoutes;

--- a/server/routes/videoDetail.js
+++ b/server/routes/videoDetail.js
@@ -1,5 +1,18 @@
 const express = require('express');
 const fs = require('fs');
+const rateLimit = require('express-rate-limit');
+
+// Metadata endpoint rate limiter. The endpoint may spawn yt-dlp on cache miss
+// (up to 60s per call), so we cap concurrent abuse. The limit is generous
+// enough for a user rapidly clicking through a video list.
+const metadataLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60, // 60 requests per minute per IP
+  message: { error: 'Too many metadata requests, please try again shortly' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { trustProxy: false },
+});
 
 /**
  * Creates video detail routes for metadata and streaming
@@ -46,7 +59,7 @@ function createVideoDetailRoutes({ verifyToken, videoMetadataModule }) {
    *       500:
    *         description: Internal server error
    */
-  router.get('/api/videos/:youtubeId/metadata', verifyToken, async (req, res) => {
+  router.get('/api/videos/:youtubeId/metadata', metadataLimiter, verifyToken, async (req, res) => {
     const { youtubeId } = req.params;
 
     if (!youtubeId || !/^[A-Za-z0-9_-]{6,20}$/.test(youtubeId)) {

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,20 @@ const { setupSwagger } = require('./swagger');
 const app = express();
 app.set('trust proxy', true); // Trust proxy headers for correct IP detection
 
+// Strip auth tokens from URLs before logging. The video streaming endpoint
+// passes the auth token as ?token=... because <video src> cannot set headers,
+// and pino-http otherwise logs the full URL.
+function redactUrl(url) {
+  if (typeof url !== 'string' || !url.includes('token=')) return url;
+  return url.replace(/([?&])token=[^&]*/g, '$1token=[REDACTED]');
+}
+
+function redactQuery(query) {
+  if (!query || typeof query !== 'object') return query;
+  if (!('token' in query)) return query;
+  return { ...query, token: '[REDACTED]' };
+}
+
 // Setup HTTP request logging with pino-http
 // This must come after trust proxy but before other middleware
 app.use(pinoHttp({
@@ -44,9 +58,9 @@ app.use(pinoHttp({
     req: (req) => ({
       id: req.id,
       method: req.method,
-      url: req.url,
+      url: redactUrl(req.url),
       // Only include query/params if they exist
-      ...(Object.keys(req.query || {}).length > 0 && { query: req.query }),
+      ...(Object.keys(req.query || {}).length > 0 && { query: redactQuery(req.query) }),
       ...(Object.keys(req.params || {}).length > 0 && { params: req.params }),
       remoteAddress: req.remoteAddress,
     }),
@@ -56,10 +70,10 @@ app.use(pinoHttp({
   },
   // Customize the success message to be more concise
   customSuccessMessage: (req, res) => {
-    return `${req.method} ${req.url} ${res.statusCode}`;
+    return `${req.method} ${redactUrl(req.url)} ${res.statusCode}`;
   },
   customErrorMessage: (req, res, err) => {
-    return `${req.method} ${req.url} ${res.statusCode} - ${err?.message || 'Error'}`;
+    return `${req.method} ${redactUrl(req.url)} ${res.statusCode} - ${err?.message || 'Error'}`;
   },
 }));
 


### PR DESCRIPTION
## Summary 

- Add a video detail modal that opens when clicking any video thumbnail, from both the Videos page and Channel pages
- Stream downloaded videos directly in the browser via a new /api/videos/:youtubeId/stream endpoint
- Show extended metadata (description, view count, likes, tags, resolution, fps, file sizes, related files) pulled from .info.json, fetched via yt-dlp on the fly if not cached
- All existing actions (protect, delete, ignore, rate, download) work from inside the modal and sync back to the source page on close
- Mobile gets a fullscreen dialog with a back arrow instead of the desktop close button
- Extract new videoMetadataModule from videosModule to keep module sizes in check
- Add shared ThumbnailClickOverlay component replacing duplicate click hotspots across views
- Add tests for the modal, video player, metadata hook, streaming route, and metadata module

## PC Screenshots
<img width="1854" height="1452" alt="image" src="https://github.com/user-attachments/assets/c0239b7b-90ef-4dd4-93da-2f5d4e13e5d0" />
<img width="1514" height="1351" alt="image" src="https://github.com/user-attachments/assets/d7d9529b-a917-4eb7-b690-96d8815e722a" />

## Mobile Screenshots
<img width="504" height="1145" alt="image" src="https://github.com/user-attachments/assets/8b7ab3ef-0dc3-4184-b08a-7f4d080b4394" />
<img width="515" height="1142" alt="image" src="https://github.com/user-attachments/assets/7a92a7f0-bca8-4f19-ac91-e67f3b208e29" />
