### PR TITLE
feat(downloads): improve Manual Download chip layout and bulk import UX

### DIFF
--- a/client/src/components/DownloadManager/ManualDownload/BulkImportDialog.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/BulkImportDialog.tsx
@@ -21,6 +21,8 @@ import {
 import { VideoInfo } from './types';
 import { parseYoutubeUrls, BulkParseResult } from './urlParser';
 
+const MAX_BULK_IMPORT_URLS = 100;
+
 interface BulkImportDialogProps {
   open: boolean;
   onClose: () => void;
@@ -100,7 +102,8 @@ const BulkImportDialog: React.FC<BulkImportDialogProps> = ({
   const handleImport = useCallback(() => {
     if (!parseResult || parseResult.valid.length === 0) return;
 
-    const videos: VideoInfo[] = parseResult.valid.map((parsed) => ({
+    const capped = parseResult.valid.slice(0, MAX_BULK_IMPORT_URLS);
+    const videos: VideoInfo[] = capped.map((parsed) => ({
       youtubeId: parsed.youtubeId,
       url: parsed.url,
       channelName: '',
@@ -138,13 +141,15 @@ const BulkImportDialog: React.FC<BulkImportDialogProps> = ({
   const dupeCount = parseResult?.duplicates.length ?? 0;
   const invalidCount = parseResult?.invalid.length ?? 0;
   const playlistCount = parseResult?.playlistLines.length ?? 0;
+  const exceedsCap = validCount > MAX_BULK_IMPORT_URLS;
+  const effectiveImportCount = Math.min(validCount, MAX_BULK_IMPORT_URLS);
   const hasResults = parseResult !== null && (validCount > 0 || dupeCount > 0 || invalidCount > 0 || playlistCount > 0);
 
   return (
     <Dialog
       open={open}
       onClose={onClose}
-      maxWidth="sm"
+      maxWidth="md"
       fullWidth
       data-testid="bulk-import-dialog"
     >
@@ -154,7 +159,7 @@ const BulkImportDialog: React.FC<BulkImportDialogProps> = ({
 
       <DialogContent>
         <Typography variant="body2" color="text.secondary" className="mb-4">
-          Paste YouTube video URLs, one per line:
+          Paste YouTube video URLs, one per line (max {MAX_BULK_IMPORT_URLS} per import):
         </Typography>
 
         <TextField
@@ -205,6 +210,14 @@ const BulkImportDialog: React.FC<BulkImportDialogProps> = ({
             {validCount > 0 && (
               <Alert severity="success" variant="outlined">
                 {validCount} valid URL{validCount !== 1 ? 's' : ''} found
+              </Alert>
+            )}
+
+            {exceedsCap && (
+              <Alert severity="warning" variant="outlined">
+                Only the first {MAX_BULK_IMPORT_URLS} URLs will be imported
+                ({validCount - MAX_BULK_IMPORT_URLS} extra will be skipped).
+                Run Bulk Import again with the remainder if you need them.
               </Alert>
             )}
 
@@ -271,7 +284,7 @@ const BulkImportDialog: React.FC<BulkImportDialogProps> = ({
           disabled={validCount === 0}
           data-testid="bulk-import-confirm"
         >
-          Add {validCount > 0 ? validCount : ''} to Queue
+          Add {effectiveImportCount > 0 ? effectiveImportCount : ''} to Queue
         </Button>
       </DialogActions>
     </Dialog>

--- a/client/src/components/DownloadManager/ManualDownload/ManualDownload.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/ManualDownload.tsx
@@ -12,6 +12,7 @@ import {
   Collapse
 } from '../../ui';
 import { TransitionGroup } from 'react-transition-group';
+import { useMediaQuery, breakpoints } from '../../../hooks/useMediaQuery';
 import {
   Download as DownloadIcon,
   X as ClearIcon,
@@ -24,6 +25,33 @@ import DownloadSettingsDialog from './DownloadSettingsDialog';
 import BulkImportDialog from './BulkImportDialog';
 import { VideoInfo, ValidationResponse, DownloadSettings } from './types';
 
+const ENRICH_CHUNK_SIZE = 25;
+
+interface EnrichedVideoMeta {
+  title: string;
+  channelName: string;
+}
+
+async function enrichBulkImports(
+  ids: string[],
+  token: string | null,
+  onChunk: (chunk: Record<string, EnrichedVideoMeta>) => void
+): Promise<void> {
+  for (let i = 0; i < ids.length; i += ENRICH_CHUNK_SIZE) {
+    const chunk = ids.slice(i, i + ENRICH_CHUNK_SIZE);
+    try {
+      const { data } = await axios.post<{ enriched: Record<string, EnrichedVideoMeta> }>(
+        '/api/bulkEnrichVideos',
+        { ids: chunk },
+        { headers: { 'x-access-token': token || '' } }
+      );
+      if (data?.enriched) onChunk(data.enriched);
+    } catch (err) {
+      console.error('Bulk enrichment chunk failed:', err);
+    }
+  }
+}
+
 interface ManualDownloadProps {
   onStartDownload: (urls: string[], settings?: DownloadSettings | null) => void;
   token: string | null;
@@ -31,6 +59,7 @@ interface ManualDownloadProps {
 }
 
 const ManualDownload: React.FC<ManualDownloadProps> = ({ onStartDownload, token, defaultResolution = '1080' }) => {
+  const isMobile = useMediaQuery(breakpoints.down('sm'));
   const [validatedVideos, setValidatedVideos] = useState<VideoInfo[]>([]);
   const [isValidating, setIsValidating] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -39,12 +68,32 @@ const ManualDownload: React.FC<ManualDownloadProps> = ({ onStartDownload, token,
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
   const [previouslyDownloadedCount, setPreviouslyDownloadedCount] = useState(0);
   const [showBulkImport, setShowBulkImport] = useState(false);
+  const [isEnrichingBulk, setIsEnrichingBulk] = useState(false);
 
   const handleBulkImport = useCallback((videos: VideoInfo[]) => {
     setValidatedVideos(prev => [...prev, ...videos]);
     setShowBulkImport(false);
     setSuccessMessage(`Added ${videos.length} URL${videos.length !== 1 ? 's' : ''} to download queue.`);
-  }, []);
+
+    const ids = videos.map(v => v.youtubeId).filter(Boolean);
+    if (ids.length === 0) return;
+
+    setIsEnrichingBulk(true);
+    void enrichBulkImports(ids, token, (chunk) => {
+      setValidatedVideos(prev => prev.map(v => {
+        const meta = chunk[v.youtubeId];
+        if (!meta || !v.isBulkImport) return v;
+        return {
+          ...v,
+          videoTitle: meta.title || v.videoTitle,
+          channelName: meta.channelName || v.channelName,
+          isBulkImport: false,
+        };
+      }));
+    }).finally(() => {
+      setIsEnrichingBulk(false);
+    });
+  }, [token]);
 
   const validateUrl = useCallback(async (url: string): Promise<boolean> => {
     setIsValidating(true);
@@ -227,8 +276,8 @@ const ManualDownload: React.FC<ManualDownloadProps> = ({ onStartDownload, token,
             <TransitionGroup
               style={{
                 display: 'grid',
-                gridTemplateColumns: window.innerWidth < 900 ? '1fr' : '1fr 1fr',
-                gap: '8px'
+                gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr',
+                gap: '12px'
               }}
             >
               {validatedVideos.map((video) => (
@@ -236,6 +285,7 @@ const ManualDownload: React.FC<ManualDownloadProps> = ({ onStartDownload, token,
                   <VideoChip
                     video={video}
                     onDelete={handleRemoveVideo}
+                    isEnriching={isEnrichingBulk}
                   />
                 </Collapse>
               ))}

--- a/client/src/components/DownloadManager/ManualDownload/VideoChip.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/VideoChip.tsx
@@ -1,14 +1,17 @@
 import React, { useState } from 'react';
 import { Chip, Tooltip, Box, Grow, Popover, Typography, IconButton } from '../../ui';
-import { Close as CloseIcon, Lock, Link as LinkIcon } from '../../../lib/icons';
+import { Close as CloseIcon, Lock, Link as LinkIcon, Loader2 } from '../../../lib/icons';
 import { History as HistoryIcon } from 'lucide-react';
 import { VideoInfo } from './types';
-import { useThemeEngine } from '../../../contexts/ThemeEngineContext';
 
 interface VideoChipProps {
   video: VideoInfo;
   onDelete: (youtubeId: string) => void;
+  isEnriching?: boolean;
 }
+
+const THUMBNAIL_WIDTH = 64;
+const THUMBNAIL_HEIGHT = 36;
 
 const formatMediaTypeLabel = (mediaType: string): string => {
   return mediaType
@@ -33,20 +36,65 @@ const getMediaTypeInfo = (mediaType?: string) => {
   }
 };
 
-const VideoChip: React.FC<VideoChipProps> = ({ video, onDelete }) => {
+interface VideoThumbnailProps {
+  youtubeId: string;
+}
+
+const VideoThumbnail: React.FC<VideoThumbnailProps> = ({ youtubeId }) => {
+  const [visible, setVisible] = useState(true);
+  if (!visible) return null;
+  return (
+    <img
+      src={`https://i.ytimg.com/vi/${youtubeId}/mqdefault.jpg`}
+      alt=""
+      aria-hidden="true"
+      onError={() => setVisible(false)}
+      style={{
+        width: THUMBNAIL_WIDTH,
+        height: THUMBNAIL_HEIGHT,
+        objectFit: 'cover',
+        borderRadius: 4,
+        flexShrink: 0,
+        backgroundColor: 'var(--muted)',
+      }}
+    />
+  );
+};
+
+const VideoChip: React.FC<VideoChipProps> = ({ video, onDelete, isEnriching = false }) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  const [tooltipOpen, setTooltipOpen] = useState(false);
 
   if (video.isBulkImport) {
     const bulkLabel = (
-      <Box className="flex items-center gap-2">
-        <LinkIcon size={14} data-testid="LinkIcon" style={{ color: 'var(--muted-foreground)', flexShrink: 0 }} />
-        <Box>
-          <Box className="text-xs font-bold">
+      <Box className="flex items-center gap-2 w-full min-w-0">
+        <VideoThumbnail youtubeId={video.youtubeId} />
+        {isEnriching ? (
+          <Loader2
+            size={14}
+            data-testid="EnrichingSpinner"
+            className="animate-spin"
+            style={{ color: 'var(--muted-foreground)', flexShrink: 0 }}
+            aria-label="Fetching video details"
+          />
+        ) : (
+          <LinkIcon
+            size={14}
+            data-testid="LinkIcon"
+            style={{ color: 'var(--muted-foreground)', flexShrink: 0 }}
+          />
+        )}
+        <Box className="min-w-0 flex-1">
+          <Box
+            className="text-xs font-bold truncate"
+            style={{ color: 'var(--foreground)' }}
+          >
             {video.youtubeId}
           </Box>
-          <Box className="text-[0.7rem] text-muted-foreground">
-            URL-only import
+          <Box
+            className="text-[0.7rem] truncate"
+            style={{ color: 'var(--muted-foreground)' }}
+          >
+            {isEnriching ? 'Fetching details...' : 'URL-only import'}
           </Box>
         </Box>
       </Box>
@@ -54,17 +102,17 @@ const VideoChip: React.FC<VideoChipProps> = ({ video, onDelete }) => {
 
     return (
       <Grow in={true} timeout={300}>
-        <Tooltip title={video.url} open={tooltipOpen}>
+        <Tooltip title={video.url} fullWidth>
           <Chip
-            onMouseOver={() => setTooltipOpen(true)}
-            onMouseOut={() => setTooltipOpen(false)}
             onClick={() => {}}
             aria-label={video.url}
             label={bulkLabel}
             onDelete={() => onDelete(video.youtubeId)}
             deleteIcon={<CloseIcon size={14} data-testid="CloseIcon" />}
-            color="info"
+            color="default"
             variant="filled"
+            className="!justify-start"
+            labelClassName="flex-1 min-w-0 !overflow-visible !whitespace-normal"
             style={{
               height: 'auto',
               paddingTop: 8,
@@ -90,7 +138,6 @@ const VideoChip: React.FC<VideoChipProps> = ({ video, onDelete }) => {
 
   const open = Boolean(anchorEl);
   const mediaTypeInfo = getMediaTypeInfo(video.media_type);
-  const { themeMode } = useThemeEngine();
 
   const formatDuration = (seconds: number): string => {
     const hours = Math.floor(seconds / 3600);
@@ -103,67 +150,86 @@ const VideoChip: React.FC<VideoChipProps> = ({ video, onDelete }) => {
     return `${minutes}:${secs.toString().padStart(2, '0')}`;
   };
 
-  const truncateText = (text: string, maxLength: number): string => {
-    if (text.length <= maxLength) return text;
-    return text.substring(0, maxLength - 3) + '...';
-  };
+  const formattedPublishDate = video.publishedAt
+    ? new Date(video.publishedAt * 1000).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: '2-digit',
+      })
+    : null;
 
   const getChipColor = (): 'default' | 'success' | 'warning' | 'error' => {
-    if (video.isAlreadyDownloaded) return 'warning';  // Changed to warning (yellow/orange)
+    if (video.isAlreadyDownloaded) return 'warning';
     if (video.isMembersOnly) return 'error';
     return 'default';
   };
 
   const chipLabel = (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-      <div>
-        <div style={{ fontWeight: 'bold', fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: 3 }}>
-          {truncateText(video.channelName, 20)}
+    <div className="flex items-center gap-2 w-full min-w-0">
+      <VideoThumbnail youtubeId={video.youtubeId} />
+      <div className="min-w-0 flex-1 flex flex-col">
+        <div className="flex items-center gap-1 text-[0.75rem] font-bold min-w-0">
+          <span className="truncate">{video.channelName}</span>
           {video.isAlreadyDownloaded && (
             <IconButton
               size="small"
               aria-label="Download history"
               onClick={handlePopoverOpen}
-              style={{ background: 'none', border: 'none', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', padding: 0, marginLeft: 4 }}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', display: 'inline-flex', alignItems: 'center', padding: 0, flexShrink: 0 }}
             >
               <HistoryIcon size={14} data-testid="HistoryIcon" style={{ color: 'var(--muted-foreground)' }} />
             </IconButton>
           )}
         </div>
-        <div style={{ fontSize: '0.7rem' }}>
-          {truncateText(video.videoTitle, 40)}
+        <div className="text-[0.7rem] truncate">
+          {video.videoTitle}
         </div>
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginLeft: 8 }}>
-        {mediaTypeInfo && (
-          <span
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 3,
-              fontSize: '0.65rem',
-              fontWeight: 600,
-              color: 'var(--muted-foreground)',
-            }}
-          >
+      <div className="flex flex-col items-end gap-0.5 flex-shrink-0">
+        <div className="flex items-center gap-1">
+          {mediaTypeInfo && (
             <span
               style={{
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                backgroundColor: mediaTypeInfo.color,
-                flexShrink: 0,
-                display: 'inline-block',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 3,
+                fontSize: '0.65rem',
+                fontWeight: 600,
+                color: 'var(--muted-foreground)',
               }}
-            />
-            {mediaTypeInfo.label}
+            >
+              <span
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  backgroundColor: mediaTypeInfo.color,
+                  flexShrink: 0,
+                  display: 'inline-block',
+                }}
+              />
+              {mediaTypeInfo.label}
+            </span>
+          )}
+          {video.duration > 0 && (
+            <span style={{ fontSize: '0.65rem', backgroundColor: 'rgba(0,0,0,0.1)', padding: '2px 4px', borderRadius: 'var(--radius-ui)' }}>
+              {formatDuration(video.duration)}
+            </span>
+          )}
+          {video.isMembersOnly && <Lock size={16} data-testid="LockIcon" />}
+        </div>
+        {formattedPublishDate && (
+          <span
+            style={{
+              fontSize: '0.6rem',
+              color: 'var(--muted-foreground)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {formattedPublishDate}
           </span>
         )}
-        <span style={{ fontSize: '0.65rem', backgroundColor: 'rgba(0,0,0,0.1)', padding: '2px 4px', borderRadius: 'var(--radius-ui)' }}>
-          {formatDuration(video.duration)}
-        </span>
       </div>
-      {video.isMembersOnly && <Lock size={16} data-testid="LockIcon" style={{ marginLeft: 4 }} />}
     </div>
   );
 
@@ -180,10 +246,8 @@ const VideoChip: React.FC<VideoChipProps> = ({ video, onDelete }) => {
   return (
     <>
       <Grow in={true} timeout={300}>
-        <Tooltip title={getTooltipTitle()} open={tooltipOpen}>
+        <Tooltip title={getTooltipTitle()} fullWidth>
           <Chip
-            onMouseOver={() => setTooltipOpen(true)}
-            onMouseOut={() => setTooltipOpen(false)}
             onClick={() => {}}
             aria-label={getTooltipTitle()}
             label={chipLabel}
@@ -191,6 +255,8 @@ const VideoChip: React.FC<VideoChipProps> = ({ video, onDelete }) => {
             deleteIcon={<CloseIcon size={14} data-testid="CloseIcon" />}
             color={getChipColor()}
             variant="filled"
+            className="!justify-start"
+            labelClassName="flex-1 min-w-0 !overflow-visible !whitespace-normal"
             style={{
               height: 'auto',
               paddingTop: 8,
@@ -199,7 +265,6 @@ const VideoChip: React.FC<VideoChipProps> = ({ video, onDelete }) => {
               transition: 'all 0.2s ease',
               boxShadow: 'var(--chip-shadow)',
             }}
-
           />
         </Tooltip>
       </Grow>

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/BulkImportDialog.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/BulkImportDialog.test.tsx
@@ -31,8 +31,9 @@ describe('BulkImportDialog', () => {
 
       expect(screen.getByText('Bulk Import URLs')).toBeInTheDocument();
       expect(
-        screen.getByText('Paste YouTube video URLs, one per line:')
+        screen.getByText(/Paste YouTube video URLs, one per line/i)
       ).toBeInTheDocument();
+      expect(screen.getByText(/max 100 per import/i)).toBeInTheDocument();
       expect(screen.getByTestId('bulk-import-textarea')).toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: /upload .txt file/i })
@@ -219,6 +220,36 @@ describe('BulkImportDialog', () => {
         youtubeId: 'jNQXAC9IVRw',
         isBulkImport: true,
       });
+    });
+
+    test('caps import at 100 URLs and warns the user', async () => {
+      // Build 110 distinct valid YouTube URLs. The video IDs must be 11 chars
+      // and distinct so the parser does not dedupe them.
+      const chars = 'abcdefghijklmnopqrstuvwxyz0123456789_-';
+      const urls: string[] = [];
+      for (let i = 0; i < 110; i++) {
+        const a = chars[Math.floor(i / chars.length) % chars.length];
+        const b = chars[i % chars.length];
+        const id = `${a}${b}aaaaaaaaa`;
+        urls.push(`https://www.youtube.com/watch?v=${id}`);
+      }
+
+      render(<BulkImportDialog {...defaultProps} />);
+      const textarea = screen.getByTestId('bulk-import-textarea');
+      fireEvent.change(textarea, { target: { value: urls.join('\n') } });
+
+      jest.advanceTimersByTime(300);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Only the first 100 URLs will be imported/i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('bulk-import-confirm')).toHaveTextContent('Add 100 to Queue');
+
+      fireEvent.click(screen.getByTestId('bulk-import-confirm'));
+
+      expect(mockOnImport).toHaveBeenCalledTimes(1);
+      expect(mockOnImport.mock.calls[0][0]).toHaveLength(100);
     });
 
     test('shows correct count in button text', async () => {

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/ManualDownload.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/ManualDownload.test.tsx
@@ -33,9 +33,12 @@ jest.mock('../UrlInput', () => {
 });
 
 jest.mock('../VideoChip', () => {
-  return function MockVideoChip({ video, onDelete }: any) {
+  return function MockVideoChip({ video, onDelete, isEnriching }: any) {
     return (
-      <div data-testid={`video-chip-${video.youtubeId}`}>
+      <div
+        data-testid={`video-chip-${video.youtubeId}`}
+        data-enriching={isEnriching ? 'true' : 'false'}
+      >
         <span>{video.videoTitle}</span>
         <button
           onClick={() => onDelete(video.youtubeId)}
@@ -133,6 +136,14 @@ describe('ManualDownload', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: enrichment returns nothing. Individual tests can override.
+    mockedAxios.post.mockImplementation((url: string) => {
+      if (url === '/api/bulkEnrichVideos') {
+        return Promise.resolve({ data: { enriched: {} } });
+      }
+      // Leave other URLs for explicit mockResolvedValueOnce in tests
+      return Promise.reject(new Error(`Unexpected POST to ${url}`));
+    });
   });
 
   test('renders the component with initial state', () => {
@@ -587,6 +598,102 @@ describe('ManualDownload', () => {
     });
     expect(screen.getByTestId('video-chip-bulk2')).toBeInTheDocument();
     expect(screen.getByText('Added 2 URLs to download queue.')).toBeInTheDocument();
+    expect(screen.getByText('2 videos to download')).toBeInTheDocument();
+  });
+
+  test('enriches bulk-imported videos with title and channel from oembed', async () => {
+    mockedAxios.post.mockImplementation((url: string) => {
+      if (url === '/api/bulkEnrichVideos') {
+        return Promise.resolve({
+          data: {
+            enriched: {
+              bulk1: { title: 'First Video', channelName: 'First Channel' },
+              bulk2: { title: 'Second Video', channelName: 'Second Channel' },
+            },
+          },
+        });
+      }
+      return Promise.reject(new Error(`Unexpected POST to ${url}`));
+    });
+
+    render(<ManualDownload onStartDownload={mockOnStartDownload} token={mockToken} />);
+
+    const bulkButton = screen.getByRole('button', { name: /bulk import/i });
+    fireEvent.click(bulkButton);
+    fireEvent.click(screen.getByTestId('bulk-import-confirm'));
+
+    // Initial state: titles are empty strings
+    await waitFor(() => {
+      expect(screen.getByTestId('video-chip-bulk1')).toBeInTheDocument();
+    });
+
+    // After enrichment: the mocked VideoChip shows `video.videoTitle`, so it
+    // flipping to the new title proves the state was updated from the oembed
+    // response.
+    await waitFor(() => {
+      expect(screen.getByText('First Video')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Second Video')).toBeInTheDocument();
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      '/api/bulkEnrichVideos',
+      { ids: ['bulk1', 'bulk2'] },
+      { headers: { 'x-access-token': mockToken } }
+    );
+  });
+
+  test('marks bulk-imported chips as enriching until the request resolves', async () => {
+    // Create a deferred promise so we can observe the in-flight state.
+    let resolveEnrich: (value: any) => void = () => undefined;
+    const enrichPromise = new Promise((resolve) => {
+      resolveEnrich = resolve;
+    });
+
+    mockedAxios.post.mockImplementation((url: string) => {
+      if (url === '/api/bulkEnrichVideos') return enrichPromise;
+      return Promise.reject(new Error(`Unexpected POST to ${url}`));
+    });
+
+    render(<ManualDownload onStartDownload={mockOnStartDownload} token={mockToken} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /bulk import/i }));
+    fireEvent.click(screen.getByTestId('bulk-import-confirm'));
+
+    // While the enrichment request is in flight, chips should be marked.
+    await waitFor(() => {
+      expect(screen.getByTestId('video-chip-bulk1')).toHaveAttribute('data-enriching', 'true');
+    });
+    expect(screen.getByTestId('video-chip-bulk2')).toHaveAttribute('data-enriching', 'true');
+
+    // Resolve with empty enriched map; finally-clause flips the flag back.
+    resolveEnrich({ data: { enriched: {} } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('video-chip-bulk1')).toHaveAttribute('data-enriching', 'false');
+    });
+    expect(screen.getByTestId('video-chip-bulk2')).toHaveAttribute('data-enriching', 'false');
+  });
+
+  test('leaves bulk-imported videos unchanged when enrichment fails', async () => {
+    mockedAxios.post.mockImplementation((url: string) => {
+      if (url === '/api/bulkEnrichVideos') {
+        return Promise.reject(new Error('network down'));
+      }
+      return Promise.reject(new Error(`Unexpected POST to ${url}`));
+    });
+
+    render(<ManualDownload onStartDownload={mockOnStartDownload} token={mockToken} />);
+
+    const bulkButton = screen.getByRole('button', { name: /bulk import/i });
+    fireEvent.click(bulkButton);
+    fireEvent.click(screen.getByTestId('bulk-import-confirm'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('video-chip-bulk1')).toBeInTheDocument();
+    });
+
+    // The chip should still be there with its empty title. No crash.
+    expect(screen.getByTestId('video-chip-bulk2')).toBeInTheDocument();
     expect(screen.getByText('2 videos to download')).toBeInTheDocument();
   });
 

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/VideoChip.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/VideoChip.test.tsx
@@ -59,24 +59,24 @@ describe('VideoChip', () => {
       expect(screen.getByText('1:00:01')).toBeInTheDocument();
     });
 
-    test('truncates long channel names', () => {
-      const video = {
-        ...baseVideo,
-        channelName: 'This is a very long channel name that should be truncated',
-      };
+    test('renders full channel name in a CSS-truncated container', () => {
+      const longChannelName = 'This is a very long channel name that should be truncated';
+      const video = { ...baseVideo, channelName: longChannelName };
       render(<VideoChip video={video} onDelete={mockOnDelete} />);
 
-      expect(screen.getByText('This is a very lo...')).toBeInTheDocument();
+      const element = screen.getByText(longChannelName);
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveClass('truncate');
     });
 
-    test('truncates long video titles', () => {
-      const video = {
-        ...baseVideo,
-        videoTitle: 'This is a very long video title that should definitely be truncated after a certain number of characters',
-      };
+    test('renders full video title in a CSS-truncated container', () => {
+      const longTitle = 'This is a very long video title that should definitely be truncated after a certain number of characters';
+      const video = { ...baseVideo, videoTitle: longTitle };
       render(<VideoChip video={video} onDelete={mockOnDelete} />);
 
-      expect(screen.getByText('This is a very long video title that ...')).toBeInTheDocument();
+      const element = screen.getByText(longTitle);
+      expect(element).toBeInTheDocument();
+      expect(element).toHaveClass('truncate');
     });
 
     test('does not truncate short text', () => {
@@ -191,34 +191,29 @@ describe('VideoChip', () => {
     });
   });
 
-  describe('Tooltip', () => {
-    test('shows basic tooltip with video title', async () => {
+  describe('Accessible name', () => {
+    test('exposes video title as the chip accessible name', () => {
       render(<VideoChip video={baseVideo} onDelete={mockOnDelete} />);
 
-      const chip = screen.getByRole('button');
-      fireEvent.mouseOver(chip);
-
-      expect(await screen.findByRole('tooltip')).toHaveTextContent('Test Video Title');
+      expect(screen.getByRole('button', { name: 'Test Video Title' })).toBeInTheDocument();
     });
 
-    test('shows tooltip for already downloaded videos', async () => {
+    test('annotates accessible name for already downloaded videos', () => {
       const video = { ...baseVideo, isAlreadyDownloaded: true };
       render(<VideoChip video={video} onDelete={mockOnDelete} />);
 
-      const chip = screen.getByRole('button', { name: /Test Video Title - Already downloaded/i });
-      fireEvent.mouseOver(chip);
-
-      expect(await screen.findByRole('tooltip')).toHaveTextContent('Test Video Title - Already downloaded');
+      expect(
+        screen.getByRole('button', { name: 'Test Video Title - Already downloaded' })
+      ).toBeInTheDocument();
     });
 
-    test('shows tooltip for members-only videos', async () => {
+    test('annotates accessible name for members-only videos', () => {
       const video = { ...baseVideo, isMembersOnly: true };
       render(<VideoChip video={video} onDelete={mockOnDelete} />);
 
-      const chip = screen.getByRole('button');
-      fireEvent.mouseOver(chip);
-
-      expect(await screen.findByRole('tooltip')).toHaveTextContent('Test Video Title - Members-only content (cannot download)');
+      expect(
+        screen.getByRole('button', { name: 'Test Video Title - Members-only content (cannot download)' })
+      ).toBeInTheDocument();
     });
   });
 
@@ -241,11 +236,11 @@ describe('VideoChip', () => {
   });
 
   describe('Edge Cases', () => {
-    test('handles zero duration', () => {
+    test('hides duration pill when duration is zero or unknown', () => {
       const video = { ...baseVideo, duration: 0 };
       render(<VideoChip video={video} onDelete={mockOnDelete} />);
 
-      expect(screen.getByText('0:00')).toBeInTheDocument();
+      expect(screen.queryByText('0:00')).not.toBeInTheDocument();
     });
 
     test('handles very long duration', () => {
@@ -335,22 +330,19 @@ describe('VideoChip', () => {
       expect(screen.getByText('URL-only import')).toBeInTheDocument();
     });
 
-    test('applies info color for bulk import chip', () => {
+    test('applies default color for bulk import chip', () => {
       render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} />);
 
       const chip = screen.getByRole('button');
-      expect(chip).toHaveClass('chip-info');
+      expect(chip).toHaveClass('chip-default');
     });
 
-    test('shows full URL in tooltip for bulk import', async () => {
+    test('exposes full URL as accessible name for bulk import', () => {
       render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} />);
 
-      const chip = screen.getByRole('button');
-      fireEvent.mouseOver(chip);
-
-      expect(await screen.findByRole('tooltip')).toHaveTextContent(
-        'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
-      );
+      expect(
+        screen.getByRole('button', { name: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
+      ).toBeInTheDocument();
     });
 
     test('calls onDelete with youtubeId for bulk import chip', () => {
@@ -373,6 +365,23 @@ describe('VideoChip', () => {
       render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} />);
 
       expect(screen.getByTestId('LinkIcon')).toBeInTheDocument();
+    });
+
+    test('shows a spinner and "Fetching details..." while enriching', () => {
+      render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} isEnriching />);
+
+      expect(screen.getByTestId('EnrichingSpinner')).toBeInTheDocument();
+      expect(screen.getByText('Fetching details...')).toBeInTheDocument();
+      // The link icon should give way to the spinner while enrichment is active.
+      expect(screen.queryByTestId('LinkIcon')).not.toBeInTheDocument();
+      expect(screen.queryByText('URL-only import')).not.toBeInTheDocument();
+    });
+
+    test('shows link icon again if isEnriching is false', () => {
+      render(<VideoChip video={bulkVideo} onDelete={mockOnDelete} isEnriching={false} />);
+
+      expect(screen.getByTestId('LinkIcon')).toBeInTheDocument();
+      expect(screen.queryByTestId('EnrichingSpinner')).not.toBeInTheDocument();
     });
   });
 });

--- a/client/src/components/ui/chip.tsx
+++ b/client/src/components/ui/chip.tsx
@@ -70,12 +70,13 @@ export interface ChipProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'c
   avatar?: React.ReactNode;
   disabled?: boolean;
   className?: string;
+  labelClassName?: string;
   deleteIcon?: React.ReactNode;
   style?: React.CSSProperties;
 }
 
 const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
-  ({ label, onDelete, onClick, icon, avatar, disabled, className, variant, color, size, deleteIcon, style, ...rest }, ref) => {
+  ({ label, onDelete, onClick, icon, avatar, disabled, className, labelClassName, variant, color, size, deleteIcon, style, ...rest }, ref) => {
     const isClickable = !!onClick;
     const Tag = isClickable ? 'button' : 'div';
 
@@ -108,7 +109,7 @@ const Chip = React.forwardRef<HTMLDivElement, ChipProps>(
       },
       avatar && <span className="shrink-0 -ml-0.5">{avatar}</span>,
       icon && <span className="shrink-0 [&>svg]:h-[1em] [&>svg]:w-[1em]">{icon}</span>,
-      <span key="label" className="px-0.5 truncate">{label}</span>,
+      <span key="label" className={cn('px-0.5 truncate', labelClassName)}>{label}</span>,
       onDelete && (
         <span
           key="delete"

--- a/client/src/components/ui/tooltip.tsx
+++ b/client/src/components/ui/tooltip.tsx
@@ -19,6 +19,7 @@ export interface TooltipProps {
   className?: string;
   open?: boolean;
   onClose?: () => void;
+  fullWidth?: boolean;
 }
 
 const Tooltip: React.FC<TooltipProps> = ({
@@ -34,7 +35,11 @@ const Tooltip: React.FC<TooltipProps> = ({
   className,
   open,
   onClose,
+  fullWidth = false,
 }) => {
+  const triggerWrapperStyle: React.CSSProperties = fullWidth
+    ? { position: 'relative', display: 'flex', width: '100%' }
+    : { position: 'relative', display: 'inline-flex' };
   const [touchOpen, setTouchOpen] = React.useState(false);
   const triggerRef = React.useRef<HTMLElement | null>(null);
   const [coarsePointer, setCoarsePointer] = React.useState(false);
@@ -170,7 +175,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   // Controlled mode: simple inline overlay
   if (isControlled) {
     return (
-      <span style={{ position: 'relative', display: 'inline-flex' }}>
+      <span style={triggerWrapperStyle}>
         {children}
         {open && (
           <div
@@ -219,7 +224,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   if (coarsePointer) {
     return (
       <>
-        <span style={{ position: 'relative', display: 'inline-flex' }}>
+        <span style={triggerWrapperStyle}>
           {childWithTouch}
         </span>
         {touchOpen && touchPosition && typeof document !== 'undefined'

--- a/server/modules/__tests__/videoOembedEnricher.test.js
+++ b/server/modules/__tests__/videoOembedEnricher.test.js
@@ -1,0 +1,258 @@
+/* eslint-env jest */
+
+jest.mock('../download/tempPathManager', () => ({
+  getTempBasePath: jest.fn(() => '/tmp/youtarr-downloads'),
+}));
+
+jest.mock('../../logger', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('https', () => ({ get: jest.fn() }));
+
+const https = require('https');
+const { EventEmitter } = require('events');
+const enricher = require('../videoOembedEnricher');
+
+/**
+ * Test double for http.IncomingMessage. Emits data + end on next tick
+ * so response listeners have attached first.
+ */
+function makeResponse(statusCode, body) {
+  const res = new EventEmitter();
+  res.statusCode = statusCode;
+  res.resume = jest.fn();
+  res.destroy = jest.fn();
+  setImmediate(() => {
+    if (body) res.emit('data', Buffer.from(body));
+    res.emit('end');
+  });
+  return res;
+}
+
+function stubHttpsGet(responses) {
+  // responses: { [videoId]: { status, body } | 'error' | 'timeout' | undefined (=> 404) }
+  https.get.mockImplementation((url, _options, cb) => {
+    const match = String(url).match(/v%3D([A-Za-z0-9_-]{11})/);
+    const id = match ? match[1] : null;
+    const plan = id ? responses[id] : null;
+
+    const req = new EventEmitter();
+    req.destroy = jest.fn();
+
+    if (plan === 'error') {
+      setImmediate(() => req.emit('error', new Error('connect refused')));
+      return req;
+    }
+    if (plan === 'timeout') {
+      setImmediate(() => req.emit('timeout'));
+      return req;
+    }
+    if (!plan) {
+      setImmediate(() => cb(makeResponse(404, null)));
+      return req;
+    }
+    setImmediate(() => cb(makeResponse(plan.status, plan.body)));
+    return req;
+  });
+}
+
+/**
+ * A rate limiter that never waits. Lets the dedup / cap / error-handling
+ * tests run synchronously without burning wall-clock time.
+ */
+const noopRateLimiter = { waitForSlot: () => Promise.resolve() };
+
+describe('videoOembedEnricher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('enrichByIds', () => {
+    it('returns empty object when ids is empty or invalid', async () => {
+      expect(await enricher.enrichByIds([], { rateLimiter: noopRateLimiter })).toEqual({});
+      expect(await enricher.enrichByIds(null, { rateLimiter: noopRateLimiter })).toEqual({});
+      expect(await enricher.enrichByIds(undefined, { rateLimiter: noopRateLimiter })).toEqual({});
+    });
+
+    it('drops invalid-format ids before fetching', async () => {
+      stubHttpsGet({});
+      const result = await enricher.enrichByIds(
+        ['too-short', 12345, null, '', 'has spaces!!'],
+        { rateLimiter: noopRateLimiter }
+      );
+      expect(result).toEqual({});
+      expect(https.get).not.toHaveBeenCalled();
+    });
+
+    it('fetches title and channelName for valid ids', async () => {
+      stubHttpsGet({
+        aaaaaaaaaaa: {
+          status: 200,
+          body: JSON.stringify({ title: 'Video A', author_name: 'Channel A' }),
+        },
+        bbbbbbbbbbb: {
+          status: 200,
+          body: JSON.stringify({ title: 'Video B', author_name: 'Channel B' }),
+        },
+      });
+      const result = await enricher.enrichByIds(
+        ['aaaaaaaaaaa', 'bbbbbbbbbbb'],
+        { rateLimiter: noopRateLimiter }
+      );
+      expect(result).toEqual({
+        aaaaaaaaaaa: { title: 'Video A', channelName: 'Channel A' },
+        bbbbbbbbbbb: { title: 'Video B', channelName: 'Channel B' },
+      });
+    });
+
+    it('omits ids whose oembed response is 404', async () => {
+      stubHttpsGet({
+        aaaaaaaaaaa: {
+          status: 200,
+          body: JSON.stringify({ title: 'Only Me', author_name: 'Ch' }),
+        },
+        bbbbbbbbbbb: { status: 404, body: null },
+      });
+      const result = await enricher.enrichByIds(
+        ['aaaaaaaaaaa', 'bbbbbbbbbbb'],
+        { rateLimiter: noopRateLimiter }
+      );
+      expect(result).toEqual({
+        aaaaaaaaaaa: { title: 'Only Me', channelName: 'Ch' },
+      });
+    });
+
+    it('omits ids whose oembed response is malformed JSON', async () => {
+      stubHttpsGet({
+        aaaaaaaaaaa: { status: 200, body: 'not-json{{{' },
+      });
+      const result = await enricher.enrichByIds(
+        ['aaaaaaaaaaa'],
+        { rateLimiter: noopRateLimiter }
+      );
+      expect(result).toEqual({});
+    });
+
+    it('omits ids whose fetch errors out', async () => {
+      stubHttpsGet({
+        aaaaaaaaaaa: 'error',
+        bbbbbbbbbbb: {
+          status: 200,
+          body: JSON.stringify({ title: 'B', author_name: 'CB' }),
+        },
+      });
+      const result = await enricher.enrichByIds(
+        ['aaaaaaaaaaa', 'bbbbbbbbbbb'],
+        { rateLimiter: noopRateLimiter }
+      );
+      expect(result).toEqual({ bbbbbbbbbbb: { title: 'B', channelName: 'CB' } });
+    });
+
+    it('deduplicates ids before fetching', async () => {
+      stubHttpsGet({
+        aaaaaaaaaaa: {
+          status: 200,
+          body: JSON.stringify({ title: 'A', author_name: 'CA' }),
+        },
+      });
+      const result = await enricher.enrichByIds(
+        ['aaaaaaaaaaa', 'aaaaaaaaaaa', 'aaaaaaaaaaa'],
+        { rateLimiter: noopRateLimiter }
+      );
+      expect(result).toEqual({ aaaaaaaaaaa: { title: 'A', channelName: 'CA' } });
+      expect(https.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('caps outbound fetches at OEMBED_MAX_IDS_PER_REQUEST when given many unique ids', async () => {
+      // Build OEMBED_MAX_IDS_PER_REQUEST + 20 genuinely distinct 11-char ids
+      // so that neither dedup nor format-filtering can hide a missing cap.
+      const over = enricher.OEMBED_MAX_IDS_PER_REQUEST + 20;
+      const chars = 'abcdefghijklmnopqrstuvwxyz0123456789_-';
+      const ids = [];
+      for (let i = 0; i < over; i++) {
+        // Deterministic 11-char id derived from i, guaranteed unique for i < chars.length^2.
+        const a = chars[Math.floor(i / chars.length) % chars.length];
+        const b = chars[i % chars.length];
+        ids.push(`${a}${b}aaaaaaaaa`);
+      }
+      // Safety: they must actually be unique.
+      expect(new Set(ids).size).toBe(over);
+
+      const responses = {};
+      ids.forEach((id) => {
+        responses[id] = {
+          status: 200,
+          body: JSON.stringify({ title: id, author_name: 'c' }),
+        };
+      });
+      stubHttpsGet(responses);
+
+      const result = await enricher.enrichByIds(ids, { rateLimiter: noopRateLimiter });
+
+      expect(Object.keys(result)).toHaveLength(enricher.OEMBED_MAX_IDS_PER_REQUEST);
+      expect(https.get).toHaveBeenCalledTimes(enricher.OEMBED_MAX_IDS_PER_REQUEST);
+    });
+  });
+
+  describe('createRateLimiter', () => {
+    it('rejects non-positive rps', () => {
+      expect(() => enricher.createRateLimiter({ rps: 0 })).toThrow();
+      expect(() => enricher.createRateLimiter({ rps: -1 })).toThrow();
+      expect(() => enricher.createRateLimiter({})).toThrow();
+    });
+
+    it('does not wait on the first slot', async () => {
+      let slept = 0;
+      let clock = 1000;
+      const limiter = enricher.createRateLimiter({
+        rps: 3,
+        now: () => clock,
+        sleep: (ms) => { slept += ms; clock += ms; return Promise.resolve(); },
+      });
+
+      await limiter.waitForSlot();
+      expect(slept).toBe(0);
+    });
+
+    it('spaces consecutive slots by at least 1000/rps ms', async () => {
+      let clock = 1000;
+      let slept = 0;
+      const limiter = enricher.createRateLimiter({
+        rps: 3,
+        now: () => clock,
+        sleep: (ms) => { slept += ms; clock += ms; return Promise.resolve(); },
+      });
+      const minInterval = Math.ceil(1000 / 3);
+
+      await limiter.waitForSlot(); // fires immediately
+      await limiter.waitForSlot();
+      expect(slept).toBe(minInterval);
+
+      await limiter.waitForSlot();
+      expect(slept).toBe(minInterval * 2);
+
+      await limiter.waitForSlot();
+      expect(slept).toBe(minInterval * 3);
+    });
+
+    it('does not wait when caller is already past the next slot', async () => {
+      let clock = 1000;
+      let slept = 0;
+      const limiter = enricher.createRateLimiter({
+        rps: 3,
+        now: () => clock,
+        sleep: (ms) => { slept += ms; clock += ms; return Promise.resolve(); },
+      });
+
+      await limiter.waitForSlot();      // slot at t=1000
+      clock += 5000;                     // caller stalls; next slot already due
+      await limiter.waitForSlot();       // should not sleep
+
+      expect(slept).toBe(0);
+    });
+  });
+});

--- a/server/modules/videoOembedEnricher.js
+++ b/server/modules/videoOembedEnricher.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const https = require('https');
+const logger = require('../logger');
+const createConcurrencyLimiter = require('./subscriptionImport/concurrencyLimiter');
+
+// Rate limiting: at most OEMBED_RPS outbound oEmbed requests per second.
+// This protects the user's IP from YouTube throttling / temporary bans.
+const OEMBED_RPS = 3;
+const OEMBED_CONCURRENCY = 3;
+const OEMBED_TIMEOUT_MS = 5000;
+const OEMBED_HARD_DEADLINE_MS = OEMBED_TIMEOUT_MS + 2000;
+const OEMBED_MAX_IDS_PER_REQUEST = 100;
+const OEMBED_MAX_BYTES = 64 * 1024;
+const VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{11}$/;
+
+/**
+ * Creates a rate limiter that ensures at most `rps` fires per second.
+ * Returned object has `waitForSlot()`, which resolves when the caller
+ * may proceed. Call exactly once per outbound request.
+ *
+ * Callers share state within a single limiter instance: two concurrent
+ * waitForSlot() invocations will be scheduled back-to-back, not in
+ * parallel.
+ */
+function createRateLimiter({ rps, now = Date.now, sleep } = {}) {
+  if (!Number.isFinite(rps) || rps <= 0) {
+    throw new Error('createRateLimiter: rps must be a positive number');
+  }
+  const minIntervalMs = Math.ceil(1000 / rps);
+  const sleepFn = sleep || ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  let nextSlotAt = 0;
+
+  return {
+    waitForSlot() {
+      const t = now();
+      const target = Math.max(t, nextSlotAt);
+      nextSlotAt = target + minIntervalMs;
+      const delay = target - t;
+      if (delay <= 0) return Promise.resolve();
+      return sleepFn(delay);
+    },
+  };
+}
+
+const defaultRateLimiter = createRateLimiter({ rps: OEMBED_RPS });
+
+function fetchOembed(videoId) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+
+    const deadline = setTimeout(() => {
+      logger.warn({ videoId }, 'videoOembedEnricher: hard deadline exceeded');
+      finish(null);
+    }, OEMBED_HARD_DEADLINE_MS);
+
+    try {
+      const oEmbedUrl = `https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D${videoId}&format=json`;
+      const req = https.get(oEmbedUrl, { timeout: OEMBED_TIMEOUT_MS }, (res) => {
+        const { statusCode } = res;
+
+        if (statusCode !== 200) {
+          res.resume();
+          clearTimeout(deadline);
+          if (statusCode !== 401 && statusCode !== 403 && statusCode !== 404) {
+            logger.warn({ videoId, statusCode }, 'videoOembedEnricher: non-200 oembed response');
+          }
+          finish(null);
+          return;
+        }
+
+        const chunks = [];
+        let bytesRead = 0;
+        let overflow = false;
+
+        res.on('data', (chunk) => {
+          bytesRead += chunk.length;
+          if (bytesRead > OEMBED_MAX_BYTES) {
+            overflow = true;
+            res.destroy();
+            return;
+          }
+          chunks.push(chunk);
+        });
+
+        res.on('end', () => {
+          clearTimeout(deadline);
+          if (overflow) {
+            logger.warn({ videoId, bytesRead }, 'videoOembedEnricher: oembed response too large');
+            finish(null);
+            return;
+          }
+          try {
+            const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+            const title = typeof parsed.title === 'string' ? parsed.title : '';
+            const channelName = typeof parsed.author_name === 'string' ? parsed.author_name : '';
+            if (!title && !channelName) {
+              finish(null);
+              return;
+            }
+            finish({ title, channelName });
+          } catch (err) {
+            logger.warn({ videoId, err }, 'videoOembedEnricher: failed to parse oembed JSON');
+            finish(null);
+          }
+        });
+
+        res.on('error', (err) => {
+          clearTimeout(deadline);
+          logger.warn({ videoId, err }, 'videoOembedEnricher: response stream error');
+          finish(null);
+        });
+
+        res.on('close', () => {
+          clearTimeout(deadline);
+          finish(null);
+        });
+      });
+
+      req.on('timeout', () => {
+        req.destroy();
+        clearTimeout(deadline);
+        finish(null);
+      });
+
+      req.on('error', (err) => {
+        clearTimeout(deadline);
+        logger.warn({ videoId, err }, 'videoOembedEnricher: request error');
+        finish(null);
+      });
+    } catch (err) {
+      clearTimeout(deadline);
+      logger.warn({ videoId, err }, 'videoOembedEnricher: unexpected error');
+      finish(null);
+    }
+  });
+}
+
+/**
+ * Fetch title + channel name for a batch of YouTube video IDs via oEmbed.
+ *
+ * @param {string[]} ids - YouTube video IDs
+ * @param {Object} [options]
+ * @param {{ waitForSlot: () => Promise<void> }} [options.rateLimiter]
+ *        Optional rate limiter override, used in tests.
+ * @returns {Promise<Object.<string, { title: string, channelName: string }>>}
+ */
+async function enrichByIds(ids, { rateLimiter = defaultRateLimiter } = {}) {
+  if (!Array.isArray(ids) || ids.length === 0) return {};
+
+  const cleanIds = Array.from(
+    new Set(ids.filter((id) => typeof id === 'string' && VIDEO_ID_PATTERN.test(id)))
+  ).slice(0, OEMBED_MAX_IDS_PER_REQUEST);
+
+  if (cleanIds.length === 0) return {};
+
+  const limit = createConcurrencyLimiter(OEMBED_CONCURRENCY);
+  const results = {};
+
+  await Promise.all(
+    cleanIds.map((id) =>
+      limit(async () => {
+        await rateLimiter.waitForSlot();
+        const data = await fetchOembed(id);
+        if (data) {
+          results[id] = data;
+        }
+      })
+    )
+  );
+
+  return results;
+}
+
+module.exports = {
+  enrichByIds,
+  createRateLimiter,
+  OEMBED_MAX_IDS_PER_REQUEST,
+  OEMBED_RPS,
+};

--- a/server/routes/__tests__/videos.bulkEnrich.rateLimit.test.js
+++ b/server/routes/__tests__/videos.bulkEnrich.rateLimit.test.js
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+'use strict';
+
+// The sibling routes test mocks express-rate-limit to bypass it. This file
+// intentionally does not — we are testing that the limiter engages.
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../../logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const createVideoRoutes = require('../videos');
+
+function buildApp({ enricherStub }) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.log = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+    // Express-rate-limit keys by IP; jsdom/supertest uses a stable loopback
+    // address, which is what we want for per-key accounting.
+    next();
+  });
+  const router = createVideoRoutes({
+    verifyToken: (req, res, next) => next(),
+    videosModule: {},
+    downloadModule: {},
+    videoOembedEnricher: enricherStub,
+  });
+  app.use(router);
+  return app;
+}
+
+describe('POST /api/bulkEnrichVideos rate limiter', () => {
+  it('returns 429 once the per-minute cap is exceeded', async () => {
+    const enricherStub = {
+      enrichByIds: jest.fn().mockResolvedValue({}),
+    };
+    const app = buildApp({ enricherStub });
+
+    // The limiter is 20/min. Fire 20 allowed requests, then a 21st and
+    // expect it to be rejected.
+    for (let i = 0; i < 20; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await request(app)
+        .post('/api/bulkEnrichVideos')
+        .send({ ids: [] });
+      expect(res.status).toBe(200);
+    }
+
+    const overflow = await request(app)
+      .post('/api/bulkEnrichVideos')
+      .send({ ids: [] });
+
+    expect(overflow.status).toBe(429);
+    // The limiter handler returns the message string, not JSON.
+    expect(overflow.text).toMatch(/Too many enrichment requests/i);
+  }, 15000);
+});

--- a/server/routes/__tests__/videos.routes.test.js
+++ b/server/routes/__tests__/videos.routes.test.js
@@ -75,6 +75,84 @@ describe('POST /api/videos/rating', () => {
   });
 });
 
+describe('POST /api/bulkEnrichVideos', () => {
+  const loggerMock = {
+    info: jest.fn(),
+    error: jest.fn(),
+  };
+
+  const createResponse = () => {
+    const res = {};
+    res.status = jest.fn(() => res);
+    res.json = jest.fn(() => res);
+    return res;
+  };
+
+  let enricherStub;
+
+  const getHandler = () => {
+    const router = createVideoRoutes({
+      verifyToken: (req, res, next) => next(),
+      videosModule: {},
+      downloadModule: {},
+      videoOembedEnricher: enricherStub,
+    });
+    const app = express();
+    app.use(express.json());
+    app.use(router);
+    return findRouteHandler(app, 'post', '/api/bulkEnrichVideos');
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    enricherStub = { enrichByIds: jest.fn() };
+  });
+
+  test('returns enriched map from the oembed enricher', async () => {
+    enricherStub.enrichByIds.mockResolvedValue({
+      aaaaaaaaaaa: { title: 'A', channelName: 'CA' },
+    });
+    const handler = getHandler();
+    const req = { body: { ids: ['aaaaaaaaaaa', 'bbbbbbbbbbb'] }, log: loggerMock };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(enricherStub.enrichByIds).toHaveBeenCalledWith([
+      'aaaaaaaaaaa',
+      'bbbbbbbbbbb',
+    ]);
+    expect(res.json).toHaveBeenCalledWith({
+      enriched: { aaaaaaaaaaa: { title: 'A', channelName: 'CA' } },
+    });
+  });
+
+  test('returns 400 when ids is not an array', async () => {
+    const handler = getHandler();
+    const req = { body: { ids: 'not-an-array' }, log: loggerMock };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(enricherStub.enrichByIds).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'ids must be an array' });
+  });
+
+  test('returns 500 when the enricher throws', async () => {
+    enricherStub.enrichByIds.mockRejectedValue(new Error('boom'));
+    const handler = getHandler();
+    const req = { body: { ids: ['aaaaaaaaaaa'] }, log: loggerMock };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+    expect(loggerMock.error).toHaveBeenCalled();
+  });
+});
+
 describe('PATCH /api/videos/:id/protected', () => {
   const loggerMock = {
     info: jest.fn(),

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -11,6 +11,7 @@ const createSubscriptionRoutes = require('./subscriptions');
 const createVideoDetailRoutes = require('./videoDetail');
 const createVideoSearchRoutes = require('./videoSearch');
 const videoMetadataModule = require('../modules/videoMetadataModule');
+const videoOembedEnricher = require('../modules/videoOembedEnricher');
 
 /**
  * Registers all route modules with the Express app
@@ -53,7 +54,7 @@ function registerRoutes(app, deps) {
   app.use(createChannelRoutes({ verifyToken, channelModule, archiveModule }));
 
   // Video routes
-  app.use(createVideoRoutes({ verifyToken, videosModule, downloadModule }));
+  app.use(createVideoRoutes({ verifyToken, videosModule, downloadModule, videoOembedEnricher }));
 
   // Video search routes
   app.use(createVideoSearchRoutes({ verifyToken, videoSearchModule }));

--- a/server/routes/videos.js
+++ b/server/routes/videos.js
@@ -11,6 +11,16 @@ const videoValidationLimiter = rateLimit({
   validate: { trustProxy: false },
 });
 
+// Bulk enrichment rate limiter
+const bulkEnrichLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 20, // 20 enrichment batches per minute per client
+  message: 'Too many enrichment requests, please try again later',
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { trustProxy: false },
+});
+
 // API key download rate limiter
 const apiKeyDownloadLimiter = rateLimit({
   windowMs: 1 * 60 * 1000, // 1 minute
@@ -42,7 +52,7 @@ const apiKeyDownloadLimiter = rateLimit({
  * @param {Object} deps.downloadModule - Download module
  * @returns {express.Router}
  */
-module.exports = function createVideoRoutes({ verifyToken, videosModule, downloadModule }) {
+module.exports = function createVideoRoutes({ verifyToken, videosModule, downloadModule, videoOembedEnricher }) {
   const router = express.Router();
 
   /**
@@ -466,6 +476,52 @@ module.exports = function createVideoRoutes({ verifyToken, videosModule, downloa
         isValidUrl: false,
         error: 'Internal server error'
       });
+    }
+  });
+
+  /**
+   * @swagger
+   * /api/bulkEnrichVideos:
+   *   post:
+   *     summary: Enrich a batch of YouTube video IDs with title + channel name
+   *     description: >
+   *       Fetches lightweight metadata (title, channel name) for a batch of
+   *       YouTube video IDs via YouTube's public oEmbed endpoint. Used by the
+   *       Manual Download bulk-import flow to turn raw IDs into readable
+   *       chips without the cost of a full yt-dlp metadata fetch.
+   *       Outbound requests are rate-limited to protect the server's IP.
+   *     tags: [Videos]
+   *     security:
+   *       - BearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [ids]
+   *             properties:
+   *               ids:
+   *                 type: array
+   *                 items: { type: string }
+   *                 description: YouTube video IDs (11 chars)
+   *     responses:
+   *       200:
+   *         description: Map of id to metadata; failed lookups are omitted.
+   *       400:
+   *         description: Invalid body.
+   */
+  router.post('/api/bulkEnrichVideos', verifyToken, bulkEnrichLimiter, async (req, res) => {
+    try {
+      const { ids } = req.body || {};
+      if (!Array.isArray(ids)) {
+        return res.status(400).json({ error: 'ids must be an array' });
+      }
+      const enriched = await videoOembedEnricher.enrichByIds(ids);
+      res.json({ enriched });
+    } catch (error) {
+      req.log.error({ err: error }, 'Failed to enrich videos');
+      res.status(500).json({ error: 'Internal server error' });
     }
   });
 


### PR DESCRIPTION
- Manual Download chips stretch to fill their grid column now, with a YouTube thumbnail, publish date, and duration pill stacked on each chip
- Chips hide the duration pill and date when the values aren't known, so bulk-imported items don't show "0:00" while they're still loading
- Bulk import pulls title and channel name from YouTube for each pasted URL, so chips show real video info instead of raw IDs
- A spinner and "Fetching details..." message show on bulk chips while that enrichment is in flight
- Bulk import is capped at 100 URLs per paste, with a warning in the dialog if you go over, and the dialog itself is wider on desktop
- Responsive grid tweaks: bigger gaps, cleaner two-column vs one-column behavior on mobile
- Channel Display Guide help dialog was rewritten for accuracy and layout