### PR TITLE
feat(videos): add Find on YouTube search page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 ### Backend (server/)
 - `server.js`: Express entry point. `db.js`: Sequelize setup. `logger.js`: Pino logger with request correlation.
 - `models/`: Sequelize models (channel, video, job, jobvideo, jobvideodownload, channelvideo, session, apikey). Associations: Channel hasMany Videos, Job hasMany JobVideos.
-- `routes/`: API handlers (auth, channels, videos, videoDetail, config, jobs, plex, setup, subscriptions, apikeys, health). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.
-- `modules/`: class-based singletons holding business logic. Top-level modules include `channelModule`, `downloadModule`, `plexModule`, `jobModule`, `configModule`, `videosModule`, `videoMetadataModule`, `webSocketServer`, `databaseHealthModule`, `notificationModule`, `channelSettingsModule`, `videoDeletionModule`, `nfoGenerator`, `cronJobs`, `apiKeyModule`, `ytdlpModule`, `messageEmitter`.
+- `routes/`: API handlers (auth, channels, videos, videoDetail, videoSearch, config, jobs, plex, setup, subscriptions, apikeys, health). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.
+- `modules/`: class-based singletons holding business logic. Top-level modules include `channelModule`, `downloadModule`, `plexModule`, `jobModule`, `configModule`, `videosModule`, `videoMetadataModule`, `videoSearchModule`, `webSocketServer`, `databaseHealthModule`, `notificationModule`, `channelSettingsModule`, `videoDeletionModule`, `nfoGenerator`, `cronJobs`, `apiKeyModule`, `ytdlpModule`, `messageEmitter`.
 - `modules/download/`: download orchestration (`downloadExecutor`, `ytdlpCommandBuilder`, `DownloadProgressMonitor`, `tempPathManager`, `videoMetadataProcessor`).
 - `modules/filesystem/`: path/file abstraction (`pathBuilder`, `directoryManager`, `fileOperations`, `sanitizer`, `constants`). Good example of the sub-module aggregator pattern.
 - `modules/notifications/`: multi-service notifications via Apprise (`serviceRegistry`, `formatters/`, `senders/`). Good example of a pluggable service registry.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ https://github.com/user-attachments/assets/34e5b50b-1a38-4f0b-9f84-bd47cefe4348
 - **Smart Downloads**: Pre-validate manually pasted URLs with metadata preview before downloading
 - **Channel Subscriptions**: Subscribe to channels and auto-download new videos, shorts, and streams with per-tab controls
 - **Browse Channels**: View and search all videos from subscribed channels with advanced filtering, tabbed views for Videos/Shorts/Streams, and contextual publish date accuracy tips
+- **Find on YouTube**: Search YouTube from inside Youtarr, see which results are already downloaded or missing, and click any result to queue a download
 - **In-App Playback**: Click any thumbnail to open a detail modal with extended metadata and in-browser streaming of downloaded videos; no media server required
 - **Channel Grouping & Multi-Library Support**: Organize channels into custom subfolders (e.g., `__kids`, `__music`, `__news`) to create separate media server libraries
 - **Smart Organization**: Videos organized by channel with metadata and thumbnails

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,7 @@ import { Settings } from './components/Settings/Settings';
 import ChannelManager from './components/ChannelManager';
 import DownloadManager from './components/DownloadManager';
 import VideosPage from './components/VideosPage';
+import FindVideos from './components/FindVideos';
 import LocalLogin from './components/LocalLogin';
 import InitialSetup from './components/InitialSetup';
 import ChannelPage from './components/ChannelPage';
@@ -528,6 +529,7 @@ function AppContent() {
                           <Route path="/channels/imports" element={<ImportSubscriptionsPage token={token} />} />
                           <Route path="/downloads/*" element={<DownloadManager token={token} />} />
                           <Route path="/videos" element={<VideosPage token={token} />} />
+                          <Route path="/videos/find" element={<FindVideos token={token} />} />
                           <Route path="/channel/:channel_id" element={<ChannelPage token={token} />} />
                           <Route path="/" element={<Navigate to="/channels" replace />} />
                           <Route path="/*" element={<Navigate to="/channels" replace />} />

--- a/client/src/components/FindVideos/__tests__/FindVideos.test.tsx
+++ b/client/src/components/FindVideos/__tests__/FindVideos.test.tsx
@@ -21,6 +21,24 @@ jest.mock('../../shared/VideoModal', () => ({
 const axios = require('axios');
 const FindVideos = require('../index').default;
 
+beforeAll(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+});
+
 describe('FindVideos page', () => {
   beforeEach(() => { jest.clearAllMocks(); });
 
@@ -56,5 +74,25 @@ describe('FindVideos page', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /open pick me/i }));
     expect(screen.getByTestId('mock-video-modal')).toHaveTextContent('Pick me');
+  });
+
+  test('toggling to Table View switches results to a table and row click opens modal', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: { results: [{
+        youtubeId: 'abc12345678', title: 'Row Pick', channelName: 'Chan',
+        channelId: null, duration: 120, thumbnailUrl: null, publishedAt: null,
+        viewCount: null, status: 'never_downloaded',
+      }] },
+    });
+
+    render(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'x' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    expect(await screen.findByText('Row Pick')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /table view/i }));
+    const row = screen.getByRole('row', { name: /open row pick/i });
+    fireEvent.click(row);
+    expect(screen.getByTestId('mock-video-modal')).toHaveTextContent('Row Pick');
   });
 });

--- a/client/src/components/FindVideos/__tests__/FindVideos.test.tsx
+++ b/client/src/components/FindVideos/__tests__/FindVideos.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  isCancel: (err: unknown) => Boolean(err && (err as { name?: string }).name === 'CanceledError'),
+  CanceledError: class CanceledError extends Error {
+    constructor() { super('canceled'); this.name = 'CanceledError'; }
+  },
+}));
+
+jest.mock('../../shared/VideoModal', () => ({
+  __esModule: true,
+  default: function MockVideoModal(props: { open: boolean; video: { title: string } }) {
+    const React = require('react');
+    if (!props.open) return null;
+    return React.createElement('div', { 'data-testid': 'mock-video-modal' }, props.video.title);
+  },
+}));
+
+const axios = require('axios');
+const FindVideos = require('../index').default;
+
+describe('FindVideos page', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  test('submitting a search renders results', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: { results: [{
+        youtubeId: 'abc12345678', title: 'Hello World', channelName: 'Chan',
+        channelId: null, duration: 120, thumbnailUrl: null, publishedAt: null,
+        viewCount: null, status: 'never_downloaded',
+      }] },
+    });
+
+    render(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hello' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+
+    expect(await screen.findByText('Hello World')).toBeInTheDocument();
+  });
+
+  test('clicking a result opens the VideoModal', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: { results: [{
+        youtubeId: 'abc12345678', title: 'Pick me', channelName: 'Chan',
+        channelId: null, duration: 120, thumbnailUrl: null, publishedAt: null,
+        viewCount: null, status: 'never_downloaded',
+      }] },
+    });
+
+    render(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'x' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    expect(await screen.findByText('Pick me')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /open pick me/i }));
+    expect(screen.getByTestId('mock-video-modal')).toHaveTextContent('Pick me');
+  });
+});

--- a/client/src/components/FindVideos/components/ResultCard.tsx
+++ b/client/src/components/FindVideos/components/ResultCard.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Box, Card, CardActionArea, Typography, Chip } from '../../ui';
+import { CalendarToday as CalendarTodayIcon } from '../../../lib/icons';
+import {
+  getStatusColor,
+  getStatusIcon,
+  getStatusLabel,
+  getStatusChipVariant,
+  getStatusChipStyle,
+  VideoStatus,
+} from '../../../utils/videoStatus';
+import { SHARED_THEMED_CHIP_SMALL_STYLE } from '../../shared/chipStyles';
+import { SearchResult } from '../types';
+
+function formatDuration(seconds: number | null): string {
+  if (!seconds || seconds <= 0) return '';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+}
+
+interface ResultCardProps {
+  result: SearchResult;
+  onClick: () => void;
+}
+
+export default function ResultCard({ result, onClick }: ResultCardProps) {
+  const status: VideoStatus = result.status;
+  const durationLabel = formatDuration(result.duration);
+
+  return (
+    <Card className="cursor-pointer overflow-hidden hover:shadow-md transition-shadow">
+      <CardActionArea
+        onClick={onClick}
+        aria-label={`Open ${result.title}`}
+      >
+        <Box className="relative aspect-video bg-muted">
+          {result.thumbnailUrl && (
+            <img
+              src={result.thumbnailUrl}
+              alt=""
+              className="w-full h-full object-cover"
+              loading="lazy"
+            />
+          )}
+          {durationLabel && (
+            <Chip
+              label={durationLabel}
+              size="small"
+              style={{
+                position: 'absolute',
+                bottom: 8,
+                right: 8,
+                backgroundColor: 'var(--media-overlay-background-strong)',
+                color: 'var(--media-overlay-foreground)',
+                fontSize: '0.75rem',
+                height: 22,
+              }}
+            />
+          )}
+        </Box>
+        <Box className="p-2 flex flex-col gap-2">
+          <Typography variant="body2" className="font-semibold line-clamp-2">{result.title}</Typography>
+          <Typography variant="caption" className="text-muted-foreground">{result.channelName}</Typography>
+          <Box className="flex items-center gap-2 flex-wrap">
+            {result.publishedAt && (
+              <Typography
+                variant="caption"
+                className="text-muted-foreground inline-flex items-center gap-1"
+              >
+                <CalendarTodayIcon size={12} />
+                {new Date(result.publishedAt).toLocaleDateString()}
+              </Typography>
+            )}
+            <Chip
+              icon={getStatusIcon(status)}
+              label={getStatusLabel(status)}
+              size="small"
+              color={getStatusColor(status)}
+              variant={getStatusChipVariant(status)}
+              style={{
+                flex: '0 0 auto',
+                minWidth: 'fit-content',
+                ...SHARED_THEMED_CHIP_SMALL_STYLE,
+                ...getStatusChipStyle(status),
+              }}
+            />
+          </Box>
+        </Box>
+      </CardActionArea>
+    </Card>
+  );
+}

--- a/client/src/components/FindVideos/components/ResultCard.tsx
+++ b/client/src/components/FindVideos/components/ResultCard.tsx
@@ -10,16 +10,8 @@ import {
   VideoStatus,
 } from '../../../utils/videoStatus';
 import { SHARED_THEMED_CHIP_SMALL_STYLE } from '../../shared/chipStyles';
+import { formatDurationClock } from '../../../utils';
 import { SearchResult } from '../types';
-
-function formatDuration(seconds: number | null): string {
-  if (!seconds || seconds <= 0) return '';
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
-  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
-  return `${m}:${String(s).padStart(2, '0')}`;
-}
 
 interface ResultCardProps {
   result: SearchResult;
@@ -28,7 +20,7 @@ interface ResultCardProps {
 
 export default function ResultCard({ result, onClick }: ResultCardProps) {
   const status: VideoStatus = result.status;
-  const durationLabel = formatDuration(result.duration);
+  const durationLabel = formatDurationClock(result.duration);
 
   return (
     <Card className="cursor-pointer overflow-hidden hover:shadow-md transition-shadow">

--- a/client/src/components/FindVideos/components/ResultsGrid.tsx
+++ b/client/src/components/FindVideos/components/ResultsGrid.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { Box, Typography, Alert, Button, Skeleton } from '../../ui';
+import { SearchResult, PageSize } from '../types';
+import ResultCard from './ResultCard';
+
+interface ResultsGridProps {
+  results: SearchResult[];
+  loading: boolean;
+  error: string | null;
+  hasSearched: boolean;
+  lastQuery: string;
+  pageSize: PageSize;
+  onResultClick: (result: SearchResult) => void;
+  onRetry: () => void;
+}
+
+export default function ResultsGrid({
+  results, loading, error, hasSearched, lastQuery, pageSize, onResultClick, onRetry,
+}: ResultsGridProps) {
+  if (loading) {
+    return (
+      <Box className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+        {Array.from({ length: pageSize }).map((_, i) => (
+          <Box key={i} className="space-y-2">
+            <Skeleton className="aspect-video w-full" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </Box>
+        ))}
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert
+        severity="error"
+        action={<Button variant="outlined" onClick={onRetry}>Try again</Button>}
+      >
+        {error}
+      </Alert>
+    );
+  }
+
+  if (!hasSearched) {
+    return (
+      <Typography variant="body2" className="text-muted-foreground">
+        Enter a search and click Search to find videos on YouTube.
+      </Typography>
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <Typography variant="body2" className="text-muted-foreground">
+        No videos found for &quot;{lastQuery}&quot;.
+      </Typography>
+    );
+  }
+
+  return (
+    <Box className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+      {results.map((r) => (
+        <ResultCard key={r.youtubeId} result={r} onClick={() => onResultClick(r)} />
+      ))}
+    </Box>
+  );
+}

--- a/client/src/components/FindVideos/components/ResultsGrid.tsx
+++ b/client/src/components/FindVideos/components/ResultsGrid.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Box, Typography, Alert, Button, Skeleton } from '../../ui';
-import { SearchResult, PageSize } from '../types';
+import { useMediaQuery } from '../../../hooks/useMediaQuery';
+import { SearchResult, PageSize, ViewMode } from '../types';
 import ResultCard from './ResultCard';
+import ResultsTable from './ResultsTable';
+import ResultsListMobile from './ResultsListMobile';
 
 interface ResultsGridProps {
   results: SearchResult[];
@@ -10,13 +13,16 @@ interface ResultsGridProps {
   hasSearched: boolean;
   lastQuery: string;
   pageSize: PageSize;
+  viewMode: ViewMode;
   onResultClick: (result: SearchResult) => void;
   onRetry: () => void;
 }
 
 export default function ResultsGrid({
-  results, loading, error, hasSearched, lastQuery, pageSize, onResultClick, onRetry,
+  results, loading, error, hasSearched, lastQuery, pageSize, viewMode, onResultClick, onRetry,
 }: ResultsGridProps) {
+  const isMobile = useMediaQuery('(max-width: 767px)');
+
   if (loading) {
     return (
       <Box className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
@@ -56,6 +62,12 @@ export default function ResultsGrid({
         No videos found for &quot;{lastQuery}&quot;.
       </Typography>
     );
+  }
+
+  if (viewMode === 'table') {
+    return isMobile
+      ? <ResultsListMobile results={results} onResultClick={onResultClick} />
+      : <ResultsTable results={results} onResultClick={onResultClick} />;
   }
 
   return (

--- a/client/src/components/FindVideos/components/ResultsListMobile.tsx
+++ b/client/src/components/FindVideos/components/ResultsListMobile.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { Typography, Chip } from '../../ui';
+import { CalendarToday as CalendarTodayIcon } from '../../../lib/icons';
+import {
+  getStatusColor,
+  getStatusIcon,
+  getStatusLabel,
+  getStatusChipVariant,
+  getStatusChipStyle,
+  VideoStatus,
+} from '../../../utils/videoStatus';
+import { SHARED_THEMED_CHIP_SMALL_STYLE } from '../../shared/chipStyles';
+import { formatDurationClock } from '../../../utils';
+import { SearchResult, THUMB_WIDTH, THUMB_HEIGHT } from '../types';
+
+function StatusChip({ status }: { status: VideoStatus }) {
+  return (
+    <Chip
+      icon={getStatusIcon(status)}
+      label={getStatusLabel(status)}
+      size="small"
+      color={getStatusColor(status)}
+      variant={getStatusChipVariant(status)}
+      style={{
+        ...SHARED_THEMED_CHIP_SMALL_STYLE,
+        ...getStatusChipStyle(status),
+      }}
+    />
+  );
+}
+
+interface ResultsListMobileProps {
+  results: SearchResult[];
+  onResultClick: (result: SearchResult) => void;
+}
+
+export default function ResultsListMobile({ results, onResultClick }: ResultsListMobileProps) {
+  return (
+    <div className="flex flex-col">
+      {results.map((result) => {
+        const status: VideoStatus = result.status;
+        const durationLabel = formatDurationClock(result.duration);
+        const published = result.publishedAt
+          ? new Date(result.publishedAt).toLocaleDateString(undefined, {
+              month: 'short',
+              day: 'numeric',
+              year: '2-digit',
+            })
+          : null;
+        return (
+          <div
+            key={result.youtubeId}
+            role="button"
+            tabIndex={0}
+            aria-label={`Open ${result.title}`}
+            onClick={() => onResultClick(result)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onResultClick(result);
+              }
+            }}
+            className="flex gap-3 py-2 px-1 border-b border-border cursor-pointer items-start"
+          >
+            <div
+              className="relative shrink-0 overflow-hidden bg-[var(--media-placeholder-background)] rounded-[var(--radius-thumb)]"
+              style={{ width: THUMB_WIDTH, height: THUMB_HEIGHT }}
+            >
+              {result.thumbnailUrl && (
+                <img
+                  src={result.thumbnailUrl}
+                  alt=""
+                  className="block object-cover rounded-[var(--radius-thumb)]"
+                  style={{ width: THUMB_WIDTH, height: THUMB_HEIGHT }}
+                  loading="lazy"
+                />
+              )}
+              {durationLabel && (
+                <Chip
+                  label={durationLabel}
+                  size="small"
+                  style={{
+                    position: 'absolute',
+                    bottom: 4,
+                    right: 4,
+                    backgroundColor: 'var(--media-overlay-background-strong)',
+                    color: 'var(--media-overlay-foreground)',
+                    fontSize: '0.7rem',
+                    height: 18,
+                  }}
+                />
+              )}
+            </div>
+            <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+              <Typography
+                variant="body2"
+                className="line-clamp-2 whitespace-normal text-sm leading-[1.3]"
+              >
+                {result.title}
+              </Typography>
+              <Typography
+                variant="caption"
+                className="text-muted-foreground block truncate text-xs"
+              >
+                {result.channelName}
+              </Typography>
+              <div className="flex items-center gap-2 flex-wrap mt-0.5">
+                {published && (
+                  <Typography
+                    variant="caption"
+                    className="text-muted-foreground inline-flex items-center gap-0.5 text-[0.7rem]"
+                  >
+                    <CalendarTodayIcon size={11} />
+                    {published}
+                  </Typography>
+                )}
+                <StatusChip status={status} />
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/components/FindVideos/components/ResultsTable.tsx
+++ b/client/src/components/FindVideos/components/ResultsTable.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import {
+  Typography,
+  Chip,
+  TableContainer,
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+} from '../../ui';
+import { CalendarToday as CalendarTodayIcon } from '../../../lib/icons';
+import {
+  getStatusColor,
+  getStatusIcon,
+  getStatusLabel,
+  getStatusChipVariant,
+  getStatusChipStyle,
+  VideoStatus,
+} from '../../../utils/videoStatus';
+import { SHARED_THEMED_CHIP_SMALL_STYLE } from '../../shared/chipStyles';
+import { formatDurationClock } from '../../../utils';
+import { SearchResult, THUMB_WIDTH, THUMB_HEIGHT } from '../types';
+
+function StatusChip({ status }: { status: VideoStatus }) {
+  return (
+    <Chip
+      icon={getStatusIcon(status)}
+      label={getStatusLabel(status)}
+      size="small"
+      color={getStatusColor(status)}
+      variant={getStatusChipVariant(status)}
+      style={{
+        ...SHARED_THEMED_CHIP_SMALL_STYLE,
+        ...getStatusChipStyle(status),
+      }}
+    />
+  );
+}
+
+interface ResultsTableProps {
+  results: SearchResult[];
+  onResultClick: (result: SearchResult) => void;
+}
+
+export default function ResultsTable({ results, onResultClick }: ResultsTableProps) {
+  return (
+    <TableContainer>
+      <Table size="small" className="table-fixed">
+        <TableHead>
+          <TableRow>
+            <TableCell component="th" className="w-[140px]">Thumbnail</TableCell>
+            <TableCell component="th" className="w-[40%]">Title</TableCell>
+            <TableCell component="th" className="w-[22%]">Channel</TableCell>
+            <TableCell component="th" className="w-[110px] whitespace-nowrap">Published</TableCell>
+            <TableCell component="th" className="w-[90px] whitespace-nowrap">Duration</TableCell>
+            <TableCell component="th" className="w-[160px] whitespace-nowrap">Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {results.map((result) => {
+            const status: VideoStatus = result.status;
+            return (
+              <TableRow
+                key={result.youtubeId}
+                hover
+                onClick={() => onResultClick(result)}
+                className="cursor-pointer"
+                aria-label={`Open ${result.title}`}
+              >
+                <TableCell>
+                  <div
+                    className="relative inline-block overflow-hidden bg-[var(--media-placeholder-background)] rounded-[var(--radius-thumb)]"
+                    style={{ width: THUMB_WIDTH, height: THUMB_HEIGHT }}
+                  >
+                    {result.thumbnailUrl && (
+                      <img
+                        src={result.thumbnailUrl}
+                        alt=""
+                        className="block object-cover rounded-[var(--radius-thumb)]"
+                        style={{ width: THUMB_WIDTH, height: THUMB_HEIGHT }}
+                        loading="lazy"
+                      />
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" className="line-clamp-2 whitespace-normal">
+                    {result.title}
+                  </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" className="text-muted-foreground">
+                    {result.channelName}
+                  </Typography>
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
+                  {result.publishedAt ? (
+                    <span className="inline-flex items-center gap-1">
+                      <CalendarTodayIcon size={12} />
+                      {new Date(result.publishedAt).toLocaleDateString()}
+                    </span>
+                  ) : (
+                    'N/A'
+                  )}
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
+                  {formatDurationClock(result.duration) || '-'}
+                </TableCell>
+                <TableCell>
+                  <StatusChip status={status} />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/client/src/components/FindVideos/components/SearchBar.tsx
+++ b/client/src/components/FindVideos/components/SearchBar.tsx
@@ -31,7 +31,7 @@ export default function SearchBar({
           if (e.key === 'Enter' && canSearch) onSearch();
         }}
         disabled={loading}
-        className="flex-1"
+        className="w-full sm:w-[32rem]"
       />
       <Select
         value={String(pageSize)}
@@ -49,7 +49,7 @@ export default function SearchBar({
           <Button variant="outlined" onClick={onCancel}>Cancel</Button>
         </Box>
       ) : (
-        <Button onClick={onSearch} disabled={!canSearch}>Search</Button>
+        <Button variant="contained" onClick={onSearch} disabled={!canSearch}>Search</Button>
       )}
     </Box>
   );

--- a/client/src/components/FindVideos/components/SearchBar.tsx
+++ b/client/src/components/FindVideos/components/SearchBar.tsx
@@ -1,27 +1,29 @@
 import React from 'react';
 import { Box, Button, TextField, Select, MenuItem } from '../../ui';
-import { Loader2 } from '../../../lib/icons';
-import { PAGE_SIZES, PageSize } from '../types';
+import { Loader2, LayoutGrid as ViewModuleIcon, Rows as TableChartIcon } from '../../../lib/icons';
+import { PAGE_SIZES, PageSize, ViewMode } from '../types';
 
 interface SearchBarProps {
   query: string;
   pageSize: PageSize;
   loading: boolean;
+  viewMode: ViewMode;
   onQueryChange: (q: string) => void;
   onPageSizeChange: (s: PageSize) => void;
+  onViewModeChange: (v: ViewMode) => void;
   onSearch: () => void;
   onCancel: () => void;
 }
 
 export default function SearchBar({
-  query, pageSize, loading,
-  onQueryChange, onPageSizeChange, onSearch, onCancel,
+  query, pageSize, loading, viewMode,
+  onQueryChange, onPageSizeChange, onViewModeChange, onSearch, onCancel,
 }: SearchBarProps) {
   const trimmed = query.trim();
   const canSearch = !loading && trimmed.length > 0;
 
   return (
-    <Box className="flex flex-col gap-3 sm:flex-row sm:items-center">
+    <Box className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
       <TextField
         aria-label="Search YouTube"
         placeholder="Search YouTube (e.g. Minecraft)"
@@ -51,6 +53,27 @@ export default function SearchBar({
       ) : (
         <Button variant="contained" onClick={onSearch} disabled={!canSearch}>Search</Button>
       )}
+      <Box className="flex shrink-0 self-center rounded-[var(--radius-ui)] overflow-hidden border border-border">
+        {(['table', 'grid'] as const).map((mode) => {
+          const isActive = viewMode === mode;
+          const Icon = mode === 'table' ? TableChartIcon : ViewModuleIcon;
+          const label = mode === 'table' ? 'Table View' : 'Grid View';
+          return (
+            <Button
+              key={mode}
+              variant={isActive ? 'contained' : 'text'}
+              size="sm"
+              onClick={() => onViewModeChange(mode)}
+              title={label}
+              aria-label={label}
+              aria-pressed={isActive}
+              className="rounded-none"
+            >
+              <Icon size={16} />
+            </Button>
+          );
+        })}
+      </Box>
     </Box>
   );
 }

--- a/client/src/components/FindVideos/components/SearchBar.tsx
+++ b/client/src/components/FindVideos/components/SearchBar.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Box, Button, TextField, Select, MenuItem } from '../../ui';
+import { Loader2 } from '../../../lib/icons';
+import { PAGE_SIZES, PageSize } from '../types';
+
+interface SearchBarProps {
+  query: string;
+  pageSize: PageSize;
+  loading: boolean;
+  onQueryChange: (q: string) => void;
+  onPageSizeChange: (s: PageSize) => void;
+  onSearch: () => void;
+  onCancel: () => void;
+}
+
+export default function SearchBar({
+  query, pageSize, loading,
+  onQueryChange, onPageSizeChange, onSearch, onCancel,
+}: SearchBarProps) {
+  const trimmed = query.trim();
+  const canSearch = !loading && trimmed.length > 0;
+
+  return (
+    <Box className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <TextField
+        aria-label="Search YouTube"
+        placeholder="Search YouTube (e.g. Minecraft)"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && canSearch) onSearch();
+        }}
+        disabled={loading}
+        className="flex-1"
+      />
+      <Select
+        value={String(pageSize)}
+        onValueChange={(v) => onPageSizeChange(Number(v) as PageSize)}
+        disabled={loading}
+        aria-label="Number of results"
+      >
+        {PAGE_SIZES.map((n) => (
+          <MenuItem key={n} value={String(n)}>{n} results</MenuItem>
+        ))}
+      </Select>
+      {loading ? (
+        <Box className="flex items-center gap-2">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          <Button variant="outlined" onClick={onCancel}>Cancel</Button>
+        </Box>
+      ) : (
+        <Button onClick={onSearch} disabled={!canSearch}>Search</Button>
+      )}
+    </Box>
+  );
+}

--- a/client/src/components/FindVideos/components/__tests__/ResultsGrid.test.tsx
+++ b/client/src/components/FindVideos/components/__tests__/ResultsGrid.test.tsx
@@ -28,6 +28,42 @@ jest.mock('../ResultCard', () => ({
   },
 }));
 
+jest.mock('../ResultsTable', () => ({
+  __esModule: true,
+  default: function MockResultsTable(props: { results: { youtubeId: string; title: string }[]; onResultClick: (r: { youtubeId: string; title: string }) => void }) {
+    const React = require('react');
+    return React.createElement(
+      'div',
+      { 'data-testid': 'results-table' },
+      props.results.map((r) =>
+        React.createElement(
+          'button',
+          { key: r.youtubeId, onClick: () => props.onResultClick(r), 'data-testid': `row-${r.youtubeId}` },
+          r.title
+        )
+      )
+    );
+  },
+}));
+
+jest.mock('../ResultsListMobile', () => ({
+  __esModule: true,
+  default: function MockResultsListMobile(props: { results: { youtubeId: string; title: string }[]; onResultClick: (r: { youtubeId: string; title: string }) => void }) {
+    const React = require('react');
+    return React.createElement(
+      'div',
+      { 'data-testid': 'results-list-mobile' },
+      props.results.map((r) =>
+        React.createElement(
+          'button',
+          { key: r.youtubeId, onClick: () => props.onResultClick(r), 'data-testid': `card-mobile-${r.youtubeId}` },
+          r.title
+        )
+      )
+    );
+  },
+}));
+
 const ResultsGrid = require('../ResultsGrid').default;
 
 const baseProps = {
@@ -37,6 +73,7 @@ const baseProps = {
   hasSearched: false,
   lastQuery: '',
   pageSize: 25 as const,
+  viewMode: 'grid' as const,
   onResultClick: () => {},
   onRetry: () => {},
 };
@@ -84,5 +121,70 @@ describe('ResultsGrid', () => {
 
     fireEvent.click(screen.getByTestId('card-a'));
     expect(onResultClick).toHaveBeenCalledWith(results[0]);
+  });
+
+  test('viewMode=table on desktop: renders ResultsTable; click invokes onResultClick', () => {
+    const onResultClick = jest.fn();
+    const results = [
+      {
+        youtubeId: 'a', title: 'Alpha', channelName: 'C', channelId: null,
+        duration: null, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' as const,
+      },
+    ];
+    render(<ResultsGrid {...baseProps} hasSearched viewMode="table" results={results} onResultClick={onResultClick} />);
+    expect(screen.getByTestId('results-table')).toBeInTheDocument();
+    expect(screen.queryByTestId('results-list-mobile')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('card-a')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('row-a'));
+    expect(onResultClick).toHaveBeenCalledWith(results[0]);
+  });
+
+  describe('on mobile viewport', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: (query: string) => ({
+          matches: query.includes('max-width: 767px'),
+          media: query,
+          onchange: null,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+        }),
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: (query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+        }),
+      });
+    });
+
+    test('viewMode=table renders ResultsListMobile instead of ResultsTable', () => {
+      const onResultClick = jest.fn();
+      const results = [
+        {
+          youtubeId: 'a', title: 'Alpha', channelName: 'C', channelId: null,
+          duration: null, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' as const,
+        },
+      ];
+      render(<ResultsGrid {...baseProps} hasSearched viewMode="table" results={results} onResultClick={onResultClick} />);
+      expect(screen.getByTestId('results-list-mobile')).toBeInTheDocument();
+      expect(screen.queryByTestId('results-table')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByTestId('card-mobile-a'));
+      expect(onResultClick).toHaveBeenCalledWith(results[0]);
+    });
   });
 });

--- a/client/src/components/FindVideos/components/__tests__/ResultsGrid.test.tsx
+++ b/client/src/components/FindVideos/components/__tests__/ResultsGrid.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('../../../ui', () => {
+  const React = require('react');
+  return {
+    Box: ({ children, ...rest }: { children?: React.ReactNode }) =>
+      React.createElement('div', rest, children),
+    Typography: ({ children, ...rest }: { children?: React.ReactNode }) =>
+      React.createElement('div', rest, children),
+    Alert: ({ children, action }: { children?: React.ReactNode; action?: React.ReactNode }) =>
+      React.createElement('div', { role: 'alert' }, children, action),
+    Button: ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) =>
+      React.createElement('button', { onClick }, children),
+    Skeleton: () => React.createElement('div', { 'data-testid': 'skeleton' }),
+  };
+});
+
+jest.mock('../ResultCard', () => ({
+  __esModule: true,
+  default: function MockResultCard(props: { result: { youtubeId: string; title: string }; onClick: () => void }) {
+    const React = require('react');
+    return React.createElement(
+      'button',
+      { onClick: props.onClick, 'data-testid': `card-${props.result.youtubeId}` },
+      props.result.title
+    );
+  },
+}));
+
+const ResultsGrid = require('../ResultsGrid').default;
+
+const baseProps = {
+  results: [],
+  loading: false,
+  error: null,
+  hasSearched: false,
+  lastQuery: '',
+  pageSize: 25 as const,
+  onResultClick: () => {},
+  onRetry: () => {},
+};
+
+describe('ResultsGrid', () => {
+  test('loading: renders pageSize skeleton placeholders', () => {
+    render(<ResultsGrid {...baseProps} loading pageSize={10} />);
+    // 3 skeletons per card (thumbnail + title + channel) * 10 cards = 30
+    expect(screen.getAllByTestId('skeleton')).toHaveLength(30);
+  });
+
+  test('error: renders message and Try again triggers onRetry', () => {
+    const onRetry = jest.fn();
+    render(<ResultsGrid {...baseProps} error="Search failed" onRetry={onRetry} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Search failed');
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  test('initial (no search yet): renders the prompt', () => {
+    render(<ResultsGrid {...baseProps} hasSearched={false} />);
+    expect(screen.getByText(/enter a search and click search/i)).toBeInTheDocument();
+  });
+
+  test('empty results: renders "No videos found for <query>"', () => {
+    render(<ResultsGrid {...baseProps} hasSearched results={[]} lastQuery="banana" />);
+    expect(screen.getByText(/no videos found for "banana"/i)).toBeInTheDocument();
+  });
+
+  test('results: renders one card per item; click invokes onResultClick', () => {
+    const onResultClick = jest.fn();
+    const results = [
+      {
+        youtubeId: 'a', title: 'Alpha', channelName: 'C', channelId: null,
+        duration: null, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' as const,
+      },
+      {
+        youtubeId: 'b', title: 'Bravo', channelName: 'C', channelId: null,
+        duration: null, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' as const,
+      },
+    ];
+    render(<ResultsGrid {...baseProps} hasSearched results={results} onResultClick={onResultClick} />);
+    expect(screen.getByTestId('card-a')).toHaveTextContent('Alpha');
+    expect(screen.getByTestId('card-b')).toHaveTextContent('Bravo');
+
+    fireEvent.click(screen.getByTestId('card-a'));
+    expect(onResultClick).toHaveBeenCalledWith(results[0]);
+  });
+});

--- a/client/src/components/FindVideos/components/__tests__/ResultsListMobile.test.tsx
+++ b/client/src/components/FindVideos/components/__tests__/ResultsListMobile.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import ResultsListMobile from '../ResultsListMobile';
+import { SearchResult } from '../../types';
+
+function makeResult(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    youtubeId: 'abc12345678',
+    title: 'Default Title',
+    channelName: 'Default Channel',
+    channelId: null,
+    duration: null,
+    thumbnailUrl: null,
+    publishedAt: null,
+    viewCount: null,
+    status: 'never_downloaded',
+    ...overrides,
+  };
+}
+
+describe('ResultsListMobile', () => {
+  test('renders one card per result with title and channel', () => {
+    const results = [
+      makeResult({ youtubeId: 'a', title: 'Alpha', channelName: 'Chan A' }),
+      makeResult({ youtubeId: 'b', title: 'Bravo', channelName: 'Chan B' }),
+    ];
+    render(<ResultsListMobile results={results} onResultClick={() => {}} />);
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
+    expect(screen.getByText('Chan A')).toBeInTheDocument();
+    expect(screen.getByText('Chan B')).toBeInTheDocument();
+  });
+
+  test('clicking a card invokes onResultClick with that result', () => {
+    const onResultClick = jest.fn();
+    const results = [makeResult({ youtubeId: 'x', title: 'Pick me' })];
+    render(<ResultsListMobile results={results} onResultClick={onResultClick} />);
+    const card = screen.getByRole('button', { name: /open pick me/i });
+    fireEvent.click(card);
+    expect(onResultClick).toHaveBeenCalledWith(results[0]);
+  });
+
+  test('pressing Enter or Space on a card invokes onResultClick', () => {
+    const onResultClick = jest.fn();
+    const results = [makeResult({ youtubeId: 'x', title: 'Pick me' })];
+    render(<ResultsListMobile results={results} onResultClick={onResultClick} />);
+    const card = screen.getByRole('button', { name: /open pick me/i });
+    fireEvent.keyDown(card, { key: 'Enter' });
+    fireEvent.keyDown(card, { key: ' ' });
+    expect(onResultClick).toHaveBeenCalledTimes(2);
+    expect(onResultClick).toHaveBeenLastCalledWith(results[0]);
+  });
+
+  test('other keys do not invoke onResultClick', () => {
+    const onResultClick = jest.fn();
+    const results = [makeResult({ youtubeId: 'x', title: 'Pick me' })];
+    render(<ResultsListMobile results={results} onResultClick={onResultClick} />);
+    const card = screen.getByRole('button', { name: /open pick me/i });
+    fireEvent.keyDown(card, { key: 'Tab' });
+    fireEvent.keyDown(card, { key: 'a' });
+    expect(onResultClick).not.toHaveBeenCalled();
+  });
+
+  test('renders clock-style duration overlay when duration is set', () => {
+    const results = [makeResult({ youtubeId: 'a', title: 'Alpha', duration: 3723 })];
+    render(<ResultsListMobile results={results} onResultClick={() => {}} />);
+    const card = screen.getByRole('button', { name: /open alpha/i });
+    expect(within(card).getByText('1:02:03')).toBeInTheDocument();
+  });
+
+  test('omits duration overlay when duration is null', () => {
+    const results = [makeResult({ youtubeId: 'a', title: 'Alpha', duration: null })];
+    render(<ResultsListMobile results={results} onResultClick={() => {}} />);
+    const card = screen.getByRole('button', { name: /open alpha/i });
+    expect(within(card).queryByText('-')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/FindVideos/components/__tests__/ResultsTable.test.tsx
+++ b/client/src/components/FindVideos/components/__tests__/ResultsTable.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import ResultsTable from '../ResultsTable';
+import { SearchResult } from '../../types';
+
+function makeResult(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    youtubeId: 'abc12345678',
+    title: 'Default Title',
+    channelName: 'Default Channel',
+    channelId: null,
+    duration: null,
+    thumbnailUrl: null,
+    publishedAt: null,
+    viewCount: null,
+    status: 'never_downloaded',
+    ...overrides,
+  };
+}
+
+describe('ResultsTable', () => {
+  test('renders one row per result with title and channel', () => {
+    const results = [
+      makeResult({ youtubeId: 'a', title: 'Alpha', channelName: 'Chan A' }),
+      makeResult({ youtubeId: 'b', title: 'Bravo', channelName: 'Chan B' }),
+    ];
+    render(<ResultsTable results={results} onResultClick={() => {}} />);
+    const rows = screen.getAllByRole('row');
+    // 1 header row + 2 data rows
+    expect(rows).toHaveLength(3);
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
+    expect(screen.getByText('Chan A')).toBeInTheDocument();
+    expect(screen.getByText('Chan B')).toBeInTheDocument();
+  });
+
+  test('clicking a row invokes onResultClick with that result', () => {
+    const onResultClick = jest.fn();
+    const results = [makeResult({ youtubeId: 'x', title: 'Pick me' })];
+    render(<ResultsTable results={results} onResultClick={onResultClick} />);
+    const row = screen.getByRole('row', { name: /open pick me/i });
+    fireEvent.click(row);
+    expect(onResultClick).toHaveBeenCalledWith(results[0]);
+  });
+
+  test('shows N/A when publishedAt is null and - when duration is null', () => {
+    const results = [makeResult({ youtubeId: 'a', title: 'Alpha' })];
+    render(<ResultsTable results={results} onResultClick={() => {}} />);
+    const row = screen.getByRole('row', { name: /open alpha/i });
+    expect(within(row).getByText('N/A')).toBeInTheDocument();
+    expect(within(row).getByText('-')).toBeInTheDocument();
+  });
+
+  test('formats duration as m:ss when under an hour and h:mm:ss otherwise', () => {
+    const results = [
+      makeResult({ youtubeId: 'short', title: 'Short', duration: 125 }),
+      makeResult({ youtubeId: 'long', title: 'Long', duration: 3723 }),
+    ];
+    render(<ResultsTable results={results} onResultClick={() => {}} />);
+    const shortRow = screen.getByRole('row', { name: /open short/i });
+    const longRow = screen.getByRole('row', { name: /open long/i });
+    expect(within(shortRow).getByText('2:05')).toBeInTheDocument();
+    expect(within(longRow).getByText('1:02:03')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/FindVideos/components/__tests__/SearchBar.test.tsx
+++ b/client/src/components/FindVideos/components/__tests__/SearchBar.test.tsx
@@ -2,53 +2,41 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import SearchBar from '../SearchBar';
 
+const baseProps = {
+  query: '',
+  pageSize: 25 as const,
+  loading: false,
+  viewMode: 'grid' as const,
+  onQueryChange: () => {},
+  onPageSizeChange: () => {},
+  onViewModeChange: () => {},
+  onSearch: () => {},
+  onCancel: () => {},
+};
+
 describe('SearchBar', () => {
   test('Search button is disabled when input is empty', () => {
-    render(
-      <SearchBar
-        query="" pageSize={25} loading={false}
-        onQueryChange={() => {}} onPageSizeChange={() => {}}
-        onSearch={() => {}} onCancel={() => {}}
-      />
-    );
-    expect(screen.getByRole('button', { name: /search/i })).toBeDisabled();
+    render(<SearchBar {...baseProps} />);
+    expect(screen.getByRole('button', { name: /^search$/i })).toBeDisabled();
   });
 
   test('clicking Search calls onSearch', () => {
     const onSearch = jest.fn();
-    render(
-      <SearchBar
-        query="minecraft" pageSize={25} loading={false}
-        onQueryChange={() => {}} onPageSizeChange={() => {}}
-        onSearch={onSearch} onCancel={() => {}}
-      />
-    );
-    fireEvent.click(screen.getByRole('button', { name: /search/i }));
+    render(<SearchBar {...baseProps} query="minecraft" onSearch={onSearch} />);
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
     expect(onSearch).toHaveBeenCalled();
   });
 
   test('Enter triggers onSearch when not loading', () => {
     const onSearch = jest.fn();
-    render(
-      <SearchBar
-        query="minecraft" pageSize={25} loading={false}
-        onQueryChange={() => {}} onPageSizeChange={() => {}}
-        onSearch={onSearch} onCancel={() => {}}
-      />
-    );
+    render(<SearchBar {...baseProps} query="minecraft" onSearch={onSearch} />);
     fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
     expect(onSearch).toHaveBeenCalled();
   });
 
   test('whole bar locks during loading; Cancel button visible', () => {
     const onCancel = jest.fn();
-    render(
-      <SearchBar
-        query="minecraft" pageSize={25} loading={true}
-        onQueryChange={() => {}} onPageSizeChange={() => {}}
-        onSearch={() => {}} onCancel={onCancel}
-      />
-    );
+    render(<SearchBar {...baseProps} query="minecraft" loading onCancel={onCancel} />);
     expect(screen.getByRole('textbox')).toBeDisabled();
     expect(screen.queryByRole('button', { name: /^search$/i })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
@@ -57,14 +45,17 @@ describe('SearchBar', () => {
 
   test('Enter is a no-op while loading', () => {
     const onSearch = jest.fn();
-    render(
-      <SearchBar
-        query="minecraft" pageSize={25} loading={true}
-        onQueryChange={() => {}} onPageSizeChange={() => {}}
-        onSearch={onSearch} onCancel={() => {}}
-      />
-    );
+    render(<SearchBar {...baseProps} query="minecraft" loading onSearch={onSearch} />);
     fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
     expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  test('view toggle: current mode is pressed; clicking the other calls onViewModeChange', () => {
+    const onViewModeChange = jest.fn();
+    render(<SearchBar {...baseProps} viewMode="grid" onViewModeChange={onViewModeChange} />);
+    expect(screen.getByRole('button', { name: /grid view/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /table view/i })).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(screen.getByRole('button', { name: /table view/i }));
+    expect(onViewModeChange).toHaveBeenCalledWith('table');
   });
 });

--- a/client/src/components/FindVideos/components/__tests__/SearchBar.test.tsx
+++ b/client/src/components/FindVideos/components/__tests__/SearchBar.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchBar from '../SearchBar';
+
+describe('SearchBar', () => {
+  test('Search button is disabled when input is empty', () => {
+    render(
+      <SearchBar
+        query="" pageSize={25} loading={false}
+        onQueryChange={() => {}} onPageSizeChange={() => {}}
+        onSearch={() => {}} onCancel={() => {}}
+      />
+    );
+    expect(screen.getByRole('button', { name: /search/i })).toBeDisabled();
+  });
+
+  test('clicking Search calls onSearch', () => {
+    const onSearch = jest.fn();
+    render(
+      <SearchBar
+        query="minecraft" pageSize={25} loading={false}
+        onQueryChange={() => {}} onPageSizeChange={() => {}}
+        onSearch={onSearch} onCancel={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /search/i }));
+    expect(onSearch).toHaveBeenCalled();
+  });
+
+  test('Enter triggers onSearch when not loading', () => {
+    const onSearch = jest.fn();
+    render(
+      <SearchBar
+        query="minecraft" pageSize={25} loading={false}
+        onQueryChange={() => {}} onPageSizeChange={() => {}}
+        onSearch={onSearch} onCancel={() => {}}
+      />
+    );
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+    expect(onSearch).toHaveBeenCalled();
+  });
+
+  test('whole bar locks during loading; Cancel button visible', () => {
+    const onCancel = jest.fn();
+    render(
+      <SearchBar
+        query="minecraft" pageSize={25} loading={true}
+        onQueryChange={() => {}} onPageSizeChange={() => {}}
+        onSearch={() => {}} onCancel={onCancel}
+      />
+    );
+    expect(screen.getByRole('textbox')).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /^search$/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  test('Enter is a no-op while loading', () => {
+    const onSearch = jest.fn();
+    render(
+      <SearchBar
+        query="minecraft" pageSize={25} loading={true}
+        onQueryChange={() => {}} onPageSizeChange={() => {}}
+        onSearch={onSearch} onCancel={() => {}}
+      />
+    );
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/FindVideos/hooks/__tests__/useVideoSearch.test.ts
+++ b/client/src/components/FindVideos/hooks/__tests__/useVideoSearch.test.ts
@@ -1,0 +1,83 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+jest.mock('axios', () => ({
+  post: jest.fn(),
+  isCancel: (err: unknown) => Boolean(err && (err as { name?: string }).name === 'CanceledError'),
+  CanceledError: class CanceledError extends Error {
+    constructor() { super('canceled'); this.name = 'CanceledError'; }
+  },
+}));
+
+const axios = require('axios');
+const { useVideoSearch } = require('../useVideoSearch');
+
+describe('useVideoSearch', () => {
+  beforeEach(() => { jest.clearAllMocks(); });
+
+  test('happy path: search resolves with results', async () => {
+    axios.post.mockResolvedValueOnce({ data: { results: [{ youtubeId: 'a', title: 'A' }] } });
+    const { result } = renderHook(() => useVideoSearch('token'));
+
+    await act(async () => { await result.current.search('minecraft', 25); });
+    expect(result.current.results).toEqual([{ youtubeId: 'a', title: 'A' }]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('single in-flight: second search while loading is ignored', async () => {
+    let resolveFirst: (v: unknown) => void = () => {};
+    axios.post.mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }));
+
+    const { result } = renderHook(() => useVideoSearch('token'));
+
+    act(() => { result.current.search('first', 25); });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    act(() => { result.current.search('second', 25); });
+    expect(axios.post).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirst({ data: { results: [] } });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+  });
+
+  test('cancel aborts the request and clears state without setting error', async () => {
+    axios.post.mockImplementationOnce((_url: string, _body: unknown, opts: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () => reject(new axios.CanceledError()));
+      })
+    );
+
+    const { result } = renderHook(() => useVideoSearch('token'));
+    act(() => { result.current.search('x', 25); });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    await act(async () => { result.current.cancel(); });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+  });
+
+  test('non-cancel error sets error message', async () => {
+    axios.post.mockRejectedValueOnce({ response: { status: 502, data: { error: 'Search failed' } } });
+    const { result } = renderHook(() => useVideoSearch('token'));
+    await act(async () => { await result.current.search('x', 25); });
+    expect(result.current.error).toBe('Search failed');
+    expect(result.current.loading).toBe(false);
+  });
+
+  test('unmount aborts in-flight request', async () => {
+    let signalRef: AbortSignal | undefined;
+    axios.post.mockImplementationOnce((_url: string, _body: unknown, opts: { signal?: AbortSignal }) => {
+      signalRef = opts.signal;
+      return new Promise(() => {});
+    });
+    const { result, unmount } = renderHook(() => useVideoSearch('token'));
+    act(() => { result.current.search('x', 25); });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    unmount();
+    expect(signalRef?.aborted).toBe(true);
+  });
+});

--- a/client/src/components/FindVideos/hooks/useVideoSearch.ts
+++ b/client/src/components/FindVideos/hooks/useVideoSearch.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import { SearchResult, PageSize } from '../types';
+
+interface UseVideoSearchResult {
+  results: SearchResult[];
+  loading: boolean;
+  error: string | null;
+  search: (query: string, count: PageSize) => Promise<void>;
+  cancel: () => void;
+}
+
+export function useVideoSearch(token: string | null): UseVideoSearchResult {
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => { controllerRef.current?.abort(); };
+  }, []);
+
+  const search = useCallback(async (query: string, count: PageSize) => {
+    if (controllerRef.current) return;
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await axios.post(
+        '/api/videos/search',
+        { query, count },
+        {
+          headers: token ? { 'x-access-token': token } : undefined,
+          signal: controller.signal,
+        }
+      );
+      setResults(res.data.results || []);
+    } catch (err: unknown) {
+      if (axios.isCancel(err)) {
+        // user canceled; do not surface as error
+      } else {
+        const message = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
+          || 'Search failed';
+        setError(message);
+      }
+    } finally {
+      controllerRef.current = null;
+      setLoading(false);
+    }
+  }, [token]);
+
+  const cancel = useCallback(() => {
+    controllerRef.current?.abort();
+  }, []);
+
+  return { results, loading, error, search, cancel };
+}

--- a/client/src/components/FindVideos/index.tsx
+++ b/client/src/components/FindVideos/index.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { Box, Typography } from '../ui';
+import VideoModal from '../shared/VideoModal';
+import { VideoModalData } from '../shared/VideoModal/types';
+import SearchBar from './components/SearchBar';
+import ResultsGrid from './components/ResultsGrid';
+import { useVideoSearch } from './hooks/useVideoSearch';
+import { DEFAULT_PAGE_SIZE, PageSize, SearchResult } from './types';
+
+interface FindVideosProps {
+  token: string | null;
+}
+
+function toModalData(r: SearchResult): VideoModalData {
+  return {
+    youtubeId: r.youtubeId,
+    title: r.title,
+    channelName: r.channelName,
+    thumbnailUrl: r.thumbnailUrl || '',
+    duration: r.duration,
+    publishedAt: r.publishedAt,
+    addedAt: null,
+    mediaType: 'video',
+    status: r.status,
+    isDownloaded: r.status === 'downloaded',
+    filePath: null,
+    fileSize: null,
+    audioFilePath: null,
+    audioFileSize: null,
+    isProtected: false,
+    isIgnored: false,
+    normalizedRating: null,
+    ratingSource: null,
+    databaseId: null,
+    channelId: r.channelId,
+  };
+}
+
+export default function FindVideos({ token }: FindVideosProps) {
+  const [query, setQuery] = useState('');
+  const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [modalVideo, setModalVideo] = useState<VideoModalData | null>(null);
+  const lastQueryRef = useRef('');
+  const lastPageSizeRef = useRef<PageSize>(DEFAULT_PAGE_SIZE);
+
+  const { results, loading, error, search, cancel } = useVideoSearch(token);
+
+  const doSearch = useCallback(() => {
+    const trimmed = query.trim();
+    if (!trimmed) return;
+    lastQueryRef.current = trimmed;
+    lastPageSizeRef.current = pageSize;
+    setHasSearched(true);
+    search(trimmed, pageSize);
+  }, [query, pageSize, search]);
+
+  const onRetry = useCallback(() => {
+    if (!lastQueryRef.current) return;
+    search(lastQueryRef.current, lastPageSizeRef.current);
+  }, [search]);
+
+  return (
+    <Box className="flex flex-col gap-4 py-4">
+      <Typography variant="h5">Find on YouTube</Typography>
+      <SearchBar
+        query={query}
+        pageSize={pageSize}
+        loading={loading}
+        onQueryChange={setQuery}
+        onPageSizeChange={setPageSize}
+        onSearch={doSearch}
+        onCancel={cancel}
+      />
+      <ResultsGrid
+        results={results}
+        loading={loading}
+        error={error}
+        hasSearched={hasSearched}
+        lastQuery={lastQueryRef.current}
+        pageSize={pageSize}
+        onResultClick={(r) => setModalVideo(toModalData(r))}
+        onRetry={onRetry}
+      />
+      {modalVideo && (
+        <VideoModal
+          open={modalVideo !== null}
+          onClose={() => setModalVideo(null)}
+          video={modalVideo}
+          token={token}
+          allowIgnore={false}
+        />
+      )}
+    </Box>
+  );
+}

--- a/client/src/components/FindVideos/index.tsx
+++ b/client/src/components/FindVideos/index.tsx
@@ -84,7 +84,7 @@ export default function FindVideos({ token }: FindVideosProps) {
       />
       {modalVideo && (
         <VideoModal
-          open={modalVideo !== null}
+          open
           onClose={() => setModalVideo(null)}
           video={modalVideo}
           token={token}

--- a/client/src/components/FindVideos/index.tsx
+++ b/client/src/components/FindVideos/index.tsx
@@ -2,10 +2,11 @@ import React, { useCallback, useRef, useState } from 'react';
 import { Box, Typography } from '../ui';
 import VideoModal from '../shared/VideoModal';
 import { VideoModalData } from '../shared/VideoModal/types';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
 import SearchBar from './components/SearchBar';
 import ResultsGrid from './components/ResultsGrid';
 import { useVideoSearch } from './hooks/useVideoSearch';
-import { DEFAULT_PAGE_SIZE, PageSize, SearchResult } from './types';
+import { DEFAULT_PAGE_SIZE, PageSize, SearchResult, ViewMode } from './types';
 
 interface FindVideosProps {
   token: string | null;
@@ -19,27 +20,29 @@ function toModalData(r: SearchResult): VideoModalData {
     thumbnailUrl: r.thumbnailUrl || '',
     duration: r.duration,
     publishedAt: r.publishedAt,
-    addedAt: null,
+    addedAt: r.addedAt ?? null,
     mediaType: 'video',
     status: r.status,
     isDownloaded: r.status === 'downloaded',
-    filePath: null,
-    fileSize: null,
-    audioFilePath: null,
-    audioFileSize: null,
-    isProtected: false,
+    filePath: r.filePath ?? null,
+    fileSize: r.fileSize ?? null,
+    audioFilePath: r.audioFilePath ?? null,
+    audioFileSize: r.audioFileSize ?? null,
+    isProtected: r.isProtected ?? false,
     isIgnored: false,
-    normalizedRating: null,
-    ratingSource: null,
-    databaseId: null,
+    normalizedRating: r.normalizedRating ?? null,
+    ratingSource: r.ratingSource ?? null,
+    databaseId: r.databaseId ?? null,
     channelId: r.channelId,
   };
 }
 
 export default function FindVideos({ token }: FindVideosProps) {
+  const isMobile = useMediaQuery('(max-width: 767px)');
   const [query, setQuery] = useState('');
   const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
   const [hasSearched, setHasSearched] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>(isMobile ? 'table' : 'grid');
   const [modalVideo, setModalVideo] = useState<VideoModalData | null>(null);
   const lastQueryRef = useRef('');
   const lastPageSizeRef = useRef<PageSize>(DEFAULT_PAGE_SIZE);
@@ -67,8 +70,10 @@ export default function FindVideos({ token }: FindVideosProps) {
         query={query}
         pageSize={pageSize}
         loading={loading}
+        viewMode={viewMode}
         onQueryChange={setQuery}
         onPageSizeChange={setPageSize}
+        onViewModeChange={setViewMode}
         onSearch={doSearch}
         onCancel={cancel}
       />
@@ -79,6 +84,7 @@ export default function FindVideos({ token }: FindVideosProps) {
         hasSearched={hasSearched}
         lastQuery={lastQueryRef.current}
         pageSize={pageSize}
+        viewMode={viewMode}
         onResultClick={(r) => setModalVideo(toModalData(r))}
         onRetry={onRetry}
       />

--- a/client/src/components/FindVideos/types.ts
+++ b/client/src/components/FindVideos/types.ts
@@ -1,0 +1,17 @@
+export type SearchResultStatus = 'downloaded' | 'missing' | 'never_downloaded';
+
+export interface SearchResult {
+  youtubeId: string;
+  title: string;
+  channelName: string;
+  channelId: string | null;
+  duration: number | null;
+  thumbnailUrl: string | null;
+  publishedAt: string | null;
+  viewCount: number | null;
+  status: SearchResultStatus;
+}
+
+export type PageSize = 10 | 25 | 50;
+export const PAGE_SIZES: PageSize[] = [10, 25, 50];
+export const DEFAULT_PAGE_SIZE: PageSize = 25;

--- a/client/src/components/FindVideos/types.ts
+++ b/client/src/components/FindVideos/types.ts
@@ -10,8 +10,22 @@ export interface SearchResult {
   publishedAt: string | null;
   viewCount: number | null;
   status: SearchResultStatus;
+  databaseId?: number | null;
+  filePath?: string | null;
+  fileSize?: number | null;
+  audioFilePath?: string | null;
+  audioFileSize?: number | null;
+  addedAt?: string | null;
+  isProtected?: boolean;
+  normalizedRating?: string | null;
+  ratingSource?: string | null;
 }
 
 export type PageSize = 10 | 25 | 50;
 export const PAGE_SIZES: PageSize[] = [10, 25, 50];
 export const DEFAULT_PAGE_SIZE: PageSize = 25;
+
+export type ViewMode = 'grid' | 'table';
+
+export const THUMB_WIDTH = 120;
+export const THUMB_HEIGHT = 67;

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -96,6 +96,14 @@ export function AppShell({
     []
   );
 
+  const videosSubItems = useMemo(
+    () => [
+      { key: 'videos-downloaded', label: 'Downloaded Videos', to: '/videos' },
+      { key: 'videos-find', label: 'Find on YouTube', to: '/videos/find' },
+    ],
+    []
+  );
+
   const settingsSubItems = useMemo(
     () =>
       SETTINGS_PAGES.map((page) => ({
@@ -123,6 +131,7 @@ export function AppShell({
           oldLabel: 'Downloaded Videos',
           icon: <VideoLibraryIcon />,
           to: '/videos',
+          subItems: videosSubItems,
         },
         {
           key: 'downloads' as const,
@@ -141,7 +150,7 @@ export function AppShell({
           subItems: settingsSubItems,
         },
       ],
-    [channelsSubItems, downloadsSubItems, settingsSubItems]
+    [channelsSubItems, videosSubItems, downloadsSubItems, settingsSubItems]
   );
 
   const toggleDrawer = () => {

--- a/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
+++ b/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
@@ -352,8 +352,8 @@ describe('VideoModal', () => {
 
       await waitFor(() => {
         expect(axios.post).toHaveBeenCalledWith(
-          '/api/channels/videos/test123/ignore',
-          { ignored: true },
+          '/api/channels/UC123/videos/test123/ignore',
+          undefined,
           { headers: { 'x-access-token': 'test-token' } }
         );
       });

--- a/client/src/components/shared/VideoModal/components/VideoActions.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoActions.tsx
@@ -31,6 +31,7 @@ interface VideoActionsProps {
   onRatingClick: () => void;
   protectionLoading: boolean;
   isMobile: boolean;
+  allowIgnore?: boolean;
 }
 
 function VideoActions({
@@ -42,11 +43,12 @@ function VideoActions({
   onRatingClick,
   protectionLoading,
   isMobile,
+  allowIgnore = true,
 }: VideoActionsProps) {
   const isDownloadedAndPresent = video.isDownloaded && video.status !== 'missing';
   const showProtect = isDownloadedAndPresent;
   const showDownload = !isDownloadedAndPresent;
-  const showIgnore = !isDownloadedAndPresent || video.isIgnored;
+  const showIgnore = (!isDownloadedAndPresent || video.isIgnored) && allowIgnore;
   const showDelete = video.isDownloaded || video.status === 'missing';
   const mediaTypeInfo = getMediaTypeInfo(video.mediaType);
   const statusLabel = video.status === 'downloaded' ? 'Available' : getStatusLabel(video.status);

--- a/client/src/components/shared/VideoModal/hooks/useVideoModalActions.ts
+++ b/client/src/components/shared/VideoModal/hooks/useVideoModalActions.ts
@@ -137,12 +137,17 @@ export function useVideoModalActions({
   }, [localVideo.youtubeId, token, deletion, showSnackbar, onVideoDeleted, onClose]);
 
   const handleIgnoreToggle = useCallback(async () => {
+    if (!localVideo.channelId) {
+      showSnackbar('Cannot ignore: video has no channel context', 'error');
+      return;
+    }
     const newIgnored = !localVideo.isIgnored;
+    const action = newIgnored ? 'ignore' : 'unignore';
 
     try {
       await axios.post(
-        `/api/channels/videos/${localVideo.youtubeId}/ignore`,
-        { ignored: newIgnored },
+        `/api/channels/${localVideo.channelId}/videos/${localVideo.youtubeId}/${action}`,
+        undefined,
         { headers: { 'x-access-token': token || '' } }
       );
 
@@ -159,7 +164,7 @@ export function useVideoModalActions({
     } catch (err: unknown) {
       showSnackbar(extractErrorMessage(err, 'Failed to update ignore status'), 'error');
     }
-  }, [localVideo.isIgnored, localVideo.youtubeId, token, showSnackbar, onIgnoreChanged]);
+  }, [localVideo.isIgnored, localVideo.youtubeId, localVideo.channelId, token, showSnackbar, onIgnoreChanged]);
 
   const handleDownloadConfirm = useCallback(async (settings: DownloadSettings | null) => {
     setDownloadDialogOpen(false);

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -36,6 +36,7 @@ function VideoModal({
   onIgnoreChanged,
   onDownloadQueued,
   onRatingChanged,
+  allowIgnore,
 }: VideoModalProps) {
   const isMobile = useMediaQuery('(max-width: 599px)');
 
@@ -200,6 +201,7 @@ function VideoModal({
               onRatingClick={() => setRatingDialogOpen(true)}
               protectionLoading={protectionLoading}
               isMobile={isMobile}
+              allowIgnore={allowIgnore}
             />
             <VideoMetadata
               video={localVideo}

--- a/client/src/components/shared/VideoModal/types.ts
+++ b/client/src/components/shared/VideoModal/types.ts
@@ -33,6 +33,7 @@ export interface VideoModalProps {
   onIgnoreChanged?: (youtubeId: string, isIgnored: boolean) => void;
   onDownloadQueued?: (youtubeId: string) => void;
   onRatingChanged?: (youtubeId: string, rating: string | null) => void;
+  allowIgnore?: boolean;
 }
 
 export interface VideoExtendedMetadata {

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -6,6 +6,15 @@ export const formatDuration = (duration: number | null) => {
   return hours > 0 ? `${hours}h${minutes}m` : `${minutes}m`;
 };
 
+export const formatDurationClock = (seconds: number | null): string => {
+  if (!seconds || seconds <= 0) return '';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return `${m}:${String(s).padStart(2, '0')}`;
+};
+
 // Format a date like YYYYMMDD to m/d/YYYY
 // strip leading zeros from month and day
 export const formatYTDate = (date: string | null) => {

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -13,6 +13,7 @@ This guide provides step-by-step instructions for common tasks in Youtarr. After
 - [Re-download Missing Videos](#re-download-missing-videos)
 - [Organize Channels with Multi-Library Support](#organize-channels-with-multi-library-support)
 - [Browse and Filter Channel Videos](#browse-and-filter-channel-videos)
+- [Find Videos on YouTube](#find-videos-on-youtube)
 - [Preview and Play Videos](#preview-and-play-videos)
 - [External Access with API Keys](#external-access-with-api-keys)
 - [Content Ratings](#content-ratings)
@@ -344,6 +345,27 @@ Mark specific videos to exclude them from automatic channel downloads.
    - Ignored videos are tracked in `config/complete.list`
    - They won't appear in download recommendations
    - You can still manually download them if you change your mind
+
+## Find Videos on YouTube
+
+Search YouTube from inside Youtarr and see which results you already have, which are missing, and which are new.
+
+1. **Open Find on YouTube**
+   - On the Videos page, click the "Find on YouTube" toggle
+   - Enter a search query (up to 200 characters)
+   - Pick a result count (10, 25, or 50) and click Search
+
+2. **Results**
+   - Sorted newest-to-oldest by YouTube's approximate publish date (accurate to within a day or two, same fidelity as the channel videos page)
+   - Each card shows the channel, duration, upload date, and a status chip:
+     - **Downloaded**: already in your library
+     - **Missing**: previously downloaded but removed from disk
+     - **Not Downloaded**: new result, not yet saved
+   - Click a result to open the video detail modal, where you can download, play (if downloaded), or ignore it
+
+3. **Notes**
+   - Rate-limited to 10 searches per minute per session; server-side timeout is 60 seconds
+   - Nothing is persisted from the search itself, only videos you download get saved
 
 ## Preview and Play Videos
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -351,7 +351,7 @@ Mark specific videos to exclude them from automatic channel downloads.
 Search YouTube from inside Youtarr and see which results you already have, which are missing, and which are new.
 
 1. **Open Find on YouTube**
-   - On the Videos page, click the "Find on YouTube" toggle
+   - In the sidebar, expand **Videos** and click **Find on YouTube**
    - Enter a search query (up to 200 characters)
    - Pick a result count (10, 25, or 50) and click Search
 

--- a/server/__tests__/server.additional-routes.test.js
+++ b/server/__tests__/server.additional-routes.test.js
@@ -292,6 +292,12 @@ const createServerModule = ({
           init: jest.fn(),
           ImportInProgressError: class ImportInProgressError extends Error {}
         }));
+        jest.doMock('../modules/videoSearchModule', () => ({
+          searchVideos: jest.fn().mockResolvedValue([]),
+          ALLOWED_COUNTS: [10, 25, 50],
+          SearchCanceledError: class SearchCanceledError extends Error {},
+          SearchTimeoutError: class SearchTimeoutError extends Error {},
+        }));
         jest.doMock('../modules/messageEmitter', () => ({
           emitMessage: jest.fn(),
           getLastMessages: jest.fn(() => [])

--- a/server/__tests__/server.apikeys.test.js
+++ b/server/__tests__/server.apikeys.test.js
@@ -278,6 +278,12 @@ const createServerModule = ({
           init: jest.fn(),
           ImportInProgressError: class ImportInProgressError extends Error {}
         }));
+        jest.doMock('../modules/videoSearchModule', () => ({
+          searchVideos: jest.fn().mockResolvedValue([]),
+          ALLOWED_COUNTS: [10, 25, 50],
+          SearchCanceledError: class SearchCanceledError extends Error {},
+          SearchTimeoutError: class SearchTimeoutError extends Error {},
+        }));
         jest.doMock('../modules/messageEmitter', () => ({
           emitMessage: jest.fn(),
           getLastMessages: jest.fn(() => [])

--- a/server/__tests__/server.auth-sessions.test.js
+++ b/server/__tests__/server.auth-sessions.test.js
@@ -232,6 +232,12 @@ const createServerModule = ({
           init: jest.fn(),
           ImportInProgressError: class ImportInProgressError extends Error {}
         }));
+        jest.doMock('../modules/videoSearchModule', () => ({
+          searchVideos: jest.fn().mockResolvedValue([]),
+          ALLOWED_COUNTS: [10, 25, 50],
+          SearchCanceledError: class SearchCanceledError extends Error {},
+          SearchTimeoutError: class SearchTimeoutError extends Error {},
+        }));
         jest.doMock('../modules/messageEmitter', () => ({
           emitMessage: jest.fn(),
           getLastMessages: jest.fn(() => [])

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -348,6 +348,12 @@ const createServerModule = ({
           init: jest.fn(),
           ImportInProgressError: class ImportInProgressError extends Error {}
         }));
+        jest.doMock('../modules/videoSearchModule', () => ({
+          searchVideos: jest.fn().mockResolvedValue([]),
+          ALLOWED_COUNTS: [10, 25, 50],
+          SearchCanceledError: class SearchCanceledError extends Error {},
+          SearchTimeoutError: class SearchTimeoutError extends Error {},
+        }));
         jest.doMock('../modules/messageEmitter', () => ({
           emitMessage: jest.fn(),
           getLastMessages: jest.fn(() => [])

--- a/server/modules/__tests__/videoSearchModule.test.js
+++ b/server/modules/__tests__/videoSearchModule.test.js
@@ -111,8 +111,92 @@ describe('videoSearchModule', () => {
       expect(results.find(r => r.youtubeId === 'ccccccccccc').status).toBe('never_downloaded');
       expect(Video.findAll).toHaveBeenCalledWith(expect.objectContaining({
         where: expect.objectContaining({ youtubeId: ['aaaaaaaaaaa', 'bbbbbbbbbbb', 'ccccccccccc'] }),
-        attributes: ['youtubeId', 'removed'],
+        attributes: expect.arrayContaining([
+          'id',
+          'youtubeId',
+          'removed',
+          'filePath',
+          'fileSize',
+          'audioFilePath',
+          'audioFileSize',
+          'last_downloaded_at',
+          'protected',
+          'normalized_rating',
+          'rating_source',
+        ]),
       }));
+    });
+
+    test('attaches file paths, sizes, rating, protection, and addedAt for downloaded results', async () => {
+      const downloadedAt = new Date('2025-07-02T12:34:56.000Z');
+      Video.findAll.mockResolvedValueOnce([
+        {
+          id: 42,
+          youtubeId: 'aaaaaaaaaaa',
+          removed: false,
+          filePath: '/usr/src/app/data/chan/video.mp4',
+          fileSize: 1234567,
+          audioFilePath: null,
+          audioFileSize: null,
+          last_downloaded_at: downloadedAt,
+          protected: true,
+          normalized_rating: 'PG-13',
+          rating_source: 'yt-dlp',
+        },
+      ]);
+
+      const ndjson = JSON.stringify({ id: 'aaaaaaaaaaa', title: 'A' }) + '\n';
+      ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+      const [result] = await videoSearchModule.searchVideos('test', 10, {});
+      expect(result).toMatchObject({
+        youtubeId: 'aaaaaaaaaaa',
+        status: 'downloaded',
+        databaseId: 42,
+        filePath: '/usr/src/app/data/chan/video.mp4',
+        fileSize: 1234567,
+        audioFilePath: null,
+        audioFileSize: null,
+        addedAt: downloadedAt.toISOString(),
+        isProtected: true,
+        normalizedRating: 'PG-13',
+        ratingSource: 'yt-dlp',
+      });
+    });
+
+    test('leaves enrichment fields absent on never_downloaded results', async () => {
+      Video.findAll.mockResolvedValueOnce([]);
+      const ndjson = JSON.stringify({ id: 'aaaaaaaaaaa', title: 'A' }) + '\n';
+      ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+      const [result] = await videoSearchModule.searchVideos('test', 10, {});
+      expect(result.status).toBe('never_downloaded');
+      expect(result.databaseId).toBeUndefined();
+      expect(result.filePath).toBeUndefined();
+      expect(result.addedAt).toBeUndefined();
+    });
+
+    test('addedAt is null when last_downloaded_at is missing on the record', async () => {
+      Video.findAll.mockResolvedValueOnce([
+        {
+          id: 1,
+          youtubeId: 'aaaaaaaaaaa',
+          removed: false,
+          filePath: '/data/video.mp4',
+          fileSize: 100,
+          audioFilePath: null,
+          audioFileSize: null,
+          last_downloaded_at: null,
+          protected: false,
+          normalized_rating: null,
+          rating_source: null,
+        },
+      ]);
+      const ndjson = JSON.stringify({ id: 'aaaaaaaaaaa', title: 'A' }) + '\n';
+      ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+      const [result] = await videoSearchModule.searchVideos('test', 10, {});
+      expect(result.addedAt).toBeNull();
     });
   });
 

--- a/server/modules/__tests__/videoSearchModule.test.js
+++ b/server/modules/__tests__/videoSearchModule.test.js
@@ -1,0 +1,165 @@
+jest.mock('../ytDlpRunner', () => ({ run: jest.fn() }));
+jest.mock('../download/ytdlpCommandBuilder', () => ({
+  buildSearchArgs: jest.fn((q, c) => ['--flat-playlist', '--dump-json', `ytsearch${c}:${q}`]),
+}));
+jest.mock('../../models', () => ({
+  Video: { findAll: jest.fn().mockResolvedValue([]) },
+}));
+jest.mock('../../logger', () => ({
+  info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn(),
+  child: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
+}));
+
+describe('videoSearchModule', () => {
+  let videoSearchModule;
+  let ytDlpRunner;
+  let ytdlpCommandBuilder;
+  let Video;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    videoSearchModule = require('../videoSearchModule');
+    ytDlpRunner = require('../ytDlpRunner');
+    ytdlpCommandBuilder = require('../download/ytdlpCommandBuilder');
+    Video = require('../../models').Video;
+  });
+
+  test('parses NDJSON yt-dlp output into normalized search results', async () => {
+    const ndjson = JSON.stringify({
+      id: 'aaaaaaaaaaa',
+      title: 'Minecraft Lets Play',
+      channel: 'TestChannel',
+      channel_id: 'UC123',
+      duration: 600,
+      thumbnails: [{ url: 'https://i.ytimg.com/vi/aaaaaaaaaaa/hqdefault.jpg' }],
+      view_count: 1000,
+      timestamp: 1700000000,
+    }) + '\n';
+
+    ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+    const results = await videoSearchModule.searchVideos('Minecraft', 25, {});
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      youtubeId: 'aaaaaaaaaaa',
+      title: 'Minecraft Lets Play',
+      channelName: 'TestChannel',
+      channelId: 'UC123',
+      duration: 600,
+      thumbnailUrl: 'https://i.ytimg.com/vi/aaaaaaaaaaa/hqdefault.jpg',
+      viewCount: 1000,
+      status: 'never_downloaded',
+    });
+    expect(typeof results[0].publishedAt).toBe('string');
+  });
+
+  test('calls buildSearchArgs with query and count', async () => {
+    ytDlpRunner.run.mockResolvedValueOnce('');
+
+    await videoSearchModule.searchVideos('hello "world"', 10, {});
+
+    expect(ytdlpCommandBuilder.buildSearchArgs).toHaveBeenCalledWith('hello "world"', 10);
+  });
+
+  test('skips blank lines and lines that fail to parse', async () => {
+    const ndjson = '\nnot-json\n' + JSON.stringify({ id: 'bbbbbbbbbbb', title: 'OK' }) + '\n';
+    ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+    const results = await videoSearchModule.searchVideos('test', 10, {});
+    expect(results).toHaveLength(1);
+    expect(results[0].youtubeId).toBe('bbbbbbbbbbb');
+  });
+
+  test('throws SearchCanceledError when ytDlpRunner rejects with AbortError', async () => {
+    const abortErr = Object.assign(new Error('yt-dlp run aborted'), { name: 'AbortError', code: 'ABORT_ERR' });
+    ytDlpRunner.run.mockRejectedValueOnce(abortErr);
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      videoSearchModule.searchVideos('test', 10, { signal: controller.signal })
+    ).rejects.toBeInstanceOf(videoSearchModule.SearchCanceledError);
+  });
+
+  test('throws SearchTimeoutError when ytDlpRunner rejects with timeout message', async () => {
+    ytDlpRunner.run.mockRejectedValueOnce(new Error('yt-dlp process timed out after 60000ms'));
+
+    await expect(
+      videoSearchModule.searchVideos('test', 10, {})
+    ).rejects.toBeInstanceOf(videoSearchModule.SearchTimeoutError);
+  });
+
+  describe('local status cross-reference', () => {
+    test('marks results as downloaded, missing, or never_downloaded based on DB state', async () => {
+      Video.findAll.mockResolvedValueOnce([
+        { youtubeId: 'aaaaaaaaaaa', removed: false },
+        { youtubeId: 'bbbbbbbbbbb', removed: true },
+      ]);
+
+      const ndjson =
+        JSON.stringify({ id: 'aaaaaaaaaaa', title: 'A' }) + '\n' +
+        JSON.stringify({ id: 'bbbbbbbbbbb', title: 'B' }) + '\n' +
+        JSON.stringify({ id: 'ccccccccccc', title: 'C' }) + '\n';
+      ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+      const results = await videoSearchModule.searchVideos('test', 10, {});
+      expect(results.find(r => r.youtubeId === 'aaaaaaaaaaa').status).toBe('downloaded');
+      expect(results.find(r => r.youtubeId === 'bbbbbbbbbbb').status).toBe('missing');
+      expect(results.find(r => r.youtubeId === 'ccccccccccc').status).toBe('never_downloaded');
+      expect(Video.findAll).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({ youtubeId: ['aaaaaaaaaaa', 'bbbbbbbbbbb', 'ccccccccccc'] }),
+        attributes: ['youtubeId', 'removed'],
+      }));
+    });
+  });
+
+  describe('publishedAt derivation', () => {
+    test('uses timestamp when present', async () => {
+      const ndjson = JSON.stringify({ id: 'a', title: 'A', timestamp: 1_700_000_000 }) + '\n';
+      ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+      const [result] = await videoSearchModule.searchVideos('t', 10, {});
+      expect(result.publishedAt).toBe(new Date(1_700_000_000 * 1000).toISOString());
+    });
+
+    test('falls back to release_timestamp when timestamp is missing', async () => {
+      const ndjson = JSON.stringify({ id: 'a', title: 'A', release_timestamp: 1_600_000_000 }) + '\n';
+      ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+      const [result] = await videoSearchModule.searchVideos('t', 10, {});
+      expect(result.publishedAt).toBe(new Date(1_600_000_000 * 1000).toISOString());
+    });
+
+    test('falls back to upload_date (YYYYMMDD) when timestamps are missing', async () => {
+      const ndjson = JSON.stringify({ id: 'a', title: 'A', upload_date: '20250702' }) + '\n';
+      ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+      const [result] = await videoSearchModule.searchVideos('t', 10, {});
+      expect(result.publishedAt).toBe('2025-07-02T00:00:00.000Z');
+    });
+
+    test('is null when no date fields are present', async () => {
+      const ndjson = JSON.stringify({ id: 'a', title: 'A' }) + '\n';
+      ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+      const [result] = await videoSearchModule.searchVideos('t', 10, {});
+      expect(result.publishedAt).toBeNull();
+    });
+  });
+
+  describe('sorting', () => {
+    test('sorts results newest-to-oldest by publishedAt, with nulls last', async () => {
+      const ndjson =
+        JSON.stringify({ id: 'old', title: 'Old', timestamp: 1_600_000_000 }) + '\n' +
+        JSON.stringify({ id: 'nodate', title: 'NoDate' }) + '\n' +
+        JSON.stringify({ id: 'new', title: 'New', timestamp: 1_700_000_000 }) + '\n' +
+        JSON.stringify({ id: 'mid', title: 'Mid', timestamp: 1_650_000_000 }) + '\n';
+      ytDlpRunner.run.mockResolvedValueOnce(ndjson);
+
+      const results = await videoSearchModule.searchVideos('test', 10, {});
+      expect(results.map(r => r.youtubeId)).toEqual(['new', 'mid', 'old', 'nodate']);
+    });
+  });
+});

--- a/server/modules/__tests__/videoSearchModule.test.js
+++ b/server/modules/__tests__/videoSearchModule.test.js
@@ -83,8 +83,9 @@ describe('videoSearchModule', () => {
     ).rejects.toBeInstanceOf(videoSearchModule.SearchCanceledError);
   });
 
-  test('throws SearchTimeoutError when ytDlpRunner rejects with timeout message', async () => {
-    ytDlpRunner.run.mockRejectedValueOnce(new Error('yt-dlp process timed out after 60000ms'));
+  test('throws SearchTimeoutError when ytDlpRunner rejects with YTDLP_TIMEOUT code', async () => {
+    const timeoutErr = Object.assign(new Error('yt-dlp process timed out after 60000ms'), { code: 'YTDLP_TIMEOUT' });
+    ytDlpRunner.run.mockRejectedValueOnce(timeoutErr);
 
     await expect(
       videoSearchModule.searchVideos('test', 10, {})

--- a/server/modules/__tests__/ytDlpRunner.test.js
+++ b/server/modules/__tests__/ytDlpRunner.test.js
@@ -183,13 +183,16 @@ describe('YtDlpRunner', () => {
     });
   });
 
-  it('rejects when the process reports a timeout', async () => {
+  it('rejects with a YTDLP_TIMEOUT code when the process reports a timeout', async () => {
     const runPromise = ytDlpRunner.run(['--any'], { timeoutMs: 0 });
     const proc = getLastProcess();
 
     proc.emit('close', null);
 
-    await expect(runPromise).rejects.toThrow('yt-dlp process timed out after 0ms');
+    await expect(runPromise).rejects.toMatchObject({
+      message: 'yt-dlp process timed out after 0ms',
+      code: 'YTDLP_TIMEOUT',
+    });
   });
 
   it('rejects with stderr output when process exits with error code', async () => {

--- a/server/modules/__tests__/ytDlpRunner.test.js
+++ b/server/modules/__tests__/ytDlpRunner.test.js
@@ -281,4 +281,26 @@ describe('YtDlpRunner', () => {
     expect(runSpy).toHaveBeenCalled();
     runSpy.mockRestore();
   });
+
+  it('rejects with AbortError and kills process when signal aborts after spawn', async () => {
+    const controller = new AbortController();
+    const runPromise = ytDlpRunner.run(['--version'], { timeoutMs: 0, signal: controller.signal });
+    const proc = getLastProcess();
+
+    controller.abort();
+
+    await expect(runPromise).rejects.toMatchObject({ name: 'AbortError', code: 'ABORT_ERR' });
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('rejects immediately with AbortError when signal is already aborted before run', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const runPromise = ytDlpRunner.run(['--version'], { timeoutMs: 0, signal: controller.signal });
+    const proc = getLastProcess();
+
+    await expect(runPromise).rejects.toMatchObject({ name: 'AbortError', code: 'ABORT_ERR' });
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+  });
 });

--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -44,6 +44,58 @@ describe('YtdlpCommandBuilder', () => {
     tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
   });
 
+  describe('buildSearchArgs', () => {
+    it('returns argv with ytsearch<count>:<query> for given query and count', () => {
+      const result = YtdlpCommandBuilder.buildSearchArgs('Minecraft', 25);
+      expect(result).toContain('--flat-playlist');
+      expect(result).toContain('--dump-json');
+      expect(result).toContain('--no-warnings');
+      expect(result).toContain('--default-search');
+      expect(result).toContain('ytsearch');
+      expect(result).toContain('ytsearch25:Minecraft');
+      const extractorIdx = result.indexOf('--extractor-args');
+      expect(extractorIdx).toBeGreaterThanOrEqual(0);
+      expect(result[extractorIdx + 1]).toBe('youtubetab:approximate_date');
+    });
+
+    it('includes common args (-4, --paths temp:) from buildCommonArgs', () => {
+      const result = YtdlpCommandBuilder.buildSearchArgs('test', 10);
+      expect(result).toContain('-4');
+      const pathsIdx = result.indexOf('--paths');
+      expect(pathsIdx).toBeGreaterThanOrEqual(0);
+      expect(result[pathsIdx + 1]).toMatch(/^temp:/);
+    });
+
+    it('includes --proxy when config.proxy is set', () => {
+      mockConfig.proxy = 'http://proxy.local:8080';
+      const result = YtdlpCommandBuilder.buildSearchArgs('test', 10);
+      const proxyIdx = result.indexOf('--proxy');
+      expect(proxyIdx).toBeGreaterThanOrEqual(0);
+      expect(result[proxyIdx + 1]).toBe('http://proxy.local:8080');
+    });
+
+    it('does not include --sleep-requests (search is one-shot)', () => {
+      mockConfig.sleepRequests = 5;
+      const result = YtdlpCommandBuilder.buildSearchArgs('test', 10);
+      expect(result).not.toContain('--sleep-requests');
+    });
+
+    it('includes --cookies when getCookiesPath returns a path', () => {
+      configModule.getCookiesPath.mockReturnValue('/path/to/cookies.txt');
+      const result = YtdlpCommandBuilder.buildSearchArgs('test', 10);
+      const cookiesIdx = result.indexOf('--cookies');
+      expect(cookiesIdx).toBeGreaterThanOrEqual(0);
+      expect(result[cookiesIdx + 1]).toBe('/path/to/cookies.txt');
+      expect(result).toContain('ytsearch10:test');
+    });
+
+    it('does not include --cookies flag when getCookiesPath returns null', () => {
+      configModule.getCookiesPath.mockReturnValue(null);
+      const result = YtdlpCommandBuilder.buildSearchArgs('test', 10);
+      expect(result).not.toContain('--cookies');
+    });
+  });
+
   describe('buildSponsorblockArgs', () => {
     it('should return empty array when sponsorblock is disabled', () => {
       const config = { sponsorblockEnabled: false };

--- a/server/modules/download/ytdlpCommandBuilder.js
+++ b/server/modules/download/ytdlpCommandBuilder.js
@@ -367,6 +367,30 @@ class YtdlpCommandBuilder {
   }
 
   /**
+   * Build arguments for searching YouTube via yt-dlp
+   * @param {string} query - Search query string
+   * @param {number} count - Number of results to return
+   * @returns {string[]} - Complete args array
+   */
+  static buildSearchArgs(query, count) {
+    // youtubetab:approximate_date makes flat-playlist populate an approximate
+    // upload_date/timestamp for each entry (derived from "X years ago" text),
+    // which is enough for a sortable/display date without paying for full
+    // per-video extraction.
+    const config = configModule.getConfig();
+    const args = [
+      ...this.buildCommonArgs(config, { skipSleepRequests: true }),
+      '--flat-playlist',
+      '--dump-json',
+      '--no-warnings',
+      '--extractor-args', 'youtubetab:approximate_date',
+      '--default-search', 'ytsearch',
+      `ytsearch${count}:${query}`,
+    ];
+    return args;
+  }
+
+  /**
    * Build yt-dlp command args array for channel downloads
    * @param {string} resolution - Video resolution
    * @param {boolean} allowRedownload - Allow re-downloading previously fetched videos

--- a/server/modules/download/ytdlpCommandBuilder.js
+++ b/server/modules/download/ytdlpCommandBuilder.js
@@ -366,17 +366,8 @@ class YtdlpCommandBuilder {
     return allFilters.join(' & ');
   }
 
-  /**
-   * Build arguments for searching YouTube via yt-dlp
-   * @param {string} query - Search query string
-   * @param {number} count - Number of results to return
-   * @returns {string[]} - Complete args array
-   */
   static buildSearchArgs(query, count) {
-    // youtubetab:approximate_date makes flat-playlist populate an approximate
-    // upload_date/timestamp for each entry (derived from "X years ago" text),
-    // which is enough for a sortable/display date without paying for full
-    // per-video extraction.
+    // youtubetab:approximate_date populates an approximate upload_date/timestamp from "X years ago" text without paying for full per-video extraction.
     const config = configModule.getConfig();
     const args = [
       ...this.buildCommonArgs(config, { skipSleepRequests: true }),

--- a/server/modules/videoSearchModule.js
+++ b/server/modules/videoSearchModule.js
@@ -138,8 +138,7 @@ class VideoSearchModule {
   }
 }
 
-const instance = new VideoSearchModule();
-instance.SearchCanceledError = SearchCanceledError;
-instance.SearchTimeoutError = SearchTimeoutError;
-instance.ALLOWED_COUNTS = ALLOWED_COUNTS;
-module.exports = instance;
+module.exports = new VideoSearchModule();
+module.exports.SearchCanceledError = SearchCanceledError;
+module.exports.SearchTimeoutError = SearchTimeoutError;
+module.exports.ALLOWED_COUNTS = ALLOWED_COUNTS;

--- a/server/modules/videoSearchModule.js
+++ b/server/modules/videoSearchModule.js
@@ -1,0 +1,125 @@
+const ytDlpRunner = require('./ytDlpRunner');
+const ytdlpCommandBuilder = require('./download/ytdlpCommandBuilder');
+const logger = require('../logger');
+const { Video } = require('../models');
+
+const SEARCH_TIMEOUT_MS = 60_000;
+const ALLOWED_COUNTS = [10, 25, 50];
+
+class SearchCanceledError extends Error {
+  constructor() { super('Search canceled'); this.name = 'SearchCanceledError'; }
+}
+class SearchTimeoutError extends Error {
+  constructor() { super('Search timed out'); this.name = 'SearchTimeoutError'; }
+}
+
+class VideoSearchModule {
+  async searchVideos(query, count, { signal } = {}) {
+    if (!ALLOWED_COUNTS.includes(count)) {
+      throw new Error(`count must be one of ${ALLOWED_COUNTS.join(', ')}`);
+    }
+
+    const args = ytdlpCommandBuilder.buildSearchArgs(query, count);
+
+    let stdout;
+    try {
+      stdout = await ytDlpRunner.run(args, { timeoutMs: SEARCH_TIMEOUT_MS, signal });
+    } catch (err) {
+      if (err.name === 'AbortError') throw new SearchCanceledError();
+      if (err.message && err.message.includes('timed out')) throw new SearchTimeoutError();
+      throw err;
+    }
+
+    const results = this._parseNdjson(stdout, query);
+    if (results.length > 0) await this._applyLocalStatus(results);
+    this._sortByPublishedAtDesc(results);
+    logger.info({ query, count, resultCount: results.length }, 'video search complete');
+    return results;
+  }
+
+  _parseNdjson(stdout, query) {
+    const lines = stdout.split('\n');
+    const results = [];
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const entry = JSON.parse(trimmed);
+        results.push(this._normalize(entry));
+      } catch (err) {
+        logger.warn({ err, query, line: trimmed.slice(0, 200) }, 'skipping unparseable yt-dlp line');
+      }
+    }
+    return results;
+  }
+
+  _normalize(entry) {
+    const thumbnailUrl = entry.thumbnail
+      || (Array.isArray(entry.thumbnails) && entry.thumbnails.length
+        ? entry.thumbnails[entry.thumbnails.length - 1].url
+        : null);
+    const publishedAt = this._derivePublishedAt(entry);
+    return {
+      youtubeId: entry.id,
+      title: entry.title || '',
+      channelName: entry.channel || entry.uploader || '',
+      channelId: entry.channel_id || null,
+      duration: typeof entry.duration === 'number' ? entry.duration : null,
+      thumbnailUrl,
+      publishedAt,
+      viewCount: typeof entry.view_count === 'number' ? entry.view_count : null,
+      status: 'never_downloaded',
+    };
+  }
+
+  _derivePublishedAt(entry) {
+    if (typeof entry.timestamp === 'number' && entry.timestamp > 0) {
+      return new Date(entry.timestamp * 1000).toISOString();
+    }
+    if (typeof entry.release_timestamp === 'number' && entry.release_timestamp > 0) {
+      return new Date(entry.release_timestamp * 1000).toISOString();
+    }
+    if (typeof entry.upload_date === 'string' && /^\d{8}$/.test(entry.upload_date)) {
+      const y = entry.upload_date.slice(0, 4);
+      const m = entry.upload_date.slice(4, 6);
+      const d = entry.upload_date.slice(6, 8);
+      const iso = `${y}-${m}-${d}T00:00:00.000Z`;
+      const parsed = new Date(iso);
+      if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+    }
+    return null;
+  }
+
+  async _applyLocalStatus(results) {
+    const youtubeIds = results.map(r => r.youtubeId).filter(Boolean);
+    if (youtubeIds.length === 0) return;
+    const existing = await Video.findAll({
+      where: { youtubeId: youtubeIds },
+      attributes: ['youtubeId', 'removed'],
+    });
+    const statusByYoutubeId = new Map(
+      existing.map(v => [v.youtubeId, v.removed ? 'missing' : 'downloaded'])
+    );
+    for (const r of results) {
+      const localStatus = statusByYoutubeId.get(r.youtubeId);
+      if (localStatus) r.status = localStatus;
+    }
+  }
+
+  _sortByPublishedAtDesc(results) {
+    results.sort((a, b) => {
+      if (a.publishedAt && b.publishedAt) {
+        return b.publishedAt.localeCompare(a.publishedAt);
+      }
+      if (a.publishedAt) return -1;
+      if (b.publishedAt) return 1;
+      return 0;
+    });
+  }
+}
+
+const instance = new VideoSearchModule();
+instance.SearchCanceledError = SearchCanceledError;
+instance.SearchTimeoutError = SearchTimeoutError;
+instance.ALLOWED_COUNTS = ALLOWED_COUNTS;
+module.exports = instance;

--- a/server/modules/videoSearchModule.js
+++ b/server/modules/videoSearchModule.js
@@ -26,7 +26,7 @@ class VideoSearchModule {
       stdout = await ytDlpRunner.run(args, { timeoutMs: SEARCH_TIMEOUT_MS, signal });
     } catch (err) {
       if (err.name === 'AbortError') throw new SearchCanceledError();
-      if (err.message && err.message.includes('timed out')) throw new SearchTimeoutError();
+      if (err.code === 'YTDLP_TIMEOUT') throw new SearchTimeoutError();
       throw err;
     }
 

--- a/server/modules/videoSearchModule.js
+++ b/server/modules/videoSearchModule.js
@@ -95,14 +95,34 @@ class VideoSearchModule {
     if (youtubeIds.length === 0) return;
     const existing = await Video.findAll({
       where: { youtubeId: youtubeIds },
-      attributes: ['youtubeId', 'removed'],
+      attributes: [
+        'id',
+        'youtubeId',
+        'removed',
+        'filePath',
+        'fileSize',
+        'audioFilePath',
+        'audioFileSize',
+        'last_downloaded_at',
+        'protected',
+        'normalized_rating',
+        'rating_source',
+      ],
     });
-    const statusByYoutubeId = new Map(
-      existing.map(v => [v.youtubeId, v.removed ? 'missing' : 'downloaded'])
-    );
+    const recordByYoutubeId = new Map(existing.map(v => [v.youtubeId, v]));
     for (const r of results) {
-      const localStatus = statusByYoutubeId.get(r.youtubeId);
-      if (localStatus) r.status = localStatus;
+      const record = recordByYoutubeId.get(r.youtubeId);
+      if (!record) continue;
+      r.status = record.removed ? 'missing' : 'downloaded';
+      r.databaseId = record.id;
+      r.filePath = record.filePath;
+      r.fileSize = record.fileSize;
+      r.audioFilePath = record.audioFilePath;
+      r.audioFileSize = record.audioFileSize;
+      r.addedAt = record.last_downloaded_at ? new Date(record.last_downloaded_at).toISOString() : null;
+      r.isProtected = Boolean(record.protected);
+      r.normalizedRating = record.normalized_rating;
+      r.ratingSource = record.rating_source;
     }
   }
 

--- a/server/modules/ytDlpRunner.js
+++ b/server/modules/ytDlpRunner.js
@@ -19,7 +19,7 @@ class YtDlpRunner {
    * @returns {Promise<string>} - stdout output or empty string if piped to file
    */
   async run(args, options = {}) {
-    const { timeoutMs = this.defaultTimeout, pipeToFile } = options;
+    const { timeoutMs = this.defaultTimeout, pipeToFile, signal } = options;
 
     return new Promise((resolve, reject) => {
       if (!Array.isArray(args)) {
@@ -54,6 +54,33 @@ class YtDlpRunner {
         }
       }
 
+      const makeAbortError = () => {
+        const err = new Error('yt-dlp run aborted');
+        err.name = 'AbortError';
+        err.code = 'ABORT_ERR';
+        return err;
+      };
+
+      const onAbort = () => {
+        ytDlpProcess.kill('SIGTERM');
+        const graceHandle = setTimeout(() => {
+          if (!ytDlpProcess.killed) {
+            ytDlpProcess.kill('SIGKILL');
+          }
+        }, 1000);
+        graceHandle.unref();
+        reject(makeAbortError());
+      };
+
+      if (signal) {
+        if (signal.aborted) {
+          ytDlpProcess.kill('SIGTERM');
+          reject(makeAbortError());
+          return;
+        }
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+
       ytDlpProcess.stdout.on('data', (data) => {
         if (fileStream) {
           fileStream.write(data);
@@ -67,6 +94,7 @@ class YtDlpRunner {
       });
 
       ytDlpProcess.on('close', (code) => {
+        if (signal) signal.removeEventListener('abort', onAbort);
         if (fileStream) {
           fileStream.end();
         }
@@ -88,6 +116,7 @@ class YtDlpRunner {
       });
 
       ytDlpProcess.on('error', (error) => {
+        if (signal) signal.removeEventListener('abort', onAbort);
         if (fileStream) {
           fileStream.end();
         }

--- a/server/modules/ytDlpRunner.js
+++ b/server/modules/ytDlpRunner.js
@@ -108,7 +108,9 @@ class YtDlpRunner {
         } else if (code === 0) {
           resolve(stdout);
         } else if (code === null) {
-          reject(new Error(`yt-dlp process timed out after ${timeoutMs}ms`));
+          const timeoutError = new Error(`yt-dlp process timed out after ${timeoutMs}ms`);
+          timeoutError.code = 'YTDLP_TIMEOUT';
+          reject(timeoutError);
         } else {
           const errorMessage = stderr || `yt-dlp process exited with code ${code}`;
           reject(new Error(errorMessage));

--- a/server/routes/__tests__/videoSearch.test.js
+++ b/server/routes/__tests__/videoSearch.test.js
@@ -1,0 +1,107 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('express-rate-limit', () => () => (_req, _res, next) => next());
+
+const createVideoSearchRoutes = require('../videoSearch');
+
+class SearchTimeoutError extends Error {
+  constructor() { super('t'); this.name = 'SearchTimeoutError'; }
+}
+class SearchCanceledError extends Error {
+  constructor() { super('c'); this.name = 'SearchCanceledError'; }
+}
+
+function buildApp({ verifyToken, searchVideos }) {
+  const videoSearchModule = {
+    ALLOWED_COUNTS: [10, 25, 50],
+    SearchTimeoutError,
+    SearchCanceledError,
+    searchVideos: searchVideos || jest.fn(),
+  };
+  const app = express();
+  app.use(express.json());
+  app.use(createVideoSearchRoutes({ verifyToken, videoSearchModule }));
+  return app;
+}
+
+describe('POST /api/videos/search validation', () => {
+  const verifyToken = (_req, _res, next) => next();
+
+  test('400 when query is missing', async () => {
+    const app = buildApp({ verifyToken });
+    const res = await request(app).post('/api/videos/search').send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: expect.stringMatching(/query/i) });
+  });
+
+  test('400 when query exceeds 200 chars', async () => {
+    const app = buildApp({ verifyToken });
+    const res = await request(app).post('/api/videos/search').send({ query: 'x'.repeat(201) });
+    expect(res.status).toBe(400);
+  });
+
+  test('400 when query contains control characters', async () => {
+    const app = buildApp({ verifyToken });
+    const res = await request(app).post('/api/videos/search').send({ query: 'hello\u0007' });
+    expect(res.status).toBe(400);
+  });
+
+  test('400 when count is invalid', async () => {
+    const app = buildApp({ verifyToken });
+    const res = await request(app).post('/api/videos/search').send({ query: 'ok', count: 7 });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /api/videos/search behavior', () => {
+  const verifyToken = (_req, _res, next) => next();
+
+  test('200 with results on happy path', async () => {
+    const app = buildApp({
+      verifyToken,
+      searchVideos: jest.fn().mockResolvedValueOnce([{ youtubeId: 'a', title: 'A' }]),
+    });
+    const res = await request(app).post('/api/videos/search').send({ query: 'minecraft', count: 25 });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ results: [{ youtubeId: 'a', title: 'A' }] });
+  });
+
+  test('504 when module throws SearchTimeoutError', async () => {
+    const app = buildApp({
+      verifyToken,
+      searchVideos: jest.fn().mockRejectedValueOnce(new SearchTimeoutError()),
+    });
+    const res = await request(app).post('/api/videos/search').send({ query: 'x' });
+    expect(res.status).toBe(504);
+    expect(res.body).toEqual({ error: 'Search timed out' });
+  });
+
+  test('499 when module throws SearchCanceledError', async () => {
+    const app = buildApp({
+      verifyToken,
+      searchVideos: jest.fn().mockRejectedValueOnce(new SearchCanceledError()),
+    });
+    const res = await request(app).post('/api/videos/search').send({ query: 'x' });
+    expect(res.status).toBe(499);
+    expect(res.body).toEqual({ error: 'Search canceled' });
+  });
+
+  test('502 on generic error', async () => {
+    const app = buildApp({
+      verifyToken,
+      searchVideos: jest.fn().mockRejectedValueOnce(new Error('boom')),
+    });
+    const res = await request(app).post('/api/videos/search').send({ query: 'x' });
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({ error: 'Search failed' });
+  });
+
+  test('passes AbortSignal to module', async () => {
+    const searchVideos = jest.fn().mockResolvedValueOnce([]);
+    const app = buildApp({ verifyToken, searchVideos });
+    await request(app).post('/api/videos/search').send({ query: 'x' });
+    const callOpts = searchVideos.mock.calls[0][2];
+    expect(callOpts.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/server/routes/__tests__/videoSearch.test.js
+++ b/server/routes/__tests__/videoSearch.test.js
@@ -21,6 +21,11 @@ function buildApp({ verifyToken, searchVideos }) {
   };
   const app = express();
   app.use(express.json());
+  // pino-http guarantees req.log in production; stub here so route handlers can call it.
+  app.use((req, _res, next) => {
+    req.log = { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() };
+    next();
+  });
   app.use(createVideoSearchRoutes({ verifyToken, videoSearchModule }));
   return app;
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -9,6 +9,7 @@ const createPlexRoutes = require('./plex');
 const createApiKeyRoutes = require('./apikeys');
 const createSubscriptionRoutes = require('./subscriptions');
 const createVideoDetailRoutes = require('./videoDetail');
+const createVideoSearchRoutes = require('./videoSearch');
 const videoMetadataModule = require('../modules/videoMetadataModule');
 
 /**
@@ -28,6 +29,7 @@ function registerRoutes(app, deps) {
     videosModule,
     archiveModule,
     subscriptionImportModule,
+    videoSearchModule,
     getCachedYtDlpVersion,
     refreshYtDlpVersionCache,
     validateEnvAuthCredentials,
@@ -52,6 +54,9 @@ function registerRoutes(app, deps) {
 
   // Video routes
   app.use(createVideoRoutes({ verifyToken, videosModule, downloadModule }));
+
+  // Video search routes
+  app.use(createVideoSearchRoutes({ verifyToken, videoSearchModule }));
 
   // Job routes
   app.use(createJobRoutes({ verifyToken, jobModule, downloadModule }));

--- a/server/routes/videoSearch.js
+++ b/server/routes/videoSearch.js
@@ -123,7 +123,7 @@ function createVideoSearchRoutes({ verifyToken, videoSearchModule }) {
       if (err instanceof videoSearchModule.SearchTimeoutError) {
         return res.status(504).json({ error: 'Search timed out' });
       }
-      req.log?.error({ err }, 'video search failed');
+      req.log.error({ err, query: validation.query }, 'video search failed');
       return res.status(502).json({ error: 'Search failed' });
     }
   });

--- a/server/routes/videoSearch.js
+++ b/server/routes/videoSearch.js
@@ -85,6 +85,15 @@ function createVideoSearchRoutes({ verifyToken, videoSearchModule }) {
    *                       status:
    *                         type: string
    *                         enum: [downloaded, missing, never_downloaded]
+   *                       databaseId: { type: integer, nullable: true, description: "Video row id when status is downloaded or missing." }
+   *                       filePath: { type: string, nullable: true }
+   *                       fileSize: { type: integer, nullable: true }
+   *                       audioFilePath: { type: string, nullable: true }
+   *                       audioFileSize: { type: integer, nullable: true }
+   *                       addedAt: { type: string, nullable: true, format: date-time }
+   *                       isProtected: { type: boolean, nullable: true }
+   *                       normalizedRating: { type: string, nullable: true }
+   *                       ratingSource: { type: string, nullable: true }
    *       400:
    *         description: Invalid query or count
    *       429:

--- a/server/routes/videoSearch.js
+++ b/server/routes/videoSearch.js
@@ -1,0 +1,134 @@
+const express = require('express');
+const rateLimit = require('express-rate-limit');
+
+const MAX_QUERY_LENGTH = 200;
+const DEFAULT_COUNT = 25;
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_REGEX = /[\u0000-\u001F\u007F]/;
+
+const searchLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 10,
+  message: { error: 'Too many search requests, please try again later' },
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { trustProxy: false },
+});
+
+function validate(body, ALLOWED_COUNTS) {
+  if (!body || typeof body.query !== 'string') {
+    return { error: 'query is required' };
+  }
+  const query = body.query.trim();
+  if (query.length === 0) return { error: 'query must not be empty' };
+  if (query.length > MAX_QUERY_LENGTH) return { error: `query must be at most ${MAX_QUERY_LENGTH} characters` };
+  if (CONTROL_CHAR_REGEX.test(query)) return { error: 'query contains invalid characters' };
+
+  const count = body.count === undefined ? DEFAULT_COUNT : body.count;
+  if (!ALLOWED_COUNTS.includes(count)) {
+    return { error: `count must be one of ${ALLOWED_COUNTS.join(', ')}` };
+  }
+  return { query, count };
+}
+
+function createVideoSearchRoutes({ verifyToken, videoSearchModule }) {
+  const router = express.Router();
+
+  /**
+   * @swagger
+   * /api/videos/search:
+   *   post:
+   *     summary: Search YouTube by free text
+   *     description: Search YouTube via yt-dlp and return a list of matching videos, sorted newest-to-oldest by publishedAt (entries without a timestamp sort last). Results are ephemeral; nothing is persisted. Each result includes a `status` field (`downloaded`, `missing`, or `never_downloaded`) describing the video's state in the local Video table.
+   *     tags: [Videos]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - query
+   *             properties:
+   *               query:
+   *                 type: string
+   *                 minLength: 1
+   *                 maxLength: 200
+   *                 description: Search text. Trimmed; control characters rejected.
+   *                 example: "Minecraft"
+   *               count:
+   *                 type: integer
+   *                 enum: [10, 25, 50]
+   *                 default: 25
+   *                 description: Number of results to fetch from YouTube.
+   *     responses:
+   *       200:
+   *         description: Search results
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 results:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       youtubeId: { type: string }
+   *                       title: { type: string }
+   *                       channelName: { type: string }
+   *                       channelId: { type: string, nullable: true }
+   *                       duration: { type: integer, nullable: true }
+   *                       thumbnailUrl: { type: string, nullable: true }
+   *                       publishedAt: { type: string, nullable: true, format: date-time }
+   *                       viewCount: { type: integer, nullable: true }
+   *                       status:
+   *                         type: string
+   *                         enum: [downloaded, missing, never_downloaded]
+   *       400:
+   *         description: Invalid query or count
+   *       429:
+   *         description: Rate limit exceeded (max 10 requests per minute)
+   *       499:
+   *         description: Client closed the request before search completed
+   *       502:
+   *         description: Search failed (yt-dlp error)
+   *       504:
+   *         description: Search timed out (60s server-side limit)
+   */
+  router.post('/api/videos/search', verifyToken, searchLimiter, async (req, res) => {
+    const validation = validate(req.body, videoSearchModule.ALLOWED_COUNTS);
+    if (validation.error) {
+      return res.status(400).json({ error: validation.error });
+    }
+
+    const controller = new AbortController();
+    req.on('close', () => {
+      if (!res.headersSent) controller.abort();
+    });
+
+    try {
+      const results = await videoSearchModule.searchVideos(
+        validation.query,
+        validation.count,
+        { signal: controller.signal }
+      );
+      if (res.headersSent) return;
+      res.json({ results });
+    } catch (err) {
+      if (res.headersSent) return;
+      if (err instanceof videoSearchModule.SearchCanceledError) {
+        return res.status(499).json({ error: 'Search canceled' });
+      }
+      if (err instanceof videoSearchModule.SearchTimeoutError) {
+        return res.status(504).json({ error: 'Search timed out' });
+      }
+      req.log?.error({ err }, 'video search failed');
+      return res.status(502).json({ error: 'Search failed' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createVideoSearchRoutes;

--- a/server/server.js
+++ b/server/server.js
@@ -208,6 +208,7 @@ const initialize = async () => {
     const videosModule = require('./modules/videosModule');
     const archiveModule = require('./modules/archiveModule');
     const subscriptionImportModule = require('./modules/subscriptionImport');
+    const videoSearchModule = require('./modules/videoSearchModule');
     const messageEmitter = require('./modules/messageEmitter');
     const { Channel } = require('./models');
     const { registerRoutes } = require('./routes');
@@ -527,6 +528,7 @@ const initialize = async () => {
       videosModule,
       archiveModule,
       subscriptionImportModule,
+      videoSearchModule,
       getCachedYtDlpVersion,
       refreshYtDlpVersionCache,
       validateEnvAuthCredentials,

--- a/server/swagger.js
+++ b/server/swagger.js
@@ -115,6 +115,7 @@ const options = {
     path.join(__dirname, 'routes', 'plex.js'),
     path.join(__dirname, 'routes', 'setup.js'),
     path.join(__dirname, 'routes', 'videos.js'),
+    path.join(__dirname, 'routes', 'videoSearch.js'),
     path.join(__dirname, 'routes', 'apikeys.js'),
   ],
 };


### PR DESCRIPTION
- New "Find on YouTube" entry under "Videos" with a search box, a 10/25/50 page-size picker, and a grid/table view toggle
- Every result is labeled downloaded, missing, or never downloaded based on what's in your library
- Clicking a result opens the usual video modal so you can queue it, or see file info if it's already downloaded
- Table view swaps to a compact card list on mobile
- Updated USAGE_GUIDE.md has a section walking through it

<img width="512" height="1145" alt="image" src="https://github.com/user-attachments/assets/465f3479-35c4-4145-a7a6-717fc5874c67" />

<img width="1882" height="1388" alt="image" src="https://github.com/user-attachments/assets/4fe8c06e-3dfe-4eeb-b9d6-962293252bfb" />

<img width="1902" height="1386" alt="image" src="https://github.com/user-attachments/assets/0241addc-1e0c-482a-bc4b-af8e166b80a2" />

<img width="1883" height="1242" alt="image" src="https://github.com/user-attachments/assets/1bd291b0-4ce6-4a30-bfe7-dfe69e40fa7a" />
