### PR TITLE
fix(settings): restore yt-dlp UI and tighten unsaved-changes flow

### DIFF
--- a/client/src/components/Configuration/hooks/__tests__/useConfigSave.test.ts
+++ b/client/src/components/Configuration/hooks/__tests__/useConfigSave.test.ts
@@ -1079,4 +1079,109 @@ describe('useConfigSave', () => {
       expect(dispatchEventSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('Save status reporting', () => {
+    test('saveConfig resolves to true on success', async () => {
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce({}),
+      } as any);
+
+      const { result } = renderHook(() =>
+        useConfigSave({
+          token: mockToken,
+          config: mockConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: false,
+          checkPlexConnection: mockCheckPlexConnection,
+        })
+      );
+
+      await expect(result.current.saveConfig()).resolves.toBe(true);
+    });
+
+    test('saveConfig resolves to false on HTTP error', async () => {
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: jest.fn().mockResolvedValueOnce({}),
+      } as any);
+
+      const { result } = renderHook(() =>
+        useConfigSave({
+          token: mockToken,
+          config: mockConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: false,
+          checkPlexConnection: mockCheckPlexConnection,
+        })
+      );
+
+      await expect(result.current.saveConfig()).resolves.toBe(false);
+    });
+
+    test('saveConfig resolves to false on network error', async () => {
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockRejectedValueOnce(new Error('Network down'));
+
+      const { result } = renderHook(() =>
+        useConfigSave({
+          token: mockToken,
+          config: mockConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: false,
+          checkPlexConnection: mockCheckPlexConnection,
+        })
+      );
+
+      await expect(result.current.saveConfig()).resolves.toBe(false);
+    });
+
+    test('isSaving is false initially and toggles around saveConfig', async () => {
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      let resolveFetch: (value: any) => void = () => {};
+      mockFetch.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }) as any
+      );
+
+      const { result } = renderHook(() =>
+        useConfigSave({
+          token: mockToken,
+          config: mockConfig,
+          setInitialConfig: mockSetInitialConfig,
+          setSnackbar: mockSetSnackbar,
+          hasPlexServerConfigured: false,
+          checkPlexConnection: mockCheckPlexConnection,
+        })
+      );
+
+      expect(result.current.isSaving).toBe(false);
+
+      const savePromise = result.current.saveConfig();
+
+      await waitFor(() => {
+        expect(result.current.isSaving).toBe(true);
+      });
+
+      resolveFetch({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValueOnce({}),
+      });
+
+      await savePromise;
+
+      await waitFor(() => {
+        expect(result.current.isSaving).toBe(false);
+      });
+    });
+  });
 });

--- a/client/src/components/Configuration/hooks/__tests__/useUnsavedChangesGuard.test.ts
+++ b/client/src/components/Configuration/hooks/__tests__/useUnsavedChangesGuard.test.ts
@@ -1,0 +1,202 @@
+import { renderHook, act } from '@testing-library/react';
+import { useUnsavedChangesGuard } from '../useUnsavedChangesGuard';
+
+describe('useUnsavedChangesGuard', () => {
+  let originalPushState: typeof window.history.pushState;
+  let originalReplaceState: typeof window.history.replaceState;
+
+  beforeEach(() => {
+    originalPushState = window.history.pushState;
+    originalReplaceState = window.history.replaceState;
+    window.history.replaceState(null, '', '/settings/core');
+  });
+
+  afterEach(() => {
+    window.history.pushState = originalPushState;
+    window.history.replaceState = originalReplaceState;
+  });
+
+  test('lets pushState pass through when enabled is false', () => {
+    renderHook(() =>
+      useUnsavedChangesGuard({
+        enabled: false,
+        shouldBlock: () => true,
+      })
+    );
+
+    act(() => {
+      window.history.pushState(null, '', '/channels');
+    });
+
+    expect(window.location.pathname).toBe('/channels');
+  });
+
+  test('blocks pushState and exposes pendingNav when shouldBlock returns true', () => {
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({
+        enabled: true,
+        shouldBlock: (url) => !url.startsWith('/settings'),
+      })
+    );
+
+    act(() => {
+      window.history.pushState(null, '', '/channels');
+    });
+
+    expect(window.location.pathname).toBe('/settings/core');
+    expect(result.current.pendingNav).toBe('/channels');
+  });
+
+  test('lets pushState pass through when shouldBlock returns false', () => {
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({
+        enabled: true,
+        shouldBlock: (url) => !url.startsWith('/settings'),
+      })
+    );
+
+    act(() => {
+      window.history.pushState(null, '', '/settings/plex');
+    });
+
+    expect(window.location.pathname).toBe('/settings/plex');
+    expect(result.current.pendingNav).toBeNull();
+  });
+
+  test('confirmNav performs the pending navigation and clears pendingNav', () => {
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({
+        enabled: true,
+        shouldBlock: () => true,
+      })
+    );
+
+    act(() => {
+      window.history.pushState(null, '', '/channels');
+    });
+    expect(result.current.pendingNav).toBe('/channels');
+    expect(window.location.pathname).toBe('/settings/core');
+
+    act(() => {
+      result.current.confirmNav();
+    });
+
+    expect(window.location.pathname).toBe('/channels');
+    expect(result.current.pendingNav).toBeNull();
+  });
+
+  test('confirmNav dispatches popstate so the router re-renders', () => {
+    const popstateHandler = jest.fn();
+    window.addEventListener('popstate', popstateHandler);
+
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({
+        enabled: true,
+        shouldBlock: () => true,
+      })
+    );
+
+    act(() => {
+      window.history.pushState(null, '', '/channels');
+    });
+    act(() => {
+      result.current.confirmNav();
+    });
+
+    expect(popstateHandler).toHaveBeenCalled();
+    window.removeEventListener('popstate', popstateHandler);
+  });
+
+  test('cancelNav clears pendingNav and leaves URL unchanged', () => {
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({
+        enabled: true,
+        shouldBlock: () => true,
+      })
+    );
+
+    act(() => {
+      window.history.pushState(null, '', '/channels');
+    });
+    expect(result.current.pendingNav).toBe('/channels');
+
+    act(() => {
+      result.current.cancelNav();
+    });
+
+    expect(result.current.pendingNav).toBeNull();
+    expect(window.location.pathname).toBe('/settings/core');
+  });
+
+  test('restores original history methods on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useUnsavedChangesGuard({
+        enabled: true,
+        shouldBlock: () => true,
+      })
+    );
+
+    expect(window.history.pushState).not.toBe(originalPushState);
+
+    unmount();
+
+    expect(window.history.pushState).toBe(originalPushState);
+    expect(window.history.replaceState).toBe(originalReplaceState);
+  });
+
+  test('registers beforeunload listener while enabled and removes it when disabled', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { rerender, unmount } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useUnsavedChangesGuard({
+          enabled,
+          shouldBlock: () => true,
+        }),
+      { initialProps: { enabled: true } }
+    );
+
+    expect(addSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+
+    rerender({ enabled: false });
+
+    expect(removeSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+
+    unmount();
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  test('beforeunload handler sets returnValue to trigger native warning', () => {
+    renderHook(() =>
+      useUnsavedChangesGuard({
+        enabled: true,
+        shouldBlock: () => true,
+      })
+    );
+
+    const event = new Event('beforeunload', { cancelable: true }) as BeforeUnloadEvent;
+    Object.defineProperty(event, 'returnValue', { writable: true, value: '' });
+    window.dispatchEvent(event);
+
+    expect(event.returnValue).toBe('');
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test('intercepts replaceState the same way as pushState', () => {
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({
+        enabled: true,
+        shouldBlock: (url) => !url.startsWith('/settings'),
+      })
+    );
+
+    act(() => {
+      window.history.replaceState(null, '', '/videos');
+    });
+
+    expect(window.location.pathname).toBe('/settings/core');
+    expect(result.current.pendingNav).toBe('/videos');
+  });
+});

--- a/client/src/components/Configuration/hooks/index.ts
+++ b/client/src/components/Configuration/hooks/index.ts
@@ -4,3 +4,4 @@ export { usePasswordChange } from './usePasswordChange';
 export { useCookieManagement } from './useCookieManagement';
 export { useAutoRemovalDryRun } from './useAutoRemovalDryRun';
 export { useYtDlpUpdate } from './useYtDlpUpdate';
+export { useUnsavedChangesGuard } from './useUnsavedChangesGuard';

--- a/client/src/components/Configuration/hooks/useConfigSave.ts
+++ b/client/src/components/Configuration/hooks/useConfigSave.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { ConfigState, SnackbarState } from '../types';
 import { CONFIG_UPDATED_EVENT } from '../../../hooks/useConfig';
 
@@ -19,7 +19,10 @@ export const useConfigSave = ({
   hasPlexServerConfigured,
   checkPlexConnection,
 }: UseConfigSaveParams) => {
-  const saveConfig = useCallback(async () => {
+  const [isSaving, setIsSaving] = useState(false);
+
+  const saveConfig = useCallback(async (): Promise<boolean> => {
+    setIsSaving(true);
     try {
       const response = await fetch('/updateconfig', {
         method: 'POST',
@@ -30,40 +33,44 @@ export const useConfigSave = ({
         body: JSON.stringify(config),
       });
 
-      if (response.ok) {
-        // Update initial snapshot to current config so unsaved flag resets
-        setInitialConfig(config);
-
-        if (typeof window !== 'undefined') {
-          const configUpdatedEvent = new CustomEvent<ConfigState>(CONFIG_UPDATED_EVENT, {
-            detail: config,
-          });
-          window.dispatchEvent(configUpdatedEvent);
-        }
-
-        setSnackbar({
-          open: true,
-          message: 'Configuration saved successfully',
-          severity: 'success'
-        });
-
-        // Re-check Plex connection if IP changed
-        if (hasPlexServerConfigured) {
-          checkPlexConnection();
-        }
-      } else {
+      if (!response.ok) {
         throw new Error('Failed to save configuration');
       }
+
+      setInitialConfig(config);
+
+      if (typeof window !== 'undefined') {
+        const configUpdatedEvent = new CustomEvent<ConfigState>(CONFIG_UPDATED_EVENT, {
+          detail: config,
+        });
+        window.dispatchEvent(configUpdatedEvent);
+      }
+
+      setSnackbar({
+        open: true,
+        message: 'Configuration saved successfully',
+        severity: 'success'
+      });
+
+      if (hasPlexServerConfigured) {
+        checkPlexConnection();
+      }
+
+      return true;
     } catch (error) {
       setSnackbar({
         open: true,
         message: 'Failed to save configuration',
         severity: 'error'
       });
+      return false;
+    } finally {
+      setIsSaving(false);
     }
   }, [token, config, setInitialConfig, setSnackbar, hasPlexServerConfigured, checkPlexConnection]);
 
   return {
     saveConfig,
+    isSaving,
   };
 };

--- a/client/src/components/Configuration/hooks/useUnsavedChangesGuard.ts
+++ b/client/src/components/Configuration/hooks/useUnsavedChangesGuard.ts
@@ -20,6 +20,7 @@ export function useUnsavedChangesGuard({
   shouldBlock,
 }: UseUnsavedChangesGuardArgs): UseUnsavedChangesGuardResult {
   const [pendingNav, setPendingNav] = useState<string | null>(null);
+  const pendingNavRef = useRef<string | null>(null);
   const enabledRef = useRef(enabled);
   const shouldBlockRef = useRef(shouldBlock);
   const bypassRef = useRef(false);
@@ -51,6 +52,7 @@ export function useUnsavedChangesGuard({
           return original.apply(this, args);
         }
 
+        pendingNavRef.current = targetUrl;
         setPendingNav(targetUrl);
       };
     };
@@ -77,20 +79,21 @@ export function useUnsavedChangesGuard({
   }, [enabled]);
 
   const confirmNav = useCallback(() => {
-    setPendingNav((current) => {
-      if (current === null) return null;
-      bypassRef.current = true;
-      try {
-        window.history.pushState(null, '', current);
-        window.dispatchEvent(new PopStateEvent('popstate'));
-      } finally {
-        bypassRef.current = false;
-      }
-      return null;
-    });
+    const target = pendingNavRef.current;
+    if (target === null) return;
+    pendingNavRef.current = null;
+    setPendingNav(null);
+    bypassRef.current = true;
+    try {
+      window.history.pushState(null, '', target);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    } finally {
+      bypassRef.current = false;
+    }
   }, []);
 
   const cancelNav = useCallback(() => {
+    pendingNavRef.current = null;
     setPendingNav(null);
   }, []);
 

--- a/client/src/components/Configuration/hooks/useUnsavedChangesGuard.ts
+++ b/client/src/components/Configuration/hooks/useUnsavedChangesGuard.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseUnsavedChangesGuardArgs {
+  enabled: boolean;
+  shouldBlock: (targetUrl: string) => boolean;
+}
+
+interface UseUnsavedChangesGuardResult {
+  pendingNav: string | null;
+  confirmNav: () => void;
+  cancelNav: () => void;
+}
+
+// Intercepts SPA navigation (history.pushState/replaceState) and browser unload
+// while `enabled` is true. We patch history methods because react-router 6.11 is
+// configured with <BrowserRouter>, not the data-router setup that `useBlocker`
+// requires. Browser back/forward (popstate) is intentionally not intercepted.
+export function useUnsavedChangesGuard({
+  enabled,
+  shouldBlock,
+}: UseUnsavedChangesGuardArgs): UseUnsavedChangesGuardResult {
+  const [pendingNav, setPendingNav] = useState<string | null>(null);
+  const enabledRef = useRef(enabled);
+  const shouldBlockRef = useRef(shouldBlock);
+  const bypassRef = useRef(false);
+
+  useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  useEffect(() => {
+    shouldBlockRef.current = shouldBlock;
+  }, [shouldBlock]);
+
+  useEffect(() => {
+    const originalPushState = window.history.pushState;
+    const originalReplaceState = window.history.replaceState;
+
+    const wrap = (
+      original: typeof originalPushState
+    ): typeof originalPushState => {
+      return function patched(this: History, ...args) {
+        const url = args[2];
+        const targetUrl = typeof url === 'string' ? url : url ? url.toString() : '';
+
+        if (
+          bypassRef.current ||
+          !enabledRef.current ||
+          !shouldBlockRef.current(targetUrl)
+        ) {
+          return original.apply(this, args);
+        }
+
+        setPendingNav(targetUrl);
+      };
+    };
+
+    window.history.pushState = wrap(originalPushState);
+    window.history.replaceState = wrap(originalReplaceState);
+
+    return () => {
+      window.history.pushState = originalPushState;
+      window.history.replaceState = originalReplaceState;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [enabled]);
+
+  const confirmNav = useCallback(() => {
+    setPendingNav((current) => {
+      if (current === null) return null;
+      bypassRef.current = true;
+      try {
+        window.history.pushState(null, '', current);
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      } finally {
+        bypassRef.current = false;
+      }
+      return null;
+    });
+  }, []);
+
+  const cancelNav = useCallback(() => {
+    setPendingNav(null);
+  }, []);
+
+  return { pendingNav, confirmNav, cancelNav };
+}

--- a/client/src/components/Configuration/sections/SaveBar.tsx
+++ b/client/src/components/Configuration/sections/SaveBar.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Button, Typography, CircularProgress, Slide, Tooltip } from '../../ui';
 import { Save as SaveIcon, WarningAmber as WarningAmberIcon, ErrorOutline as ErrorOutlineIcon } from '../../../lib/icons';
+import { useMediaQuery } from '../../../hooks/useMediaQuery';
+import { HEADER_HEIGHT_DESKTOP, HEADER_HEIGHT_MOBILE } from '../../layout/navLayoutConstants';
 
 interface SaveBarProps {
   hasUnsavedChanges: boolean;
@@ -33,6 +35,8 @@ export const SaveBar: React.FC<SaveBarProps> = ({
   const tooltipText = hasUnsavedChanges
     ? 'You have unsaved changes'
     : 'Save configuration settings';
+  const isMobile = useMediaQuery('(max-width: 767px)');
+  const headerHeight = isMobile ? HEADER_HEIGHT_MOBILE : HEADER_HEIGHT_DESKTOP;
 
   const bannerContent = (
     <>
@@ -135,7 +139,7 @@ export const SaveBar: React.FC<SaveBarProps> = ({
       <div
         style={{
           position: 'fixed',
-          top: 'calc(64px + var(--shell-gap, 0px))',
+          top: `calc(${headerHeight}px + var(--shell-gap, 0px))`,
           left: 0,
           right: 0,
           zIndex: 1302,

--- a/client/src/components/Configuration/sections/UnsavedChangesDialog.tsx
+++ b/client/src/components/Configuration/sections/UnsavedChangesDialog.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContentBody,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from '../../ui';
+import { useMediaQuery } from '../../../hooks/useMediaQuery';
+
+interface UnsavedChangesDialogProps {
+  open: boolean;
+  isSaving: boolean;
+  validationError: string | null;
+  onDiscard: () => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+export const UnsavedChangesDialog: React.FC<UnsavedChangesDialogProps> = ({
+  open,
+  isSaving,
+  validationError,
+  onDiscard,
+  onCancel,
+  onSave,
+}) => {
+  const isMobile = useMediaQuery('(max-width: 767px)');
+  const saveDisabled = isSaving || Boolean(validationError);
+
+  return (
+    <Dialog open={open} onClose={onCancel} maxWidth="md" disableEscapeKeyDown={isSaving}>
+      <DialogTitle>Unsaved changes</DialogTitle>
+      <DialogContentBody>
+        <DialogContentText>
+          You have unsaved configuration changes. What do you want to do?
+        </DialogContentText>
+        {validationError && (
+          <p
+            role="alert"
+            className="mt-3 text-sm font-medium text-destructive"
+          >
+            {validationError}
+          </p>
+        )}
+      </DialogContentBody>
+      <DialogActions
+        className={isMobile ? 'flex-col-reverse items-stretch gap-2' : undefined}
+      >
+        <Button
+          variant="ghost"
+          color="error"
+          onClick={onDiscard}
+          disabled={isSaving}
+          fullWidth={isMobile}
+        >
+          Discard changes
+        </Button>
+        <Button
+          variant="outlined"
+          color="inherit"
+          onClick={onCancel}
+          disabled={isSaving}
+          autoFocus
+          fullWidth={isMobile}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={onSave}
+          disabled={saveDisabled}
+          loading={isSaving}
+          fullWidth={isMobile}
+        >
+          Save and continue
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default UnsavedChangesDialog;

--- a/client/src/components/Configuration/sections/__tests__/UnsavedChangesDialog.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/UnsavedChangesDialog.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { UnsavedChangesDialog } from '../UnsavedChangesDialog';
+import { renderWithProviders } from '../../../../test-utils';
+
+describe('UnsavedChangesDialog', () => {
+  const baseProps = {
+    open: true,
+    isSaving: false,
+    validationError: null as string | null,
+    onDiscard: jest.fn(),
+    onCancel: jest.fn(),
+    onSave: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders the title and the three action buttons when open', () => {
+    renderWithProviders(<UnsavedChangesDialog {...baseProps} />);
+
+    expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /discard changes/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save and continue/i })).toBeInTheDocument();
+  });
+
+  test('renders nothing when open is false', () => {
+    renderWithProviders(<UnsavedChangesDialog {...baseProps} open={false} />);
+
+    expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /save and continue/i })).not.toBeInTheDocument();
+  });
+
+  test('clicking Discard changes calls onDiscard', async () => {
+    const onDiscard = jest.fn();
+    const user = userEvent.setup();
+    renderWithProviders(<UnsavedChangesDialog {...baseProps} onDiscard={onDiscard} />);
+
+    await user.click(screen.getByRole('button', { name: /discard changes/i }));
+
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking Cancel calls onCancel', async () => {
+    const onCancel = jest.fn();
+    const user = userEvent.setup();
+    renderWithProviders(<UnsavedChangesDialog {...baseProps} onCancel={onCancel} />);
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking Save and continue calls onSave', async () => {
+    const onSave = jest.fn();
+    const user = userEvent.setup();
+    renderWithProviders(<UnsavedChangesDialog {...baseProps} onSave={onSave} />);
+
+    await user.click(screen.getByRole('button', { name: /save and continue/i }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  test('disables Save and continue when validationError is present', () => {
+    renderWithProviders(
+      <UnsavedChangesDialog {...baseProps} validationError="Plex URL is required" />
+    );
+
+    expect(screen.getByRole('button', { name: /save and continue/i })).toBeDisabled();
+  });
+
+  test('shows validationError text when present', () => {
+    renderWithProviders(
+      <UnsavedChangesDialog {...baseProps} validationError="Plex URL is required" />
+    );
+
+    expect(screen.getByText('Plex URL is required')).toBeInTheDocument();
+  });
+
+  test('still allows Discard and Cancel when validationError is present', () => {
+    renderWithProviders(
+      <UnsavedChangesDialog {...baseProps} validationError="Plex URL is required" />
+    );
+
+    expect(screen.getByRole('button', { name: /discard changes/i })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /^cancel$/i })).not.toBeDisabled();
+  });
+
+  test('disables all buttons while isSaving', () => {
+    renderWithProviders(<UnsavedChangesDialog {...baseProps} isSaving={true} />);
+
+    expect(screen.getByRole('button', { name: /save and continue/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /discard changes/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^cancel$/i })).toBeDisabled();
+  });
+});

--- a/client/src/components/Settings/Settings.tsx
+++ b/client/src/components/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import isEqual from 'lodash/isEqual';
 import {
   Alert,
@@ -21,7 +21,13 @@ import { AutoRemovalSection } from '../Configuration/sections/AutoRemovalSection
 import { AccountSecuritySection } from '../Configuration/sections/AccountSecuritySection';
 import ApiKeysSection from '../Configuration/sections/ApiKeysSection';
 import { SaveBar } from '../Configuration/sections/SaveBar';
-import { usePlexConnection, useConfigSave, useYtDlpUpdate } from '../Configuration/hooks';
+import { UnsavedChangesDialog } from '../Configuration/sections/UnsavedChangesDialog';
+import {
+  usePlexConnection,
+  useConfigSave,
+  useYtDlpUpdate,
+  useUnsavedChangesGuard,
+} from '../Configuration/hooks';
 import { useStorageStatus } from '../../hooks/useStorageStatus';
 import { useConfig } from '../../hooks/useConfig';
 import { TRACKABLE_CONFIG_KEYS } from '../../config/configSchema';
@@ -82,7 +88,7 @@ export function Settings({ token }: SettingsProps) {
     hasPlexServerConfigured,
   });
 
-  const { saveConfig } = useConfigSave({
+  const { saveConfig, isSaving } = useConfigSave({
     token,
     config,
     setInitialConfig,
@@ -90,6 +96,31 @@ export function Settings({ token }: SettingsProps) {
     hasPlexServerConfigured,
     checkPlexConnection,
   });
+
+  const shouldBlockNav = useCallback(
+    (targetUrl: string) => !targetUrl.startsWith('/settings'),
+    []
+  );
+
+  const { pendingNav, confirmNav, cancelNav } = useUnsavedChangesGuard({
+    enabled: hasUnsavedChanges,
+    shouldBlock: shouldBlockNav,
+  });
+
+  const handleSaveAndContinue = useCallback(async () => {
+    if (validationError) {
+      setSnackbar({
+        open: true,
+        message: validationError,
+        severity: 'error',
+      });
+      return;
+    }
+    const ok = await saveConfig();
+    if (ok) {
+      confirmNav();
+    }
+  }, [validationError, saveConfig, confirmNav]);
 
   const {
     versionInfo: ytDlpVersionInfo,
@@ -162,10 +193,19 @@ export function Settings({ token }: SettingsProps) {
     <div>
       <SaveBar
         hasUnsavedChanges={hasUnsavedChanges}
-        isLoading={isLoading}
+        isLoading={isLoading || isSaving}
         onSave={handleSave}
         validationError={validationError}
-        placement="inline"
+        placement="fixed"
+      />
+
+      <UnsavedChangesDialog
+        open={pendingNav !== null}
+        isSaving={isSaving}
+        validationError={validationError ?? null}
+        onDiscard={confirmNav}
+        onCancel={cancelNav}
+        onSave={handleSaveAndContinue}
       />
 
       <div style={{ marginBottom: 16 }}>
@@ -189,6 +229,9 @@ export function Settings({ token }: SettingsProps) {
                 onConfigChange={handleConfigChange}
                 onMobileTooltipClick={setMobileTooltip}
                 token={token}
+                ytDlpVersionInfo={ytDlpVersionInfo}
+                ytDlpUpdateStatus={ytDlpUpdateStatus}
+                onYtDlpUpdate={performYtDlpUpdate}
               />
             }
           />

--- a/client/src/components/layout/NavHeaderActions.tsx
+++ b/client/src/components/layout/NavHeaderActions.tsx
@@ -108,21 +108,36 @@ export const NavHeaderActions: React.FC<NavHeaderActionsProps> = ({
 
       {layoutPolicy.headerVersionPlacement === 'mobile' && isMobile && !showLandscapeNavItems && versionParts.length > 0 && (
         <Tooltip title="Tap to view changelog" arrow placement="bottom">
-          <Typography
-            variant="caption"
+          <Box
+            className="flex flex-col items-end mr-1"
+            style={{ lineHeight: 1.1, cursor: 'pointer', userSelect: 'none' }}
             onClick={() => navigate('/changelog')}
-            style={{
-              color: 'var(--muted-foreground)',
-              fontWeight: 600,
-              fontSize: '0.6rem',
-              cursor: 'pointer',
-              marginRight: 4,
-              userSelect: 'none',
-              lineHeight: 1,
-            }}
           >
-            {versionParts[0]}
-          </Typography>
+            <Typography
+              variant="caption"
+              style={{
+                color: 'var(--muted-foreground)',
+                fontWeight: 600,
+                fontSize: '0.6rem',
+                lineHeight: 1,
+              }}
+            >
+              {versionParts[0]}
+            </Typography>
+            {versionParts[1] && (
+              <Typography
+                variant="caption"
+                style={{
+                  color: 'var(--muted-foreground)',
+                  fontSize: '0.6rem',
+                  lineHeight: 1,
+                  marginTop: 2,
+                }}
+              >
+                {versionParts[1]}
+              </Typography>
+            )}
+          </Box>
         </Tooltip>
       )}
 


### PR DESCRIPTION
- Restore the yt-dlp current-version block and update button on the Core Settings page; useYtDlpUpdate was already wired in Settings but its outputs were not being passed to CoreSettingsSection.
- Show the yt-dlp version stacked under the Youtarr version on the mobile topnav (regression vs main); desktop and sidebar layouts already handled this.
- Add an UnsavedChangesDialog + useUnsavedChangesGuard to prompt before navigating away from Settings with unsaved edits.