### PR TITLE
fix(websocket): memoize context value to prevent render loop

### DIFF
--- a/client/src/providers/WebSocketProvider.tsx
+++ b/client/src/providers/WebSocketProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, ReactNode, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, ReactNode, useRef } from 'react';
 import WebSocketContext from '../contexts/WebSocketContext';
 import { locationUtils } from '../utils/location';
 
@@ -133,8 +133,13 @@ const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }) => {
     };
   }, [connect, socket]);
 
+  const contextValue = useMemo(
+    () => ({ socket, subscribe, unsubscribe }),
+    [socket, subscribe, unsubscribe]
+  );
+
   return (
-    <WebSocketContext.Provider value={{ socket, subscribe, unsubscribe }}>
+    <WebSocketContext.Provider value={contextValue}>
       {children}
     </WebSocketContext.Provider>
   );


### PR DESCRIPTION
Fixes the 100% CPU issue on the Channels page that started after the UI refactor. WebSocketProvider wasn't memoizing its context value, and that combined with ChannelManager's effect deps turned into an infinite subscribe/resubscribe loop. No console errors, so it was easy to miss.

Wrapping the context value in useMemo breaks the loop. Before: ~15000 provider renders in 10 seconds and one CPU core pegged. After: 9 renders (stable, not increasing), CPU at 0.2%.