### PR TITLE
Bugfixes found during dev testing for UI refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Youtarr is a Dockerized application that automatically downloads videos from YouTube channels and integrates them with Plex Media Server. It consists of:
 
 - **Backend**: Node.js/Express server with MariaDB database using Sequelize ORM
-- **Frontend**: React/TypeScript application with Material-UI components
+- **Frontend**: React/TypeScript application with a custom UI layer (Radix primitives + Tailwind CSS, themed via CSS variables)
 - **Infrastructure**: Docker Compose setup with separate containers for app and database
 
 ## Scope Discipline
@@ -49,7 +49,7 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 - `hooks/`: app-wide custom hooks for data fetching and state.
 - `contexts/` and `providers/`: React Context for cross-cutting concerns (auth token, WebSocket, theme). `contexts/ThemeEngineContext.tsx` owns the active theme mode, resolves the layout policy for the current viewport, and injects theme CSS variables onto the document root.
 - `config/configSchema.ts`: the `CONFIG_FIELDS` registry. Use this pattern when adding new configuration fields; it auto-derives types, defaults, and change tracking.
-- `theme.ts`: legacy Material-UI theme (light/dark mode). `types/`, `utils/`: shared types and helpers.
+- `types/`, `utils/`: shared types and helpers.
 
 ### Database
 - MariaDB 10.3 with utf8mb4. Migrations in `migrations/` run automatically on container startup. Create new migrations with `./scripts/db-create-migration.sh migration-name`.
@@ -158,9 +158,10 @@ These standards apply when you are authoring new code or doing an explicit rewri
 - **Memoize deliberately**: `useMemo` for genuinely expensive derivations, `useCallback` for callbacks passed to memoized children. Do not over-memoize trivial values.
 
 #### Styling
-- **Use MUI's `sx` prop** for styling, not inline `style`. `sx` is theme-aware, responsive, and supports hover states and dark mode.
-- **Theme values**: `theme.palette.primary.main`, not `'#1976d2'`.
-- **Responsive breakpoints**: `useMediaQuery(theme.breakpoints.down('sm'))`.
+- **Tailwind utility classes** via `className` are the default for layout, spacing, and typography. Import UI primitives from `./ui` (Box, Card, Typography, Button, Chip, Dialog, etc.); do not reach for MUI, it is not installed.
+- **Theme tokens via CSS variables**, not hardcoded colors: `var(--destructive)`, `text-foreground`, `text-muted-foreground`, `bg-card`. Theme values are set on the document root by `ThemeEngineContext`.
+- **Inline `style` is acceptable only for computed/dynamic values** (e.g., a padding driven by `isMobile`, a length-dependent `maxHeight`). For static styling, prefer Tailwind classes.
+- **Responsive breakpoints**: use the custom `useMediaQuery` from `hooks/useMediaQuery` with a raw media query (`useMediaQuery('(max-width: 767px)')`) or the exported `breakpoints.down('sm')` helper. Tailwind's `md:`/`sm:` class prefixes are also fine for pure-CSS responsive behavior.
 
 #### API Calls
 - **Use Axios** in new hooks and components. A few legacy hooks use raw `fetch()` (`client/src/hooks/useConfig.ts` and `client/src/components/Configuration/hooks/usePlexConnection.ts`); do not copy them.

--- a/client/src/components/ChannelPage.tsx
+++ b/client/src/components/ChannelPage.tsx
@@ -383,17 +383,23 @@ function ChannelPage({ token }: ChannelPageProps) {
                   </Box>
                 </Box>
 
-                {/* Rating */}
+                {/* Content Rating */}
                 <Box className="flex flex-col gap-1">
                   <Typography variant="caption" color="text.secondary" className="font-semibold uppercase" style={{ fontSize: '0.65rem' }}>
-                    Rating
+                    Content Rating
                   </Typography>
                   {channel ? (
-                    <RatingBadge
-                      rating={channel.default_rating}
-                      ratingSource="Channel Default"
-                      size="small"
-                    />
+                    channel.default_rating ? (
+                      <RatingBadge
+                        rating={channel.default_rating}
+                        ratingSource="Channel Default"
+                        size="small"
+                      />
+                    ) : (
+                      <Typography variant="caption" color="text.secondary" className="italic" style={{ fontSize: '0.7rem' }}>
+                        No rating override
+                      </Typography>
+                    )
                   ) : (
                     <span className="text-xs text-muted">Loading...</span>
                   )}
@@ -453,14 +459,26 @@ function ChannelPage({ token }: ChannelPageProps) {
                     className="whitespace-nowrap inline-flex items-center"
                     style={{ lineHeight: 1.2 }}
                   >
-                    Rating:
+                    Content Rating:
                   </Typography>
                   {channel ? (
-                    <RatingBadge
-                      rating={channel.default_rating}
-                      ratingSource="Channel Default"
-                      size="small"
-                    />
+                    channel.default_rating ? (
+                      <RatingBadge
+                        rating={channel.default_rating}
+                        ratingSource="Channel Default"
+                        size="small"
+                      />
+                    ) : (
+                      <Typography
+                        variant="body2"
+                        component="span"
+                        color="text.secondary"
+                        className="italic"
+                        style={{ lineHeight: 1.2 }}
+                      >
+                        No rating override
+                      </Typography>
+                    )
                   ) : (
                     <span className="text-xs text-muted">Loading...</span>
                   )}

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -131,34 +131,43 @@ function VideoModal({
       >
         {/* Header bar - title + close */}
         <DialogTitle onClose={!isMobile ? onClose : undefined}>
-          {isMobile && (
-            <IconButton
-              onClick={onClose}
-              size="small"
-              aria-label="Close"
-              edge="start"
-              style={{ marginRight: 4 }}
-            >
-              <ArrowBackIcon size={20} />
-            </IconButton>
-          )}
-          <Typography
-            variant="h6"
-            component="span"
-            sx={{
-              flex: 1,
+          <span
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              width: '100%',
               minWidth: 0,
-              fontSize: isMobile ? '1rem' : '1.15rem',
-              fontWeight: 600,
-              display: '-webkit-box',
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: 'vertical',
-              overflow: 'hidden',
-              wordBreak: 'break-word',
             }}
           >
-            {localVideo.title}
-          </Typography>
+            {isMobile && (
+              <IconButton
+                onClick={onClose}
+                size="large"
+                aria-label="Close"
+                edge="start"
+              >
+                <ArrowBackIcon size={24} />
+              </IconButton>
+            )}
+            <Typography
+              variant="h6"
+              component="span"
+              sx={{
+                flex: 1,
+                minWidth: 0,
+                fontSize: isMobile ? '1rem' : '1.15rem',
+                fontWeight: 600,
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                wordBreak: 'break-word',
+              }}
+            >
+              {localVideo.title}
+            </Typography>
+          </span>
         </DialogTitle>
         <DialogContentBody
           style={{

--- a/client/src/components/ui/menu.tsx
+++ b/client/src/components/ui/menu.tsx
@@ -329,17 +329,31 @@ export interface PopoverProps {
 
 const Popover: React.FC<PopoverProps> = ({ open, anchorEl, onClose, children, className, PaperProps }) => {
   const [pos, setPos] = React.useState<{ top: number; left: number } | null>(null);
+  const popoverRef = React.useRef<HTMLDivElement | null>(null);
   const overlayInsets = getOverlayInsets();
 
   const updatePosition = React.useCallback(() => {
-    if (!open || !anchorEl) return;
+    if (!open || !anchorEl || !popoverRef.current || typeof window === 'undefined') return;
     const rect = anchorEl.getBoundingClientRect();
-    setPos({ top: rect.bottom + 4, left: rect.left });
+    const popoverEl = popoverRef.current;
+    const popoverWidth =
+      popoverEl.getBoundingClientRect().width || popoverEl.scrollWidth || 0;
+
+    const top = rect.bottom + 4;
+    const viewportLeft = VIEWPORT_GUTTER;
+    const viewportRight = window.innerWidth - VIEWPORT_GUTTER;
+    const maxLeft = Math.max(viewportRight - popoverWidth, viewportLeft);
+    const left = clamp(rect.left, viewportLeft, maxLeft);
+
+    setPos((current) => {
+      if (current && current.top === top && current.left === left) return current;
+      return { top, left };
+    });
   }, [open, anchorEl]);
 
-  React.useEffect(() => {
-    updatePosition();
+  React.useLayoutEffect(() => {
     if (!open) return;
+    updatePosition();
     window.addEventListener('resize', updatePosition);
     window.addEventListener('scroll', updatePosition, true);
     return () => {
@@ -354,16 +368,20 @@ const Popover: React.FC<PopoverProps> = ({ open, anchorEl, onClose, children, cl
     <>
       <div className="fixed inset-0 z-40" onClick={onClose} />
       <div
+        ref={popoverRef}
         onKeyDown={(e) => { if (e.key === 'Escape') onClose?.(); }}
-        style={pos ? {
+        style={{
           position: 'fixed',
-          top: pos.top,
-          left: pos.left,
+          top: pos?.top ?? 0,
+          left: pos?.left ?? 0,
           zIndex: 1300,
-          maxHeight: window.innerHeight - pos.top - overlayInsets.bottom,
+          maxHeight: pos
+            ? window.innerHeight - pos.top - overlayInsets.bottom
+            : window.innerHeight - overlayInsets.bottom,
           maxWidth: 'min(28rem, calc(100vw - 24px))',
           overflowY: 'auto',
-        } : undefined}
+          visibility: pos ? 'visible' : 'hidden',
+        }}
         className={cn(
           'overflow-x-hidden',
           'rounded-[var(--radius-ui)]',


### PR DESCRIPTION
1. fix(ui): clamp Popover position within viewport
The shared Popover placed itself at rect.bottom/rect.left with no horizontal clamping, so popovers anchored to elements near the right edge of the viewport (e.g. the per-channel settings gear in the Subscription Import review table) overflowed off-screen. Measure the popover's rendered width via a ref and clamp its left coordinate to the viewport gutter before committing position, mirroring the sibling Menu component's approach.