### PR TITLE
Release: 4K downloads and update banner

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -511,6 +511,7 @@ function AppContent() {
                     versionLabel={ytDlpLabel ? `${clientVersion} • ${ytDlpLabel}` : clientVersion}
                     updateAvailable={updateAvailable}
                     updateTooltip={updateTooltip}
+                    serverVersion={serverVersion}
                     ytDlpUpdateAvailable={ytDlpUpdateAvailable}
                     ytDlpUpdateTooltip={ytDlpUpdateTooltip}
                     onLogout={handleLogout}
@@ -522,7 +523,10 @@ function AppContent() {
                     >
                       <ErrorBoundary fallbackMessage="An unexpected error occurred. Please refresh the page to continue.">
                         <Routes>
-                          <Route path="/changelog" element={<ChangelogPage />} />
+                          <Route
+                            path="/changelog"
+                            element={<ChangelogPage updateAvailable={updateAvailable} serverVersion={serverVersion} />}
+                          />
                           <Route path="/settings/*" element={<Settings token={token} />} />
                           <Route path="/configuration" element={<Navigate to="/settings" replace />} />
                           <Route path="/channels" element={<ChannelManager token={token} />} />

--- a/client/src/components/ChangelogPage.tsx
+++ b/client/src/components/ChangelogPage.tsx
@@ -16,12 +16,38 @@ import { useChangelog } from '../hooks/useChangelog';
 const CHANGELOG_GITHUB_URL =
   'https://github.com/DialmasterOrg/Youtarr/blob/main/CHANGELOG.md';
 
-function ChangelogPage() {
+interface ChangelogPageProps {
+  updateAvailable?: boolean;
+  serverVersion?: string;
+}
+
+function ChangelogPage({ updateAvailable = false, serverVersion }: ChangelogPageProps = {}) {
   const isMobile = useMediaQuery('(max-width: 599px)');
   const { content, loading, error, refetch } = useChangelog();
 
   return (
-    <Card elevation={8} style={{ marginBottom: '16px' }}>
+    <>
+      {updateAvailable && (
+        <Alert
+          severity="info"
+          role="status"
+          className="mb-4 items-center gap-2 px-3.5 py-2 rounded-ui shadow-soft bg-card border-info"
+          data-testid="changelog-update-available"
+        >
+          <Typography variant="body2">
+            You are running an older version of Youtarr.
+            {serverVersion ? (
+              <>
+                {' '}
+                <strong>{serverVersion}</strong> is available. Pull the latest image to update.
+              </>
+            ) : (
+              <> Pull the latest image to update.</>
+            )}
+          </Typography>
+        </Alert>
+      )}
+      <Card elevation={8} style={{ marginBottom: '16px' }}>
       <CardContent>
         <div
           style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}
@@ -78,6 +104,7 @@ function ChangelogPage() {
         )}
       </CardContent>
     </Card>
+    </>
   );
 }
 

--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -602,6 +602,11 @@ function ChannelSettingsDialog({
               <Typography variant="caption" color="text.secondary" style={{ marginTop: 8, display: 'block' }}>
                 Effective channel quality: {effectiveQualityDisplay}.
               </Typography>
+              {(settings.video_quality === '1440' || settings.video_quality === '2160') && (
+                <Typography variant="caption" color="warning.main" style={{ marginTop: 4, display: 'block' }}>
+                  YouTube only serves H.264 MP4 up to 1080p. {settings.video_quality === '2160' ? '4K' : '1440p'} uses VP9/AV1 (remuxed into MP4); older Plex clients without native VP9/AV1 decode may transcode.
+                </Typography>
+              )}
             </div>
 
             <FormControl fullWidth style={{ marginTop: 8 }}>

--- a/client/src/components/Configuration/sections/CoreSettingsSection.tsx
+++ b/client/src/components/Configuration/sections/CoreSettingsSection.tsx
@@ -317,10 +317,15 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
                         <MenuItem value="360">360p</MenuItem>
                       </Select>
                       <InfoTooltip
-                        text="The resolution we will try to download from YouTube. Note that this is not guaranteed as YouTube may not have your preferred resolution available."
+                        text="The resolution we will try to download from YouTube. Note that this is not guaranteed as YouTube may not have your preferred resolution available. YouTube only provides H.264 MP4 up to 1080p. Selecting 1440p or 2160p (4K) will use VP9 or AV1 (remuxed into MP4), which older Plex clients (Apple TV HD, iOS, older Rokus) may need to transcode."
                         onMobileClick={onMobileTooltipClick}
                       />
                     </Box>
+                    {(config.preferredResolution === '1440' || config.preferredResolution === '2160') && (
+                      <Box component="span" className="text-xs text-muted-foreground">
+                        1440p+ uses VP9/AV1 (remuxed into MP4). Older Plex clients without native VP9/AV1 decode may transcode. Select H.264 codec below for best compatibility (caps at 1080p).
+                      </Box>
+                    )}
                   </FormControl>
                 </Grid>
 
@@ -341,12 +346,12 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
                         <MenuItem value="h265">H.265/HEVC (Balanced)</MenuItem>
                       </Select>
                       <InfoTooltip
-                        text="Select your preferred video codec. Youtarr will download this codec when available, and fall back to other codecs if your preference is not available for a video. H.264 is recommended for Apple TV and maximum device compatibility. VP9 is the default codec for most YouTube videos."
+                        text="Select your preferred video codec. Youtarr will download this codec when available, and fall back if it is not. H.264 is recommended for Apple TV and maximum device compatibility, but YouTube does not provide H.264 above 1080p so selecting it effectively caps downloads at 1080p regardless of the resolution preference above. Default lets YouTube pick the best codec (typically VP9 or AV1 at 1440p+)."
                         onMobileClick={onMobileTooltipClick}
                       />
                     </Box>
                     <Box component="span" className="text-xs text-muted-foreground">
-                      Note: H.264 produces larger file sizes but offers maximum compatibility for Apple TV. This is a preference and will fall back to available codecs.
+                      Note: H.264 offers maximum compatibility (Apple TV HD, iOS, older Rokus direct-play) but YouTube caps H.264 at 1080p, so it will override any 1440p/2160p preference.
                     </Box>
                   </FormControl>
                 </Grid>

--- a/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
@@ -492,7 +492,7 @@ describe('CoreSettingsSection Component', () => {
     test('displays helper text about codec preferences', () => {
       const props = createSectionProps();
       renderWithProviders(<CoreSettingsSection {...props} />);
-      expect(screen.getByText(/Note: H\.264 produces larger file sizes/i)).toBeInTheDocument();
+      expect(screen.getByText(/YouTube caps H\.264 at 1080p/i)).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
@@ -369,10 +369,13 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
                 </FormHelperText>
               </FormControl>
 
-              {resolution === '2160' && (
+              {(resolution === '2160' || resolution === '1440') && (
                 <Alert severity="warning" className="mb-4">
                   <Typography variant="body2">
-                    4K videos may take significantly longer to download and use more storage space.
+                    {resolution === '2160'
+                      ? '4K videos may take significantly longer to download and use more storage space. '
+                      : ''}
+                    YouTube only provides H.264 MP4 up to 1080p, so {resolution === '2160' ? '4K' : '1440p'} uses VP9 or AV1 (remuxed into MP4). Older Plex clients without native VP9/AV1 decode (Apple TV HD, iOS, older Rokus) may transcode.
                   </Typography>
                 </Alert>
               )}

--- a/client/src/components/__tests__/ChangelogPage.test.tsx
+++ b/client/src/components/__tests__/ChangelogPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ChangelogPage from '../ChangelogPage';
@@ -182,6 +182,53 @@ describe('ChangelogPage', () => {
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
     expect(screen.queryByText('Old cached content')).not.toBeInTheDocument();
+  });
+
+  describe('update-available banner', () => {
+    beforeEach(() => {
+      useChangelog.mockReturnValue({
+        content: '# Changelog',
+        loading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+    });
+
+    test('renders the update banner with server version when updateAvailable is true', () => {
+      render(<ChangelogPage updateAvailable serverVersion="v1.71.0" />);
+
+      const banner = screen.getByTestId('changelog-update-available');
+      expect(banner).toHaveTextContent('You are running an older version of Youtarr.');
+      expect(banner).toHaveTextContent('v1.71.0');
+      expect(banner).toHaveTextContent('Pull the latest image to update.');
+    });
+
+    test('renders a generic update message when serverVersion is not provided', () => {
+      render(<ChangelogPage updateAvailable />);
+
+      const banner = screen.getByTestId('changelog-update-available');
+      expect(banner).toHaveTextContent('You are running an older version of Youtarr.');
+      expect(banner).toHaveTextContent('Pull the latest image to update.');
+    });
+
+    test('does not render the update banner when updateAvailable is false', () => {
+      render(<ChangelogPage updateAvailable={false} serverVersion="v1.71.0" />);
+
+      expect(screen.queryByTestId('changelog-update-available')).not.toBeInTheDocument();
+    });
+
+    test('does not render the update banner by default', () => {
+      render(<ChangelogPage />);
+
+      expect(screen.queryByTestId('changelog-update-available')).not.toBeInTheDocument();
+    });
+
+    test('update banner has no dismiss button', () => {
+      render(<ChangelogPage updateAvailable serverVersion="v1.71.0" />);
+
+      const banner = screen.getByTestId('changelog-update-available');
+      expect(within(banner).queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+    });
   });
 
   test('renders markdown with proper structure', () => {

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import { useThemeEngine } from '../../contexts/ThemeEngineContext';
 import { NavHeader } from './NavHeader';
 import { NavSidebar } from './NavSidebar';
 import { BackgroundDecorations } from './BackgroundDecorations';
+import UpdateAvailableBanner from './UpdateAvailableBanner';
 import { NavItem } from './navigation';
 import { getThemeById, getThemeLayoutCssVars, resolveThemeLayoutPolicy } from '../../themes';
 import { useMediaQuery } from '../../hooks/useMediaQuery';
@@ -22,6 +23,7 @@ interface AppShellProps {
   onLogout?: () => void;
   updateAvailable?: boolean;
   updateTooltip?: string;
+  serverVersion?: string;
   ytDlpUpdateAvailable?: boolean;
   ytDlpUpdateTooltip?: string;
   children: React.ReactNode;
@@ -37,6 +39,7 @@ export function AppShell({
   onLogout,
   updateAvailable = false,
   updateTooltip,
+  serverVersion,
   ytDlpUpdateAvailable = false,
   ytDlpUpdateTooltip,
   children,
@@ -285,6 +288,8 @@ export function AppShell({
           {children}
         </div>
       </main>
+
+      <UpdateAvailableBanner show={updateAvailable} serverVersion={serverVersion} />
     </div>
   );
 }

--- a/client/src/components/layout/UpdateAvailableBanner.tsx
+++ b/client/src/components/layout/UpdateAvailableBanner.tsx
@@ -1,0 +1,74 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Alert, Slide, Typography } from '../ui';
+import { Download as DownloadIcon } from '../../lib/icons';
+
+const DISMISSED_VERSION_STORAGE_KEY = 'dismissedUpdateVersion';
+
+interface UpdateAvailableBannerProps {
+  show: boolean;
+  serverVersion?: string;
+}
+
+const readDismissedVersion = (): string | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(DISMISSED_VERSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const UpdateAvailableBanner: React.FC<UpdateAvailableBannerProps> = ({ show, serverVersion }) => {
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(readDismissedVersion);
+
+  useEffect(() => {
+    setDismissedVersion(readDismissedVersion());
+  }, [serverVersion]);
+
+  const handleDismiss = useCallback(() => {
+    if (!serverVersion) return;
+    try {
+      window.localStorage.setItem(DISMISSED_VERSION_STORAGE_KEY, serverVersion);
+    } catch {
+      // Storage may be unavailable (private mode, quota); still hide for this session.
+    }
+    setDismissedVersion(serverVersion);
+  }, [serverVersion]);
+
+  const isDismissedForThisVersion = Boolean(serverVersion && dismissedVersion === serverVersion);
+  const visible = show && !isDismissedForThisVersion;
+
+  return (
+    <Slide direction="up" in={visible} mountOnEnter unmountOnExit>
+      <div
+        role="status"
+        aria-live="polite"
+        className="fixed inset-x-0 z-[1300] flex justify-center px-3 pb-3 pointer-events-none"
+        style={{
+          bottom: 'calc(var(--mobile-nav-total-offset, 0px) + env(safe-area-inset-bottom, 0px))',
+        }}
+      >
+        <Alert
+          severity="info"
+          icon={<DownloadIcon className="h-4 w-4" />}
+          variant="outlined"
+          onClose={handleDismiss}
+          className="w-full max-w-[560px] items-center gap-2 px-3.5 py-1.5 pointer-events-auto rounded-ui shadow-soft bg-card border-info"
+        >
+          <Typography variant="body2" className="text-center leading-tight">
+            {serverVersion ? (
+              <>
+                <strong>Youtarr {serverVersion}</strong> is available. Pull the latest image to update.
+              </>
+            ) : (
+              <>A new Youtarr version is available. Pull the latest image to update.</>
+            )}
+          </Typography>
+        </Alert>
+      </div>
+    </Slide>
+  );
+};
+
+export { DISMISSED_VERSION_STORAGE_KEY };
+export default UpdateAvailableBanner;

--- a/client/src/components/layout/__tests__/UpdateAvailableBanner.test.tsx
+++ b/client/src/components/layout/__tests__/UpdateAvailableBanner.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UpdateAvailableBanner, {
+  DISMISSED_VERSION_STORAGE_KEY,
+} from '../UpdateAvailableBanner';
+
+const SLIDE_TRANSITION_MS = 300;
+
+const flushSlideExit = () => {
+  act(() => {
+    jest.advanceTimersByTime(SLIDE_TRANSITION_MS);
+  });
+};
+
+describe('UpdateAvailableBanner', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  test('renders the server version and update message when show is true', () => {
+    render(<UpdateAvailableBanner show serverVersion="v1.70.0" />);
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent('Youtarr v1.70.0');
+    expect(banner).toHaveTextContent('Pull the latest image to update.');
+  });
+
+  test('renders a generic message when serverVersion is not provided', () => {
+    render(<UpdateAvailableBanner show />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'A new Youtarr version is available.'
+    );
+  });
+
+  test('does not render when show is false', () => {
+    render(<UpdateAvailableBanner show={false} serverVersion="v1.70.0" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  test('does not render when the current serverVersion was previously dismissed', () => {
+    window.localStorage.setItem(DISMISSED_VERSION_STORAGE_KEY, 'v1.70.0');
+
+    render(<UpdateAvailableBanner show serverVersion="v1.70.0" />);
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  test('renders again when a newer serverVersion differs from the dismissed one', () => {
+    window.localStorage.setItem(DISMISSED_VERSION_STORAGE_KEY, 'v1.70.0');
+
+    render(<UpdateAvailableBanner show serverVersion="v1.71.0" />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Youtarr v1.71.0');
+  });
+
+  test('clicking close persists the current version and hides the banner', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(<UpdateAvailableBanner show serverVersion="v1.70.0" />);
+
+    await user.click(screen.getByRole('button', { name: /close/i }));
+
+    expect(window.localStorage.getItem(DISMISSED_VERSION_STORAGE_KEY)).toBe('v1.70.0');
+
+    flushSlideExit();
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  test('re-reads dismissed version when serverVersion changes', () => {
+    const { rerender } = render(
+      <UpdateAvailableBanner show serverVersion="v1.70.0" />
+    );
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    window.localStorage.setItem(DISMISSED_VERSION_STORAGE_KEY, 'v1.71.0');
+    rerender(<UpdateAvailableBanner show serverVersion="v1.71.0" />);
+
+    flushSlideExit();
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  test('dismissal does not hide banner for a subsequent different version', async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    const { rerender } = render(
+      <UpdateAvailableBanner show serverVersion="v1.70.0" />
+    );
+
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    flushSlideExit();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+    rerender(<UpdateAvailableBanner show serverVersion="v1.71.0" />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Youtarr v1.71.0');
+  });
+});

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -83,13 +83,14 @@ Configuration can be modified through:
 - **Options**: `"4320"`, `"2160"`, `"1440"`, `"1080"`, `"720"`, `"480"`, `"360"`, `"240"`, `"144"`
 - **Description**: Global setting for preferred download resolution
 - **Note**: Downloads from YouTube at best available quality up to this limit
+- **Codec implication**: YouTube only provides H.264 in MP4 up to 1080p. Selecting 1440p or 2160p forces Youtarr to pick a VP9 or AV1 source stream (YouTube does not offer H.264 at those resolutions) and remux it into MP4 via `--merge-output-format mp4`. The remux is lossless (no re-encode), but Plex clients without native VP9/AV1 hardware decode (Apple TV HD, older Apple TV 4K, iOS, older Rokus) will transcode at playback. If direct-play compatibility matters more than resolution, keep this at 1080p or set `videoCodec` to `h264`.
 
 ### Preferred Video Codec
 - **Config Key**: `videoCodec`
 - **Type**: `string`
 - **Default**: `"default"`
 - **Options**: `"default"`, `"h264"`, `"h265"`
-- **Description**: Preferred video codec for downloads, default generally downloads as vp9 or av1
+- **Description**: Preferred video codec for downloads. `"default"` picks the best stream YouTube offers at the requested resolution (typically VP9 or AV1 above 1080p). `"h264"` forces H.264/AVC, which maximizes client compatibility but effectively caps resolution at 1080p because YouTube does not serve H.264 above that height. `"h265"` prefers HEVC but YouTube rarely provides it, so it almost always falls back to H.264 MP4.
 - **Compatibility**:
   - `h264`: Best compatibility with all devices
   - `h265`: Better compression, requires modern devices

--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -221,9 +221,19 @@ describe('YtdlpCommandBuilder', () => {
       expect(result).toBe('bestvideo[height<=720][ext=mp4][vcodec^=hev]+bestaudio[ext=m4a]/bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
     });
 
-    it('should handle 4K resolution with default codec', () => {
+    it('should handle 4K resolution with default codec by dropping [ext=mp4] (YouTube has no H.264 MP4 above 1080p)', () => {
       const result = YtdlpCommandBuilder.buildFormatString('2160', 'default');
-      expect(result).toBe('bestvideo[height<=2160][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+      expect(result).toBe('bestvideo[height<=2160]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should handle 1440p resolution with default codec by dropping [ext=mp4]', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('1440', 'default');
+      expect(result).toBe('bestvideo[height<=1440]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should keep [ext=mp4] for 720p default codec (H.264 MP4 available)', () => {
+      const result = YtdlpCommandBuilder.buildFormatString('720', 'default');
+      expect(result).toBe('bestvideo[height<=720][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
     });
 
     it('should use default resolution (1080) when resolution is null', () => {
@@ -718,8 +728,27 @@ describe('YtdlpCommandBuilder', () => {
       const result = YtdlpCommandBuilder.getBaseCommandArgs();
       const formatIndex = result.indexOf('-f');
       const formatString = result[formatIndex + 1];
-      // Default codec should not include vcodec filters
+      // Default codec at 1080p keeps [ext=mp4] for Plex compatibility
       expect(formatString).toBe('bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should not include --merge-output-format at <=1080p', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgs('1080');
+      expect(result).not.toContain('--merge-output-format');
+    });
+
+    it('should include --merge-output-format mp4 at 1440p to keep container MP4 after VP9 remux', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgs('1440');
+      const idx = result.indexOf('--merge-output-format');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(result[idx + 1]).toBe('mp4');
+    });
+
+    it('should include --merge-output-format mp4 at 2160p', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgs('2160');
+      const idx = result.indexOf('--merge-output-format');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(result[idx + 1]).toBe('mp4');
     });
 
     it('should use h264 videoCodec when configured', () => {
@@ -902,6 +931,18 @@ describe('YtdlpCommandBuilder', () => {
       const formatIndex = result.indexOf('-f');
       const formatString = result[formatIndex + 1];
       expect(formatString).toBe('bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best');
+    });
+
+    it('should not include --merge-output-format at <=1080p', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload('1080');
+      expect(result).not.toContain('--merge-output-format');
+    });
+
+    it('should include --merge-output-format mp4 at 2160p', () => {
+      const result = YtdlpCommandBuilder.getBaseCommandArgsForManualDownload('2160');
+      const idx = result.indexOf('--merge-output-format');
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(result[idx + 1]).toBe('mp4');
     });
 
     it('should use h264 videoCodec when configured', () => {

--- a/server/modules/download/ytdlpCommandBuilder.js
+++ b/server/modules/download/ytdlpCommandBuilder.js
@@ -51,6 +51,19 @@ class YtdlpCommandBuilder {
     return path.join(...segments);
   }
   /**
+   * YouTube caps H.264 MP4 streams at 1080p. Above that, only VP9 (typically
+   * webm) and AV1 are available. When this returns true, the default format
+   * selector must not restrict to [ext=mp4], and the caller must pass
+   * --merge-output-format mp4 so the final container stays MP4.
+   * @param {string|number|null} resolution - Requested max height
+   * @returns {boolean}
+   */
+  static resolutionRequiresNonMp4Source(resolution) {
+    const height = Number(resolution);
+    return Number.isFinite(height) && height > 1080;
+  }
+
+  /**
    * Build format string based on resolution, codec preference, and audio format
    * @param {string} resolution - Video resolution (e.g., '1080', '720')
    * @param {string} videoCodec - Video codec preference ('h264', 'h265', 'default')
@@ -84,10 +97,18 @@ class YtdlpCommandBuilder {
       break;
 
     case 'default':
-    default:
-      // Default behavior: no codec preference, just resolution and container
-      videoFormat = `bestvideo[height<=${res}][ext=mp4]+${audioFmt}/${fallbackMp4}/${ultimateFallback}`;
+    default: {
+      // At 1080p and below, H.264 MP4 is available on YouTube so we keep the
+      // [ext=mp4] constraint for maximum Plex client compatibility (direct-play
+      // on Apple TV HD, older Rokus, iOS, etc.). Above 1080p, YouTube only
+      // serves VP9/AV1, so we drop the constraint and rely on
+      // --merge-output-format mp4 to keep the output container MP4.
+      const primarySelector = this.resolutionRequiresNonMp4Source(res)
+        ? `bestvideo[height<=${res}]+${audioFmt}`
+        : `bestvideo[height<=${res}][ext=mp4]+${audioFmt}`;
+      videoFormat = `${primarySelector}/${fallbackMp4}/${ultimateFallback}`;
       break;
+    }
     }
 
     return videoFormat;
@@ -425,6 +446,9 @@ class YtdlpCommandBuilder {
       // Clean @ prefix from uploader_id when it's used as fallback
       '--replace-in-metadata', 'uploader_id', '^@', '',
       '-f', this.buildFormatString(res, videoCodec, audioFormat),
+      // Only force MP4 remux when sources might be webm (1440p+).
+      // At <=1080p the format selector already picks MP4 sources.
+      ...(this.resolutionRequiresNonMp4Source(res) ? ['--merge-output-format', 'mp4'] : []),
       '--write-thumbnail',
       '--convert-thumbnails', 'jpg',
     ];
@@ -502,6 +526,9 @@ class YtdlpCommandBuilder {
       // Clean @ prefix from uploader_id when it's used as fallback
       '--replace-in-metadata', 'uploader_id', '^@', '',
       '-f', this.buildFormatString(res, videoCodec, audioFormat),
+      // Only force MP4 remux when sources might be webm (1440p+).
+      // At <=1080p the format selector already picks MP4 sources.
+      ...(this.resolutionRequiresNonMp4Source(res) ? ['--merge-output-format', 'mp4'] : []),
       '--write-thumbnail',
       '--convert-thumbnails', 'jpg',
     ];


### PR DESCRIPTION
Two fixes in this release:

- 1440p/2160p downloads were silently dropping to 1080p MP4 because the format selector required `[ext=mp4]` and YouTube only serves those resolutions in VP9/AV1. See #557.
- The "update available" banner stopped showing. See #558.