### PR TITLE
fix: restore download progress bar fill

### DIFF
--- a/client/src/components/DownloadManager/DownloadProgress.tsx
+++ b/client/src/components/DownloadManager/DownloadProgress.tsx
@@ -129,19 +129,19 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
   const progressColor = useMemo(() => {
     if (!currentProgress) return 'var(--muted-foreground)';
 
-    if (currentProgress.stalled) return 'hsl(var(--warning))';
+    if (currentProgress.stalled) return 'var(--warning)';
 
     switch (currentProgress.state) {
       case 'initiating':
         return 'var(--muted-foreground)';
       case 'complete':
-        return 'hsl(var(--success))';
+        return 'var(--success)';
       case 'terminated':
-        return 'hsl(var(--warning))';
+        return 'var(--warning)';
       case 'error':
-        return 'hsl(var(--destructive))';
+        return 'var(--destructive)';
       default:
-        return 'hsl(var(--primary))';
+        return 'var(--primary)';
     }
   }, [currentProgress]);
 


### PR DESCRIPTION
progressColor was returning hsl(var(--primary)) etc., but ThemeEngineContext already sets --primary to hsl(262 83% 58%), yielding invalid hsl(hsl(...)) and a transparent indicator. Use the already-wrapped var(--*) tokens directly.