### PR TITLE
Release: restore download progress bar fill

### DIFF
--- a/client/src/components/DownloadManager/DownloadProgress.tsx
+++ b/client/src/components/DownloadManager/DownloadProgress.tsx
@@ -129,19 +129,19 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
   const progressColor = useMemo(() => {
     if (!currentProgress) return 'var(--muted-foreground)';
 
-    if (currentProgress.stalled) return 'hsl(var(--warning))';
+    if (currentProgress.stalled) return 'var(--warning)';
 
     switch (currentProgress.state) {
       case 'initiating':
         return 'var(--muted-foreground)';
       case 'complete':
-        return 'hsl(var(--success))';
+        return 'var(--success)';
       case 'terminated':
-        return 'hsl(var(--warning))';
+        return 'var(--warning)';
       case 'error':
-        return 'hsl(var(--destructive))';
+        return 'var(--destructive)';
       default:
-        return 'hsl(var(--primary))';
+        return 'var(--primary)';
     }
   }, [currentProgress]);
 


### PR DESCRIPTION
- The download progress bar stopped filling during active downloads after the theme migration, even though the stats text and ETA still updated correctly. The bar rendered as one flat color across its full width. This fixes the regression and restores the progress bar functionality.