### PR TITLE
docs: document video detail modal and in-app playback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 ### Backend (server/)
 - `server.js`: Express entry point. `db.js`: Sequelize setup. `logger.js`: Pino logger with request correlation.
 - `models/`: Sequelize models (channel, video, job, jobvideo, jobvideodownload, channelvideo, session, apikey). Associations: Channel hasMany Videos, Job hasMany JobVideos.
-- `routes/`: API handlers (auth, channels, videos, config, jobs, plex, setup, subscriptions, apikeys, health). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.
-- `modules/`: class-based singletons holding business logic. Top-level modules include `channelModule`, `downloadModule`, `plexModule`, `jobModule`, `configModule`, `videosModule`, `webSocketServer`, `databaseHealthModule`, `notificationModule`, `channelSettingsModule`, `videoDeletionModule`, `nfoGenerator`, `cronJobs`, `apiKeyModule`, `ytdlpModule`, `messageEmitter`.
+- `routes/`: API handlers (auth, channels, videos, videoDetail, config, jobs, plex, setup, subscriptions, apikeys, health). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.
+- `modules/`: class-based singletons holding business logic. Top-level modules include `channelModule`, `downloadModule`, `plexModule`, `jobModule`, `configModule`, `videosModule`, `videoMetadataModule`, `webSocketServer`, `databaseHealthModule`, `notificationModule`, `channelSettingsModule`, `videoDeletionModule`, `nfoGenerator`, `cronJobs`, `apiKeyModule`, `ytdlpModule`, `messageEmitter`.
 - `modules/download/`: download orchestration (`downloadExecutor`, `ytdlpCommandBuilder`, `DownloadProgressMonitor`, `tempPathManager`, `videoMetadataProcessor`).
 - `modules/filesystem/`: path/file abstraction (`pathBuilder`, `directoryManager`, `fileOperations`, `sanitizer`, `constants`). Good example of the sub-module aggregator pattern.
 - `modules/notifications/`: multi-service notifications via Apprise (`serviceRegistry`, `formatters/`, `senders/`). Good example of a pluggable service registry.
@@ -41,6 +41,7 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 ### Frontend (client/src/)
 - `App.tsx`: app routing plus a global `fetch()` override that detects 503 `requiresDbFix` responses and surfaces the database error overlay. You can use normal `fetch()` anywhere; database errors are handled automatically.
 - `components/`: feature directories and pages. Complex features pair a top-level `FeatureName.tsx` with a same-named `FeatureName/` directory holding `components/`, `hooks/`, and `__tests__/`. Examples of this sibling-file layout: `ChannelManager.tsx` + `ChannelManager/`, `Configuration.tsx` + `Configuration/`, `ChannelPage.tsx` + `ChannelPage/`. Newer features (e.g. `SubscriptionImport/`) put the main component at `FeatureName/index.tsx` instead; either layout is acceptable for new features.
+- `components/shared/`: reusable components used across multiple features (e.g. `VideoModal/` for the video detail modal, `ThumbnailClickOverlay` for clickable thumbnail hotspots, `DeleteVideosDialog`).
 - `hooks/`: app-wide custom hooks for data fetching and state.
 - `contexts/` and `providers/`: React Context for cross-cutting concerns (auth token, WebSocket, theme).
 - `config/configSchema.ts`: the `CONFIG_FIELDS` registry. Use this pattern when adding new configuration fields; it auto-derives types, defaults, and change tracking.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ https://github.com/user-attachments/assets/cc153624-c905-42c2-8ee9-9c213816be3a
 - **Smart Downloads**: Pre-validate manually pasted URLs with metadata preview before downloading
 - **Channel Subscriptions**: Subscribe to channels and auto-download new videos, shorts, and streams with per-tab controls
 - **Browse Channels**: View and search all videos from subscribed channels with advanced filtering, tabbed views for Videos/Shorts/Streams, and contextual publish date accuracy tips
+- **In-App Playback**: Click any thumbnail to open a detail modal with extended metadata and in-browser streaming of downloaded videos; no media server required
 - **Channel Grouping & Multi-Library Support**: Organize channels into custom subfolders (e.g., `__kids`, `__music`, `__news`) to create separate media server libraries
 - **Smart Organization**: Videos organized by channel with metadata and thumbnails
 - **SponsorBlock Integration**: Remove sponsored segments automatically

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -13,6 +13,7 @@ This guide provides step-by-step instructions for common tasks in Youtarr. After
 - [Re-download Missing Videos](#re-download-missing-videos)
 - [Organize Channels with Multi-Library Support](#organize-channels-with-multi-library-support)
 - [Browse and Filter Channel Videos](#browse-and-filter-channel-videos)
+- [Preview and Play Videos](#preview-and-play-videos)
 - [External Access with API Keys](#external-access-with-api-keys)
 - [Content Ratings](#content-ratings)
 
@@ -343,6 +344,27 @@ Mark specific videos to exclude them from automatic channel downloads.
    - Ignored videos are tracked in `config/complete.list`
    - They won't appear in download recommendations
    - You can still manually download them if you change your mind
+
+## Preview and Play Videos
+
+Click any thumbnail on the Videos page or a channel page to open a video detail modal with extended metadata and in-browser playback.
+
+1. **Open the modal**
+   - Click the thumbnail of any video in the Videos page, a channel's video list, or the channel page's grid/list/table views
+   - On mobile, the modal opens fullscreen with a back arrow; on desktop it opens as a centered dialog
+
+2. **Extended metadata**
+   - Description, tags, view count, likes, resolution, fps, file sizes, and related file paths
+   - For downloaded videos, data is served from the cached `.info.json`
+   - For videos not yet downloaded, Youtarr fetches metadata on demand via yt-dlp (this can take a few seconds on the first open)
+
+3. **In-browser playback**
+   - Downloaded videos stream directly from Youtarr through the built-in player; no media server required
+   - Playback is authenticated via your existing session
+
+4. **Actions from the modal**
+   - Download, protect, delete, ignore, and rate actions are all available inside the modal
+   - Changes sync back to the source page when the modal closes
 
 ## Common tasks
 


### PR DESCRIPTION
- Add "In-App Playback" bullet to README key features list
- Add "Preview and Play Videos" section and TOC entry to USAGE_GUIDE covering the modal, extended metadata, in-browser streaming, and available actions
- Update CLAUDE.md architecture notes to list videoDetail route, videoMetadataModule, and the components/shared/ directory