### PR TITLE
fix: restore update available notification banner

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -511,6 +511,7 @@ function AppContent() {
                     versionLabel={ytDlpLabel ? `${clientVersion} • ${ytDlpLabel}` : clientVersion}
                     updateAvailable={updateAvailable}
                     updateTooltip={updateTooltip}
+                    serverVersion={serverVersion}
                     ytDlpUpdateAvailable={ytDlpUpdateAvailable}
                     ytDlpUpdateTooltip={ytDlpUpdateTooltip}
                     onLogout={handleLogout}
@@ -522,7 +523,10 @@ function AppContent() {
                     >
                       <ErrorBoundary fallbackMessage="An unexpected error occurred. Please refresh the page to continue.">
                         <Routes>
-                          <Route path="/changelog" element={<ChangelogPage />} />
+                          <Route
+                            path="/changelog"
+                            element={<ChangelogPage updateAvailable={updateAvailable} serverVersion={serverVersion} />}
+                          />
                           <Route path="/settings/*" element={<Settings token={token} />} />
                           <Route path="/configuration" element={<Navigate to="/settings" replace />} />
                           <Route path="/channels" element={<ChannelManager token={token} />} />

--- a/client/src/components/ChangelogPage.tsx
+++ b/client/src/components/ChangelogPage.tsx
@@ -16,12 +16,38 @@ import { useChangelog } from '../hooks/useChangelog';
 const CHANGELOG_GITHUB_URL =
   'https://github.com/DialmasterOrg/Youtarr/blob/main/CHANGELOG.md';
 
-function ChangelogPage() {
+interface ChangelogPageProps {
+  updateAvailable?: boolean;
+  serverVersion?: string;
+}
+
+function ChangelogPage({ updateAvailable = false, serverVersion }: ChangelogPageProps = {}) {
   const isMobile = useMediaQuery('(max-width: 599px)');
   const { content, loading, error, refetch } = useChangelog();
 
   return (
-    <Card elevation={8} style={{ marginBottom: '16px' }}>
+    <>
+      {updateAvailable && (
+        <Alert
+          severity="info"
+          role="status"
+          className="mb-4 items-center gap-2 px-3.5 py-2 rounded-ui shadow-soft bg-card border-info"
+          data-testid="changelog-update-available"
+        >
+          <Typography variant="body2">
+            You are running an older version of Youtarr.
+            {serverVersion ? (
+              <>
+                {' '}
+                <strong>{serverVersion}</strong> is available. Pull the latest image to update.
+              </>
+            ) : (
+              <> Pull the latest image to update.</>
+            )}
+          </Typography>
+        </Alert>
+      )}
+      <Card elevation={8} style={{ marginBottom: '16px' }}>
       <CardContent>
         <div
           style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}
@@ -78,6 +104,7 @@ function ChangelogPage() {
         )}
       </CardContent>
     </Card>
+    </>
   );
 }
 

--- a/client/src/components/__tests__/ChangelogPage.test.tsx
+++ b/client/src/components/__tests__/ChangelogPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ChangelogPage from '../ChangelogPage';
@@ -182,6 +182,53 @@ describe('ChangelogPage', () => {
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
     expect(screen.queryByText('Old cached content')).not.toBeInTheDocument();
+  });
+
+  describe('update-available banner', () => {
+    beforeEach(() => {
+      useChangelog.mockReturnValue({
+        content: '# Changelog',
+        loading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+    });
+
+    test('renders the update banner with server version when updateAvailable is true', () => {
+      render(<ChangelogPage updateAvailable serverVersion="v1.71.0" />);
+
+      const banner = screen.getByTestId('changelog-update-available');
+      expect(banner).toHaveTextContent('You are running an older version of Youtarr.');
+      expect(banner).toHaveTextContent('v1.71.0');
+      expect(banner).toHaveTextContent('Pull the latest image to update.');
+    });
+
+    test('renders a generic update message when serverVersion is not provided', () => {
+      render(<ChangelogPage updateAvailable />);
+
+      const banner = screen.getByTestId('changelog-update-available');
+      expect(banner).toHaveTextContent('You are running an older version of Youtarr.');
+      expect(banner).toHaveTextContent('Pull the latest image to update.');
+    });
+
+    test('does not render the update banner when updateAvailable is false', () => {
+      render(<ChangelogPage updateAvailable={false} serverVersion="v1.71.0" />);
+
+      expect(screen.queryByTestId('changelog-update-available')).not.toBeInTheDocument();
+    });
+
+    test('does not render the update banner by default', () => {
+      render(<ChangelogPage />);
+
+      expect(screen.queryByTestId('changelog-update-available')).not.toBeInTheDocument();
+    });
+
+    test('update banner has no dismiss button', () => {
+      render(<ChangelogPage updateAvailable serverVersion="v1.71.0" />);
+
+      const banner = screen.getByTestId('changelog-update-available');
+      expect(within(banner).queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+    });
   });
 
   test('renders markdown with proper structure', () => {

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import { useThemeEngine } from '../../contexts/ThemeEngineContext';
 import { NavHeader } from './NavHeader';
 import { NavSidebar } from './NavSidebar';
 import { BackgroundDecorations } from './BackgroundDecorations';
+import UpdateAvailableBanner from './UpdateAvailableBanner';
 import { NavItem } from './navigation';
 import { getThemeById, getThemeLayoutCssVars, resolveThemeLayoutPolicy } from '../../themes';
 import { useMediaQuery } from '../../hooks/useMediaQuery';
@@ -22,6 +23,7 @@ interface AppShellProps {
   onLogout?: () => void;
   updateAvailable?: boolean;
   updateTooltip?: string;
+  serverVersion?: string;
   ytDlpUpdateAvailable?: boolean;
   ytDlpUpdateTooltip?: string;
   children: React.ReactNode;
@@ -37,6 +39,7 @@ export function AppShell({
   onLogout,
   updateAvailable = false,
   updateTooltip,
+  serverVersion,
   ytDlpUpdateAvailable = false,
   ytDlpUpdateTooltip,
   children,
@@ -285,6 +288,8 @@ export function AppShell({
           {children}
         </div>
       </main>
+
+      <UpdateAvailableBanner show={updateAvailable} serverVersion={serverVersion} />
     </div>
   );
 }

--- a/client/src/components/layout/UpdateAvailableBanner.tsx
+++ b/client/src/components/layout/UpdateAvailableBanner.tsx
@@ -1,0 +1,74 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Alert, Slide, Typography } from '../ui';
+import { Download as DownloadIcon } from '../../lib/icons';
+
+const DISMISSED_VERSION_STORAGE_KEY = 'dismissedUpdateVersion';
+
+interface UpdateAvailableBannerProps {
+  show: boolean;
+  serverVersion?: string;
+}
+
+const readDismissedVersion = (): string | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(DISMISSED_VERSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const UpdateAvailableBanner: React.FC<UpdateAvailableBannerProps> = ({ show, serverVersion }) => {
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(readDismissedVersion);
+
+  useEffect(() => {
+    setDismissedVersion(readDismissedVersion());
+  }, [serverVersion]);
+
+  const handleDismiss = useCallback(() => {
+    if (!serverVersion) return;
+    try {
+      window.localStorage.setItem(DISMISSED_VERSION_STORAGE_KEY, serverVersion);
+    } catch {
+      // Storage may be unavailable (private mode, quota); still hide for this session.
+    }
+    setDismissedVersion(serverVersion);
+  }, [serverVersion]);
+
+  const isDismissedForThisVersion = Boolean(serverVersion && dismissedVersion === serverVersion);
+  const visible = show && !isDismissedForThisVersion;
+
+  return (
+    <Slide direction="up" in={visible} mountOnEnter unmountOnExit>
+      <div
+        role="status"
+        aria-live="polite"
+        className="fixed inset-x-0 z-[1300] flex justify-center px-3 pb-3 pointer-events-none"
+        style={{
+          bottom: 'calc(var(--mobile-nav-total-offset, 0px) + env(safe-area-inset-bottom, 0px))',
+        }}
+      >
+        <Alert
+          severity="info"
+          icon={<DownloadIcon className="h-4 w-4" />}
+          variant="outlined"
+          onClose={handleDismiss}
+          className="w-full max-w-[560px] items-center gap-2 px-3.5 py-1.5 pointer-events-auto rounded-ui shadow-soft bg-card border-info"
+        >
+          <Typography variant="body2" className="text-center leading-tight">
+            {serverVersion ? (
+              <>
+                <strong>Youtarr {serverVersion}</strong> is available. Pull the latest image to update.
+              </>
+            ) : (
+              <>A new Youtarr version is available. Pull the latest image to update.</>
+            )}
+          </Typography>
+        </Alert>
+      </div>
+    </Slide>
+  );
+};
+
+export { DISMISSED_VERSION_STORAGE_KEY };
+export default UpdateAvailableBanner;

--- a/client/src/components/layout/__tests__/UpdateAvailableBanner.test.tsx
+++ b/client/src/components/layout/__tests__/UpdateAvailableBanner.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UpdateAvailableBanner, {
+  DISMISSED_VERSION_STORAGE_KEY,
+} from '../UpdateAvailableBanner';
+
+const SLIDE_TRANSITION_MS = 300;
+
+const flushSlideExit = () => {
+  act(() => {
+    jest.advanceTimersByTime(SLIDE_TRANSITION_MS);
+  });
+};
+
+describe('UpdateAvailableBanner', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  test('renders the server version and update message when show is true', () => {
+    render(<UpdateAvailableBanner show serverVersion="v1.70.0" />);
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent('Youtarr v1.70.0');
+    expect(banner).toHaveTextContent('Pull the latest image to update.');
+  });
+
+  test('renders a generic message when serverVersion is not provided', () => {
+    render(<UpdateAvailableBanner show />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'A new Youtarr version is available.'
+    );
+  });
+
+  test('does not render when show is false', () => {
+    render(<UpdateAvailableBanner show={false} serverVersion="v1.70.0" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  test('does not render when the current serverVersion was previously dismissed', () => {
+    window.localStorage.setItem(DISMISSED_VERSION_STORAGE_KEY, 'v1.70.0');
+
+    render(<UpdateAvailableBanner show serverVersion="v1.70.0" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  test('renders again when a newer serverVersion differs from the dismissed one', () => {
+    window.localStorage.setItem(DISMISSED_VERSION_STORAGE_KEY, 'v1.70.0');
+
+    render(<UpdateAvailableBanner show serverVersion="v1.71.0" />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Youtarr v1.71.0');
+  });
+
+  test('clicking close persists the current version and hides the banner', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(<UpdateAvailableBanner show serverVersion="v1.70.0" />);
+
+    await user.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(window.localStorage.getItem(DISMISSED_VERSION_STORAGE_KEY)).toBe('v1.70.0');
+
+    flushSlideExit();
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  test('re-reads dismissed version when serverVersion changes', () => {
+    const { rerender } = render(
+      <UpdateAvailableBanner show serverVersion="v1.70.0" />
+    );
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    window.localStorage.setItem(DISMISSED_VERSION_STORAGE_KEY, 'v1.71.0');
+    rerender(<UpdateAvailableBanner show serverVersion="v1.71.0" />);
+
+    flushSlideExit();
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  test('dismissal does not hide banner for a subsequent different version', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    const { rerender } = render(
+      <UpdateAvailableBanner show serverVersion="v1.70.0" />
+    );
+
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    flushSlideExit();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    rerender(<UpdateAvailableBanner show serverVersion="v1.71.0" />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Youtarr v1.71.0');
+  });
+});


### PR DESCRIPTION
Add UpdateAvailableBanner component surfacing new releases via the app shell with versioned localStorage dismissal, and show an in-page update hint on the changelog route.