### PR TITLE
More ui fixes

### DIFF
--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -1330,7 +1330,7 @@ function ChannelVideos({ token, channelAutoDownloadTabs, channelId: propChannelI
         <div
           style={{
             padding: isMobile ? 10 : 12,
-            paddingBottom: isMobile ? 'calc(var(--mobile-nav-total-offset, 0px) + 96px)' : 16,
+            paddingBottom: isMobile && (selectionMode || mobileActionsOpen) ? 96 : 16,
             position: 'relative',
             minHeight: '100vh',
             overflowX: 'clip',

--- a/server/__tests__/server.additional-routes.test.js
+++ b/server/__tests__/server.additional-routes.test.js
@@ -205,6 +205,7 @@ const createServerModule = ({
         const jobModuleMock = {
           getJob: jest.fn(),
           getRunningJobs: jest.fn(() => []),
+          getRunningJobsWithFreshVideos: jest.fn().mockResolvedValue([]),
           getAllJobs: jest.fn().mockResolvedValue([
             { id: 'job-1', type: 'Download', status: 'Completed' }
           ])

--- a/server/__tests__/server.apikeys.test.js
+++ b/server/__tests__/server.apikeys.test.js
@@ -258,7 +258,8 @@ const createServerModule = ({
           doSpecificDownloads: jest.fn().mockResolvedValue({ success: true })
         }));
         jest.doMock('../modules/jobModule', () => ({
-          getRunningJobs: jest.fn(() => [])
+          getRunningJobs: jest.fn(() => []),
+          getRunningJobsWithFreshVideos: jest.fn().mockResolvedValue([])
         }));
         jest.doMock('../modules/videosModule', () => ({}));
         jest.doMock('../modules/videoMetadataModule', () => ({

--- a/server/__tests__/server.auth-sessions.test.js
+++ b/server/__tests__/server.auth-sessions.test.js
@@ -212,7 +212,8 @@ const createServerModule = ({
         jest.doMock('../modules/plexModule', () => ({}));
         jest.doMock('../modules/downloadModule', () => ({}));
         jest.doMock('../modules/jobModule', () => ({
-          getRunningJobs: jest.fn(() => [])
+          getRunningJobs: jest.fn(() => []),
+          getRunningJobsWithFreshVideos: jest.fn().mockResolvedValue([])
         }));
         jest.doMock('../modules/videosModule', () => ({}));
         jest.doMock('../modules/videoMetadataModule', () => ({

--- a/server/__tests__/server.core.test.js
+++ b/server/__tests__/server.core.test.js
@@ -169,7 +169,8 @@ const createServerModule = ({
 
         const jobModuleMock = {
           getJob: jest.fn(),
-          getRunningJobs: jest.fn(() => [])
+          getRunningJobs: jest.fn(() => []),
+          getRunningJobsWithFreshVideos: jest.fn().mockResolvedValue([])
         };
 
         const videosModuleMock = {

--- a/server/__tests__/server.plex-routes.test.js
+++ b/server/__tests__/server.plex-routes.test.js
@@ -132,7 +132,8 @@ const setupServer = async ({ authEnabled = 'false', passwordHash = null } = {}) 
   }));
   jest.doMock('../modules/jobModule', () => ({
     getJob: jest.fn(),
-    getRunningJobs: jest.fn(() => [])
+    getRunningJobs: jest.fn(() => []),
+    getRunningJobsWithFreshVideos: jest.fn().mockResolvedValue([])
   }));
   jest.doMock('../modules/videosModule', () => ({
     getVideos: jest.fn().mockResolvedValue([])

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -219,7 +219,8 @@ const createServerModule = ({
             }
             return null;
           }),
-          getRunningJobs: jest.fn(() => [])
+          getRunningJobs: jest.fn(() => []),
+          getRunningJobsWithFreshVideos: jest.fn().mockResolvedValue([])
         };
 
         const videosModuleMock = {
@@ -1661,7 +1662,7 @@ describe('server routes - jobs', () => {
   describe('GET /runningjobs', () => {
     test('returns list of running jobs', async () => {
       const { app, jobModuleMock } = await createServerModule();
-      jobModuleMock.getRunningJobs.mockReturnValueOnce([
+      jobModuleMock.getRunningJobsWithFreshVideos.mockResolvedValueOnce([
         { id: 'job-1', status: 'In Progress' },
         { id: 'job-2', status: 'In Progress' }
       ]);
@@ -1674,7 +1675,7 @@ describe('server routes - jobs', () => {
 
       await runningJobsHandler(req, res);
 
-      expect(jobModuleMock.getRunningJobs).toHaveBeenCalled();
+      expect(jobModuleMock.getRunningJobsWithFreshVideos).toHaveBeenCalled();
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual([
         { id: 'job-1', status: 'In Progress' },

--- a/server/modules/__tests__/jobModule.test.js
+++ b/server/modules/__tests__/jobModule.test.js
@@ -1376,6 +1376,100 @@ describe('JobModule', () => {
     });
   });
 
+  describe('getRunningJobsWithFreshVideos', () => {
+    beforeEach(() => {
+      fs.existsSync.mockReturnValue(false);
+      fs.readFileSync.mockReturnValue(JSON.stringify({ plexApiKey: 'test-key' }));
+      JobModule = require('../jobModule');
+    });
+
+    test('replaces snapshot videos with fresh rows from the Videos table', async () => {
+      const now = Date.now();
+      JobModule.jobs = {
+        'job-1': {
+          timeCreated: now,
+          status: 'Complete',
+          data: {
+            videos: [
+              { id: 1, youtubeId: 'a', removed: false, protected: false, normalized_rating: null },
+              { id: 2, youtubeId: 'b', removed: false, protected: false, normalized_rating: null }
+            ]
+          }
+        }
+      };
+
+      Video.findAll.mockResolvedValueOnce([
+        { id: 1, dataValues: { id: 1, youtubeId: 'a', removed: true, protected: false, normalized_rating: null } },
+        { id: 2, dataValues: { id: 2, youtubeId: 'b', removed: false, protected: true, normalized_rating: 'PG-13' } }
+      ]);
+
+      const result = await JobModule.getRunningJobsWithFreshVideos();
+
+      expect(Video.findAll).toHaveBeenCalledWith({ where: { id: [1, 2] } });
+      expect(result[0].data.videos[0]).toMatchObject({ id: 1, removed: true });
+      expect(result[0].data.videos[1]).toMatchObject({ id: 2, protected: true, normalized_rating: 'PG-13' });
+    });
+
+    test('falls back to snapshot when a video row is missing from the DB', async () => {
+      const now = Date.now();
+      JobModule.jobs = {
+        'job-1': {
+          timeCreated: now,
+          status: 'Complete',
+          data: {
+            videos: [
+              { id: 1, youtubeId: 'a', removed: false },
+              { id: 99, youtubeId: 'gone', removed: false }
+            ]
+          }
+        }
+      };
+
+      Video.findAll.mockResolvedValueOnce([
+        { id: 1, dataValues: { id: 1, youtubeId: 'a', removed: true } }
+      ]);
+
+      const result = await JobModule.getRunningJobsWithFreshVideos();
+
+      expect(result[0].data.videos[0]).toMatchObject({ id: 1, removed: true });
+      expect(result[0].data.videos[1]).toMatchObject({ id: 99, youtubeId: 'gone', removed: false });
+    });
+
+    test('skips DB query when no videos have ids', async () => {
+      const now = Date.now();
+      JobModule.jobs = {
+        'job-1': { timeCreated: now, status: 'Complete', data: { videos: [] } },
+        'job-2': { timeCreated: now, status: 'Complete' }
+      };
+
+      const result = await JobModule.getRunningJobsWithFreshVideos();
+
+      expect(Video.findAll).not.toHaveBeenCalled();
+      expect(result).toHaveLength(2);
+    });
+
+    test('does not mutate the in-memory jobs structure', async () => {
+      const now = Date.now();
+      const originalVideo = { id: 1, youtubeId: 'a', removed: false };
+      JobModule.jobs = {
+        'job-1': {
+          timeCreated: now,
+          status: 'Complete',
+          data: { videos: [originalVideo] }
+        }
+      };
+
+      Video.findAll.mockResolvedValueOnce([
+        { id: 1, dataValues: { id: 1, youtubeId: 'a', removed: true } }
+      ]);
+
+      await JobModule.getRunningJobsWithFreshVideos();
+
+      expect(JobModule.jobs['job-1'].data.videos[0]).toBe(originalVideo);
+      expect(JobModule.jobs['job-1'].data.videos[0].removed).toBe(false);
+    });
+  });
+
   describe('saveJobOnly', () => {
     beforeEach(() => {
       fs.existsSync.mockReturnValue(false);

--- a/server/modules/jobModule.js
+++ b/server/modules/jobModule.js
@@ -1008,6 +1008,46 @@ class JobModule {
     return jobsArray.slice(0, 240);
   }
 
+  // The in-memory job snapshot only refreshes at job completion or server
+  // startup, so per-video fields (removed, protected, normalized_rating, etc.)
+  // go stale after the user mutates a video. Re-read fresh rows from the
+  // Videos table and substitute them in before returning to the client.
+  async getRunningJobsWithFreshVideos() {
+    const jobs = this.getRunningJobs();
+
+    const videoIds = new Set();
+    for (const job of jobs) {
+      const videos = job.data?.videos;
+      if (!Array.isArray(videos)) continue;
+      for (const video of videos) {
+        if (typeof video?.id === 'number') {
+          videoIds.add(video.id);
+        }
+      }
+    }
+
+    if (videoIds.size === 0) {
+      return jobs;
+    }
+
+    const freshVideos = await Video.findAll({
+      where: { id: Array.from(videoIds) }
+    });
+    const freshById = new Map(freshVideos.map(v => [v.id, v.dataValues]));
+
+    return jobs.map(job => {
+      const videos = job.data?.videos;
+      if (!Array.isArray(videos)) return job;
+      return {
+        ...job,
+        data: {
+          ...job.data,
+          videos: videos.map(video => freshById.get(video?.id) || video),
+        },
+      };
+    });
+  }
+
   getAllJobs() {
     return this.jobs;
   }

--- a/server/routes/jobs.js
+++ b/server/routes/jobs.js
@@ -80,9 +80,14 @@ module.exports = function createJobRoutes({ verifyToken, jobModule, downloadModu
    *                   progress:
    *                     type: number
    */
-  router.get('/runningjobs', verifyToken, (req, res) => {
-    const runningJobs = jobModule.getRunningJobs();
-    res.json(runningJobs);
+  router.get('/runningjobs', verifyToken, async (req, res) => {
+    try {
+      const runningJobs = await jobModule.getRunningJobsWithFreshVideos();
+      res.json(runningJobs);
+    } catch (error) {
+      req.log.error({ err: error }, 'Failed to get running jobs');
+      res.status(500).json({ error: 'Failed to get running jobs' });
+    }
   });
 
   /**


### PR DESCRIPTION
1. fix(channels): remove excess bottom padding on mobile ChannelVideos

The content area duplicated the mobile nav clearance already applied by AppShell and always added 96px extra, leaving ~300px of empty space below the last video on mobile. Now only apply the 96px buffer when a floating selection or actions bar is visible.

2. fix(downloads): refresh job video data from DB before serving /runningjobs

The in-memory job snapshot only refreshes at job completion or server
startup, so per-video fields (removed, protected, normalized_rating)
went stale after the user mutated a video. The DownloadHistory modal
read from this snapshot and showed stale state: missing videos
appeared as available, and protect/rating/delete actions seemed not
to persist (the backend writes succeeded; the snapshot was the lie).

Add getRunningJobsWithFreshVideos() that bulk-loads the current
videos rows by id and substitutes them into each job's videos array
before returning. Wire /runningjobs to it.