### PR TITLE
feat: unify pagination and inline loading on lists

### DIFF
--- a/client/src/components/ChannelManager.tsx
+++ b/client/src/components/ChannelManager.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
   Divider,
   Grid,
+  LinearProgress,
   List,
   Menu,
   MenuItem,
@@ -53,7 +54,12 @@ import {
 } from '../utils/channelHelpers';
 import HelpDialog from './ChannelManager/HelpDialog';
 import PendingSaveBanner from './ChannelManager/components/PendingSaveBanner';
-import PageControls from './shared/PageControls';
+import {
+  INFINITE_SCROLL_FETCH_SIZE,
+  VideoListPaginationBar,
+  useListPageSize,
+  type PageSize,
+} from './shared/VideoList';
 import ActiveImportBanner from './ChannelManager/components/ActiveImportBanner';
 import { useActiveImport } from '../hooks/useActiveImport';
 
@@ -94,25 +100,25 @@ const ChannelManager: React.FC<ChannelManagerProps> = ({ token }) => {
   const [folderMenuAnchor, setFolderMenuAnchor] = useState<null | HTMLElement>(null);
   const [mobileActionsAnchorEl, setMobileActionsAnchorEl] = useState<null | HTMLElement>(null);
   const [mobileFilterOpen, setMobileFilterOpen] = useState(false);
-  const channelsContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const pageSize = useMemo(() => {
-    if (isMobile) {
-      return 16;
-    }
-    return viewMode === 'grid' ? 27 : 20;
-  }, [isMobile, viewMode]);
+  const [pageSize, setPageSize] = useListPageSize('youtarr.channelManager.pageSize');
+  const effectivePageSize = useInfiniteScroll ? INFINITE_SCROLL_FETCH_SIZE : pageSize;
+
+  const handlePageSizeChange = useCallback((newSize: PageSize) => {
+    setPageSize(newSize);
+    setPage(1);
+  }, [setPageSize]);
 
   // Senior State Architect: Memoize params to kill identity-based re-fetch loops
   const channelListParams = useMemo(() => ({
     token,
     page,
-    pageSize,
+    pageSize: effectivePageSize,
     searchTerm: filterValue,
     sortOrder,
     subFolder: selectedSubFolder || undefined,
     append: useInfiniteScroll,
-  }), [token, page, pageSize, filterValue, sortOrder, selectedSubFolder, useInfiniteScroll]);
+  }), [token, page, effectivePageSize, filterValue, sortOrder, selectedSubFolder, useInfiniteScroll]);
 
   const {
     channels: serverChannels,
@@ -211,13 +217,6 @@ const ChannelManager: React.FC<ChannelManagerProps> = ({ token }) => {
   useEffect(() => {
     setPage(1);
   }, [useInfiniteScroll]);
-
-  // Scroll to channels container when page changes (from pagination controls)
-  useEffect(() => {
-    if (page > 1 && channelsContainerRef.current && !useInfiniteScroll) {
-      channelsContainerRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }, [page, useInfiniteScroll]);
 
   useEffect(() => {
     if (!useInfiniteScroll) {
@@ -602,10 +601,22 @@ const ChannelManager: React.FC<ChannelManagerProps> = ({ token }) => {
           </div>
           )}
 
-          <Divider style={{ marginBottom: 8 }} />
-
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }} ref={channelsContainerRef}>
-            {loading ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <VideoListPaginationBar
+              placement="top"
+              hasContent={displayChannels.length > 0}
+              useInfiniteScroll={useInfiniteScroll}
+              page={page}
+              totalPages={pageCount}
+              onPageChange={setPage}
+              pageSize={pageSize}
+              onPageSizeChange={handlePageSizeChange}
+              isMobile={isMobile}
+            />
+            {loading && displayChannels.length > 0 && !useInfiniteScroll && (
+              <LinearProgress height={2} style={{ marginBottom: 4 }} />
+            )}
+            {loading && displayChannels.length === 0 ? (
               <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', paddingTop: 24, paddingBottom: 24 }}>
                 <CircularProgress />
               </div>
@@ -692,19 +703,22 @@ const ChannelManager: React.FC<ChannelManagerProps> = ({ token }) => {
                 )}
               </>
             ) : (
-              <div
-                style={{
-                  paddingTop: isMobile ? 4 : 8,
-                  paddingBottom: 0,
-                }}
-              >
-                <PageControls
+              <>
+                {loading && displayChannels.length > 0 && (
+                  <LinearProgress height={2} style={{ marginTop: 4 }} />
+                )}
+                <VideoListPaginationBar
+                  placement="bottom"
+                  hasContent={displayChannels.length > 0}
+                  useInfiniteScroll={useInfiniteScroll}
                   page={page}
                   totalPages={pageCount}
                   onPageChange={setPage}
-                  compact={isMobile}
+                  pageSize={pageSize}
+                  onPageSizeChange={handlePageSizeChange}
+                  isMobile={isMobile}
                 />
-              </div>
+              </>
             )}
           </div>
         </div>

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -41,6 +41,7 @@ import VideoModal from '../shared/VideoModal';
 import { VideoModalData } from '../shared/VideoModal/types';
 import { ChannelVideo } from '../../types/ChannelVideo';
 import {
+  INFINITE_SCROLL_FETCH_SIZE,
   VideoListContainer,
   VideoListPaginationBar,
   useListPageSize,
@@ -263,6 +264,7 @@ function ChannelVideos({
   const defaultResolution = channelVideoQuality || config.preferredResolution || '1080';
   const defaultResolutionSource: 'channel' | 'global' = hasChannelOverride ? 'channel' : 'global';
   const useInfiniteScroll = config.channelVideosHotLoad ?? false;
+  const effectivePageSize = useInfiniteScroll ? INFINITE_SCROLL_FETCH_SIZE : pageSize;
 
   const resetKey = useMemo(
     () =>
@@ -313,7 +315,7 @@ function ChannelVideos({
   } = useChannelVideos({
     channelId,
     page,
-    pageSize,
+    pageSize: effectivePageSize,
     hideDownloaded,
     searchQuery: listState.search,
     sortBy,
@@ -389,7 +391,7 @@ function ChannelVideos({
     loading: localFetchingAllVideos,
     error: fetchAllError,
     clearError: clearFetchAllError,
-  } = useRefreshChannelVideos(channelId, page, pageSize, hideDownloaded, selectedTab, token);
+  } = useRefreshChannelVideos(channelId, page, effectivePageSize, hideDownloaded, selectedTab, token);
 
   const {
     isFetching: backgroundFetching,
@@ -428,7 +430,7 @@ function ChannelVideos({
   }, [videos, localIgnoreStatus, localProtectedStatus]);
 
   const paginatedVideos = videosWithOverrides;
-  const totalPages = Math.ceil(totalCount / pageSize) || 1;
+  const totalPages = Math.ceil(totalCount / effectivePageSize) || 1;
   const hasNextPage = page < totalPages;
 
   const selectionMode: 'download' | 'delete' | null =
@@ -446,6 +448,26 @@ function ChannelVideos({
     setCheckedBoxes([]);
     setSelectedForDeletion([]);
   }, []);
+
+  // Clear selection when a filter changes so bulk actions can't fire on IDs
+  // that are no longer in the filtered dataset. Sort and pagination are
+  // deliberately excluded: they do not remove videos from the selection's
+  // eligible set. Tab changes are handled separately in handleTabChange.
+  useEffect(() => {
+    clearAllSelections();
+  }, [
+    filters.minDuration,
+    filters.maxDuration,
+    filters.dateFrom,
+    filters.dateTo,
+    listState.search,
+    maxRating,
+    protectedFilter,
+    missingFilter,
+    ignoredFilter,
+    hideDownloaded,
+    clearAllSelections,
+  ]);
 
   const handleSelectAll = useCallback(() => {
     if (selectionMode === 'delete') {
@@ -925,7 +947,7 @@ function ChannelVideos({
         Loading and fetching/indexing new videos for this channel tab...
       </Typography>
       <Grid container spacing={2} style={{ marginTop: 16 }}>
-        {[...Array(pageSize)].map((_, index) => (
+        {[...Array(effectivePageSize)].map((_, index) => (
           <Grid item xs={12} sm={6} md={4} lg={3} key={`skeleton-${index}`}>
             <Skeleton variant="rectangular" height={200} />
             <Skeleton variant="text" style={{ marginTop: 8 }} />
@@ -1237,7 +1259,7 @@ function ChannelVideos({
           toolbarRightActions={toolbarRightActions}
           tabsSlot={tabsSlot}
           itemCount={itemCount}
-          isLoading={videosLoading && videos.length === 0}
+          isLoading={videosLoading}
           isError={Boolean(customEmptyMessage)}
           errorMessage={customEmptyMessage}
           renderContent={renderContent}

--- a/client/src/components/VideosPage/components/VideosListMobile.tsx
+++ b/client/src/components/VideosPage/components/VideosListMobile.tsx
@@ -3,7 +3,7 @@ import { Link as RouterLink } from 'react-router-dom';
 import { Box, Typography, Chip, Checkbox, Stack } from '../../ui';
 import { AlertCircle as ErrorOutlineIcon } from 'lucide-react';
 import { formatDuration, formatYTDate } from '../../../utils';
-import { formatAddedDate, formatFileSize } from '../../../utils/formatters';
+import { formatAddedDateTime, formatFileSize } from '../../../utils/formatters';
 import { getMediaTypeInfo } from '../../../utils/videoStatus';
 import { getEnabledChannelId } from '../../../utils/enabledChannels';
 import { VideoData, EnabledChannel } from '../../../types/VideoData';
@@ -320,7 +320,7 @@ function VideosListMobile({
                 color="text.secondary"
                 style={{ fontSize: '0.65rem', lineHeight: 1.3 }}
               >
-                Downloaded: {formatAddedDate(video.timeCreated)}
+                Downloaded: {formatAddedDateTime(video.timeCreated)}
                 {fileSizeNumber && !(video.filePath || video.audioFilePath)
                   ? ` • ${formatFileSize(fileSizeNumber)}`
                   : ''}

--- a/client/src/components/VideosPage/index.tsx
+++ b/client/src/components/VideosPage/index.tsx
@@ -17,6 +17,7 @@ import VideosTable from './components/VideosTable';
 import VideosListMobile from './components/VideosListMobile';
 import { useVideosData } from './hooks/useVideosData';
 import {
+  INFINITE_SCROLL_FETCH_SIZE,
   VideoListContainer,
   VideoListPaginationBar,
   useListPageSize,
@@ -99,6 +100,7 @@ function VideosPage({ token }: VideosPageProps) {
   } = useVideoProtection(token);
 
   const [videosPerPage, setVideosPerPage] = useListPageSize('youtarr.videosPage.pageSize');
+  const effectivePageSize = useInfiniteScroll ? INFINITE_SCROLL_FETCH_SIZE : videosPerPage;
 
   const handlePageSizeChange = (newSize: PageSize) => {
     setVideosPerPage(newSize);
@@ -118,7 +120,7 @@ function VideosPage({ token }: VideosPageProps) {
   } = useVideosData({
     token,
     page,
-    videosPerPage,
+    videosPerPage: effectivePageSize,
     orderBy,
     sortOrder,
     search: listState.search,
@@ -241,6 +243,22 @@ function VideosPage({ token }: VideosPageProps) {
   );
 
   const selection = useVideoSelection<number>({ actions: selectionActions });
+
+  // Clear selection when a filter changes so bulk actions can't fire on IDs that
+  // are no longer in the filtered dataset. Sort and pagination are deliberately
+  // excluded: they do not remove videos from the selection's eligible set.
+  useEffect(() => {
+    selection.clear();
+  }, [
+    listState.search,
+    channelFilter,
+    dateFrom,
+    dateTo,
+    maxRatingFilter,
+    protectedFilter,
+    missingFilter,
+    selection.clear,
+  ]);
 
   const handleToggleSelect = (videoId: number) => {
     selection.toggle(videoId);

--- a/client/src/components/__tests__/ChannelManager.test.tsx
+++ b/client/src/components/__tests__/ChannelManager.test.tsx
@@ -210,6 +210,23 @@ describe('ChannelManager Component', () => {
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
     });
 
+    test('keeps channel list rendered during a refetch when items already loaded', () => {
+      useChannelList.mockReturnValue({
+        channels: mockChannels,
+        total: 2,
+        totalPages: 1,
+        loading: true,
+        error: null,
+        refetch: mockRefetchChannels,
+        subFolders: [],
+      });
+
+      renderChannelManager();
+      expect(screen.getByTestId(`channel-row-${mockChannels[0].url}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`channel-row-${mockChannels[1].url}`)).toBeInTheDocument();
+      expect(screen.getAllByRole('progressbar').length).toBeGreaterThan(0);
+    });
+
     test('shows error message when channel fetch fails', () => {
       useChannelList.mockReturnValue({
         channels: [],
@@ -974,7 +991,7 @@ describe('ChannelManager Component', () => {
       });
 
       renderChannelManager();
-      expect(screen.getByRole('navigation')).toBeInTheDocument();
+      expect(screen.getAllByRole('navigation', { name: /pagination/i }).length).toBeGreaterThan(0);
     });
 
     test('changes page when pagination button clicked', async () => {
@@ -991,7 +1008,7 @@ describe('ChannelManager Component', () => {
 
       renderChannelManager();
 
-      const nextButton = screen.getByRole('button', { name: /go to page 2/i });
+      const [nextButton] = screen.getAllByRole('button', { name: /go to page 2/i });
       await user.click(nextButton);
 
       await waitFor(() => {
@@ -1192,34 +1209,12 @@ describe('ChannelManager Component', () => {
   });
 
   describe('Responsive Behavior', () => {
-    test('uses mobile page size on mobile', () => {
-      (useMediaQuery as jest.Mock).mockReturnValue(true);
+    test('uses the default persisted page size on initial render', () => {
       renderChannelManager();
 
       expect(useChannelList).toHaveBeenCalledWith(
         expect.objectContaining({ pageSize: 16 })
       );
-    });
-
-    test('uses desktop page size on desktop in list view', () => {
-      renderChannelManager();
-
-      expect(useChannelList).toHaveBeenCalledWith(
-        expect.objectContaining({ pageSize: 20 })
-      );
-    });
-
-    test('uses grid page size on desktop in grid view', async () => {
-      const user = userEvent.setup();
-      renderChannelManager();
-
-      await user.click(screen.getByLabelText('Grid view'));
-
-      await waitFor(() => {
-        expect(useChannelList).toHaveBeenCalledWith(
-          expect.objectContaining({ pageSize: 27 })
-        );
-      });
     });
   });
 

--- a/client/src/components/shared/VideoList/VideoListContainer.tsx
+++ b/client/src/components/shared/VideoList/VideoListContainer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { LinearProgress } from '../../ui';
 import VideoListToolbar from './VideoListToolbar';
 import VideoListFilterChips, { countActiveFilters } from './VideoListFilterChips';
 import VideoListFilterPanel from './VideoListFilterPanel';
@@ -63,6 +64,7 @@ function VideoListContainer<IdType extends string | number>({
   renderContent,
   loadingSkeleton,
   customEmptyMessage,
+  paginationMode = 'pages',
   pagination,
   paginationTop,
   infiniteScrollSentinel,
@@ -119,6 +121,15 @@ function VideoListContainer<IdType extends string | number>({
 
       {hasContent && paginationTop}
 
+      {isLoading && hasContent && paginationMode === 'pages' && (
+        <div
+          data-testid="video-list-loading-bar-top"
+          style={{ padding: isMobile ? '0 10px' : '0 16px' }}
+        >
+          <LinearProgress height={2} />
+        </div>
+      )}
+
       <div
         style={{
           padding: isMobile ? 10 : 12,
@@ -144,6 +155,15 @@ function VideoListContainer<IdType extends string | number>({
 
         {infiniteScrollSentinel}
       </div>
+
+      {isLoading && hasContent && paginationMode === 'pages' && (
+        <div
+          data-testid="video-list-loading-bar-bottom"
+          style={{ padding: isMobile ? '0 10px' : '0 16px' }}
+        >
+          <LinearProgress height={2} />
+        </div>
+      )}
 
       {pagination}
 

--- a/client/src/components/shared/VideoList/VideoListPaginationBar.tsx
+++ b/client/src/components/shared/VideoList/VideoListPaginationBar.tsx
@@ -29,13 +29,14 @@ function VideoListPaginationBar({
   allowedPageSizes = ALLOWED_PAGE_SIZES,
 }: VideoListPaginationBarProps) {
   if (!hasContent) return null;
+  if (useInfiniteScroll) return null;
 
   const borderStyle =
     placement === 'top'
       ? { borderBottom: '1px solid var(--border)' }
       : { borderTop: '1px solid var(--border)' };
 
-  const showPageControls = !useInfiniteScroll && totalPages > 1;
+  const showPageControls = totalPages > 1;
 
   return (
     <div

--- a/client/src/components/shared/VideoList/__tests__/VideoListContainer.test.tsx
+++ b/client/src/components/shared/VideoList/__tests__/VideoListContainer.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VideoListContainer from '../VideoListContainer';
+import { useVideoListState } from '../hooks/useVideoListState';
+import { renderWithProviders } from '../../../../test-utils';
+
+interface HarnessProps {
+  isLoading?: boolean;
+  itemCount?: number;
+  paginationMode?: 'pages' | 'infinite';
+}
+
+function Harness({
+  isLoading = false,
+  itemCount = 0,
+  paginationMode = 'pages',
+}: HarnessProps) {
+  const state = useVideoListState({ initialViewMode: 'grid' });
+  return (
+    <VideoListContainer
+      state={state}
+      itemCount={itemCount}
+      isLoading={isLoading}
+      isError={false}
+      paginationMode={paginationMode}
+      renderContent={() => (
+        <div data-testid="content">{itemCount} items</div>
+      )}
+      isMobile={false}
+    />
+  );
+}
+
+describe('VideoListContainer', () => {
+  test('renders top and bottom loading bars during a paginated refetch with existing content', () => {
+    renderWithProviders(
+      <Harness isLoading itemCount={10} paginationMode="pages" />
+    );
+    expect(screen.getByTestId('video-list-loading-bar-top')).toBeInTheDocument();
+    expect(screen.getByTestId('video-list-loading-bar-bottom')).toBeInTheDocument();
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
+
+  test('does not render loading bars in infinite scroll mode', () => {
+    renderWithProviders(
+      <Harness isLoading itemCount={10} paginationMode="infinite" />
+    );
+    expect(screen.queryByTestId('video-list-loading-bar-top')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('video-list-loading-bar-bottom')).not.toBeInTheDocument();
+  });
+
+  test('does not render loading bars when there is no content yet', () => {
+    renderWithProviders(
+      <Harness isLoading itemCount={0} paginationMode="pages" />
+    );
+    expect(screen.queryByTestId('video-list-loading-bar-top')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('video-list-loading-bar-bottom')).not.toBeInTheDocument();
+  });
+
+  test('does not render loading bars when not loading', () => {
+    renderWithProviders(
+      <Harness isLoading={false} itemCount={10} paginationMode="pages" />
+    );
+    expect(screen.queryByTestId('video-list-loading-bar-top')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('video-list-loading-bar-bottom')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/shared/VideoList/__tests__/VideoListPaginationBar.test.tsx
+++ b/client/src/components/shared/VideoList/__tests__/VideoListPaginationBar.test.tsx
@@ -32,13 +32,13 @@ describe('VideoListPaginationBar', () => {
     expect(screen.getByRole('navigation', { name: /pagination/i })).toBeInTheDocument();
   });
 
-  test('hides page controls in infinite scroll mode but still shows the page size selector', () => {
+  test('renders nothing in infinite scroll mode', () => {
     renderWithProviders(
       <VideoListPaginationBar {...defaultProps()} useInfiniteScroll />
     );
+    expect(screen.queryByTestId('video-list-pagination-bar-bottom')).not.toBeInTheDocument();
     expect(screen.queryByRole('navigation', { name: /pagination/i })).not.toBeInTheDocument();
-    expect(screen.getByText('Per page:')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '16' })).toBeInTheDocument();
+    expect(screen.queryByText('Per page:')).not.toBeInTheDocument();
   });
 
   test('hides page controls when only one page exists but still shows the selector', () => {

--- a/client/src/components/shared/VideoList/filters/ToggleChipFilter.tsx
+++ b/client/src/components/shared/VideoList/filters/ToggleChipFilter.tsx
@@ -30,6 +30,8 @@ function ToggleChipFilter({
   const label = value === 'only' ? onlyLabel : value === 'exclude' ? excludeLabel : inactiveLabel;
   const color = value === 'only' ? 'primary' : value === 'exclude' ? 'warning' : 'default';
   const variant = value === 'off' ? 'outlined' : 'filled';
+  const ariaPressed: boolean | 'mixed' =
+    value === 'off' ? false : value === 'only' ? true : 'mixed';
 
   return (
     <Chip
@@ -41,6 +43,7 @@ function ToggleChipFilter({
       onClick={() => onChange(NEXT_MODE[value])}
       onDelete={value === 'off' ? undefined : () => onChange('off')}
       style={{ cursor: 'pointer' }}
+      aria-pressed={ariaPressed}
     />
   );
 }

--- a/client/src/components/shared/VideoList/index.ts
+++ b/client/src/components/shared/VideoList/index.ts
@@ -23,6 +23,6 @@ export type {
 } from './types';
 
 export { default as VideoListPaginationBar } from './VideoListPaginationBar';
-export { ALLOWED_PAGE_SIZES, DEFAULT_PAGE_SIZE, isPageSize } from './pageSizes';
+export { ALLOWED_PAGE_SIZES, DEFAULT_PAGE_SIZE, INFINITE_SCROLL_FETCH_SIZE, isPageSize } from './pageSizes';
 export type { PageSize } from './pageSizes';
 export { useListPageSize } from './useListPageSize';

--- a/client/src/components/shared/VideoList/pageSizes.ts
+++ b/client/src/components/shared/VideoList/pageSizes.ts
@@ -1,5 +1,6 @@
 export const ALLOWED_PAGE_SIZES = [8, 16, 32, 64, 128] as const;
 export const DEFAULT_PAGE_SIZE = 16;
+export const INFINITE_SCROLL_FETCH_SIZE = 16;
 
 export type PageSize = (typeof ALLOWED_PAGE_SIZES)[number];
 


### PR DESCRIPTION
Swap ChannelManager's bespoke pagination for the shared VideoListPaginationBar and useListPageSize hook so channels, channel videos, and the library share one toolbar, per-page selector, and storage key shape.

Show inline LinearProgress bars at the top and bottom during paginated refetches instead of replacing the list with a full spinner, so the previous page stays visible while new data loads. Gate the behavior via a new paginationMode prop on VideoListContainer so infinite scroll mode skips it.

Auto-clear selection when filter inputs change in ChannelVideos and VideosPage so bulk actions cannot target IDs no longer in the filtered set. Sort and page changes are excluded.

Also hide the pagination bar entirely in infinite scroll mode instead of leaving the per-page selector visible, add aria-pressed to ToggleChipFilter, and use formatAddedDateTime for the mobile library Downloaded timestamp.