### PR TITLE
fix(release): remove empty template braces from shell comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Create or update CHANGELOG.md
-          # Pass interpolated values via env vars (not ${{ }} text substitution)
-          # so quotes/parens in commit messages can't break bash parsing.
+          # Values are passed via env vars (see `env:` above) so quotes/parens
+          # in commit messages do not break bash parsing.
           CHANGELOG_ENTRY="## [${NEW_TAG}](https://github.com/${REPO}/releases/tag/${NEW_TAG}) - $(date +%Y-%m-%d)
 
           ${CHANGELOG_BODY}


### PR DESCRIPTION
GitHub Actions parses `${{ ... }}` inside `run:` scripts even within shell comments. The previous commit's explanatory comment contained a literal empty pair of braces, which actionlint and GitHub's parser reject with `unexpected end of input while parsing ... expression`. That broke the release.yml workflow at parse time, so the run never started.

Rewrite the comment without the empty-template text. actionlint now passes for all workflows.