### PR TITLE
Misc fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,10 @@ These standards apply when you are authoring new code or doing an explicit rewri
 ### General Principles
 - **DRY when writing the third copy**: if you find yourself writing the same logic a third time in your own new code, extract it.
 - **Single responsibility**: each module, class, or function should have one clear purpose. If a function name requires "and" to describe it, split it.
-- **Right-size your extractions**: do not create helpers, components, or hooks for one-time operations. Three similar lines of code is better than a premature abstraction. If a helper is used in exactly one place, inline it.
+- **Extract deliberately, inline small snippets**:
+  - **Extract** when a block is substantial and has a clear external interface. Rough threshold: ~30+ lines of JSX/logic with its own props or state, or two usages in structurally different parents (e.g. mobile card vs desktop table row). Size and interface clarity matter more than copy count.
+  - **Inline** one-off snippets used in a single place. Three similar lines of code is better than a premature abstraction. The "three copies" rule applies to small repeated patterns, not to substantial blocks.
+  - Before creating a new component/module file, answer: (1) is this substantial enough to extract, or should it stay inline? (2) which directory -- feature-local, `shared/`, or `ui/` -- and why? (3) what test file am I adding alongside it?
 - **File size targets for new files**: backend modules under ~500 lines, frontend components under ~300 lines. Several legacy files exceed these limits (notably `channelModule.js`, `jobModule.js`, `channelSettingsModule.js`, `videoDeletionModule.js`, `VideosPage.tsx`, `ChannelVideos.tsx`, `DownloadProgress.tsx`) - do not use them as examples. The codebase is migrating toward these targets over time.
 - **Named constants for magic values**: in new code, timeouts, retry counts, limits, and defaults should be named constants at the top of the file or in a shared constants module.
 - **Early returns** for error and edge cases, to keep happy-path nesting shallow.
@@ -132,6 +135,11 @@ These standards apply when you are authoring new code or doing an explicit rewri
 
 #### Component Structure
 - **When authoring or rewriting a component**: aim for fewer than 10 `useState` calls and under 300 lines. If you cross that threshold while writing new code, extract logic into custom hooks and UI into child components.
+- **Placement of new components and modules** (prescriptive, not just descriptive -- `shared/` is not the default):
+  - **Feature-local** (used by a single feature/page): place in the feature directory, e.g. `components/DownloadManager/VideoThumbnail.tsx`. This is the default.
+  - **Cross-feature** (imported by 2+ feature directories *today*, not hypothetically): place in `components/shared/`.
+  - **Theme-neutral UI primitive** (Button-like, Card-like, no business logic): place in `components/ui/`.
+  - Promote to `shared/` later when a second feature actually imports it -- do not speculatively place in `shared/` "in case" it gets reused.
 - **Feature directory layout** for new complex features, either of these is acceptable:
   ```
   # Sibling-file layout (most common in this repo)
@@ -199,6 +207,9 @@ npm run test:backend -- server/modules/__tests__/foo.test.js # one backend test
 npm run lint                                                  # lint front + back
 npm run lint:ts                                               # TypeScript typecheck
 ```
+
+### Tests Accompany New Files
+**New component/module files ship with tests in the same change.** When you create a new `.tsx`/`.ts` component, hook, or backend module, add its test file in the same commit. Co-locate in the nearest `__tests__/` directory. Cover externally-observable behavior: renders with required props, responds to interactions, handles the missing/error/loading states the component declares. The `write-tests` and `write-tests-react` slash commands scaffold these. Trivial pure-display components (no props, no logic) are the only exception.
 
 ### Test Execution Policy
 **NEVER skip tests.** No `test.skip()`, no `describe.skip()`, no commented-out failing tests. Fix failing tests or delete them if obsolete. If a test is written, it must run and pass in CI.

--- a/client/src/components/DownloadManager.tsx
+++ b/client/src/components/DownloadManager.tsx
@@ -133,6 +133,7 @@ function DownloadManager({ token }: DownloadManagerProps) {
               currentTime={currentTime}
               isMobile={isMobile}
               token={token}
+              onVideoDeleted={fetchRunningJobs}
             />
           </Grid>
         }

--- a/client/src/components/DownloadManager/DownloadHistory.tsx
+++ b/client/src/components/DownloadManager/DownloadHistory.tsx
@@ -27,6 +27,8 @@ import { useConfig } from '../../hooks/useConfig';
 import PageControls from '../shared/PageControls';
 import VideoModal from '../shared/VideoModal';
 import { VideoModalData } from '../shared/VideoModal/types';
+import VideoThumbnail from './VideoThumbnail';
+import MissingVideoChip from './MissingVideoChip';
 
 interface DownloadHistoryProps {
   jobs: Job[];
@@ -35,6 +37,7 @@ interface DownloadHistoryProps {
   handleExpandCell: (id: string) => void;
   isMobile: boolean;
   token?: string | null;
+  onVideoDeleted?: () => void;
 }
 
 function cleanJobTypeLabel(jobType: string): string {
@@ -84,9 +87,11 @@ const DownloadHistory: React.FC<DownloadHistoryProps> = ({
   handleExpandCell,
   isMobile,
   token = null,
+  onVideoDeleted,
 }) => {
   const [modalVideo, setModalVideo] = useState<VideoData | null>(null);
   const [showNoVideoJobs, setShowNoVideoJobs] = useState(false);
+  const [imageErrors, setImageErrors] = useState<Record<string, boolean>>({});
   const buttonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage] = useState(12);
@@ -94,6 +99,10 @@ const DownloadHistory: React.FC<DownloadHistoryProps> = ({
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const { config } = useConfig(token);
   const useInfiniteScroll = config.channelVideosHotLoad ?? false;
+
+  const handleImageError = (youtubeId: string) => {
+    setImageErrors((prev) => ({ ...prev, [youtubeId]: true }));
+  };
 
   const jobsToDisplay = jobs
     .filter((job) => !job.jobType?.includes('Import Subscriptions'))
@@ -168,6 +177,10 @@ const DownloadHistory: React.FC<DownloadHistoryProps> = ({
         onClose={() => setModalVideo(null)}
         video={jobVideoToModalData(modalVideo)}
         token={token}
+        onVideoDeleted={() => {
+          setModalVideo(null);
+          onVideoDeleted?.();
+        }}
       />
     ) : null;
 
@@ -235,9 +248,8 @@ const DownloadHistory: React.FC<DownloadHistoryProps> = ({
                     const hasMultiple = videos.length > 1;
                     const titleText = singleVideo?.youTubeVideoName || (hasMultiple ? `Multiple (${videos.length})` : cleanJobTypeLabel(job.jobType));
                     const channelText = !hasMultiple ? singleVideo?.youTubeChannelName : undefined;
-                    const thumbnailSrc = !hasMultiple && singleVideo?.youtubeId
-                      ? `https://i.ytimg.com/vi/${singleVideo.youtubeId}/mqdefault.jpg`
-                      : null;
+                    const showThumbnail = !hasMultiple && !!singleVideo;
+                    const missingCount = videos.filter((v: VideoData) => v.removed).length;
 
                     return (
                       <Box
@@ -246,22 +258,30 @@ const DownloadHistory: React.FC<DownloadHistoryProps> = ({
                         className="p-3"
                       >
                         <Box className="flex items-start justify-between gap-2">
-                          <Typography variant="subtitle2" className="font-semibold">
-                            {hasMultiple ? (
-                              `Multiple (${videos.length})`
-                            ) : singleVideo ? (
-                              <Link
-                                component="button"
-                                type="button"
-                                onClick={() => setModalVideo(singleVideo)}
-                                style={{ background: 'none', border: 'none', padding: 0, textAlign: 'left' }}
-                              >
-                                {singleVideo.youTubeVideoName}
-                              </Link>
-                            ) : (
-                              titleText
+                          <Box className="flex items-center gap-2 flex-wrap min-w-0">
+                            <Typography variant="subtitle2" className="font-semibold">
+                              {hasMultiple ? (
+                                `Multiple (${videos.length})`
+                              ) : singleVideo ? (
+                                <Link
+                                  component="button"
+                                  type="button"
+                                  onClick={() => setModalVideo(singleVideo)}
+                                  style={{ background: 'none', border: 'none', padding: 0, textAlign: 'left' }}
+                                >
+                                  {singleVideo.youTubeVideoName}
+                                </Link>
+                              ) : (
+                                titleText
+                              )}
+                            </Typography>
+                            {hasMultiple && missingCount > 0 && (
+                              <MissingVideoChip
+                                label={`${missingCount} missing`}
+                                tooltip={`${missingCount} of ${videos.length} video files not found on disk`}
+                              />
                             )}
-                          </Typography>
+                          </Box>
                           {hasMultiple && (
                             <IconButton size="small" onClick={() => handleExpandCell(job.id)}>
                               {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
@@ -276,46 +296,57 @@ const DownloadHistory: React.FC<DownloadHistoryProps> = ({
                         )}
 
                         <Box className="mt-2 flex items-start gap-3">
-                          {thumbnailSrc && (
-                            <Box
-                              onClick={singleVideo ? () => setModalVideo(singleVideo) : undefined}
-                              style={{
-                                width: 96,
-                                height: 72,
-                                borderRadius: 'var(--radius-thumb)',
-                                overflow: 'hidden',
-                                backgroundColor: 'rgb(17 24 39)',
-                                flexShrink: 0,
-                                cursor: singleVideo ? 'pointer' : 'default',
-                              }}
-                            >
-                              <img
-                                src={thumbnailSrc}
-                                alt={titleText}
-                                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
-                                loading="lazy"
-                              />
-                            </Box>
+                          {showThumbnail && singleVideo && (
+                            <VideoThumbnail
+                              video={singleVideo}
+                              width={96}
+                              height={72}
+                              onClick={() => setModalVideo(singleVideo)}
+                              hasError={!!imageErrors[singleVideo.youtubeId]}
+                              onError={() => handleImageError(singleVideo.youtubeId)}
+                              iconSize={24}
+                            />
                           )}
 
-                          <Box className="min-w-0 flex flex-1 flex-col gap-0.5">
-                            <Typography variant="caption" color="secondary">
-                              Date: {formattedTimeCreated}
-                            </Typography>
-                            {formattedJobType && (
+                          {hasMultiple ? (
+                            <Box className="min-w-0 flex flex-1 flex-col gap-0.5">
+                              <Box className="flex items-baseline gap-1 flex-wrap">
+                                <Typography variant="caption" color="secondary">Date:</Typography>
+                                <Typography variant="caption" className="font-medium">{formattedTimeCreated}</Typography>
+                              </Box>
+                              <Box className="flex items-baseline gap-x-4 gap-y-0.5 flex-wrap">
+                                {formattedJobType && (
+                                  <Box className="flex items-baseline gap-1">
+                                    <Typography variant="caption" color="secondary">Source:</Typography>
+                                    <Typography variant="caption" className="font-medium">{formattedJobType}</Typography>
+                                  </Box>
+                                )}
+                                <Box className="flex items-baseline gap-1">
+                                  <Typography variant="caption" color="secondary">Status:</Typography>
+                                  <Typography variant="caption" className="font-medium">{durationString}</Typography>
+                                </Box>
+                              </Box>
+                            </Box>
+                          ) : (
+                            <Box className="min-w-0 flex flex-1 flex-col gap-0.5">
                               <Typography variant="caption" color="secondary">
-                                Source: {formattedJobType}
+                                Date: {formattedTimeCreated}
                               </Typography>
-                            )}
-                            <Typography variant="caption" color="secondary">
-                              Status: {durationString}
-                            </Typography>
-                          </Box>
+                              {formattedJobType && (
+                                <Typography variant="caption" color="secondary">
+                                  Source: {formattedJobType}
+                                </Typography>
+                              )}
+                              <Typography variant="caption" color="secondary">
+                                Status: {durationString}
+                              </Typography>
+                            </Box>
+                          )}
                         </Box>
 
                         {hasMultiple && (
                           <Collapse in={isExpanded} timeout="auto" unmountOnExit>
-                            <Box className="mt-1.5 flex flex-col gap-1">
+                            <Box className="mt-1.5 flex flex-col gap-1.5">
                               {videos.map((video: VideoData) => (
                                 <Box key={video.youtubeId} className="flex flex-col">
                                   <Link
@@ -326,9 +357,12 @@ const DownloadHistory: React.FC<DownloadHistoryProps> = ({
                                   >
                                     {video.youTubeVideoName}
                                   </Link>
-                                  <Typography variant="caption" color="secondary">
-                                    {video.youTubeChannelName}
-                                  </Typography>
+                                  <Box className="flex items-center gap-2 flex-wrap">
+                                    <Typography variant="caption" color="secondary">
+                                      {video.youTubeChannelName}
+                                    </Typography>
+                                    {video.removed && <MissingVideoChip />}
+                                  </Box>
                                 </Box>
                               ))}
                             </Box>
@@ -424,11 +458,22 @@ const DownloadHistory: React.FC<DownloadHistoryProps> = ({
                     const formattedTimeCreated = `${month}-${day} ${hours}:${minutes} ${period}`;
 
                     if (videos.length > 1) {
+                      const missingCount = videos.filter((v: VideoData) => v.removed).length;
                       return (
                         <React.Fragment key={job.id}>
                           <TableRow hover onClick={() => handleExpandCell(job.id)}>
                             <TableCell style={{ fontSize: isMobile ? 'small' : 'medium' }}>{formattedTimeCreated}</TableCell>
-                            <TableCell style={{ fontSize: isMobile ? 'small' : 'medium' }}>Multiple ({videos.length})</TableCell>
+                            <TableCell style={{ fontSize: isMobile ? 'small' : 'medium' }}>
+                              <Box className="flex items-center gap-2 flex-wrap">
+                                <span>Multiple ({videos.length})</span>
+                                {missingCount > 0 && (
+                                  <MissingVideoChip
+                                    label={`${missingCount} missing`}
+                                    tooltip={`${missingCount} of ${videos.length} video files not found on disk`}
+                                  />
+                                )}
+                              </Box>
+                            </TableCell>
                             <TableCell style={{ fontSize: isMobile ? 'small' : 'medium' }}>{formattedJobType}</TableCell>
                             <TableCell style={{ fontSize: isMobile ? 'small' : 'medium' }}>{job.status}</TableCell>
                             <TableCell align="right">
@@ -448,14 +493,17 @@ const DownloadHistory: React.FC<DownloadHistoryProps> = ({
                                         <TableRow key={video.youtubeId}>
                                           <TableCell style={{ width: 180 }}>{formattedTimeCreated}</TableCell>
                                           <TableCell>
-                                            <Link
-                                              component="button"
-                                              type="button"
-                                              onClick={(e: React.MouseEvent) => { e.stopPropagation(); setModalVideo(video); }}
-                                              style={{ background: 'none', border: 'none', padding: 0, textAlign: 'left' }}
-                                            >
-                                              {video.youTubeVideoName}
-                                            </Link>
+                                            <Box className="flex items-start gap-2 flex-wrap">
+                                              <Link
+                                                component="button"
+                                                type="button"
+                                                onClick={(e: React.MouseEvent) => { e.stopPropagation(); setModalVideo(video); }}
+                                                style={{ background: 'none', border: 'none', padding: 0, textAlign: 'left' }}
+                                              >
+                                                {video.youTubeVideoName}
+                                              </Link>
+                                              {video.removed && <MissingVideoChip />}
+                                            </Box>
                                             <Typography variant="caption" color="secondary" className="block">{video.youTubeChannelName}</Typography>
                                           </TableCell>
                                           <TableCell>{formattedJobType}</TableCell>
@@ -479,18 +527,29 @@ const DownloadHistory: React.FC<DownloadHistoryProps> = ({
                         <TableCell style={{ fontSize: isMobile ? 'small' : 'medium' }}>{formattedTimeCreated}</TableCell>
                         <TableCell style={{ fontSize: isMobile ? 'small' : 'medium' }}>
                           {singleVideo ? (
-                            <>
+                            <Box className="flex items-start gap-3">
                               <span aria-hidden="true" style={{ display: 'none' }}>1</span>
-                              <Link
-                                component="button"
-                                type="button"
+                              <VideoThumbnail
+                                video={singleVideo}
+                                width={128}
+                                height={72}
                                 onClick={() => setModalVideo(singleVideo)}
-                                style={{ background: 'none', border: 'none', padding: 0, textAlign: 'left' }}
-                              >
-                                {singleVideo.youTubeVideoName}
-                              </Link>
-                              <Typography variant="caption" color="secondary" className="block">{singleVideo.youTubeChannelName}</Typography>
-                            </>
+                                hasError={!!imageErrors[singleVideo.youtubeId]}
+                                onError={() => handleImageError(singleVideo.youtubeId)}
+                                iconSize={32}
+                              />
+                              <Box className="min-w-0 flex-1">
+                                <Link
+                                  component="button"
+                                  type="button"
+                                  onClick={() => setModalVideo(singleVideo)}
+                                  style={{ background: 'none', border: 'none', padding: 0, textAlign: 'left' }}
+                                >
+                                  {singleVideo.youTubeVideoName}
+                                </Link>
+                                <Typography variant="caption" color="secondary" className="block">{singleVideo.youTubeChannelName}</Typography>
+                              </Box>
+                            </Box>
                           ) : job.status === 'In Progress' ? (
                             <span>---</span>
                           ) : (

--- a/client/src/components/DownloadManager/MissingVideoChip.tsx
+++ b/client/src/components/DownloadManager/MissingVideoChip.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Chip, Tooltip } from '../ui';
+import { AlertCircle } from 'lucide-react';
+import { SHARED_THEMED_CHIP_SMALL_STYLE } from '../shared/chipStyles';
+
+const DEFAULT_TOOLTIP = 'Video file not found on disk. It may have been deleted or moved.';
+
+interface MissingVideoChipProps {
+  label?: string;
+  tooltip?: string;
+}
+
+function MissingVideoChip({ label = 'Missing', tooltip = DEFAULT_TOOLTIP }: MissingVideoChipProps) {
+  return (
+    <Tooltip title={tooltip} enterTouchDelay={0}>
+      <Chip
+        size="small"
+        icon={<AlertCircle size={12} />}
+        label={label}
+        color="error"
+        variant="filled"
+        style={SHARED_THEMED_CHIP_SMALL_STYLE}
+      />
+    </Tooltip>
+  );
+}
+
+export default MissingVideoChip;

--- a/client/src/components/DownloadManager/VideoThumbnail.tsx
+++ b/client/src/components/DownloadManager/VideoThumbnail.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Box, Typography } from '../ui';
+import { AlertCircle as ErrorOutlineIcon } from 'lucide-react';
+import { VideoData } from '../../types/VideoData';
+
+const MISSING_OVERLAY_BG = 'color-mix(in srgb, var(--destructive) 30%, transparent)';
+
+interface VideoThumbnailProps {
+  video: VideoData;
+  width: number;
+  height: number;
+  onClick: () => void;
+  hasError: boolean;
+  onError: () => void;
+  iconSize: number;
+}
+
+function VideoThumbnail({
+  video,
+  width,
+  height,
+  onClick,
+  hasError,
+  onError,
+  iconSize,
+}: VideoThumbnailProps) {
+  const isMissing = Boolean(video.removed);
+
+  return (
+    <Box
+      data-testid="video-thumbnail"
+      onClick={onClick}
+      className="relative flex items-center justify-center shrink-0 overflow-hidden cursor-pointer"
+      style={{
+        width,
+        height,
+        borderRadius: 'var(--radius-thumb)',
+        backgroundColor: 'var(--media-placeholder-background)',
+        border: 'var(--media-placeholder-border)',
+      }}
+    >
+      {hasError ? (
+        <Typography
+          variant="caption"
+          className="text-center px-1"
+          style={{
+            filter: isMissing ? 'grayscale(100%) brightness(0.6)' : 'none',
+          }}
+        >
+          No thumbnail
+        </Typography>
+      ) : (
+        <img
+          src={`/images/videothumb-${video.youtubeId}.jpg`}
+          alt={video.youTubeVideoName}
+          loading="lazy"
+          onError={onError}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: video.media_type === 'short' ? 'contain' : 'cover',
+            filter: isMissing ? 'grayscale(100%) brightness(0.6)' : 'none',
+          }}
+        />
+      )}
+      {isMissing && (
+        <Box
+          data-testid="video-thumbnail-missing-overlay"
+          className="absolute inset-0 z-[1] flex items-center justify-center"
+          style={{ backgroundColor: MISSING_OVERLAY_BG }}
+        >
+          <ErrorOutlineIcon
+            size={iconSize}
+            className="text-destructive"
+            style={{ filter: 'drop-shadow(0px 2px 4px rgba(0,0,0,0.5))' }}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export default VideoThumbnail;

--- a/client/src/components/DownloadManager/__tests__/DownloadHistory.test.tsx
+++ b/client/src/components/DownloadManager/__tests__/DownloadHistory.test.tsx
@@ -25,7 +25,59 @@ jest.mock('../../../hooks/useConfig', () => ({
   useConfig: jest.fn(),
 }));
 
+// Mock VideoModal: render a visible wrapper with a button that fires onVideoDeleted,
+// so tests can drive the deletion wiring without the real modal's async flow.
+jest.mock('../../shared/VideoModal', () => ({
+  __esModule: true,
+  default: function MockVideoModal(props: {
+    open: boolean;
+    onVideoDeleted?: (youtubeId: string) => void;
+    video: { youtubeId: string };
+  }) {
+    const React = require('react');
+    if (!props.open) return null;
+    return React.createElement(
+      'div',
+      { 'data-testid': 'mock-video-modal' },
+      React.createElement(
+        'button',
+        {
+          'data-testid': 'mock-delete-video',
+          onClick: () => props.onVideoDeleted?.(props.video.youtubeId),
+        },
+        'Mock Delete'
+      )
+    );
+  },
+}));
+
 const mockUseConfig = useConfig as jest.MockedFunction<typeof useConfig>;
+
+function makeVideo(overrides: Partial<VideoData> = {}): VideoData {
+  return {
+    id: 1,
+    youtubeId: 'video1',
+    youTubeChannelName: 'Test Channel',
+    youTubeVideoName: 'Test Video 1',
+    duration: 120,
+    timeCreated: '2024-01-15T09:00:00Z',
+    originalDate: null,
+    description: null,
+    ...overrides,
+  };
+}
+
+function makeMultiVideoJob(id: string, videos: VideoData[]): Job {
+  return {
+    id,
+    jobType: 'Channel Downloads',
+    status: 'Completed',
+    output: '',
+    timeCreated: new Date('2024-01-15T09:00:00Z').getTime(),
+    timeInitiated: new Date('2024-01-15T09:00:30Z').getTime(),
+    data: { videos },
+  };
+}
 
 describe('DownloadHistory', () => {
   const mockHandleExpandCell = jest.fn();
@@ -568,6 +620,126 @@ describe('DownloadHistory', () => {
       const tableCells = screen.getAllByRole('cell');
       const cellTexts = tableCells.map(cell => cell.textContent || '');
       expect(cellTexts.some(text => text === 'API: iPhone Shortcut #1')).toBe(true);
+    });
+  });
+
+  describe('Missing video indicators (multi-video jobs)', () => {
+    test('desktop summary row shows "N missing" chip when at least one video is removed', () => {
+      const job = makeMultiVideoJob('job-multi', [
+        makeVideo({ id: 1, youtubeId: 'v1', youTubeVideoName: 'Video A' }),
+        makeVideo({ id: 2, youtubeId: 'v2', youTubeVideoName: 'Video B', removed: true }),
+        makeVideo({ id: 3, youtubeId: 'v3', youTubeVideoName: 'Video C' }),
+      ]);
+
+      render(<DownloadHistory {...defaultProps} jobs={[job]} />);
+
+      expect(screen.getByText('Multiple (3)')).toBeInTheDocument();
+      expect(screen.getByText('1 missing')).toBeInTheDocument();
+    });
+
+    test('desktop summary row hides the aggregate chip when no videos are removed', () => {
+      const job = makeMultiVideoJob('job-multi-none', [
+        makeVideo({ id: 1, youtubeId: 'v1' }),
+        makeVideo({ id: 2, youtubeId: 'v2' }),
+      ]);
+
+      render(<DownloadHistory {...defaultProps} jobs={[job]} />);
+
+      expect(screen.getByText('Multiple (2)')).toBeInTheDocument();
+      expect(screen.queryByText(/missing/i)).not.toBeInTheDocument();
+    });
+
+    test('desktop expanded row shows "Missing" chip next to removed videos only', () => {
+      const job = makeMultiVideoJob('job-multi-expanded', [
+        makeVideo({ id: 1, youtubeId: 'v1', youTubeVideoName: 'Kept Video' }),
+        makeVideo({ id: 2, youtubeId: 'v2', youTubeVideoName: 'Gone Video', removed: true }),
+      ]);
+
+      render(
+        <DownloadHistory
+          {...defaultProps}
+          jobs={[job]}
+          expanded={{ 'job-multi-expanded': true }}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: 'Gone Video' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Kept Video' })).toBeInTheDocument();
+      expect(screen.getByText('Missing')).toBeInTheDocument();
+    });
+
+    test('mobile summary card shows "N missing" chip when at least one video is removed', () => {
+      const job = makeMultiVideoJob('job-mobile-multi', [
+        makeVideo({ id: 1, youtubeId: 'v1' }),
+        makeVideo({ id: 2, youtubeId: 'v2', removed: true }),
+      ]);
+
+      render(<DownloadHistory {...defaultProps} jobs={[job]} isMobile />);
+
+      expect(screen.getByText('Multiple (2)')).toBeInTheDocument();
+      expect(screen.getByText('1 missing')).toBeInTheDocument();
+    });
+
+    test('mobile summary card hides the aggregate chip when no videos are removed', () => {
+      const job = makeMultiVideoJob('job-mobile-multi-clean', [
+        makeVideo({ id: 1, youtubeId: 'v1' }),
+        makeVideo({ id: 2, youtubeId: 'v2' }),
+      ]);
+
+      render(<DownloadHistory {...defaultProps} jobs={[job]} isMobile />);
+
+      expect(screen.getByText('Multiple (2)')).toBeInTheDocument();
+      expect(screen.queryByText(/missing/i)).not.toBeInTheDocument();
+    });
+
+    test('mobile expanded card shows per-video "Missing" chip only for removed videos', () => {
+      const job = makeMultiVideoJob('job-mobile-expanded', [
+        makeVideo({ id: 1, youtubeId: 'v1', youTubeVideoName: 'Present Video' }),
+        makeVideo({ id: 2, youtubeId: 'v2', youTubeVideoName: 'Removed Video', removed: true }),
+      ]);
+
+      render(
+        <DownloadHistory
+          {...defaultProps}
+          jobs={[job]}
+          isMobile
+          expanded={{ 'job-mobile-expanded': true }}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: 'Present Video' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Removed Video' })).toBeInTheDocument();
+      expect(screen.getByText('Missing')).toBeInTheDocument();
+    });
+  });
+
+  describe('Video deletion wiring', () => {
+    test('invokes onVideoDeleted after a video is deleted via the modal', async () => {
+      const user = userEvent.setup();
+      const onVideoDeleted = jest.fn();
+      const job = makeMultiVideoJob('job-delete', [
+        makeVideo({ id: 1, youtubeId: 'del-1', youTubeVideoName: 'Deletable Video' }),
+        makeVideo({ id: 2, youtubeId: 'del-2', youTubeVideoName: 'Other Video' }),
+      ]);
+
+      render(
+        <DownloadHistory
+          {...defaultProps}
+          jobs={[job]}
+          expanded={{ 'job-delete': true }}
+          onVideoDeleted={onVideoDeleted}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Deletable Video' }));
+      expect(screen.getByTestId('mock-video-modal')).toBeInTheDocument();
+
+      await user.click(screen.getByTestId('mock-delete-video'));
+
+      expect(onVideoDeleted).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(screen.queryByTestId('mock-video-modal')).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/client/src/components/DownloadManager/__tests__/MissingVideoChip.test.tsx
+++ b/client/src/components/DownloadManager/__tests__/MissingVideoChip.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import MissingVideoChip from '../MissingVideoChip';
+
+describe('MissingVideoChip', () => {
+  test('renders with the default "Missing" label', () => {
+    render(<MissingVideoChip />);
+    expect(screen.getByText('Missing')).toBeInTheDocument();
+  });
+
+  test('renders a custom label when provided', () => {
+    render(<MissingVideoChip label="2 missing" />);
+    expect(screen.getByText('2 missing')).toBeInTheDocument();
+    expect(screen.queryByText('Missing')).not.toBeInTheDocument();
+  });
+
+  test('shows the default tooltip message on hover', async () => {
+    const user = userEvent.setup();
+    render(<MissingVideoChip />);
+
+    await user.hover(screen.getByText('Missing'));
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(
+      'Video file not found on disk. It may have been deleted or moved.'
+    );
+  });
+
+  test('shows a custom tooltip message on hover when the tooltip prop is provided', async () => {
+    const user = userEvent.setup();
+    render(
+      <MissingVideoChip label="2 missing" tooltip="2 of 5 video files not found on disk" />
+    );
+
+    await user.hover(screen.getByText('2 missing'));
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent('2 of 5 video files not found on disk');
+  });
+});

--- a/client/src/components/DownloadManager/__tests__/VideoThumbnail.test.tsx
+++ b/client/src/components/DownloadManager/__tests__/VideoThumbnail.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import VideoThumbnail from '../VideoThumbnail';
+import { VideoData } from '../../../types/VideoData';
+
+const baseVideo: VideoData = {
+  id: 1,
+  youtubeId: 'abc123',
+  youTubeChannelName: 'Test Channel',
+  youTubeVideoName: 'Test Video',
+  duration: 120,
+  timeCreated: '2024-01-15T09:00:00Z',
+  originalDate: null,
+  description: null,
+};
+
+function renderThumbnail(overrides: Partial<React.ComponentProps<typeof VideoThumbnail>> = {}) {
+  const onClick = jest.fn();
+  const onError = jest.fn();
+
+  const utils = render(
+    <VideoThumbnail
+      video={baseVideo}
+      width={128}
+      height={72}
+      onClick={onClick}
+      hasError={false}
+      onError={onError}
+      iconSize={32}
+      {...overrides}
+    />
+  );
+
+  return { ...utils, onClick, onError };
+}
+
+describe('VideoThumbnail', () => {
+  test('renders the image with the local thumbnail URL and alt from video title', () => {
+    renderThumbnail();
+
+    const img = screen.getByRole('img', { name: 'Test Video' });
+    expect(img).toHaveAttribute('src', '/images/videothumb-abc123.jpg');
+  });
+
+  test('invokes onClick when the thumbnail is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClick } = renderThumbnail();
+
+    await user.click(screen.getByTestId('video-thumbnail'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onError when the image fails to load', () => {
+    const { onError } = renderThumbnail();
+
+    fireEvent.error(screen.getByRole('img', { name: 'Test Video' }));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders "No thumbnail" fallback when hasError is true', () => {
+    renderThumbnail({ hasError: true });
+
+    expect(screen.getByText('No thumbnail')).toBeInTheDocument();
+    expect(screen.queryByRole('img', { name: 'Test Video' })).not.toBeInTheDocument();
+  });
+
+  test('does not render the missing overlay for a non-removed video', () => {
+    renderThumbnail();
+
+    expect(screen.queryByTestId('video-thumbnail-missing-overlay')).not.toBeInTheDocument();
+  });
+
+  test('renders the missing overlay when video.removed is true', () => {
+    renderThumbnail({ video: { ...baseVideo, removed: true } });
+
+    expect(screen.getByTestId('video-thumbnail-missing-overlay')).toBeInTheDocument();
+  });
+
+  test('shows missing overlay on top of the "No thumbnail" fallback for a removed video', () => {
+    renderThumbnail({ hasError: true, video: { ...baseVideo, removed: true } });
+
+    expect(screen.getByText('No thumbnail')).toBeInTheDocument();
+    expect(screen.getByTestId('video-thumbnail-missing-overlay')).toBeInTheDocument();
+  });
+
+  test('uses objectFit: contain for shorts and objectFit: cover for regular videos', () => {
+    const { rerender } = render(
+      <VideoThumbnail
+        video={{ ...baseVideo, media_type: 'short' }}
+        width={128}
+        height={72}
+        onClick={jest.fn()}
+        hasError={false}
+        onError={jest.fn()}
+        iconSize={32}
+      />
+    );
+    expect(screen.getByRole('img', { name: 'Test Video' })).toHaveStyle({ objectFit: 'contain' });
+
+    rerender(
+      <VideoThumbnail
+        video={{ ...baseVideo, media_type: 'video' }}
+        width={128}
+        height={72}
+        onClick={jest.fn()}
+        hasError={false}
+        onError={jest.fn()}
+        iconSize={32}
+      />
+    );
+    expect(screen.getByRole('img', { name: 'Test Video' })).toHaveStyle({ objectFit: 'cover' });
+  });
+});

--- a/server/modules/__tests__/channelSettingsModule.test.js
+++ b/server/modules/__tests__/channelSettingsModule.test.js
@@ -599,11 +599,10 @@ describe('ChannelSettingsModule', () => {
       });
     });
 
-    test('should throw error when channel not found', async () => {
+    test('should return null when channel not found', async () => {
       Channel.findOne.mockResolvedValue(null);
-      await expect(
-        channelSettingsModule.getChannelSettings('UC999999')
-      ).rejects.toThrow('Channel not found');
+      const result = await channelSettingsModule.getChannelSettings('UC999999');
+      expect(result).toBeNull();
     });
 
     test('includes detected_tabs, hidden_tabs, and effective available_tabs', async () => {

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -566,7 +566,7 @@ class ChannelSettingsModule {
     });
 
     if (!channel) {
-      throw new Error('Channel not found');
+      return null;
     }
 
     const detectedTabs = parseTabCsv(channel.available_tabs);

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -476,12 +476,17 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
    *     responses:
    *       200:
    *         description: Channel settings
+   *       404:
+   *         description: Channel not found (e.g. not subscribed)
    *       500:
    *         description: Failed to get settings
    */
   router.get('/api/channels/:channelId/settings', verifyToken, async (req, res) => {
     try {
       const settings = await channelSettingsModule.getChannelSettings(req.params.channelId);
+      if (!settings) {
+        return res.status(404).json({ error: 'Channel not found' });
+      }
       res.json(settings);
     } catch (error) {
       console.error('Error getting channel settings:', error);


### PR DESCRIPTION

1. fix: return 404 instead of 500 for unsubscribed channel settings
GET /api/channels/:channelId/settings threw and logged a 500 whenever VideoModal opened a video whose channel is not in the DB (i.e. not subscribed). The modal's fallback to global defaults hid any user-facing impact, but the logs were noisy. Return null from the module on not-found and let the route emit a quiet 404.

2. feat: show thumbnails and missing indicators in download history