### PR TITLE
feat: add downloaded filter chip to video lists

### DIFF
--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -8,8 +8,6 @@ import {
   Tabs,
   Tab,
   Button,
-  FormControlLabel,
-  Switch,
   LinearProgress,
   Tooltip,
   Chip,
@@ -133,11 +131,10 @@ function ChannelVideos({
   const [selectedTab, setSelectedTab] = useState<string | null>(null);
   const [availableTabs, setAvailableTabs] = useState<string[]>([]);
   const [tabsLoading, setTabsLoading] = useState<boolean>(true);
-  const [tabAutoDownloadStatus, setTabAutoDownloadStatus] = useState<Record<string, boolean>>({});
 
   const [pageSize, setPageSize] = useListPageSize('youtarr.channelVideos.pageSize');
   const [page, setPage] = useState(1);
-  const [hideDownloaded, setHideDownloaded] = useState(false);
+  const [downloadedFilter, setDownloadedFilter] = useState<ChipFilterMode>('off');
   const [mobileTooltip, setMobileTooltip] = useState<string | null>(null);
   const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
   const [hoveredVideo, setHoveredVideo] = useState<string | null>(null);
@@ -236,27 +233,25 @@ function ChannelVideos({
     return () => clearInterval(pollInterval);
   }, [channelId, token, tabsLoading]);
 
-  useEffect(() => {
-    if (!channelAutoDownloadTabs) {
-      setTabAutoDownloadStatus({});
-      return;
-    }
+  // Derived: map each tab to whether auto-download is enabled for its media
+  // type. Derived (not state) so that saving new settings via the dialog --
+  // which updates channelAutoDownloadTabs upstream -- always refreshes the
+  // indicator dots without requiring a reload.
+  const tabAutoDownloadStatus = useMemo<Record<string, boolean>>(() => {
     const mediaTypeMap: Record<string, string> = {
       videos: 'video',
       shorts: 'short',
       streams: 'livestream',
     };
-    const enabledTabs = channelAutoDownloadTabs.split(',').map((t) => t.trim());
-    setTabAutoDownloadStatus((prevStatus) => {
-      const newStatus: Record<string, boolean> = { ...prevStatus };
-      availableTabs.forEach((tabType) => {
-        if (!(tabType in newStatus)) {
-          const mediaType = mediaTypeMap[tabType];
-          newStatus[tabType] = mediaType ? enabledTabs.includes(mediaType) : false;
-        }
-      });
-      return newStatus;
+    const enabled = channelAutoDownloadTabs
+      ? channelAutoDownloadTabs.split(',').map((t) => t.trim())
+      : [];
+    const status: Record<string, boolean> = {};
+    availableTabs.forEach((tabType) => {
+      const mediaType = mediaTypeMap[tabType];
+      status[tabType] = mediaType ? enabled.includes(mediaType) : false;
     });
+    return status;
   }, [channelAutoDownloadTabs, availableTabs]);
 
   const { config } = useConfig(token);
@@ -271,7 +266,7 @@ function ChannelVideos({
       [
         channelId || '',
         selectedTab || '',
-        hideDownloaded,
+        downloadedFilter,
         listState.search,
         sortBy,
         sortOrder,
@@ -288,7 +283,7 @@ function ChannelVideos({
     [
       channelId,
       selectedTab,
-      hideDownloaded,
+      downloadedFilter,
       listState.search,
       sortBy,
       sortOrder,
@@ -308,7 +303,7 @@ function ChannelVideos({
     videos,
     totalCount,
     oldestVideoDate,
-    videoFailed,
+    error: fetchError,
     availableTabs: availableTabsFromVideos,
     loading: videosLoading,
     refetch: refetchVideos,
@@ -316,7 +311,7 @@ function ChannelVideos({
     channelId,
     page,
     pageSize: effectivePageSize,
-    hideDownloaded,
+    downloadedFilter,
     searchQuery: listState.search,
     sortBy,
     sortOrder,
@@ -356,7 +351,7 @@ function ChannelVideos({
   useEffect(() => {
     setLocalIgnoreStatus({});
     setLocalProtectedStatus({});
-  }, [page, selectedTab, hideDownloaded, listState.search, sortBy, sortOrder, filters]);
+  }, [page, selectedTab, downloadedFilter, listState.search, sortBy, sortOrder, filters]);
 
   useEffect(() => {
     setPage(1);
@@ -370,7 +365,7 @@ function ChannelVideos({
     protectedFilter,
     missingFilter,
     ignoredFilter,
-    hideDownloaded,
+    downloadedFilter,
     sortBy,
     sortOrder,
     selectedTab,
@@ -391,7 +386,7 @@ function ChannelVideos({
     loading: localFetchingAllVideos,
     error: fetchAllError,
     clearError: clearFetchAllError,
-  } = useRefreshChannelVideos(channelId, page, effectivePageSize, hideDownloaded, selectedTab, token);
+  } = useRefreshChannelVideos(channelId, page, effectivePageSize, downloadedFilter, selectedTab, token);
 
   const {
     isFetching: backgroundFetching,
@@ -465,7 +460,7 @@ function ChannelVideos({
     protectedFilter,
     missingFilter,
     ignoredFilter,
-    hideDownloaded,
+    downloadedFilter,
     clearAllSelections,
   ]);
 
@@ -674,26 +669,7 @@ function ChannelVideos({
     setProtectedFilter('off');
     setMissingFilter('off');
     setIgnoredFilter('off');
-  };
-
-  const handleAutoDownloadChange = async (enabled: boolean) => {
-    if (!channelId || !token || !selectedTab) return;
-    const currentTab = selectedTab;
-    try {
-      const response = await fetch(
-        `/api/channels/${channelId}/tabs/${currentTab}/auto-download`,
-        {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json', 'x-access-token': token },
-          body: JSON.stringify({ enabled }),
-        }
-      );
-      if (!response.ok) throw new Error('Failed to update auto download setting');
-      setTabAutoDownloadStatus((prev) => ({ ...prev, [currentTab]: enabled }));
-    } catch (error) {
-      console.error('Error updating auto download setting:', error);
-      setErrorMessage('Failed to update auto download setting');
-    }
+    setDownloadedFilter('off');
   };
 
   const handlePageChange = (value: number) => setPage(value);
@@ -800,6 +776,7 @@ function ChannelVideos({
       { id: 'protected', value: protectedFilter, onChange: setProtectedFilter },
       { id: 'missing', value: missingFilter, onChange: setMissingFilter },
       { id: 'ignored', value: ignoredFilter, onChange: setIgnoredFilter },
+      { id: 'downloaded', value: downloadedFilter, onChange: setDownloadedFilter },
     ];
     return configs;
   }, [
@@ -817,6 +794,7 @@ function ChannelVideos({
     protectedFilter,
     missingFilter,
     ignoredFilter,
+    downloadedFilter,
     selectedTab,
   ]);
 
@@ -1080,32 +1058,6 @@ function ChannelVideos({
     </div>
   );
 
-  const toolbarExtras = (
-    <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap' }}>
-      <FormControlLabel
-        control={
-          <Switch
-            checked={hideDownloaded}
-            onChange={(e) => setHideDownloaded(e.target.checked)}
-            size="small"
-          />
-        }
-        label="Hide Downloaded"
-      />
-      <FormControlLabel
-        control={
-          <Switch
-            checked={isTabAutoDownloadEnabled(selectedTab || 'videos')}
-            onChange={(e) => handleAutoDownloadChange(e.target.checked)}
-            size="small"
-            aria-label="Enable Channel Downloads"
-          />
-        }
-        label="Auto-download"
-      />
-    </div>
-  );
-
   const tabsSlot =
     availableTabs.length > 0 ? (
       <div
@@ -1225,11 +1177,10 @@ function ChannelVideos({
     </div>
   ) : null;
 
-  const itemCount = videoFailed && videos.length === 0 ? 0 : paginatedVideos.length;
-  const customEmptyMessage =
-    videoFailed && videos.length === 0
-      ? 'Failed to fetch channel videos. Please try again later.'
-      : undefined;
+  const itemCount = paginatedVideos.length;
+  const fetchErrorMessage = fetchError
+    ? 'Failed to fetch channel videos. Please try again later.'
+    : undefined;
 
   const availableViewModes: VideoListViewMode[] = isMobile
     ? ['grid', 'list']
@@ -1255,13 +1206,12 @@ function ChannelVideos({
           filters={filterConfigs}
           searchPlaceholder="Search videos..."
           headerSlot={headerSlot}
-          toolbarExtras={toolbarExtras}
           toolbarRightActions={toolbarRightActions}
           tabsSlot={tabsSlot}
           itemCount={itemCount}
           isLoading={videosLoading}
-          isError={Boolean(customEmptyMessage)}
-          errorMessage={customEmptyMessage}
+          isError={Boolean(fetchError)}
+          errorMessage={fetchErrorMessage}
           renderContent={renderContent}
           loadingSkeleton={videosLoading && videos.length === 0 ? loadingSkeleton : undefined}
           pagination={paginationNode}

--- a/client/src/components/ChannelPage/__tests__/ChannelVideos.story.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideos.story.tsx
@@ -25,7 +25,6 @@ const meta: Meta<typeof ChannelVideos> = {
             videos: [],
             totalCount: 0,
             oldestVideoDate: null,
-            videoFail: false,
             autoDownloadsEnabled: false,
             availableTabs: ['videos'],
           })

--- a/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
@@ -300,7 +300,7 @@ describe('ChannelVideos Component', () => {
       videos: [],
       totalCount: 0,
       oldestVideoDate: null,
-      videoFailed: false,
+      error: null,
       autoDownloadsEnabled: false,
       loading: false,
       refetch: mockRefetchVideos,
@@ -343,7 +343,6 @@ describe('ChannelVideos Component', () => {
         videos: [],
         totalCount: 0,
         oldestVideoDate: null,
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: true,
         refetch: mockRefetchVideos,
@@ -359,7 +358,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -380,7 +378,7 @@ describe('ChannelVideos Component', () => {
         videos: [],
         totalCount: 0,
         oldestVideoDate: null,
-        videoFailed: true,
+        error: new Error('Network error'),
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -388,6 +386,28 @@ describe('ChannelVideos Component', () => {
 
       renderChannelVideos();
       expect(screen.getByText('Failed to fetch channel videos. Please try again later.')).toBeInTheDocument();
+    });
+
+    test('shows filtered empty message when an active filter returns no videos', () => {
+      // No thrown error, just zero results. ChannelVideos must not treat
+      // this as an error; the shared VideoListEmptyState surfaces the
+      // filter-aware empty copy when the user has an active filter.
+      useChannelVideos.mockReturnValue({
+        videos: [],
+        totalCount: 0,
+        oldestVideoDate: null,
+        error: null,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+
+      renderChannelVideos();
+      expect(
+        screen.queryByText('Failed to fetch channel videos. Please try again later.')
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(screen.getByTestId('video-list-empty-state')).toBeInTheDocument();
     });
   });
 
@@ -495,7 +515,6 @@ describe('ChannelVideos Component', () => {
         videos: [],
         totalCount: 0,
         oldestVideoDate: null,
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: true,
         refetch: mockRefetchVideos,
@@ -524,7 +543,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -542,7 +560,6 @@ describe('ChannelVideos Component', () => {
         videos: [mockVideos[0]],
         totalCount: 1,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -575,7 +592,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -606,7 +622,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -637,7 +652,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -683,7 +697,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -726,7 +739,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 32,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -745,7 +757,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -761,7 +772,6 @@ describe('ChannelVideos Component', () => {
         videos: [],
         totalCount: 0,
         oldestVideoDate: null,
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -777,7 +787,6 @@ describe('ChannelVideos Component', () => {
         videos: [],
         totalCount: 0,
         oldestVideoDate: null,
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: true,
         refetch: mockRefetchVideos,
@@ -793,7 +802,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -813,7 +821,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -835,7 +842,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 48, // enough for multiple pages at size 16
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -880,7 +886,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -900,7 +905,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 32,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -1003,7 +1007,7 @@ describe('ChannelVideos Component', () => {
         channelId: 'UC123456',
         page: 1,
         pageSize: 16, // Desktop default
-        hideDownloaded: false,
+        downloadedFilter: 'off',
         searchQuery: '',
         sortBy: 'date',
         sortOrder: 'desc',
@@ -1030,7 +1034,7 @@ describe('ChannelVideos Component', () => {
         'UC123456',
         1, // page
         16, // pageSize
-        false, // hideDownloaded
+        'off', // downloadedFilter
         null, // tabType - null until tabs are loaded
         mockToken
       );
@@ -1146,7 +1150,6 @@ describe('ChannelVideos Component', () => {
         videos: [],
         totalCount: 0,
         oldestVideoDate: null,
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: true,
         refetch: mockRefetchVideos,
@@ -1179,7 +1182,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -1216,7 +1218,6 @@ describe('ChannelVideos Component', () => {
         videos: [mockVideos[0]],
         totalCount: 1,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -1245,7 +1246,6 @@ describe('ChannelVideos Component', () => {
         videos: [ignoredVideo],
         totalCount: 1,
         oldestVideoDate: '2023-01-04',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -1271,7 +1271,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -1301,7 +1300,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -1324,7 +1322,6 @@ describe('ChannelVideos Component', () => {
         videos: mockVideos,
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -1352,7 +1349,6 @@ describe('ChannelVideos Component', () => {
         videos: [mockVideos[0]],
         totalCount: 1,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -1381,7 +1377,6 @@ describe('ChannelVideos Component', () => {
         videos: [mockVideos[0]],
         totalCount: 1,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -1402,7 +1397,6 @@ describe('ChannelVideos Component', () => {
         videos: [mockVideos[0]],
         totalCount: 1,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,
@@ -1426,7 +1420,6 @@ describe('ChannelVideos Component', () => {
         ],
         totalCount: 3,
         oldestVideoDate: '2023-01-01',
-        videoFailed: false,
         autoDownloadsEnabled: false,
         loading: false,
         refetch: mockRefetchVideos,

--- a/client/src/components/ChannelPage/hooks/__tests__/useChannelVideos.test.ts
+++ b/client/src/components/ChannelPage/hooks/__tests__/useChannelVideos.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { useChannelVideos } from '../useChannelVideos';
 import { ChannelVideo } from '../../../../types/ChannelVideo';
+import type { ChipFilterMode } from '../../../shared/VideoList/types';
 
 // Mock fetch
 const mockFetch = jest.fn();
@@ -14,7 +15,7 @@ describe('useChannelVideos', () => {
     channelId: mockChannelId,
     page: 1,
     pageSize: 16,
-    hideDownloaded: false,
+    downloadedFilter: 'off' as ChipFilterMode,
     searchQuery: '',
     sortBy: 'date',
     sortOrder: 'desc',
@@ -51,7 +52,6 @@ describe('useChannelVideos', () => {
     videos: mockVideos,
     totalCount: 2,
     oldestVideoDate: '2023-01-01T00:00:00Z',
-    videoFail: false,
     autoDownloadsEnabled: true,
   };
 
@@ -69,7 +69,6 @@ describe('useChannelVideos', () => {
       expect(result.current.videos).toEqual([]);
       expect(result.current.totalCount).toBe(0);
       expect(result.current.oldestVideoDate).toBeNull();
-      expect(result.current.videoFailed).toBe(false);
       expect(result.current.loading).toBe(true);
       expect(result.current.error).toBeNull();
       expect(result.current.autoDownloadsEnabled).toBe(false);
@@ -93,7 +92,6 @@ describe('useChannelVideos', () => {
       expect(result.current.videos).toEqual(mockVideos);
       expect(result.current.totalCount).toBe(2);
       expect(result.current.oldestVideoDate).toBe('2023-01-01T00:00:00Z');
-      expect(result.current.videoFailed).toBe(false);
       expect(result.current.autoDownloadsEnabled).toBe(true);
       expect(result.current.error).toBeNull();
     });
@@ -109,7 +107,7 @@ describe('useChannelVideos', () => {
           ...defaultParams,
           page: 2,
           pageSize: 8,
-          hideDownloaded: true,
+          downloadedFilter: 'exclude',
           searchQuery: 'test query',
           sortBy: 'title',
           sortOrder: 'asc',
@@ -127,11 +125,48 @@ describe('useChannelVideos', () => {
       expect(url).toContain(`/getchannelvideos/${mockChannelId}`);
       expect(url).toContain('page=2');
       expect(url).toContain('pageSize=8');
-      expect(url).toContain('hideDownloaded=true');
+      expect(url).toContain('downloadedFilter=exclude');
       expect(url).toContain('searchQuery=test+query');
       expect(url).toContain('sortBy=title');
       expect(url).toContain('sortOrder=asc');
       expect(url).toContain('tabType=shorts');
+    });
+
+    test('sends downloadedFilter=only when mode is only', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      renderHook(() =>
+        useChannelVideos({
+          ...defaultParams,
+          downloadedFilter: 'only',
+        })
+      );
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      const url = mockFetch.mock.calls[0][0];
+      expect(url).toContain('downloadedFilter=only');
+    });
+
+    test('omits downloadedFilter param when mode is off', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      const url = mockFetch.mock.calls[0][0];
+      expect(url).not.toContain('downloadedFilter');
     });
 
     test('includes correct authentication header', async () => {
@@ -163,7 +198,6 @@ describe('useChannelVideos', () => {
           videos: [],
           totalCount: 0,
           oldestVideoDate: null,
-          videoFail: false,
           autoDownloadsEnabled: false,
         }),
       });
@@ -184,7 +218,6 @@ describe('useChannelVideos', () => {
         ok: true,
         json: jest.fn().mockResolvedValueOnce({
           totalCount: 0,
-          videoFail: false,
         }),
       });
 
@@ -204,7 +237,6 @@ describe('useChannelVideos', () => {
         json: jest.fn().mockResolvedValueOnce({
           videos: null,
           totalCount: 0,
-          videoFail: false,
         }),
       });
 
@@ -234,7 +266,6 @@ describe('useChannelVideos', () => {
       expect(result.current.videos).toEqual(mockVideos);
       expect(result.current.totalCount).toBe(0);
       expect(result.current.oldestVideoDate).toBeNull();
-      expect(result.current.videoFailed).toBe(false);
       expect(result.current.autoDownloadsEnabled).toBe(false);
     });
   });
@@ -298,6 +329,50 @@ describe('useChannelVideos', () => {
       expect(result.current.error?.message).toBe('Unknown error');
 
       consoleErrorSpy.mockRestore();
+    });
+
+    test('surfaces an error when response body has fetchError=true', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          videos: [],
+          totalCount: 0,
+          oldestVideoDate: null,
+          autoDownloadsEnabled: false,
+          fetchError: true,
+        }),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('Failed to fetch channel videos');
+      expect(result.current.videos).toEqual([]);
+    });
+
+    test('does not surface an error when fetchError is absent (filter returned no results)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          videos: [],
+          totalCount: 0,
+          oldestVideoDate: null,
+          autoDownloadsEnabled: false,
+        }),
+      });
+
+      const { result } = renderHook(() => useChannelVideos(defaultParams));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.videos).toEqual([]);
     });
 
     test('clears previous error on successful refetch', async () => {
@@ -475,7 +550,7 @@ describe('useChannelVideos', () => {
       });
     });
 
-    test('refetches when hideDownloaded changes', async () => {
+    test('refetches when downloadedFilter changes', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: jest.fn().mockResolvedValue(mockResponse),
@@ -492,7 +567,7 @@ describe('useChannelVideos', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1);
       });
 
-      rerender({ params: { ...defaultParams, hideDownloaded: true } });
+      rerender({ params: { ...defaultParams, downloadedFilter: 'exclude' as ChipFilterMode } });
 
       await waitFor(() => {
         expect(mockFetch).toHaveBeenCalledTimes(2);
@@ -743,7 +818,6 @@ describe('useChannelVideos', () => {
           videos: pageOneVideos,
           totalCount: 3,
           oldestVideoDate: '2023-03-01T00:00:00Z',
-          videoFail: false,
           autoDownloadsEnabled: false,
         }),
       });
@@ -768,7 +842,6 @@ describe('useChannelVideos', () => {
           videos: pageTwoVideos,
           totalCount: 3,
           oldestVideoDate: '2023-03-01T00:00:00Z',
-          videoFail: false,
           autoDownloadsEnabled: false,
         }),
       });
@@ -792,7 +865,6 @@ describe('useChannelVideos', () => {
           videos: pageOneVideos,
           totalCount: 3,
           oldestVideoDate: '2023-03-01T00:00:00Z',
-          videoFail: false,
           autoDownloadsEnabled: false,
         }),
       });
@@ -818,7 +890,6 @@ describe('useChannelVideos', () => {
           videos: pageTwoVideos,
           totalCount: 3,
           oldestVideoDate: '2023-03-01T00:00:00Z',
-          videoFail: false,
           autoDownloadsEnabled: false,
         }),
       });
@@ -852,7 +923,6 @@ describe('useChannelVideos', () => {
           videos: afterResetVideos,
           totalCount: 1,
           oldestVideoDate: '2023-04-01T00:00:00Z',
-          videoFail: false,
           autoDownloadsEnabled: false,
         }),
       });
@@ -871,40 +941,4 @@ describe('useChannelVideos', () => {
     });
   });
 
-  describe('VideoFailed Flag', () => {
-    test('sets videoFailed to true when response indicates failure', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          ...mockResponse,
-          videoFail: true,
-        }),
-      });
-
-      const { result } = renderHook(() => useChannelVideos(defaultParams));
-
-      await waitFor(() => {
-        expect(result.current.loading).toBe(false);
-      });
-
-      expect(result.current.videoFailed).toBe(true);
-    });
-
-    test('sets videoFailed to false when not in response', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce({
-          videos: mockVideos,
-        }),
-      });
-
-      const { result } = renderHook(() => useChannelVideos(defaultParams));
-
-      await waitFor(() => {
-        expect(result.current.loading).toBe(false);
-      });
-
-      expect(result.current.videoFailed).toBe(false);
-    });
-  });
 });

--- a/client/src/components/ChannelPage/hooks/__tests__/useRefreshChannelVideos.test.ts
+++ b/client/src/components/ChannelPage/hooks/__tests__/useRefreshChannelVideos.test.ts
@@ -49,7 +49,7 @@ describe('useRefreshChannelVideos', () => {
   describe('Initial State', () => {
     test('returns default state values on initialization', () => {
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       expect(result.current.loading).toBe(false);
@@ -67,7 +67,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -91,7 +91,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 2, 8, true, 'shorts', mockToken)
+        useRefreshChannelVideos(mockChannelId, 2, 8, 'exclude', 'shorts', mockToken)
       );
 
       await act(async () => {
@@ -104,7 +104,7 @@ describe('useRefreshChannelVideos', () => {
       expect(url).toContain(`/fetchallchannelvideos/${mockChannelId}`);
       expect(url).toContain('page=2');
       expect(url).toContain('pageSize=8');
-      expect(url).toContain('hideDownloaded=true');
+      expect(url).toContain('downloadedFilter=exclude');
       expect(url).toContain('tabType=shorts');
     });
 
@@ -115,7 +115,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       await act(async () => {
@@ -145,7 +145,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -169,7 +169,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -199,7 +199,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -229,7 +229,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -258,7 +258,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -284,7 +284,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -305,7 +305,7 @@ describe('useRefreshChannelVideos', () => {
       mockFetch.mockRejectedValueOnce(networkError);
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -329,7 +329,7 @@ describe('useRefreshChannelVideos', () => {
       mockFetch.mockRejectedValueOnce({ status: 500 });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -350,7 +350,7 @@ describe('useRefreshChannelVideos', () => {
       mockFetch.mockRejectedValueOnce(new Error('First error'));
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       await act(async () => {
@@ -378,7 +378,7 @@ describe('useRefreshChannelVideos', () => {
   describe('Conditional Refresh', () => {
     test('returns null when channelId is undefined', async () => {
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(undefined, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(undefined, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -392,7 +392,7 @@ describe('useRefreshChannelVideos', () => {
 
     test('returns null when token is null', async () => {
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', null)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', null)
       );
 
       let refreshResult;
@@ -406,7 +406,7 @@ describe('useRefreshChannelVideos', () => {
 
     test('returns null when both channelId and token are missing', async () => {
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(undefined, 1, 16, false, 'videos', null)
+        useRefreshChannelVideos(undefined, 1, 16, 'off', 'videos', null)
       );
 
       let refreshResult;
@@ -429,7 +429,7 @@ describe('useRefreshChannelVideos', () => {
       mockFetch.mockReturnValueOnce(promise);
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       expect(result.current.loading).toBe(false);
@@ -461,7 +461,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -483,7 +483,7 @@ describe('useRefreshChannelVideos', () => {
       mockFetch.mockRejectedValueOnce(new Error('Fetch error'));
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       await act(async () => {
@@ -504,7 +504,7 @@ describe('useRefreshChannelVideos', () => {
       mockFetch.mockRejectedValueOnce(new Error('Test error'));
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult;
@@ -526,7 +526,7 @@ describe('useRefreshChannelVideos', () => {
 
     test('clearError does nothing when no error exists', () => {
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       expect(result.current.error).toBeNull();
@@ -542,14 +542,14 @@ describe('useRefreshChannelVideos', () => {
   describe('Callback Stability', () => {
     test('refreshVideos function changes when dependencies change', () => {
       const { result, rerender } = renderHook(
-        ({ channelId, page, pageSize, hideDownloaded, tabType, token }) =>
-          useRefreshChannelVideos(channelId, page, pageSize, hideDownloaded, tabType, token),
+        ({ channelId, page, pageSize, downloadedFilter, tabType, token }) =>
+          useRefreshChannelVideos(channelId, page, pageSize, downloadedFilter, tabType, token),
         {
           initialProps: {
             channelId: mockChannelId,
             page: 1,
             pageSize: 16,
-            hideDownloaded: false,
+            downloadedFilter: 'off' as const,
             tabType: 'videos',
             token: mockToken,
           },
@@ -562,7 +562,7 @@ describe('useRefreshChannelVideos', () => {
         channelId: mockChannelId,
         page: 2,
         pageSize: 16,
-        hideDownloaded: false,
+        downloadedFilter: 'off' as const,
         tabType: 'videos',
         token: mockToken,
       });
@@ -573,7 +573,7 @@ describe('useRefreshChannelVideos', () => {
     test('clearError function remains stable across rerenders', () => {
       const { result, rerender } = renderHook(
         ({ channelId, page }) =>
-          useRefreshChannelVideos(channelId, page, 16, false, 'videos', mockToken),
+          useRefreshChannelVideos(channelId, page, 16, 'off', 'videos', mockToken),
         {
           initialProps: { channelId: mockChannelId, page: 1 },
         }
@@ -595,7 +595,7 @@ describe('useRefreshChannelVideos', () => {
       });
 
       const { result } = renderHook(() =>
-        useRefreshChannelVideos(mockChannelId, 1, 16, false, 'videos', mockToken)
+        useRefreshChannelVideos(mockChannelId, 1, 16, 'off', 'videos', mockToken)
       );
 
       let refreshResult1;

--- a/client/src/components/ChannelPage/hooks/useChannelVideos.ts
+++ b/client/src/components/ChannelPage/hooks/useChannelVideos.ts
@@ -6,7 +6,7 @@ interface UseChannelVideosParams {
   channelId: string | undefined;
   page: number;
   pageSize: number;
-  hideDownloaded: boolean;
+  downloadedFilter: ChipFilterMode;
   searchQuery: string;
   sortBy: string;
   sortOrder: string;
@@ -28,7 +28,6 @@ interface UseChannelVideosResult {
   videos: ChannelVideo[];
   totalCount: number;
   oldestVideoDate: string | null;
-  videoFailed: boolean;
   loading: boolean;
   error: Error | null;
   autoDownloadsEnabled: boolean;
@@ -40,7 +39,7 @@ export function useChannelVideos({
   channelId,
   page,
   pageSize,
-  hideDownloaded,
+  downloadedFilter,
   searchQuery,
   sortBy,
   sortOrder,
@@ -60,7 +59,6 @@ export function useChannelVideos({
   const [videos, setVideos] = useState<ChannelVideo[]>([]);
   const [totalCount, setTotalCount] = useState<number>(0);
   const [oldestVideoDate, setOldestVideoDate] = useState<string | null>(null);
-  const [videoFailed, setVideoFailed] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
   const [autoDownloadsEnabled, setAutoDownloadsEnabled] = useState<boolean>(false);
@@ -77,12 +75,15 @@ export function useChannelVideos({
       const queryParams = new URLSearchParams({
         page: page.toString(),
         pageSize: pageSize.toString(),
-        hideDownloaded: hideDownloaded.toString(),
         searchQuery: searchQuery,
         sortBy: sortBy,
         sortOrder: sortOrder,
         tabType: tabType,
       });
+
+      if (downloadedFilter && downloadedFilter !== 'off') {
+        queryParams.set('downloadedFilter', downloadedFilter);
+      }
 
       if (maxRating) {
         queryParams.set('maxRating', maxRating);
@@ -96,10 +97,15 @@ export function useChannelVideos({
         queryParams.append('maxDuration', (maxDuration * 60).toString());
       }
       if (dateFrom) {
-        queryParams.append('dateFrom', dateFrom.toISOString().split('T')[0]);
+        // dateFrom is a local-midnight Date for the picked day; send as a full ISO
+        // timestamp so the server compares against publishedAt in the viewer's
+        // timezone, not UTC (avoids off-by-one near midnight).
+        queryParams.append('dateFrom', dateFrom.toISOString());
       }
       if (dateTo) {
-        queryParams.append('dateTo', dateTo.toISOString().split('T')[0]);
+        const endOfDay = new Date(dateTo);
+        endOfDay.setHours(23, 59, 59, 999);
+        queryParams.append('dateTo', endOfDay.toISOString());
       }
       if (protectedFilter && protectedFilter !== 'off') {
         queryParams.append('protectedFilter', protectedFilter);
@@ -146,18 +152,23 @@ export function useChannelVideos({
       } else if (isReset) {
         setVideos([]);
       }
-      setVideoFailed(data.videoFail || false);
       setTotalCount(data.totalCount || 0);
       setOldestVideoDate(data.oldestVideoDate || null);
       setAutoDownloadsEnabled(data.autoDownloadsEnabled || false);
       setAvailableTabs(data.availableTabs || []);
+      // Server sets fetchError when the upstream YouTube fetch failed and
+      // no cached fallback was available. Surface it as an error so the UI
+      // distinguishes "fetch failed" from "filter matched nothing".
+      if (data.fetchError) {
+        setError(new Error('Failed to fetch channel videos'));
+      }
     } catch (err) {
       console.error('Error fetching channel videos:', err);
       setError(err instanceof Error ? err : new Error('Unknown error'));
     } finally {
       setLoading(false);
     }
-  }, [channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, maxRating, token, append, resetKey, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter]);
+  }, [channelId, page, pageSize, downloadedFilter, searchQuery, sortBy, sortOrder, tabType, maxRating, token, append, resetKey, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter]);
 
   useEffect(() => {
     fetchVideos();
@@ -167,7 +178,6 @@ export function useChannelVideos({
     videos,
     totalCount,
     oldestVideoDate,
-    videoFailed,
     loading,
     error,
     autoDownloadsEnabled,

--- a/client/src/components/ChannelPage/hooks/useRefreshChannelVideos.ts
+++ b/client/src/components/ChannelPage/hooks/useRefreshChannelVideos.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { ChannelVideo } from '../../../types/ChannelVideo';
+import { ChipFilterMode } from '../../shared/VideoList/types';
 
 interface RefreshResult {
   videos: ChannelVideo[];
@@ -18,7 +19,7 @@ export function useRefreshChannelVideos(
   channelId: string | undefined,
   page: number,
   pageSize: number,
-  hideDownloaded: boolean,
+  downloadedFilter: ChipFilterMode,
   tabType: string | null,
   token: string | null
 ): UseRefreshChannelVideosResult {
@@ -38,8 +39,16 @@ export function useRefreshChannelVideos(
     setError(null);
 
     try {
+      const queryParams = new URLSearchParams({
+        page: page.toString(),
+        pageSize: pageSize.toString(),
+        tabType: tabType,
+      });
+      if (downloadedFilter && downloadedFilter !== 'off') {
+        queryParams.set('downloadedFilter', downloadedFilter);
+      }
       const response = await fetch(
-        `/fetchallchannelvideos/${channelId}?page=${page}&pageSize=${pageSize}&hideDownloaded=${hideDownloaded}&tabType=${tabType}`,
+        `/fetchallchannelvideos/${channelId}?${queryParams}`,
         {
           method: 'POST',
           headers: {
@@ -69,7 +78,7 @@ export function useRefreshChannelVideos(
     } finally {
       setLoading(false);
     }
-  }, [channelId, page, pageSize, hideDownloaded, tabType, token]);
+  }, [channelId, page, pageSize, downloadedFilter, tabType, token]);
 
   const clearError = useCallback(() => {
     setError(null);

--- a/client/src/components/__tests__/ChannelPage.story.tsx
+++ b/client/src/components/__tests__/ChannelPage.story.tsx
@@ -105,7 +105,6 @@ export const Default: Story = {
             totalPages: 1,
             page: 1,
             limit: 12,
-            videoFail: false,
             oldestVideoDate: '2024-01-15',
             autoDownloadsEnabled: true,
             availableTabs: ['videos'],

--- a/client/src/components/shared/VideoList/VideoListFilterChips.tsx
+++ b/client/src/components/shared/VideoList/VideoListFilterChips.tsx
@@ -4,12 +4,13 @@ import {
   AccessTime as DurationIcon,
   CalendarToday as CalendarIcon,
   Close as CloseIcon,
-  Shield as ShieldIcon,
-  CloudOff as CloudOffIcon,
-  Block as BlockIcon,
   ListFilter as FilterIcon,
 } from '../../../lib/icons';
 import { FilterConfig } from './types';
+import {
+  STATUS_CHIP_DESCRIPTORS,
+  isStatusFilter,
+} from './statusFilters';
 import { RATING_OPTIONS } from '../../../utils/ratings';
 
 export interface VideoListFilterChipsProps {
@@ -36,7 +37,13 @@ function formatDateRange(from: Date | null, to: Date | null): string {
 
 function formatDateString(value: string): string {
   if (!value) return '';
-  const parsed = new Date(value);
+  // Parse YYYY-MM-DD as a local date. `new Date(value)` treats the string as
+  // UTC midnight, which renders as the previous day in any timezone west of
+  // UTC when formatted with toLocaleDateString.
+  const parts = value.split('-').map(Number);
+  if (parts.length !== 3 || parts.some((p) => Number.isNaN(p))) return value;
+  const [year, month, day] = parts;
+  const parsed = new Date(year, month - 1, day);
   if (Number.isNaN(parsed.getTime())) return value;
   return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
 }
@@ -50,7 +57,7 @@ function formatDateStringRange(from: string, to: string): string {
 
 function ratingLabel(value: string): string {
   const option = RATING_OPTIONS.find((opt) => opt.value === value);
-  return option ? option.label.split(' — ')[0] : value;
+  return option ? option.shortLabel : value;
 }
 
 function VideoListFilterChips({ filters }: VideoListFilterChipsProps) {
@@ -144,46 +151,14 @@ function VideoListFilterChips({ filters }: VideoListFilterChipsProps) {
       continue;
     }
 
-    if (filter.id === 'protected' && filter.value !== 'off') {
+    if (isStatusFilter(filter)) {
+      if (filter.value === 'off') continue;
+      const { Icon, noun } = STATUS_CHIP_DESCRIPTORS[filter.id];
       chips.push(
         <Chip
-          key="protected"
-          icon={<ShieldIcon size={14} />}
-          label={filter.value === 'only' ? 'Only: Protected' : 'Hide: Protected'}
-          size="small"
-          onDelete={() => filter.onChange('off')}
-          onClick={() => filter.onChange('off')}
-          deleteIcon={<CloseIcon data-testid="CancelIcon" size={14} />}
-          color={filter.value === 'only' ? 'primary' : 'warning'}
-          variant="outlined"
-        />
-      );
-      continue;
-    }
-
-    if (filter.id === 'missing' && filter.value !== 'off') {
-      chips.push(
-        <Chip
-          key="missing"
-          icon={<CloudOffIcon size={14} />}
-          label={filter.value === 'only' ? 'Only: Missing' : 'Hide: Missing'}
-          size="small"
-          onDelete={() => filter.onChange('off')}
-          onClick={() => filter.onChange('off')}
-          deleteIcon={<CloseIcon data-testid="CancelIcon" size={14} />}
-          color={filter.value === 'only' ? 'primary' : 'warning'}
-          variant="outlined"
-        />
-      );
-      continue;
-    }
-
-    if (filter.id === 'ignored' && filter.value !== 'off') {
-      chips.push(
-        <Chip
-          key="ignored"
-          icon={<BlockIcon size={14} />}
-          label={filter.value === 'only' ? 'Only: Ignored' : 'Hide: Ignored'}
+          key={filter.id}
+          icon={<Icon size={14} />}
+          label={filter.value === 'only' ? `Only: ${noun}` : `Hide: ${noun}`}
           size="small"
           onDelete={() => filter.onChange('off')}
           onClick={() => filter.onChange('off')}
@@ -233,9 +208,7 @@ export function countActiveFilters(filters: FilterConfig[]): number {
     else if (filter.id === 'dateRange' && !filter.hidden && (filter.dateFrom !== null || filter.dateTo !== null)) count++;
     else if (filter.id === 'dateRangeString' && !filter.hidden && (filter.dateFrom || filter.dateTo)) count++;
     else if (filter.id === 'maxRating' && filter.value) count++;
-    else if (filter.id === 'protected' && filter.value !== 'off') count++;
-    else if (filter.id === 'missing' && filter.value !== 'off') count++;
-    else if (filter.id === 'ignored' && filter.value !== 'off') count++;
+    else if (isStatusFilter(filter) && filter.value !== 'off') count++;
     else if (filter.id === 'channel' && filter.value) count++;
   }
   return count;
@@ -258,11 +231,7 @@ export function clearAllFilters(filters: FilterConfig[]): void {
       filter.onToChange('');
     } else if (filter.id === 'maxRating') {
       filter.onChange('');
-    } else if (filter.id === 'protected') {
-      filter.onChange('off');
-    } else if (filter.id === 'missing') {
-      filter.onChange('off');
-    } else if (filter.id === 'ignored') {
+    } else if (isStatusFilter(filter)) {
       filter.onChange('off');
     } else if (filter.id === 'channel') {
       filter.onChange('');

--- a/client/src/components/shared/VideoList/VideoListFilterPanel.tsx
+++ b/client/src/components/shared/VideoList/VideoListFilterPanel.tsx
@@ -1,12 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Button, Divider, Typography } from '../../ui';
-import {
-  Close as CloseIcon,
-  Shield as ShieldIcon,
-  CloudOff as CloudOffIcon,
-  Block as BlockIcon,
-} from '../../../lib/icons';
+import { Close as CloseIcon } from '../../../lib/icons';
 import { FilterConfig } from './types';
 import DurationFilter from './filters/DurationFilter';
 import DateRangeFilter from './filters/DateRangeFilter';
@@ -15,33 +10,11 @@ import MaxRatingFilter from './filters/MaxRatingFilter';
 import ToggleChipFilter from './filters/ToggleChipFilter';
 import ChannelFilter from './filters/ChannelFilter';
 import { hasActiveFilters, clearAllFilters } from './VideoListFilterChips';
-
-const TOGGLE_CHIP_CONFIG = {
-  protected: {
-    icon: <ShieldIcon size={16} />,
-    inactiveLabel: 'Protected',
-    onlyLabel: 'Only: Protected',
-    excludeLabel: 'Hide: Protected',
-  },
-  missing: {
-    icon: <CloudOffIcon size={16} />,
-    inactiveLabel: 'Missing',
-    onlyLabel: 'Only: Missing',
-    excludeLabel: 'Hide: Missing',
-  },
-  ignored: {
-    icon: <BlockIcon size={16} />,
-    inactiveLabel: 'Ignored',
-    onlyLabel: 'Only: Ignored',
-    excludeLabel: 'Hide: Ignored',
-  },
-} as const;
-
-const STATUS_FILTER_IDS = ['protected', 'missing', 'ignored'] as const;
-
-function isStatusFilter(filter: FilterConfig): boolean {
-  return (STATUS_FILTER_IDS as readonly string[]).includes(filter.id);
-}
+import {
+  STATUS_CHIP_DESCRIPTORS,
+  isStatusChipId,
+  isStatusFilter,
+} from './statusFilters';
 
 export interface VideoListFilterPanelProps {
   filters: FilterConfig[];
@@ -99,16 +72,16 @@ function renderFilter(filter: FilterConfig, compact: boolean): React.ReactNode {
   if (filter.id === 'maxRating') {
     return <MaxRatingFilter value={filter.value} onChange={filter.onChange} compact={compact} />;
   }
-  if (filter.id === 'protected' || filter.id === 'missing' || filter.id === 'ignored') {
-    const config = TOGGLE_CHIP_CONFIG[filter.id];
+  if (isStatusFilter(filter)) {
+    const { Icon, noun } = STATUS_CHIP_DESCRIPTORS[filter.id];
     return (
       <ToggleChipFilter
         value={filter.value}
         onChange={filter.onChange}
-        icon={config.icon}
-        inactiveLabel={config.inactiveLabel}
-        onlyLabel={config.onlyLabel}
-        excludeLabel={config.excludeLabel}
+        icon={<Icon size={16} />}
+        inactiveLabel={noun}
+        onlyLabel={`Only: ${noun}`}
+        excludeLabel={`Hide: ${noun}`}
       />
     );
   }
@@ -121,6 +94,7 @@ function renderFilter(filter: FilterConfig, compact: boolean): React.ReactNode {
 }
 
 function filterLabel(filter: FilterConfig): string {
+  if (isStatusChipId(filter.id)) return 'Status';
   switch (filter.id) {
     case 'duration':
       return 'Duration';
@@ -129,28 +103,32 @@ function filterLabel(filter: FilterConfig): string {
       return 'Published Date';
     case 'maxRating':
       return 'Max Rating';
-    case 'protected':
-    case 'missing':
-    case 'ignored':
-      return 'Status';
     case 'channel':
       return 'Channel';
   }
+  return '';
 }
 
 function InlinePanel({ filters, open, customFilters }: { filters: FilterConfig[]; open: boolean; customFilters?: React.ReactNode }) {
   if (!open) return null;
+  const nonStatusFilters = filters.filter((f) => !isStatusFilter(f));
+  const statusFiltersList = filters.filter(isStatusFilter);
   return (
     <div
       data-testid="video-list-filter-panel-inline"
+      // Scoped override: make the floating label notch blend with the panel
+      // bg instead of punching through with --card. The matching
+      // --input-border / input bg / min-height rules live in index.css,
+      // keyed off this data-testid -- keep the two in sync if renaming.
       style={{
         padding: '12px 16px',
         borderBottom: '1px solid var(--border)',
         backgroundColor: 'var(--muted)',
+        ['--field-label-background' as string]: 'var(--muted)',
       }}
     >
-      <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', alignItems: 'center' }}>
-        {filters.map((filter, index) => (
+      <div style={{ display: 'flex', gap: 20, flexWrap: 'wrap', alignItems: 'flex-end' }}>
+        {nonStatusFilters.map((filter, index) => (
           <div key={filter.id + '-' + index}>{renderFilter(filter, false)}</div>
         ))}
         {customFilters}
@@ -163,6 +141,26 @@ function InlinePanel({ filters, open, customFilters }: { filters: FilterConfig[]
           >
             Clear All
           </Button>
+        )}
+        {statusFiltersList.length > 0 && (
+          <div
+            key="status-group"
+            data-testid="video-list-filter-status-group-inline"
+            // flexBasis 100% forces this item to a row by itself so toggling
+            // a chip's label length can't shuffle the non-status filters on
+            // the row above.
+            style={{
+              flexBasis: '100%',
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 8,
+              alignItems: 'center',
+            }}
+          >
+            {statusFiltersList.map((sf) => (
+              <React.Fragment key={sf.id}>{renderFilter(sf, false)}</React.Fragment>
+            ))}
+          </div>
         )}
       </div>
     </div>

--- a/client/src/components/shared/VideoList/__tests__/VideoListFilterChips.test.tsx
+++ b/client/src/components/shared/VideoList/__tests__/VideoListFilterChips.test.tsx
@@ -99,6 +99,7 @@ describe('VideoListFilterChips', () => {
     const onProtected = jest.fn();
     const onMissing = jest.fn();
     const onIgnored = jest.fn();
+    const onDownloaded = jest.fn();
 
     const filters: FilterConfig[] = [
       {
@@ -121,6 +122,7 @@ describe('VideoListFilterChips', () => {
       { id: 'protected', value: 'only', onChange: onProtected },
       { id: 'missing', value: 'exclude', onChange: onMissing },
       { id: 'ignored', value: 'only', onChange: onIgnored },
+      { id: 'downloaded', value: 'exclude', onChange: onDownloaded },
     ];
 
     clearAllFilters(filters);
@@ -132,6 +134,7 @@ describe('VideoListFilterChips', () => {
     expect(onProtected).toHaveBeenCalledWith('off');
     expect(onMissing).toHaveBeenCalledWith('off');
     expect(onIgnored).toHaveBeenCalledWith('off');
+    expect(onDownloaded).toHaveBeenCalledWith('off');
   });
 
   test('renders missing and ignored chips in only mode', () => {
@@ -183,5 +186,49 @@ describe('VideoListFilterChips', () => {
     ];
     expect(countActiveFilters(filters)).toBe(0);
     expect(hasActiveFilters(filters)).toBe(false);
+  });
+
+  test('renders downloaded chip with "Only: Downloaded" label in only mode', () => {
+    const filters: FilterConfig[] = [
+      { id: 'downloaded', value: 'only', onChange: jest.fn() },
+    ];
+    renderWithProviders(<VideoListFilterChips filters={filters} />);
+    expect(screen.getByText(/Only: Downloaded/i)).toBeInTheDocument();
+  });
+
+  test('renders downloaded chip with "Hide: Downloaded" label in exclude mode', () => {
+    const filters: FilterConfig[] = [
+      { id: 'downloaded', value: 'exclude', onChange: jest.fn() },
+    ];
+    renderWithProviders(<VideoListFilterChips filters={filters} />);
+    expect(screen.getByText(/Hide: Downloaded/i)).toBeInTheDocument();
+  });
+
+  test('downloaded chip is not rendered when value is off', () => {
+    const filters: FilterConfig[] = [
+      { id: 'downloaded', value: 'off', onChange: jest.fn() },
+    ];
+    renderWithProviders(<VideoListFilterChips filters={filters} />);
+    expect(screen.queryByText(/Downloaded/i)).not.toBeInTheDocument();
+  });
+
+  test('clicking the delete icon on the downloaded chip clears it', async () => {
+    const user = userEvent.setup();
+    const onDownloadedChange = jest.fn();
+    const filters: FilterConfig[] = [
+      { id: 'downloaded', value: 'exclude', onChange: onDownloadedChange },
+    ];
+    renderWithProviders(<VideoListFilterChips filters={filters} />);
+    const deleteIcon = screen.getByTestId('CancelIcon');
+    await user.click(deleteIcon);
+    expect(onDownloadedChange).toHaveBeenCalledWith('off');
+  });
+
+  test('countActiveFilters counts downloaded when active', () => {
+    const filters: FilterConfig[] = [
+      { id: 'downloaded', value: 'only', onChange: jest.fn() },
+    ];
+    expect(countActiveFilters(filters)).toBe(1);
+    expect(hasActiveFilters(filters)).toBe(true);
   });
 });

--- a/client/src/components/shared/VideoList/__tests__/VideoListFilterPanel.test.tsx
+++ b/client/src/components/shared/VideoList/__tests__/VideoListFilterPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import VideoListFilterPanel from '../VideoListFilterPanel';
@@ -80,6 +80,51 @@ describe('VideoListFilterPanel - inline variant', () => {
     );
     expect(screen.getByTestId('custom-filter')).toBeInTheDocument();
   });
+
+  test('renders a consistent label above each labelled filter in the inline panel', () => {
+    const filters: FilterConfig[] = [
+      {
+        id: 'duration',
+        min: null,
+        max: null,
+        inputMin: null,
+        inputMax: null,
+        onMinChange: jest.fn(),
+        onMaxChange: jest.fn(),
+      },
+      {
+        id: 'dateRangeString',
+        dateFrom: '',
+        dateTo: '',
+        onFromChange: jest.fn(),
+        onToChange: jest.fn(),
+      },
+      { id: 'maxRating', value: '', onChange: jest.fn() },
+    ];
+    renderWithProviders(
+      <VideoListFilterPanel filters={filters} variant="inline" open />
+    );
+    const panel = screen.getByTestId('video-list-filter-panel-inline');
+    expect(within(panel).getByText('Duration (min)')).toBeInTheDocument();
+    expect(within(panel).getByText('Published')).toBeInTheDocument();
+    expect(within(panel).getByText('Max Rating')).toBeInTheDocument();
+  });
+
+  test('groups all status chips (including downloaded) into a single inline flex container', () => {
+    const filters: FilterConfig[] = [
+      ...statusFilters(),
+      { id: 'downloaded', value: 'off', onChange: jest.fn() },
+    ];
+    renderWithProviders(
+      <VideoListFilterPanel filters={filters} variant="inline" open />
+    );
+    const group = screen.getByTestId('video-list-filter-status-group-inline');
+    for (const name of ['Protected', 'Missing', 'Ignored', 'Downloaded']) {
+      expect(
+        within(group).getByRole('button', { name: new RegExp(`^${name}$`, 'i') })
+      ).toBeInTheDocument();
+    }
+  });
 });
 
 describe('VideoListFilterPanel - drawer variant', () => {
@@ -119,6 +164,31 @@ describe('VideoListFilterPanel - drawer variant', () => {
       />
     );
     expect(screen.getAllByText('Status')).toHaveLength(1);
+  });
+
+  test('groups the downloaded filter under the same Status heading as other status chips', () => {
+    const filters: FilterConfig[] = [
+      ...statusFilters(),
+      { id: 'downloaded', value: 'off', onChange: jest.fn() },
+    ];
+    renderWithProviders(
+      <VideoListFilterPanel filters={filters} variant="drawer" open onClose={jest.fn()} />
+    );
+    expect(screen.getAllByText('Status')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /^Downloaded$/i })).toBeInTheDocument();
+  });
+
+  test('cycles the downloaded chip through off → only → exclude when clicked in the panel', async () => {
+    const user = userEvent.setup();
+    const onDownloaded = jest.fn();
+    const filters: FilterConfig[] = [
+      { id: 'downloaded', value: 'off', onChange: onDownloaded },
+    ];
+    renderWithProviders(
+      <VideoListFilterPanel filters={filters} variant="inline" open />
+    );
+    await user.click(screen.getByRole('button', { name: /^Downloaded$/i }));
+    expect(onDownloaded).toHaveBeenCalledWith('only');
   });
 
   test('close button calls onClose', async () => {

--- a/client/src/components/shared/VideoList/filters/DatePickerButton.tsx
+++ b/client/src/components/shared/VideoList/filters/DatePickerButton.tsx
@@ -1,0 +1,101 @@
+import React, { useRef } from 'react';
+import { Calendar, Close as CloseIcon } from '../../../../lib/icons';
+import { cn } from '../../../../lib/cn';
+
+export interface DatePickerButtonProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  ariaLabel: string;
+  clearAriaLabel?: string;
+  minWidth?: number | string;
+}
+
+function formatShortDate(iso: string): string {
+  if (!iso) return '';
+  const parts = iso.split('-').map(Number);
+  if (parts.length !== 3 || parts.some((p) => Number.isNaN(p))) return '';
+  const [year, month, day] = parts;
+  const date = new Date(year, month - 1, day);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: '2-digit',
+  });
+}
+
+function DatePickerButton({
+  value,
+  onChange,
+  placeholder = 'Pick date',
+  ariaLabel,
+  clearAriaLabel,
+  minWidth,
+}: DatePickerButtonProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const openPicker = () => {
+    const input = inputRef.current;
+    if (!input) return;
+    const picker = (input as HTMLInputElement & { showPicker?: () => void }).showPicker;
+    if (typeof picker === 'function') {
+      try {
+        picker.call(input);
+        return;
+      } catch {
+        // fall through to focus/click fallback
+      }
+    }
+    input.focus();
+    input.click();
+  };
+
+  return (
+    <div
+      style={minWidth ? { minWidth } : undefined}
+      className={cn(
+        'relative inline-flex items-center gap-1 pl-3 pr-1 min-h-[36px] text-sm',
+        'rounded-[var(--radius-input)] border border-[var(--input-border,var(--border))]',
+        'bg-[var(--card)] text-foreground',
+        'focus-within:border-primary focus-within:ring-1 focus-within:ring-primary',
+        'transition-colors',
+      )}
+    >
+      <button
+        type="button"
+        onClick={openPicker}
+        aria-label={ariaLabel}
+        className="flex-1 inline-flex items-center gap-2 py-1.5 bg-transparent border-0 outline-none text-left cursor-pointer"
+      >
+        <Calendar size={16} aria-hidden="true" className="shrink-0 text-muted-foreground" />
+        <span className={cn('leading-none', !value && 'text-muted-foreground')}>
+          {value ? formatShortDate(value) : placeholder}
+        </span>
+      </button>
+      {value ? (
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          aria-label={clearAriaLabel ?? 'Clear date'}
+          className="inline-flex items-center justify-center rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <CloseIcon size={14} aria-hidden="true" />
+        </button>
+      ) : (
+        <span className="w-1" aria-hidden="true" />
+      )}
+      <input
+        ref={inputRef}
+        type="date"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-hidden="true"
+        tabIndex={-1}
+        className="absolute inset-0 w-full h-full opacity-0 pointer-events-none"
+      />
+    </div>
+  );
+}
+
+export default DatePickerButton;

--- a/client/src/components/shared/VideoList/filters/DateRangeFilter.tsx
+++ b/client/src/components/shared/VideoList/filters/DateRangeFilter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { TextField, Typography } from '../../../ui';
+import { FormControl, InputLabel, Typography } from '../../../ui';
+import DatePickerButton from './DatePickerButton';
 
 export interface DateRangeFilterProps {
   dateFrom: Date | null;
@@ -33,36 +34,54 @@ function DateRangeFilter({
   onToChange,
   compact = false,
 }: DateRangeFilterProps) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-      <TextField
-        label={compact ? undefined : 'Published From'}
-        type="date"
-        size="small"
-        value={toInputValue(dateFrom)}
-        onChange={(e) => onFromChange(fromInputValue(e.target.value))}
-        InputLabelProps={compact ? undefined : { shrink: true }}
-        inputProps={{ 'aria-label': 'Published from date' }}
-        variant="outlined"
-        style={{ minWidth: compact ? 0 : 180, flex: compact ? 1 : undefined }}
-      />
-      {compact && (
+  if (compact) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <DatePickerButton
+          value={toInputValue(dateFrom)}
+          onChange={(v) => onFromChange(fromInputValue(v))}
+          placeholder="From"
+          ariaLabel="Published from date"
+          clearAriaLabel="Clear published from date"
+        />
         <Typography variant="body2" color="text.secondary">
           to
         </Typography>
-      )}
-      <TextField
-        label={compact ? undefined : 'Published To'}
-        type="date"
-        size="small"
-        value={toInputValue(dateTo)}
-        onChange={(e) => onToChange(fromInputValue(e.target.value))}
-        InputLabelProps={compact ? undefined : { shrink: true }}
-        inputProps={{ 'aria-label': 'Published to date' }}
-        variant="outlined"
-        style={{ minWidth: compact ? 0 : 180, flex: compact ? 1 : undefined }}
-      />
-    </div>
+        <DatePickerButton
+          value={toInputValue(dateTo)}
+          onChange={(v) => onToChange(fromInputValue(v))}
+          placeholder="To"
+          ariaLabel="Published to date"
+          clearAriaLabel="Clear published to date"
+        />
+      </div>
+    );
+  }
+  return (
+    <FormControl>
+      <InputLabel shrink>Published</InputLabel>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <DatePickerButton
+          value={toInputValue(dateFrom)}
+          onChange={(v) => onFromChange(fromInputValue(v))}
+          placeholder="From"
+          ariaLabel="Published from date"
+          clearAriaLabel="Clear published from date"
+          minWidth={160}
+        />
+        <Typography variant="body2" color="text.secondary">
+          to
+        </Typography>
+        <DatePickerButton
+          value={toInputValue(dateTo)}
+          onChange={(v) => onToChange(fromInputValue(v))}
+          placeholder="To"
+          ariaLabel="Published to date"
+          clearAriaLabel="Clear published to date"
+          minWidth={160}
+        />
+      </div>
+    </FormControl>
   );
 }
 

--- a/client/src/components/shared/VideoList/filters/DateRangeStringFilter.tsx
+++ b/client/src/components/shared/VideoList/filters/DateRangeStringFilter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { TextField, Typography } from '../../../ui';
+import { FormControl, InputLabel, Typography } from '../../../ui';
+import DatePickerButton from './DatePickerButton';
 
 export interface DateRangeStringFilterProps {
   dateFrom: string;
@@ -16,36 +17,55 @@ function DateRangeStringFilter({
   onToChange,
   compact = false,
 }: DateRangeStringFilterProps) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-      <TextField
-        label={compact ? undefined : 'Published From'}
-        type="date"
-        size="small"
-        value={dateFrom}
-        onChange={(e) => onFromChange(e.target.value)}
-        InputLabelProps={compact ? undefined : { shrink: true }}
-        inputProps={{ 'aria-label': 'Published from date' }}
-        variant="outlined"
-        style={{ minWidth: compact ? 0 : 180, flex: compact ? 1 : undefined }}
-      />
-      {compact && (
+  if (compact) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <DatePickerButton
+          value={dateFrom}
+          onChange={onFromChange}
+          placeholder="From"
+          ariaLabel="Published from date"
+          clearAriaLabel="Clear published from date"
+        />
         <Typography variant="body2" color="text.secondary">
           to
         </Typography>
-      )}
-      <TextField
-        label={compact ? undefined : 'Published To'}
-        type="date"
-        size="small"
-        value={dateTo}
-        onChange={(e) => onToChange(e.target.value)}
-        InputLabelProps={compact ? undefined : { shrink: true }}
-        inputProps={{ 'aria-label': 'Published to date' }}
-        variant="outlined"
-        style={{ minWidth: compact ? 0 : 180, flex: compact ? 1 : undefined }}
-      />
-    </div>
+        <DatePickerButton
+          value={dateTo}
+          onChange={onToChange}
+          placeholder="To"
+          ariaLabel="Published to date"
+          clearAriaLabel="Clear published to date"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <FormControl>
+      <InputLabel shrink>Published</InputLabel>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <DatePickerButton
+          value={dateFrom}
+          onChange={onFromChange}
+          placeholder="From"
+          ariaLabel="Published from date"
+          clearAriaLabel="Clear published from date"
+          minWidth={160}
+        />
+        <Typography variant="body2" color="text.secondary">
+          to
+        </Typography>
+        <DatePickerButton
+          value={dateTo}
+          onChange={onToChange}
+          placeholder="To"
+          ariaLabel="Published to date"
+          clearAriaLabel="Clear published to date"
+          minWidth={160}
+        />
+      </div>
+    </FormControl>
   );
 }
 

--- a/client/src/components/shared/VideoList/filters/DurationFilter.tsx
+++ b/client/src/components/shared/VideoList/filters/DurationFilter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextField, Typography } from '../../../ui';
+import { FormControl, InputLabel, TextField, Typography } from '../../../ui';
 
 export interface DurationFilterProps {
   minDuration: number | null;
@@ -23,38 +23,64 @@ function DurationFilter({
   onMaxChange,
   compact = false,
 }: DurationFilterProps) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-      {!compact && (
-        <Typography variant="body2" color="text.secondary" style={{ minWidth: 60 }}>
-          Duration:
+  if (compact) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <TextField
+          size="small"
+          type="number"
+          placeholder="Min"
+          value={minDuration ?? ''}
+          onChange={(e) => onMinChange(parseMinutes(e.target.value))}
+          inputProps={{ min: 0, 'aria-label': 'Minimum duration in minutes' }}
+          style={{ width: 70 }}
+        />
+        <Typography variant="body2" color="text.secondary">
+          to
         </Typography>
-      )}
-      <TextField
-        size="small"
-        type="number"
-        placeholder="Min"
-        value={minDuration ?? ''}
-        onChange={(e) => onMinChange(parseMinutes(e.target.value))}
-        inputProps={{ min: 0, 'aria-label': 'Minimum duration in minutes' }}
-        style={{ width: compact ? 70 : 80 }}
-      />
-      <Typography variant="body2" color="text.secondary">
-        to
-      </Typography>
-      <TextField
-        size="small"
-        type="number"
-        placeholder="Max"
-        value={maxDuration ?? ''}
-        onChange={(e) => onMaxChange(parseMinutes(e.target.value))}
-        inputProps={{ min: 0, 'aria-label': 'Maximum duration in minutes' }}
-        style={{ width: compact ? 70 : 80 }}
-      />
-      <Typography variant="body2" color="text.secondary">
-        min
-      </Typography>
-    </div>
+        <TextField
+          size="small"
+          type="number"
+          placeholder="Max"
+          value={maxDuration ?? ''}
+          onChange={(e) => onMaxChange(parseMinutes(e.target.value))}
+          inputProps={{ min: 0, 'aria-label': 'Maximum duration in minutes' }}
+          style={{ width: 70 }}
+        />
+        <Typography variant="body2" color="text.secondary">
+          min
+        </Typography>
+      </div>
+    );
+  }
+
+  return (
+    <FormControl>
+      <InputLabel shrink>Duration (min)</InputLabel>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <TextField
+          size="small"
+          type="number"
+          placeholder="Min"
+          value={minDuration ?? ''}
+          onChange={(e) => onMinChange(parseMinutes(e.target.value))}
+          inputProps={{ min: 0, 'aria-label': 'Minimum duration in minutes' }}
+          style={{ width: 80 }}
+        />
+        <Typography variant="body2" color="text.secondary">
+          to
+        </Typography>
+        <TextField
+          size="small"
+          type="number"
+          placeholder="Max"
+          value={maxDuration ?? ''}
+          onChange={(e) => onMaxChange(parseMinutes(e.target.value))}
+          inputProps={{ min: 0, 'aria-label': 'Maximum duration in minutes' }}
+          style={{ width: 80 }}
+        />
+      </div>
+    </FormControl>
   );
 }
 

--- a/client/src/components/shared/VideoList/filters/MaxRatingFilter.tsx
+++ b/client/src/components/shared/VideoList/filters/MaxRatingFilter.tsx
@@ -12,7 +12,7 @@ export interface MaxRatingFilterProps {
 function MaxRatingFilter({ value, onChange, label = 'Max Rating', compact = false }: MaxRatingFilterProps) {
   return (
     <FormControl
-      style={compact ? { width: '100%' } : { minWidth: 180 }}
+      style={compact ? { width: '100%' } : { minWidth: 110 }}
     >
       {!compact && <InputLabel shrink>{label}</InputLabel>}
       <Select
@@ -24,7 +24,7 @@ function MaxRatingFilter({ value, onChange, label = 'Max Rating', compact = fals
       >
         {RATING_OPTIONS.map((option) => (
           <MenuItem key={option.value} value={option.value}>
-            {option.label}
+            {option.shortLabel}
           </MenuItem>
         ))}
       </Select>

--- a/client/src/components/shared/VideoList/filters/__tests__/DatePickerButton.test.tsx
+++ b/client/src/components/shared/VideoList/filters/__tests__/DatePickerButton.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import DatePickerButton from '../DatePickerButton';
+import { renderWithProviders } from '../../../../../test-utils';
+
+describe('DatePickerButton', () => {
+  test('renders placeholder when value is empty', () => {
+    renderWithProviders(
+      <DatePickerButton
+        value=""
+        onChange={jest.fn()}
+        placeholder="From"
+        ariaLabel="Published from date"
+      />
+    );
+    expect(screen.getByText('From')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Published from date' })).toBeInTheDocument();
+  });
+
+  test('renders a formatted date when a value is set', () => {
+    renderWithProviders(
+      <DatePickerButton
+        value="2024-03-15"
+        onChange={jest.fn()}
+        placeholder="From"
+        ariaLabel="Published from date"
+      />
+    );
+    expect(screen.queryByText('From')).not.toBeInTheDocument();
+    // Locale-formatted short date. Avoid asserting exact locale; just check year.
+    expect(screen.getByRole('button', { name: 'Published from date' })).toBeInTheDocument();
+  });
+
+  test('clicking the main button opens the native picker', async () => {
+    const user = userEvent.setup();
+    const showPicker = jest.fn();
+    const original = HTMLInputElement.prototype.showPicker as unknown;
+    (HTMLInputElement.prototype as unknown as { showPicker: () => void }).showPicker = showPicker;
+    try {
+      renderWithProviders(
+        <DatePickerButton
+          value=""
+          onChange={jest.fn()}
+          ariaLabel="Published from date"
+        />
+      );
+      await user.click(screen.getByRole('button', { name: 'Published from date' }));
+      expect(showPicker).toHaveBeenCalledTimes(1);
+    } finally {
+      if (typeof original === 'function') {
+        (HTMLInputElement.prototype as unknown as { showPicker: () => void }).showPicker = original as () => void;
+      } else {
+        delete (HTMLInputElement.prototype as unknown as Record<string, unknown>).showPicker;
+      }
+    }
+  });
+
+  test('falls back to focus+click when showPicker is unavailable', async () => {
+    const user = userEvent.setup();
+    const original = (HTMLInputElement.prototype as unknown as { showPicker?: () => void }).showPicker;
+    delete (HTMLInputElement.prototype as unknown as Record<string, unknown>).showPicker;
+    try {
+      const onChange = jest.fn();
+      renderWithProviders(
+        <DatePickerButton
+          value=""
+          onChange={onChange}
+          ariaLabel="Published from date"
+        />
+      );
+      // Should not throw when clicking even without showPicker support.
+      await user.click(screen.getByRole('button', { name: 'Published from date' }));
+      expect(onChange).not.toHaveBeenCalled();
+    } finally {
+      if (typeof original === 'function') {
+        (HTMLInputElement.prototype as unknown as { showPicker: () => void }).showPicker = original;
+      }
+    }
+  });
+
+  test('clear button clears the value', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    renderWithProviders(
+      <DatePickerButton
+        value="2024-03-15"
+        onChange={onChange}
+        ariaLabel="Published from date"
+        clearAriaLabel="Clear published from date"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: 'Clear published from date' }));
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  test('no clear button is rendered when value is empty', () => {
+    renderWithProviders(
+      <DatePickerButton
+        value=""
+        onChange={jest.fn()}
+        ariaLabel="Published from date"
+        clearAriaLabel="Clear published from date"
+      />
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Clear published from date' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/shared/VideoList/statusFilters.ts
+++ b/client/src/components/shared/VideoList/statusFilters.ts
@@ -1,0 +1,38 @@
+import {
+  Shield as ShieldIcon,
+  CloudOff as CloudOffIcon,
+  Block as BlockIcon,
+  Download as DownloadIcon,
+} from '../../../lib/icons';
+import type { FilterConfig } from './types';
+
+export type StatusChipId = 'protected' | 'missing' | 'ignored' | 'downloaded';
+export type StatusFilterConfig = Extract<FilterConfig, { id: StatusChipId }>;
+
+// Shape kept deliberately thin: the Icon component (not an element) so each
+// consumer can size it, plus the chip's "noun" -- consumers compose the full
+// label (e.g. "Only: Protected") from this noun.
+export interface StatusChipDescriptor {
+  // Lucide's icon components accept size as string | number.
+  Icon: React.ComponentType<{ size?: string | number; 'data-testid'?: string }>;
+  noun: string;
+}
+
+export const STATUS_CHIP_DESCRIPTORS: Record<StatusChipId, StatusChipDescriptor> = {
+  protected: { Icon: ShieldIcon, noun: 'Protected' },
+  missing: { Icon: CloudOffIcon, noun: 'Missing' },
+  ignored: { Icon: BlockIcon, noun: 'Ignored' },
+  downloaded: { Icon: DownloadIcon, noun: 'Downloaded' },
+};
+
+export const STATUS_CHIP_IDS = Object.keys(STATUS_CHIP_DESCRIPTORS) as StatusChipId[];
+
+export function isStatusChipId(id: string): id is StatusChipId {
+  return id in STATUS_CHIP_DESCRIPTORS;
+}
+
+// Narrows FilterConfig (not just the id) so consumers can access value/onChange
+// without per-branch checks.
+export function isStatusFilter(filter: FilterConfig): filter is StatusFilterConfig {
+  return isStatusChipId(filter.id);
+}

--- a/client/src/components/shared/VideoList/types.ts
+++ b/client/src/components/shared/VideoList/types.ts
@@ -50,6 +50,11 @@ export type FilterConfig =
       onChange: (value: ChipFilterMode) => void;
     }
   | {
+      id: 'downloaded';
+      value: ChipFilterMode;
+      onChange: (value: ChipFilterMode) => void;
+    }
+  | {
       id: 'duration';
       min: number | null;
       max: number | null;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -523,3 +523,58 @@ html {
   background-color: transparent;
   padding: 0;
 }
+
+/*
+ * VideoList inline filter panel scoped styles.
+ * The panel root is identified by data-testid="video-list-filter-panel-inline"
+ * (see client/src/components/shared/VideoList/VideoListFilterPanel.tsx).
+ * Both sides key off that testid -- if you rename it, rename it here too.
+ *
+ * Why these rules live here and not inline on the JSX:
+ *   - @supports guards let us upgrade to color-mix when available and fall
+ *     back to var(--border) otherwise (inline style attrs can't do that).
+ *   - input background/min-height target descendant <input> elements, which
+ *     inline style on the panel root can't address.
+ *
+ * The panel sits on --muted. Two problems the defaults don't solve:
+ *   1. TextFields default to bg-transparent, and in several themes (Dark
+ *      Modern, Bold Flat light) --input equals --muted, so bg-input can't
+ *      provide contrast either. Paint number fields with --card which
+ *      always contrasts with --muted across themes.
+ *   2. --input-border often equals --muted hue-for-hue in dark themes,
+ *      leaving the default border invisible. Override it with a foreground
+ *      mix that's theme-agnostic; fall back to --border on older browsers.
+ *
+ * Mobile drawer sits on --card already and doesn't need these overrides.
+ */
+[data-testid="video-list-filter-panel-inline"] {
+  --input-border: var(--border);
+}
+@supports (color: color-mix(in oklab, black, white)) {
+  [data-testid="video-list-filter-panel-inline"] {
+    --input-border: color-mix(in oklab, var(--foreground) 25%, transparent);
+  }
+}
+/*
+ * Applies to any number input inside the inline panel by design, so new
+ * filters that render a number field (e.g. future size/byte-count filters)
+ * inherit the same 36px height as DatePickerButton and the duration inputs.
+ * If a filter needs a different height, override it with a more specific
+ * selector rather than narrowing this one.
+ */
+[data-testid="video-list-filter-panel-inline"] input[type="number"] {
+  background-color: var(--card);
+  min-height: 36px;
+}
+
+/*
+ * Mirror the app's color mode to the native UA, so browser-rendered widgets
+ * (number spinners, native scrollbars) render in the matching light/dark
+ * palette. ThemeEngineContext sets data-theme="light" or "dark" on <html>.
+ */
+html[data-theme="dark"] {
+  color-scheme: dark;
+}
+html[data-theme="light"] {
+  color-scheme: light;
+}

--- a/client/src/utils/ratings.ts
+++ b/client/src/utils/ratings.ts
@@ -1,22 +1,23 @@
 export type RatingOption = {
   value: string;
   label: string;
+  shortLabel: string;
 };
 
 export const RATING_OPTIONS: RatingOption[] = [
-  { value: '', label: 'No limit' },
-  { value: 'G', label: 'G — General Audiences' },
-  { value: 'PG', label: 'PG — Parental Guidance' },
-  { value: 'PG-13', label: 'PG-13 — Parents Strongly Cautioned' },
-  { value: 'R', label: 'R — Restricted' },
-  { value: 'NC-17', label: 'NC-17 — Adults Only' },
-  { value: 'TV-Y', label: 'TV-Y — Young Children' },
-  { value: 'TV-Y7', label: 'TV-Y7 — Ages 7+' },
-  { value: 'TV-G', label: 'TV-G — General Audience' },
-  { value: 'TV-PG', label: 'TV-PG — Parental Guidance' },
-  { value: 'TV-14', label: 'TV-14 — 14+' },
-  { value: 'TV-MA', label: 'TV-MA — Mature Audiences' },
-  { value: 'NR', label: 'NR — Not Rated' },
+  { value: '', label: 'No limit', shortLabel: 'No limit' },
+  { value: 'G', label: 'G — General Audiences', shortLabel: 'G' },
+  { value: 'PG', label: 'PG — Parental Guidance', shortLabel: 'PG' },
+  { value: 'PG-13', label: 'PG-13 — Parents Strongly Cautioned', shortLabel: 'PG-13' },
+  { value: 'R', label: 'R — Restricted', shortLabel: 'R' },
+  { value: 'NC-17', label: 'NC-17 — Adults Only', shortLabel: 'NC-17' },
+  { value: 'TV-Y', label: 'TV-Y — Young Children', shortLabel: 'TV-Y' },
+  { value: 'TV-Y7', label: 'TV-Y7 — Ages 7+', shortLabel: 'TV-Y7' },
+  { value: 'TV-G', label: 'TV-G — General Audience', shortLabel: 'TV-G' },
+  { value: 'TV-PG', label: 'TV-PG — Parental Guidance', shortLabel: 'TV-PG' },
+  { value: 'TV-14', label: 'TV-14 — 14+', shortLabel: 'TV-14' },
+  { value: 'TV-MA', label: 'TV-MA — Mature Audiences', shortLabel: 'TV-MA' },
+  { value: 'NR', label: 'NR — Not Rated', shortLabel: 'NR' },
 ];
 
 const RATING_LIMITS: Record<string, number> = {

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -180,8 +180,7 @@ const createServerModule = ({
           writeChannels: jest.fn().mockResolvedValue(),
           getChannelInfo: jest.fn().mockResolvedValue({ id: 'channel-1', title: 'Channel' }),
           getChannelVideos: jest.fn().mockResolvedValue({
-            videos: [{ id: 'video-1', title: 'Video 1' }],
-            videoFail: false
+            videos: [{ id: 'video-1', title: 'Video 1' }]
           }),
           fetchAllChannelVideos: jest.fn().mockResolvedValue({
             success: true,
@@ -906,7 +905,7 @@ describe('server routes - channels', () => {
         'channel-1',
         1,    // default page
         50,   // default pageSize
-        false, // default hideDownloaded
+        'off', // default downloadedFilter
         '',   // default searchQuery
         'date', // default sortBy
         'desc', // default sortOrder
@@ -921,8 +920,7 @@ describe('server routes - channels', () => {
       );
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
-        videos: [{ id: 'video-1', title: 'Video 1' }],
-        videoFail: false
+        videos: [{ id: 'video-1', title: 'Video 1' }]
       });
     });
 
@@ -945,8 +943,7 @@ describe('server routes - channels', () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
-        videos: [{ id: 'video-1', title: 'Video 1' }],
-        videoFail: false
+        videos: [{ id: 'video-1', title: 'Video 1' }]
       });
     });
 
@@ -961,7 +958,7 @@ describe('server routes - channels', () => {
         query: {
           page: '2',
           pageSize: '25',
-          hideDownloaded: 'true',
+          downloadedFilter: 'exclude',
           searchQuery: 'test search',
           sortBy: 'title',
           sortOrder: 'asc'
@@ -975,7 +972,7 @@ describe('server routes - channels', () => {
         'channel-1',
         2,
         25,
-        true,
+        'exclude',
         'test search',
         'title',
         'asc',
@@ -1002,7 +999,7 @@ describe('server routes - channels', () => {
         query: {
           page: '1',
           pageSize: '50',
-          hideDownloaded: 'false',
+          downloadedFilter: 'off',
           searchQuery: '',
           sortBy: 'date',
           sortOrder: 'desc',
@@ -1017,7 +1014,7 @@ describe('server routes - channels', () => {
         'channel-1',
         1,
         50,
-        false,
+        'off',
         '',
         'date',
         'desc',
@@ -1053,7 +1050,7 @@ describe('server routes - channels', () => {
         'channel-1',
         1,    // default page
         50,   // default pageSize
-        false, // default hideDownloaded
+        'off', // default downloadedFilter
         'videos' // default tabType
       );
       expect(res.statusCode).toBe(200);
@@ -1075,7 +1072,7 @@ describe('server routes - channels', () => {
         query: {
           page: '3',
           pageSize: '100',
-          hideDownloaded: 'true'
+          downloadedFilter: 'exclude'
         }
       });
       const res = createMockResponse();
@@ -1086,7 +1083,7 @@ describe('server routes - channels', () => {
         'channel-1',
         3,
         100,
-        true,
+        'exclude',
         'videos' // default tabType
       );
       expect(res.statusCode).toBe(200);
@@ -1103,7 +1100,7 @@ describe('server routes - channels', () => {
         query: {
           page: '1',
           pageSize: '50',
-          hideDownloaded: 'false',
+          downloadedFilter: 'off',
           tabType: 'streams'
         }
       });
@@ -1115,7 +1112,7 @@ describe('server routes - channels', () => {
         'channel-1',
         1,
         50,
-        false,
+        'off',
         'streams'
       );
       expect(res.statusCode).toBe(200);

--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -1269,7 +1269,7 @@ describe('ChannelModule', () => {
         expect(result[0].youtube_id).toBe('video20');
       });
 
-      test('should filter out downloaded videos when excludeDownloaded=true', async () => {
+      test('should filter out downloaded videos when downloadedFilter="exclude"', async () => {
         const Video = require('../../models/video');
         const mockVideos = [
           { youtube_id: 'video1', title: 'Video 1', toJSON() { return this; } },
@@ -1282,11 +1282,31 @@ describe('ChannelModule', () => {
           { id: 2, youtubeId: 'video2', removed: true, fileSize: null, filePath: '/path' }
         ]);
 
-        const result = await ChannelModule.fetchNewestVideosFromDb('UC123', 50, 0, true);
+        const result = await ChannelModule.fetchNewestVideosFromDb('UC123', 50, 0, 'exclude');
 
         // Should only return video2 (removed) and video3 (not downloaded)
         expect(result).toHaveLength(2);
         expect(result.find(v => v.youtube_id === 'video1')).toBeUndefined();
+      });
+
+      test('should keep only downloaded videos when downloadedFilter="only"', async () => {
+        const Video = require('../../models/video');
+        const mockVideos = [
+          { youtube_id: 'video1', title: 'Video 1', toJSON() { return this; } },
+          { youtube_id: 'video2', title: 'Video 2', toJSON() { return this; } },
+          { youtube_id: 'video3', title: 'Video 3', toJSON() { return this; } }
+        ];
+        ChannelVideo.findAll.mockResolvedValue(mockVideos);
+        Video.findAll = jest.fn().mockResolvedValue([
+          { id: 1, youtubeId: 'video1', removed: false, fileSize: 1000, filePath: '/path' },
+          { id: 2, youtubeId: 'video2', removed: true, fileSize: null, filePath: '/path' }
+        ]);
+
+        const result = await ChannelModule.fetchNewestVideosFromDb('UC123', 50, 0, 'only');
+
+        // Should only return video1 (downloaded and not removed)
+        expect(result).toHaveLength(1);
+        expect(result[0].youtube_id).toBe('video1');
       });
 
       test('should filter by search query', async () => {
@@ -1299,7 +1319,7 @@ describe('ChannelModule', () => {
         ChannelVideo.findAll.mockResolvedValue(mockVideos);
         Video.findAll = jest.fn().mockResolvedValue([]);
 
-        const result = await ChannelModule.fetchNewestVideosFromDb('UC123', 50, 0, false, 'cook');
+        const result = await ChannelModule.fetchNewestVideosFromDb('UC123', 50, 0, 'off', 'cook');
 
         expect(result).toHaveLength(2);
         expect(result.every(v => v.title.toLowerCase().includes('cook'))).toBe(true);
@@ -1315,7 +1335,7 @@ describe('ChannelModule', () => {
         ChannelVideo.findAll.mockResolvedValue(mockVideos);
         Video.findAll = jest.fn().mockResolvedValue([]);
 
-        const result = await ChannelModule.fetchNewestVideosFromDb('UC123', 50, 0, false, '', 'title', 'asc');
+        const result = await ChannelModule.fetchNewestVideosFromDb('UC123', 50, 0, 'off', '', 'title', 'asc');
 
         expect(result[0].title).toBe('Apple');
         expect(result[1].title).toBe('Banana');
@@ -1751,7 +1771,7 @@ describe('ChannelModule', () => {
         ChannelVideo.count.mockResolvedValue(25);
         ChannelVideo.findOne.mockResolvedValue({ publishedAt: '2024-01-01' });
 
-        await ChannelModule.getChannelVideoStats('UC123', false, '', 'short');
+        await ChannelModule.getChannelVideoStats('UC123', 'off', '', 'short');
 
         expect(ChannelVideo.count).toHaveBeenCalledWith({
           where: { channel_id: 'UC123', media_type: 'short' }
@@ -1763,7 +1783,7 @@ describe('ChannelModule', () => {
         });
       });
 
-      test('should filter by excludeDownloaded when specified', async () => {
+      test('should filter by downloadedFilter="exclude" when specified', async () => {
         const Video = require('../../models/video');
         // Videos should be in DESC order (newest first) as returned by the database
         const mockVideos = [
@@ -1776,10 +1796,28 @@ describe('ChannelModule', () => {
           { id: 1, youtubeId: 'video1', removed: false, fileSize: 1000, filePath: '/path' }
         ]);
 
-        const result = await ChannelModule.getChannelVideoStats('UC123', true);
+        const result = await ChannelModule.getChannelVideoStats('UC123', 'exclude');
 
         expect(result.totalCount).toBe(2); // video2 and video3 are not downloaded
         expect(result.oldestVideoDate).toBe('2024-01-02');
+      });
+
+      test('should filter by downloadedFilter="only" when specified', async () => {
+        const Video = require('../../models/video');
+        const mockVideos = [
+          { youtube_id: 'video3', publishedAt: '2024-01-03', toJSON() { return this; } },
+          { youtube_id: 'video2', publishedAt: '2024-01-02', toJSON() { return this; } },
+          { youtube_id: 'video1', publishedAt: '2024-01-01', toJSON() { return this; } }
+        ];
+        ChannelVideo.findAll.mockResolvedValue(mockVideos);
+        Video.findAll = jest.fn().mockResolvedValue([
+          { id: 1, youtubeId: 'video1', removed: false, fileSize: 1000, filePath: '/path' }
+        ]);
+
+        const result = await ChannelModule.getChannelVideoStats('UC123', 'only');
+
+        expect(result.totalCount).toBe(1); // Only video1 is downloaded and not removed
+        expect(result.oldestVideoDate).toBe('2024-01-01');
       });
 
       test('should filter by search query', async () => {
@@ -1792,12 +1830,12 @@ describe('ChannelModule', () => {
         ChannelVideo.findAll.mockResolvedValue(mockVideos);
         Video.findAll = jest.fn().mockResolvedValue([]);
 
-        const result = await ChannelModule.getChannelVideoStats('UC123', false, 'cook');
+        const result = await ChannelModule.getChannelVideoStats('UC123', 'off', 'cook');
 
         expect(result.totalCount).toBe(2); // Only videos with 'cook' in title
       });
 
-      test('should combine excludeDownloaded and search filters', async () => {
+      test('should combine downloadedFilter="exclude" and search filters', async () => {
         const Video = require('../../models/video');
         const mockVideos = [
           { youtube_id: 'video1', title: 'How to cook', publishedAt: '2024-01-01', toJSON() { return this; } },
@@ -1809,7 +1847,7 @@ describe('ChannelModule', () => {
           { id: 1, youtubeId: 'video1', removed: false, fileSize: 1000, filePath: '/path' }
         ]);
 
-        const result = await ChannelModule.getChannelVideoStats('UC123', true, 'cook');
+        const result = await ChannelModule.getChannelVideoStats('UC123', 'exclude', 'cook');
 
         expect(result.totalCount).toBe(1); // Only video3 matches both filters
         expect(result.oldestVideoDate).toBe('2024-01-03');
@@ -2409,8 +2447,6 @@ describe('ChannelModule', () => {
 
         expect(result).toEqual({
           videos: videos,
-          videoFail: false,
-          failureReason: null,
           dataSource: 'yt_dlp',
           lastFetched: new Date('2024-01-01'),
           totalCount: videos.length,
@@ -2420,13 +2456,11 @@ describe('ChannelModule', () => {
         });
       });
 
-      test('should build failure response when no videos', () => {
+      test('should build response with empty videos array', () => {
         const result = ChannelModule.buildChannelVideosResponse([], mockChannelData, 'cache', null, false, 'video');
 
         expect(result).toEqual({
           videos: [],
-          videoFail: true,
-          failureReason: 'fetch_error',
           dataSource: 'cache',
           lastFetched: new Date('2024-01-01'),
           totalCount: 0,
@@ -2458,15 +2492,15 @@ describe('ChannelModule', () => {
         expect(result.oldestVideoDate).toBe('2023-01-01T00:00:00Z');
       });
 
-      test('should not fail when videos empty but stats show totalCount > 0', () => {
+      test('should reflect stats totalCount when videos are empty', () => {
         const stats = {
           totalCount: 50,
           oldestVideoDate: '2023-01-01T00:00:00Z'
         };
         const result = ChannelModule.buildChannelVideosResponse([], mockChannelData, 'cache', stats);
 
-        expect(result.videoFail).toBe(false);
-        expect(result.failureReason).toBeNull();
+        expect(result.totalCount).toBe(50);
+        expect(result.oldestVideoDate).toBe('2023-01-01T00:00:00Z');
       });
 
       test('should include autoDownloadsEnabled parameter', () => {
@@ -2554,6 +2588,8 @@ describe('ChannelModule', () => {
         const result = await ChannelModule.getChannelVideos('UC123');
 
         expect(result.videos).toBeDefined();
+        // Cached fallback has content, so no user-visible error.
+        expect(result.fetchError).toBeUndefined();
         expect(logger.error).toHaveBeenCalledWith(
           expect.objectContaining({
             err: expect.any(Error),
@@ -2561,6 +2597,23 @@ describe('ChannelModule', () => {
           }),
           'Error fetching channel videos'
         );
+      });
+
+      test('should set fetchError=true when catch path yields no cached videos', async () => {
+        const Video = require('../../models/video');
+        const mockChannel = { ...mockChannelData, auto_download_enabled_tabs: 'video' };
+
+        Channel.findOne.mockResolvedValue(mockChannel);
+        ChannelVideo.findAll.mockResolvedValue([]);
+        ChannelVideo.count.mockResolvedValue(0);
+        Video.findAll = jest.fn().mockResolvedValue([]);
+
+        jest.spyOn(ChannelModule, 'fetchAndSaveVideosViaYtDlp').mockRejectedValue(new Error('Network error'));
+
+        const result = await ChannelModule.getChannelVideos('UC123');
+
+        expect(result.videos).toEqual([]);
+        expect(result.fetchError).toBe(true);
       });
     });
 

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -1411,8 +1411,10 @@ class ChannelModule {
    * @param {Array} videos - Array of video objects to filter
    * @param {number|null} minDuration - Minimum duration in seconds
    * @param {number|null} maxDuration - Maximum duration in seconds
-   * @param {string|null} dateFrom - Filter videos from this date (ISO string)
-   * @param {string|null} dateTo - Filter videos to this date (ISO string)
+   * @param {string|null} dateFrom - Filter videos from this instant (ISO string,
+   *   expected to represent the viewer's local start-of-day)
+   * @param {string|null} dateTo - Filter videos to this instant (ISO string,
+   *   expected to represent the viewer's local end-of-day, 23:59:59.999)
    * @returns {Array} - Filtered array of videos
    */
   _applyDurationAndDateFilters(videos, minDuration, maxDuration, dateFrom, dateTo) {
@@ -1436,7 +1438,6 @@ class ChannelModule {
     }
     if (dateTo) {
       const toDate = new Date(dateTo);
-      toDate.setHours(23, 59, 59, 999); // Include entire day
       filtered = filtered.filter(video =>
         video.publishedAt && new Date(video.publishedAt) <= toDate
       );
@@ -1485,7 +1486,7 @@ class ChannelModule {
    * @param {string} channelId - Channel ID to fetch videos for
    * @param {number} limit - Maximum number of videos to return (default 50)
    * @param {number} offset - Number of videos to skip (default 0)
-   * @param {boolean} excludeDownloaded - Whether to exclude downloaded videos (default false)
+   * @param {string} downloadedFilter - Tri-state filter on download status: 'off' | 'only' | 'exclude' (default 'off')
    * @param {string} searchQuery - Search query to filter videos by title (default '')
    * @param {string} sortBy - Field to sort by: 'date', 'title', 'duration', 'size' (default 'date')
    * @param {string} sortOrder - Sort order: 'asc' or 'desc' (default 'desc')
@@ -1497,7 +1498,7 @@ class ChannelModule {
    * @param {string|null} dateTo - Filter videos to this date (ISO string, default null)
    * @returns {Promise<Array>} - Array of video objects with download status
    */
-  async fetchNewestVideosFromDb(channelId, limit = 50, offset = 0, excludeDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', checkFiles = false, mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = 'off', missingFilter = 'off', ignoredFilter = 'off') {
+  async fetchNewestVideosFromDb(channelId, limit = 50, offset = 0, downloadedFilter = 'off', searchQuery = '', sortBy = 'date', sortOrder = 'desc', checkFiles = false, mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = 'off', missingFilter = 'off', ignoredFilter = 'off') {
     // First get all videos to enrich with download status
     const allChannelVideos = await ChannelVideo.findAll({
       where: {
@@ -1513,8 +1514,10 @@ class ChannelModule {
 
     // Filter if needed
     let filteredVideos = enrichedVideos;
-    if (excludeDownloaded) {
+    if (downloadedFilter === 'exclude') {
       filteredVideos = enrichedVideos.filter(video => !video.added || video.removed);
+    } else if (downloadedFilter === 'only') {
+      filteredVideos = enrichedVideos.filter(video => video.added && !video.removed);
     }
 
     // Apply search filter
@@ -1597,7 +1600,7 @@ class ChannelModule {
   /**
    * Get the total count and oldest video date for a channel
    * @param {string} channelId - Channel ID
-   * @param {boolean} excludeDownloaded - Whether to exclude downloaded videos (default false)
+   * @param {string} downloadedFilter - Tri-state filter on download status: 'off' | 'only' | 'exclude' (default 'off')
    * @param {string} searchQuery - Search query to filter videos by title (default '')
    * @param {string} mediaType - Media type to filter by: 'video', 'short', 'livestream' (default 'video')
    * @param {number|null} minDuration - Minimum duration in seconds (default null)
@@ -1606,9 +1609,9 @@ class ChannelModule {
    * @param {string|null} dateTo - Filter videos to this date (ISO string, default null)
    * @returns {Promise<Object>} - Object with totalCount and oldestVideoDate
    */
-  async getChannelVideoStats(channelId, excludeDownloaded = false, searchQuery = '', mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = 'off', missingFilter = 'off', ignoredFilter = 'off') {
+  async getChannelVideoStats(channelId, downloadedFilter = 'off', searchQuery = '', mediaType = 'video', minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = 'off', missingFilter = 'off', ignoredFilter = 'off') {
     // If we have search or filter, we need to get all videos
-    if (excludeDownloaded || searchQuery || minDuration !== null || maxDuration !== null || dateFrom || dateTo || protectedFilter !== 'off' || missingFilter !== 'off' || ignoredFilter !== 'off') {
+    if (downloadedFilter !== 'off' || searchQuery || minDuration !== null || maxDuration !== null || dateFrom || dateTo || protectedFilter !== 'off' || missingFilter !== 'off' || ignoredFilter !== 'off') {
       // Need to filter by download status and/or search
       const allChannelVideos = await ChannelVideo.findAll({
         where: {
@@ -1623,8 +1626,10 @@ class ChannelModule {
       let filteredVideos = enrichedVideos;
 
       // Apply download filter
-      if (excludeDownloaded) {
+      if (downloadedFilter === 'exclude') {
         filteredVideos = filteredVideos.filter(video => !video.added || video.removed);
+      } else if (downloadedFilter === 'only') {
+        filteredVideos = filteredVideos.filter(video => video.added && !video.removed);
       }
 
       // Apply search filter
@@ -1879,8 +1884,6 @@ class ChannelModule {
 
     return {
       videos: videos,
-      videoFail: videos.length === 0 && (!stats || stats.totalCount === 0),
-      failureReason: videos.length === 0 && (!stats || stats.totalCount === 0) ? 'fetch_error' : null,
       dataSource: dataSource,
       lastFetched: lastFetched,
       totalCount: stats ? stats.totalCount : videos.length,
@@ -2253,7 +2256,7 @@ class ChannelModule {
    * @param {string} channelId - Channel ID to get videos for
    * @param {number} page - Page number (1-based, default 1)
    * @param {number} pageSize - Number of videos per page (default 50)
-   * @param {boolean} hideDownloaded - Whether to hide downloaded videos (default false)
+   * @param {string} downloadedFilter - Tri-state filter on download status: 'off' | 'only' | 'exclude' (default 'off')
    * @param {string} searchQuery - Search query to filter videos by title (default '')
    * @param {string} sortBy - Field to sort by: 'date', 'title', 'duration', 'size' (default 'date')
    * @param {string} sortOrder - Sort order: 'asc' or 'desc' (default 'desc')
@@ -2264,7 +2267,7 @@ class ChannelModule {
    * @param {string|null} dateTo - Filter videos to this date (ISO string, default null)
    * @returns {Promise<Object>} - Response object with videos and metadata
    */
-  async getChannelVideos(channelId, page = 1, pageSize = 50, hideDownloaded = false, searchQuery = '', sortBy = 'date', sortOrder = 'desc', tabType = TAB_TYPES.VIDEOS, minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = 'off', missingFilter = 'off', ignoredFilter = 'off') {
+  async getChannelVideos(channelId, page = 1, pageSize = 50, downloadedFilter = 'off', searchQuery = '', sortBy = 'date', sortOrder = 'desc', tabType = TAB_TYPES.VIDEOS, minDuration = null, maxDuration = null, dateFrom = null, dateTo = null, protectedFilter = 'off', missingFilter = 'off', ignoredFilter = 'off') {
     const channel = await Channel.findOne({
       where: { channel_id: channelId },
     });
@@ -2294,7 +2297,7 @@ class ChannelModule {
 
     try {
       // First check if we need to refresh recent videos from YouTube
-      const allVideos = await this.fetchNewestVideosFromDb(channelId, 1, 0, false, '', 'date', 'desc', false, mediaType);
+      const allVideos = await this.fetchNewestVideosFromDb(channelId, 1, 0, 'off', '', 'date', 'desc', false, mediaType);
       const mostRecentVideoDate = allVideos.length > 0 ? allVideos[0].publishedAt : null;
 
       if (shouldFetchFromYoutube && this.shouldRefreshChannelVideos(channel, allVideos.length, mediaType)) {
@@ -2324,7 +2327,7 @@ class ChannelModule {
 
       // Now fetch the requested page of videos with file checking enabled
       const offset = (page - 1) * pageSize;
-      const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
+      const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, downloadedFilter, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
 
       // Check if videos still exist on YouTube and mark as removed if they don't
       const videoValidationModule = require('./videoValidationModule');
@@ -2394,16 +2397,23 @@ class ChannelModule {
       }
 
       // Get stats for the response
-      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
+      const stats = await this.getChannelVideoStats(channelId, downloadedFilter, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
 
       return this.buildChannelVideosResponse(paginatedVideos, channel, 'cache', stats, autoDownloadsEnabled, mediaType);
 
     } catch (error) {
       logger.error({ err: error, channelId }, 'Error fetching channel videos');
       const offset = (page - 1) * pageSize;
-      const cachedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, hideDownloaded, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
-      const stats = await this.getChannelVideoStats(channelId, hideDownloaded, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
-      return this.buildChannelVideosResponse(cachedVideos, channel, 'cache', stats, autoDownloadsEnabled, mediaType);
+      const cachedVideos = await this.fetchNewestVideosFromDb(channelId, pageSize, offset, downloadedFilter, searchQuery, sortBy, sortOrder, true, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
+      const stats = await this.getChannelVideoStats(channelId, downloadedFilter, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
+      const response = this.buildChannelVideosResponse(cachedVideos, channel, 'cache', stats, autoDownloadsEnabled, mediaType);
+      // Only surface a user-visible error when we have nothing to show.
+      // Silent recovery when cached results exist; the filter-aware empty
+      // state handles "fetch ok, zero matches" on its own.
+      if ((stats ? stats.totalCount : cachedVideos.length) === 0) {
+        response.fetchError = true;
+      }
+      return response;
     }
   }
 
@@ -2456,11 +2466,11 @@ class ChannelModule {
    * @param {string} channelId - Channel ID
    * @param {number} requestedPage - Page requested by frontend
    * @param {number} requestedPageSize - Page size requested by frontend
-   * @param {boolean} hideDownloaded - Whether to hide downloaded videos in response
+   * @param {string} downloadedFilter - Tri-state filter on download status: 'off' | 'only' | 'exclude' (default 'off')
    * @param {string} tabType - Tab type to fetch: 'videos', 'shorts', or 'streams' (default 'videos')
    * @returns {Promise<Object>} - Response with success status and paginated data
    */
-  async fetchAllChannelVideos(channelId, requestedPage = 1, requestedPageSize = 50, hideDownloaded = false, tabType = TAB_TYPES.VIDEOS) {
+  async fetchAllChannelVideos(channelId, requestedPage = 1, requestedPageSize = 50, downloadedFilter = 'off', tabType = TAB_TYPES.VIDEOS) {
     // Use composite key to allow concurrent fetches for different tabs
     const fetchKey = `${channelId}:${tabType}`;
 
@@ -2536,8 +2546,8 @@ class ChannelModule {
 
         // Get the requested page of videos after the full fetch
         const offset = (requestedPage - 1) * requestedPageSize;
-        const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, requestedPageSize, offset, hideDownloaded, '', 'date', 'desc', false, mediaType);
-        const stats = await this.getChannelVideoStats(channelId, hideDownloaded, '', mediaType);
+        const paginatedVideos = await this.fetchNewestVideosFromDb(channelId, requestedPageSize, offset, downloadedFilter, '', 'date', 'desc', false, mediaType);
+        const stats = await this.getChannelVideoStats(channelId, downloadedFilter, '', mediaType);
 
         const elapsedSeconds = (Date.now() - startTime) / 1000;
         logger.info({

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -1,6 +1,11 @@
 const express = require('express');
 const router = express.Router();
 
+// Tri-state filter query params ('off' | 'only' | 'exclude'). Any other
+// value (missing, empty string, garbage) falls back to 'off'.
+const parseFilterMode = (value) =>
+  value === 'only' || value === 'exclude' ? value : 'off';
+
 /**
  * Creates channel routes
  * @param {Object} deps - Dependencies
@@ -664,10 +669,12 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
    *           type: integer
    *           default: 50
    *       - in: query
-   *         name: hideDownloaded
+   *         name: downloadedFilter
    *         schema:
-   *           type: boolean
-   *           default: false
+   *           type: string
+   *           enum: [off, only, exclude]
+   *           default: off
+   *         description: Tri-state filter on download status. `only` keeps downloaded videos, `exclude` hides them, `off` returns everything.
    *       - in: query
    *         name: searchQuery
    *         schema:
@@ -698,7 +705,6 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
     const channelId = req.params.channelId;
     const page = parseInt(req.query.page) || 1;
     const pageSize = parseInt(req.query.pageSize) || 50;
-    const hideDownloaded = req.query.hideDownloaded === 'true';
     const searchQuery = req.query.searchQuery || '';
     const sortBy = req.query.sortBy || 'date';
     const sortOrder = req.query.sortOrder || 'desc';
@@ -710,17 +716,14 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
     const maxDuration = (parsedMaxDuration !== null && !isNaN(parsedMaxDuration)) ? parsedMaxDuration : null;
     const dateFrom = req.query.dateFrom || null;
     const dateTo = req.query.dateTo || null;
-    const parseFilterMode = (value) => (value === 'only' || value === 'exclude' ? value : 'off');
+    const downloadedFilter = parseFilterMode(req.query.downloadedFilter);
     const protectedFilter = parseFilterMode(req.query.protectedFilter);
     const missingFilter = parseFilterMode(req.query.missingFilter);
     const ignoredFilter = parseFilterMode(req.query.ignoredFilter);
-    const result = await channelModule.getChannelVideos(channelId, page, pageSize, hideDownloaded, searchQuery, sortBy, sortOrder, tabType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
+    const result = await channelModule.getChannelVideos(channelId, page, pageSize, downloadedFilter, searchQuery, sortBy, sortOrder, tabType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
 
     if (Array.isArray(result)) {
-      res.status(200).json({
-        videos: result,
-        videoFail: result.length === 0,
-      });
+      res.status(200).json({ videos: result });
     } else {
       res.status(200).json(result);
     }
@@ -751,10 +754,12 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
    *           type: integer
    *           default: 50
    *       - in: query
-   *         name: hideDownloaded
+   *         name: downloadedFilter
    *         schema:
-   *           type: boolean
-   *           default: false
+   *           type: string
+   *           enum: [off, only, exclude]
+   *           default: off
+   *         description: Tri-state filter on download status. `only` keeps downloaded videos, `exclude` hides them, `off` returns everything.
    *       - in: query
    *         name: tabType
    *         schema:
@@ -774,11 +779,11 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
     const channelId = req.params.channelId;
     const page = parseInt(req.query.page) || 1;
     const pageSize = parseInt(req.query.pageSize) || 50;
-    const hideDownloaded = req.query.hideDownloaded === 'true';
+    const downloadedFilter = parseFilterMode(req.query.downloadedFilter);
     const tabType = req.query.tabType || 'videos';
 
     try {
-      const result = await channelModule.fetchAllChannelVideos(channelId, page, pageSize, hideDownloaded, tabType);
+      const result = await channelModule.fetchAllChannelVideos(channelId, page, pageSize, downloadedFilter, tabType);
       res.status(200).json(result);
     } catch (error) {
       req.log.error({ err: error, channelId }, 'Failed to fetch all channel videos');


### PR DESCRIPTION
- Replace the boolean "hide downloaded" toggle with a tri-state chip that joins protected/missing/ignored in the status group.
- Extract a shared DatePickerButton so all date range filters use the same compact button UI.
- Send dateFrom/dateTo as full ISO timestamps anchored to the viewer's local day so the filter includes the selected days end to end.
- Drop the legacy videoFail field; server now sets fetchError only when the catch path runs and the cached fallback is empty, which the hook surfaces as a user-visible error.
- Remove the channel-wide auto-download toggle from the filter toolbar; it still lives in ChannelSettings.