### PR TITLE
fix(channels): lift floating Save button above mobile bottom nav

### DIFF
--- a/client/src/components/ChannelManager.tsx
+++ b/client/src/components/ChannelManager.tsx
@@ -35,6 +35,7 @@ import {
   Upload as UploadIcon,
 } from '../lib/icons';
 import { Undo2 as UndoIcon, FolderOpen as FolderSpecialIcon } from 'lucide-react';
+import { MOBILE_NAV_SAFE_GAP } from './layout/navLayoutConstants';
 import useMediaQuery from '../hooks/useMediaQuery';
 import { useNavigate } from 'react-router-dom';
 import WebSocketContext, { Message } from '../contexts/WebSocketContext';
@@ -827,7 +828,7 @@ const ChannelManager: React.FC<ChannelManagerProps> = ({ token }) => {
         <div
           style={{
             position: 'fixed',
-            bottom: 72,
+            bottom: isMobile ? `calc(var(--mobile-nav-total-offset, 0px) + ${MOBILE_NAV_SAFE_GAP}px)` : 72,
             right: isMobile ? 16 : 32,
             zIndex: 1401,
             pointerEvents: hasPendingChanges ? 'auto' : 'none',


### PR DESCRIPTION
The floating Save/Undo cluster on ChannelManager used a hardcoded bottom: 72, which on mobile placed the Save button behind the bottom nav bar, making it unclickable. Use the --mobile-nav-total-offset CSS variable on mobile (same pattern as the other floating overlays in this codebase) and the MOBILE_NAV_SAFE_GAP constant for the padding. Desktop behavior is unchanged.