### PR TITLE
Release: UI refresh, theme engine, and Find on YouTube (v1.66.0 retry)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Create or update CHANGELOG.md
-          # Pass interpolated values via env vars (not ${{ }} text substitution)
-          # so quotes/parens in commit messages can't break bash parsing.
+          # Values are passed via env vars (see `env:` above) so quotes/parens
+          # in commit messages do not break bash parsing.
           CHANGELOG_ENTRY="## [${NEW_TAG}](https://github.com/${REPO}/releases/tag/${NEW_TAG}) - $(date +%Y-%m-%d)
 
           ${CHANGELOG_BODY}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,11 +157,17 @@ jobs:
 
       - name: Update CHANGELOG.md
         if: ${{ !inputs.dry_run && steps.calculate_version.outputs.release_type != 'none' }}
+        env:
+          NEW_TAG: ${{ steps.calculate_version.outputs.new_tag }}
+          CHANGELOG_BODY: ${{ steps.calculate_version.outputs.changelog }}
+          REPO: ${{ github.repository }}
         run: |
           # Create or update CHANGELOG.md
-          CHANGELOG_ENTRY="## [${{ steps.calculate_version.outputs.new_tag }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.calculate_version.outputs.new_tag }}) - $(date +%Y-%m-%d)
+          # Pass interpolated values via env vars (not ${{ }} text substitution)
+          # so quotes/parens in commit messages can't break bash parsing.
+          CHANGELOG_ENTRY="## [${NEW_TAG}](https://github.com/${REPO}/releases/tag/${NEW_TAG}) - $(date +%Y-%m-%d)
 
-          ${{ steps.calculate_version.outputs.changelog }}
+          ${CHANGELOG_BODY}
 
           "
 
@@ -181,7 +187,7 @@ jobs:
 
           # Commit the CHANGELOG update
           git add CHANGELOG.md
-          git commit -m "docs: update CHANGELOG for ${{ steps.calculate_version.outputs.new_tag }} [skip ci]"
+          git commit -m "docs: update CHANGELOG for ${NEW_TAG} [skip ci]"
           git push
 
       - name: Record CHANGELOG commit SHA
@@ -305,24 +311,30 @@ jobs:
 
       - name: Display dry run results
         if: ${{ inputs.dry_run }}
+        env:
+          NEW_TAG: ${{ steps.calculate_version.outputs.new_tag }}
+          PREVIOUS_TAG: ${{ steps.calculate_version.outputs.previous_tag }}
+          RELEASE_TYPE: ${{ steps.calculate_version.outputs.release_type }}
+          CHANGELOG_BODY: ${{ steps.calculate_version.outputs.changelog }}
+          DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
         run: |
           echo "🔍 DRY RUN RESULTS:"
           echo "==================="
-          echo "Would have created tag: ${{ steps.calculate_version.outputs.new_tag }}"
-          echo "Previous tag: ${{ steps.calculate_version.outputs.previous_tag }}"
-          echo "Bump type: ${{ steps.calculate_version.outputs.release_type }}"
+          echo "Would have created tag: ${NEW_TAG}"
+          echo "Previous tag: ${PREVIOUS_TAG}"
+          echo "Bump type: ${RELEASE_TYPE}"
           echo ""
-          echo "Would have created GitHub Release: ${{ steps.calculate_version.outputs.new_tag }}"
+          echo "Would have created GitHub Release: ${NEW_TAG}"
           echo ""
           echo "Release Notes Preview:"
           echo "----------------------"
-          echo "${{ steps.calculate_version.outputs.changelog }}"
+          echo "${CHANGELOG_BODY}"
           echo ""
           echo "Docker images that would be pushed:"
-          echo "  - ${{ vars.DOCKERHUB_USERNAME }}/youtarr:${{ steps.calculate_version.outputs.new_tag }}"
-          echo "  - ${{ vars.DOCKERHUB_USERNAME }}/youtarr:latest"
+          echo "  - ${DOCKERHUB_USERNAME}/youtarr:${NEW_TAG}"
+          echo "  - ${DOCKERHUB_USERNAME}/youtarr:latest"
           echo ""
-          if [ "${{ steps.calculate_version.outputs.release_type }}" = "none" ]; then
+          if [ "${RELEASE_TYPE}" = "none" ]; then
             echo "No changes detected since the last release; no build attempted in dry run."
           else
             echo "✅ Build verification steps succeeded (client and Docker)"


### PR DESCRIPTION
Re-release of the content that was already approved in #548. The original merge fired v1.66.0 but the release workflow failed at the Update CHANGELOG.md step (bash quoting bug); the cleanup steps reverted the tag and bump commit cleanly, so main went back to its pre-release state. This PR ships the same payload with the workflow fix applied.

### Content (unchanged from #548)

- Rebuilt the frontend on Radix + Tailwind with three selectable themes (playful, linear, flat) and dark mode
- New "Find on YouTube" page: search YouTube from inside Youtarr and see which results are already downloaded, missing, or new
- Channel Display Guide rewritten to match the actual columns
- Docs refreshed for the Tailwind/Radix stack (CLAUDE.md, README Quick Start, DEVELOPMENT.md)
- Added tests to cover new UI surfaces after the refactor

### Additional changes on top

- #550: route the changelog through env vars in release.yml so quotes/parens in commit subjects stop breaking bash parsing
- #551: remove literal empty `${{ }}` from a shell comment that made the workflow itself unparseable

<img width="1898" height="1033" alt="image" src="https://github.com/user-attachments/assets/5f9f7e1c-4097-4f8d-8ccf-25610847f53d" />

<img width="1904" height="1027" alt="image" src="https://github.com/user-attachments/assets/c67caf43-635c-4aa2-a05b-17760fb82af5" />

<img width="1888" height="1064" alt="image" src="https://github.com/user-attachments/assets/8aecc498-53e8-480d-ab0a-be07dc202f88" />