### PR TITLE
fix: download true 1440p/2160p with VP9/AV1 remuxed into MP4 (#534)

### DIFF
--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -602,6 +602,11 @@ function ChannelSettingsDialog({
               <Typography variant="caption" color="text.secondary" style={{ marginTop: 8, display: 'block' }}>
                 Effective channel quality: {effectiveQualityDisplay}.
               </Typography>
+              {(settings.video_quality === '1440' || settings.video_quality === '2160') && (
+                <Typography variant="caption" color="warning.main" style={{ marginTop: 4, display: 'block' }}>
+                  YouTube only serves H.264 MP4 up to 1080p. {settings.video_quality === '2160' ? '4K' : '1440p'} uses VP9/AV1 (remuxed into MP4); older Plex clients without native VP9/AV1 decode may transcode.
+                </Typography>
+              )}
             </div>
 
             <FormControl fullWidth style={{ marginTop: 8 }}>

--- a/client/src/components/Configuration/sections/CoreSettingsSection.tsx
+++ b/client/src/components/Configuration/sections/CoreSettingsSection.tsx
@@ -317,10 +317,15 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
                         <MenuItem value="360">360p</MenuItem>
                       </Select>
                       <InfoTooltip
-                        text="The resolution we will try to download from YouTube. Note that this is not guaranteed as YouTube may not have your preferred resolution available."
+                        text="The resolution we will try to download from YouTube. Note that this is not guaranteed as YouTube may not have your preferred resolution available. YouTube only provides H.264 MP4 up to 1080p. Selecting 1440p or 2160p (4K) will use VP9 or AV1 (remuxed into MP4), which older Plex clients (Apple TV HD, iOS, older Rokus) may need to transcode."
                         onMobileClick={onMobileTooltipClick}
                       />
                     </Box>
+                    {(config.preferredResolution === '1440' || config.preferredResolution === '2160') && (
+                      <Box component="span" className="text-xs text-muted-foreground">
+                        1440p+ uses VP9/AV1 (remuxed into MP4). Older Plex clients without native VP9/AV1 decode may transcode. Select H.264 codec below for best compatibility (caps at 1080p).
+                      </Box>
+                    )}
                   </FormControl>
                 </Grid>
 
@@ -341,12 +346,12 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
                         <MenuItem value="h265">H.265/HEVC (Balanced)</MenuItem>
                       </Select>
                       <InfoTooltip
-                        text="Select your preferred video codec. Youtarr will download this codec when available, and fall back to other codecs if your preference is not available for a video. H.264 is recommended for Apple TV and maximum device compatibility. VP9 is the default codec for most YouTube videos."
+                        text="Select your preferred video codec. Youtarr will download this codec when available, and fall back if it is not. H.264 is recommended for Apple TV and maximum device compatibility, but YouTube does not provide H.264 above 1080p so selecting it effectively caps downloads at 1080p regardless of the resolution preference above. Default lets YouTube pick the best codec (typically VP9 or AV1 at 1440p+)."
                         onMobileClick={onMobileTooltipClick}
                       />
                     </Box>
                     <Box component="span" className="text-xs text-muted-foreground">
-                      Note: H.264 produces larger file sizes but offers maximum compatibility for Apple TV. This is a preference and will fall back to available codecs.
+                      Note: H.264 offers maximum compatibility (Apple TV HD, iOS, older Rokus direct-play) but YouTube caps H.264 at 1080p, so it will override any 1440p/2160p preference.
                     </Box>
                   </FormControl>
                 </Grid>

--- a/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
@@ -492,7 +492,7 @@ describe('CoreSettingsSection Component', () => {
     test('displays helper text about codec preferences', () => {
       const props = createSectionProps();
       renderWithProviders(<CoreSettingsSection {...props} />);
-      expect(screen.getByText(/Note: H\.264 produces larger file sizes/i)).toBeInTheDocument();
+      expect(screen.getByText(/YouTube caps H\.264 at 1080p/i)).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
@@ -369,10 +369,13 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
                 </FormHelperText>
               </FormControl>
 
-              {resolution === '2160' && (
+              {(resolution === '2160' || resolution === '1440') && (
                 <Alert severity="warning" className="mb-4">
                   <Typography variant="body2">
-                    4K videos may take significantly longer to download and use more storage space.
+                    {resolution === '2160'
+                      ? '4K videos may take significantly longer to download and use more storage space. '
+                      : ''}
+                    YouTube only provides H.264 MP4 up to 1080p, so {resolution === '2160' ? '4K' : '1440p'} uses VP9 or AV1 (remuxed into MP4). Older Plex clients without native VP9/AV1 decode (Apple TV HD, iOS, older Rokus) may transcode.
                   </Typography>
                 </Alert>
               )}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -83,13 +83,14 @@ Configuration can be modified through:
 - **Options**: `"4320"`, `"2160"`, `"1440"`, `"1080"`, `"720"`, `"480"`, `"360"`, `"240"`, `"144"`
 - **Description**: Global setting for preferred download resolution
 - **Note**: Downloads from YouTube at best available quality up to this limit
+- **Codec implication**: YouTube only provides H.264 in MP4 up to 1080p. Selecting 1440p or 2160p forces Youtarr to pick a VP9 or AV1 source stream (YouTube does not offer H.264 at those resolutions) and remux it into MP4 via `--merge-output-format mp4`. The remux is lossless (no re-encode), but Plex clients without native VP9/AV1 hardware decode (Apple TV HD, older Apple TV 4K, iOS, older Rokus) will transcode at playback. If direct-play compatibility matters more than resolution, keep this at 1080p or set `videoCodec` to `h264`.
 
 ### Preferred Video Codec
 - **Config Key**: `videoCodec`
 - **Type**: `string`
 - **Default**: `"default"`
 - **Options**: `"default"`, `"h264"`, `"h265"`
-- **Description**: Preferred video codec for downloads, default generally downloads as vp9 or av1
+- **Description**: Preferred video codec for downloads. `"default"` picks the best stream YouTube offers at the requested resolution (typically VP9 or AV1 above 1080p). `"h264"` forces H.264/AVC, which maximizes client compatibility but effectively caps resolution at 1080p because YouTube does not serve H.264 above that height. `"h265"` prefers HEVC but YouTube rarely provides it, so it almost always falls back to H.264 MP4.
 - **Compatibility**:
   - `h264`: Best compatibility with all devices
   - `h265`: Better compression, requires modern devices

--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -221,9 +221,19 @@ describe('YtdlpCommandBuilder', () => {
       expect(result).toBe('bestvideo[height<=720][ext=mp4][vcodec^=hev]+bestaudio[ext=m4a]/bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
     });
 
-    it('should handle 4K resolution with default codec', () => {
+    it('should handle 4K resolution with default codec by dropping [ext=mp4] (YouTube has no H.264 MP4 above 1080p)', () => {
       const result = YtdlpCommandBuilder.buildFormatString('2160', 'default');
-      expect(result).toBe('bestvideo[height<=2160][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+      expect(result).toBe('bestvideo[height<=2160]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should handle 1440p resolution with default codec by dropping [ext=mp4]', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('1440', 'default');
+      expect(result).toBe('bestvideo[height<=1440]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should keep [ext=mp4] for 720p default codec (H.264 MP4 available)', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('720', 'default');
+      expect(result).toBe('bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
     });
 
     it('should use default resolution (1080) when resolution is null', () => {
@@ -718,8 +728,27 @@ describe('YtdlpCommandBuilder', () => {
       const result = YtdlpCommandBuilder.getBaseCommandArgs();
       const formatIndex = result.indexOf('-f');
       const formatString = result[formatIndex + 1];
-      // Default codec should not include vcodec filters
+      // Default codec at 1080p keeps [ext=mp4] for Plex compatibility
       expect(formatString).toBe('bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should not include --merge-output-format at <=1080p', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgs('1080');
+      expect(result).not.toContain('--merge-output-format');
+    });
+
+    it('should include --merge-output-format mp4 at 1440p to keep container MP4 after VP9 remux', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgs('1440');
+      const idx = result.indexOf('--merge-output-format');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(result[idx + 1]).toBe('mp4');
+    });
+
+    it('should include --merge-output-format mp4 at 2160p', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgs('2160');
+      const idx = result.indexOf('--merge-output-format');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(result[idx + 1]).toBe('mp4');
     });
 
     it('should use h264 videoCodec when configured', () => {
@@ -902,6 +931,18 @@ describe('YtdlpCommandBuilder', () => {
       const formatIndex = result.indexOf('-f');
       const formatString = result[formatIndex + 1];
       expect(formatString).toBe('bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should not include --merge-output-format at <=1080p', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload('1080');
+      expect(result).not.toContain('--merge-output-format');
+    });
+
+    it('should include --merge-output-format mp4 at 2160p', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload('2160');
+      const idx = result.indexOf('--merge-output-format');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(result[idx + 1]).toBe('mp4');
     });
 
     it('should use h264 videoCodec when configured', () => {

--- a/server/modules/download/ytdlpCommandBuilder.js
+++ b/server/modules/download/ytdlpCommandBuilder.js
@@ -51,6 +51,19 @@ class YtdlpCommandBuilder {
     return path.join(...segments);
   }
   /**
+   * YouTube caps H.264 MP4 streams at 1080p. Above that, only VP9 (typically
+   * webm) and AV1 are available. When this returns true, the default format
+   * selector must not restrict to [ext=mp4], and the caller must pass
+   * --merge-output-format mp4 so the final container stays MP4.
+   * @param {string|number|null} resolution - Requested max height
+   * @returns {boolean}
+   */
+  static resolutionRequiresNonMp4Source(resolution) {
+    const height = Number(resolution);
+    return Number.isFinite(height) && height > 1080;
+  }
+
+  /**
    * Build format string based on resolution, codec preference, and audio format
    * @param {string} resolution - Video resolution (e.g., '1080', '720')
    * @param {string} videoCodec - Video codec preference ('h264', 'h265', 'default')
@@ -84,10 +97,18 @@ class YtdlpCommandBuilder {
       break;
 
     case 'default':
-    default:
-      // Default behavior: no codec preference, just resolution and container
-      videoFormat = `bestvideo[height<=${res}][ext=mp4]+${audioFmt}/${fallbackMp4}/${ultimateFallback}`;
+    default: {
+      // At 1080p and below, H.264 MP4 is available on YouTube so we keep the
+      // [ext=mp4] constraint for maximum Plex client compatibility (direct-play
+      // on Apple TV HD, older Rokus, iOS, etc.). Above 1080p, YouTube only
+      // serves VP9/AV1, so we drop the constraint and rely on
+      // --merge-output-format mp4 to keep the output container MP4.
+      const primarySelector = this.resolutionRequiresNonMp4Source(res)
+        ? `bestvideo[height<=${res}]+${audioFmt}`
+        : `bestvideo[height<=${res}][ext=mp4]+${audioFmt}`;
+      videoFormat = `${primarySelector}/${fallbackMp4}/${ultimateFallback}`;
       break;
+    }
     }
 
     return videoFormat;
@@ -425,6 +446,9 @@ class YtdlpCommandBuilder {
       // Clean @ prefix from uploader_id when it's used as fallback
       '--replace-in-metadata', 'uploader_id', '^@', '',
       '-f', this.buildFormatString(res, videoCodec, audioFormat),
+      // Only force MP4 remux when sources might be webm (1440p+).
+      // At <=1080p the format selector already picks MP4 sources.
+      ...(this.resolutionRequiresNonMp4Source(res) ? ['--merge-output-format', 'mp4'] : []),
       '--write-thumbnail',
       '--convert-thumbnails', 'jpg',
     ];
@@ -502,6 +526,9 @@ class YtdlpCommandBuilder {
       // Clean @ prefix from uploader_id when it's used as fallback
       '--replace-in-metadata', 'uploader_id', '^@', '',
       '-f', this.buildFormatString(res, videoCodec, audioFormat),
+      // Only force MP4 remux when sources might be webm (1440p+).
+      // At <=1080p the format selector already picks MP4 sources.
+      ...(this.resolutionRequiresNonMp4Source(res) ? ['--merge-output-format', 'mp4'] : []),
       '--write-thumbnail',
       '--convert-thumbnails', 'jpg',
     ];


### PR DESCRIPTION
YouTube only serves H.264 MP4 up to 1080p; above that, only VP9 and AV1 are available (typically in webm). The default-codec format selector required [ext=mp4], so 1440p/2160p downloads silently fell back to 1080p MP4.

Drop the [ext=mp4] constraint above 1080p and pass --merge-output-format mp4 so the final container stays MP4. H.264 and H.265 codec preferences are unchanged and still effectively cap at 1080p, which is now documented in the UI tooltips, helper text, and docs/CONFIG.md. Adds resolution-specific compatibility warnings in the core settings, channel settings, and manual-download dialogs.