### PR TITLE
fix: set group-writable umask and protect config.json secrets

### DIFF
--- a/docs/platforms/unraid.md
+++ b/docs/platforms/unraid.md
@@ -44,7 +44,7 @@ curl -L https://raw.githubusercontent.com/DialmasterOrg/unraid-templates/main/Yo
   - Ensure that your MariaDB instance is setup with a database name, user and password matching what you set in the Youtarr configuration
   - Use the LAN IP of your Unraid server as DB_HOST (eg `192.168.1.100`)
     - Do not use `127.0.0.1` or `localhost`, as those refer to the container itself, not the Unraid host.
-  - Map your persistent paths (for example `/mnt/user/appdata/youtarr/config` for `/app/config` and `/mnt/user/media/youtube` for `/data`) and supply the MariaDB connection variables before deploying.
+  - Map your persistent paths (for example `/mnt/user/appdata/youtarr` for `/app/config` and `/mnt/user/media/youtube` for `/data`) and supply the MariaDB connection variables before deploying.
   - Set both `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` to set credentials for login to Youtarr
   - **IMPORTANT**: `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` must meet these rules or they’ll be ignored:
     - `AUTH_PRESET_USERNAME`: 3-32 characters in length
@@ -68,11 +68,10 @@ By default, Youtarr runs as root inside the container. This works fine for most 
 
 2. **Set correct ownership on your directories** by opening an Unraid terminal and running:
    ```bash
-   chown -R 99:100 /mnt/user/appdata/youtarr/config
-   chown -R 99:100 /mnt/user/appdata/youtarr/jobs
+   chown -R 99:100 /mnt/user/appdata/youtarr
    chown -R 99:100 /path/to/your/youtube_videos
    ```
-   Replace the paths with your actual mapped directories. The `99:100` corresponds to the `nobody:users` user/group on Unraid.
+   Replace the paths with your actual mapped directories. The `99:100` corresponds to the `nobody:users` user/group on Unraid. The `/app/config` volume is mapped to `/mnt/user/appdata/youtarr` (not a `/config` subfolder), so recursing from the top picks up `config.json`, `jobs/`, and `images/` in one shot.
 
 3. **Add the user parameter to your container**:
    - Edit your Youtarr container in Unraid
@@ -87,3 +86,17 @@ By default, Youtarr runs as root inside the container. This works fine for most 
    You should see `uid=99(nobody) gid=100(users)` instead of `uid=0(root)`.
 
 After this setup, Youtarr will create files with `nobody:users` ownership, which matches the default permissions that Plex and other media apps use on Unraid, allowing them to delete files as needed.
+
+## Troubleshooting file permissions over SMB (Windows, macOS)
+
+If you can see Youtarr's downloaded videos on a Windows or macOS SMB share but can't move, rename, or delete them ("You require permission from TOWER\nobody to make changes to this file" on Windows, or a padlock icon on macOS), the cause is almost always the file mode, not the ownership.
+
+Older versions of Youtarr wrote files with mode `644` (`rw-r--r--`), which means only the file owner (`nobody`) could modify them. If your SMB client authenticated as any other user, access was read-only. Current versions write downloads as `664` / directories as `775` by default, so **new downloads do not need any repair**.
+
+**One-time repair for files downloaded before this change:**
+```bash
+find /path/to/your/youtube_videos -type f -exec chmod 664 {} \;
+find /path/to/your/youtube_videos -type d -exec chmod 775 {} \;
+```
+
+Separately, your SMB share must be configured so the connecting user is either mapped to `nobody` or is a member of the `users` group, otherwise even group-writable files will still appear read-only. On Unraid, the simplest path is Shares -> edit the share -> SMB Security Settings -> set to `Public`, which maps all SMB users to `nobody`.

--- a/server/modules/__tests__/configModule.test.js
+++ b/server/modules/__tests__/configModule.test.js
@@ -86,7 +86,8 @@ describe('ConfigModule', () => {
       // Assert
       expect(fs.writeFileSync).toHaveBeenCalledWith(
         expect.stringContaining('config.json'),
-        expect.stringContaining('test-uuid-1234')
+        expect.stringContaining('test-uuid-1234'),
+        { mode: 0o640 }
       );
       expect(logger.info).toHaveBeenCalledWith(
         'Auto-creating config.json from config.example.json template'
@@ -566,6 +567,67 @@ describe('ConfigModule', () => {
       const savedConfig = JSON.parse(fs.writeFileSync.mock.calls[fs.writeFileSync.mock.calls.length - 1][1]);
       expect(savedConfig.useTmpForDownloads).toBeUndefined();
       expect(savedConfig.tmpFilePath).toBeUndefined();
+    });
+
+    test('should create config.json with mode 0o640 and tighten permissions', () => {
+      // Arrange
+      fs.existsSync.mockImplementation((filePath) => {
+        if (filePath.includes('config.json') && !filePath.includes('example')) return false;
+        if (filePath.includes('config.example.json')) return true;
+        return true;
+      });
+      fs.readFileSync.mockReturnValue(JSON.stringify(defaultTemplate));
+
+      // Act
+      ConfigModule = require('../configModule');
+
+      // Assert
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('config.json'),
+        expect.any(String),
+        { mode: 0o640 }
+      );
+      expect(fs.chmodSync).toHaveBeenCalledWith(
+        expect.stringContaining('config.json'),
+        0o640
+      );
+    });
+
+    test('saveConfig writes with mode 0o640 and chmods the file', () => {
+      // Arrange
+      ConfigModule = require('../configModule');
+      fs.writeFileSync.mockClear();
+      fs.chmodSync.mockClear();
+
+      // Act
+      ConfigModule.saveConfig();
+
+      // Assert
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('config.json'),
+        expect.any(String),
+        { mode: 0o640 }
+      );
+      expect(fs.chmodSync).toHaveBeenCalledWith(
+        expect.stringContaining('config.json'),
+        0o640
+      );
+    });
+
+    test('saveConfig does not throw if chmod fails (EPERM on legacy-owned file)', () => {
+      // Arrange
+      ConfigModule = require('../configModule');
+      const chmodError = Object.assign(new Error('chmod EPERM'), { code: 'EPERM' });
+      fs.chmodSync.mockImplementationOnce(() => {
+        throw chmodError;
+      });
+
+      // Act + Assert
+      expect(() => ConfigModule.saveConfig()).not.toThrow();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ err: chmodError, configPath: expect.stringContaining('config.json') }),
+        expect.stringContaining('Could not tighten config.json permissions')
+      );
     });
   });
 

--- a/server/modules/configModule.js
+++ b/server/modules/configModule.js
@@ -232,7 +232,9 @@ class ConfigModule extends EventEmitter {
 
     // Write the config file and provide actionable guidance if permissions fail
     try {
-      fs.writeFileSync(this.configPath, JSON.stringify(defaultConfig, null, 2));
+      // mode 0o640 keeps plexApiKey and other secrets out of world-readable (umask is 0o002 → 0o664 default)
+      fs.writeFileSync(this.configPath, JSON.stringify(defaultConfig, null, 2), { mode: 0o640 });
+      this.tightenConfigPermissions();
       logger.info({ configPath: this.configPath }, 'Created config.json from template');
     } catch (error) {
       if (error.code === 'EACCES') {
@@ -347,12 +349,26 @@ class ConfigModule extends EventEmitter {
     this.isSaving = true;
     const configContent = JSON.stringify(configToSave, null, 2);
     this.lastConfigContent = configContent;
-    fs.writeFileSync(this.configPath, configContent);
+    fs.writeFileSync(this.configPath, configContent, { mode: 0o640 });
+    this.tightenConfigPermissions();
 
     // Clear the flag after a short delay to account for fs.watch() firing
     setTimeout(() => {
       this.isSaving = false;
     }, 200);
+  }
+
+  // chmod fails with EPERM if the file is owned by a different UID (common on upgrades
+  // from older Youtarr versions). Best-effort only — the content is already saved.
+  tightenConfigPermissions() {
+    try {
+      fs.chmodSync(this.configPath, 0o640);
+    } catch (error) {
+      logger.warn(
+        { err: error, configPath: this.configPath },
+        'Could not tighten config.json permissions to 0640; file content is saved but mode may be permissive. Run `chmod 640` on the file manually if it contains secrets.'
+      );
+    }
   }
 
   watchConfig() {

--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,10 @@
+// Ensure files Youtarr (and yt-dlp, which inherits this umask) creates are
+// group-writable by default, so SMB clients, Plex, and Jellyfin can rename/delete
+// downloads without an extra chmod step. Node's default umask is 0022 (files 644),
+// which is the root cause of many Unraid/NAS permission complaints. config.json
+// is separately locked to 0640 on write to keep plexApiKey out of world-read.
+process.umask(0o002);
+
 const express = require('express');
 const rateLimit = require('express-rate-limit');
 const { ipKeyGenerator } = require('express-rate-limit');


### PR DESCRIPTION
- Set process.umask(0o002) so Youtarr and yt-dlp write files as 664/dirs as 775, fixing SMB rename/delete failures on Unraid and other NAS setups where the SMB client authenticates as a different user than the container UID.
- Write config.json with mode 0o640 (not world-readable) via writeFileSync options + best-effort chmodSync. chmod is now wrapped in try/catch and logs a warn on EPERM so legacy-owned config files from older versions do not break saves.
- Reframe unraid.md SMB troubleshooting as a one-time repair for pre-existing files; new downloads no longer need a chmod workaround.
- Simplify unraid.md chown guidance to match the actual template volume mapping (/mnt/user/appdata/youtarr -> /app/config).