### PR TITLE
feat: add nightly yt-dlp auto-update

### DIFF
--- a/client/src/components/ChannelPage/__tests__/ChannelSettingsDialog.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelSettingsDialog.test.tsx
@@ -70,7 +70,8 @@ describe('ChannelSettingsDialog', () => {
       isPlatformManaged: {
         plexUrl: false,
         authEnabled: true,
-        useTmpForDownloads: false
+        useTmpForDownloads: false,
+        ytdlpUpdates: false
       },
       deploymentEnvironment: {
         platform: null,
@@ -354,7 +355,8 @@ describe('ChannelSettingsDialog', () => {
         isPlatformManaged: {
           plexUrl: false,
           authEnabled: true,
-          useTmpForDownloads: false
+          useTmpForDownloads: false,
+          ytdlpUpdates: false
         },
         deploymentEnvironment: {
           platform: null,

--- a/client/src/components/Configuration/sections/CoreSettingsSection.tsx
+++ b/client/src/components/Configuration/sections/CoreSettingsSection.tsx
@@ -36,6 +36,7 @@ import { useSubfolders } from '../../../hooks/useSubfolders';
 import { ConfigState, DeploymentEnvironment, PlatformManagedState } from '../types';
 import { reverseFrequencyMapping, getChannelFilesOptions } from '../helpers';
 import { FREQUENCY_MAPPING } from '../constants';
+import { formatDateTime } from '../../../utils/formatters';
 
 interface CoreSettingsSectionProps {
   config: ConfigState;
@@ -536,7 +537,7 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
               >
                 {ytDlpVersionInfo.currentVersion}
               </Typography>
-              {ytDlpVersionInfo.updateAvailable && ytDlpVersionInfo.latestVersion ? (
+              {!isPlatformManaged.ytdlpUpdates && ytDlpVersionInfo.updateAvailable && ytDlpVersionInfo.latestVersion ? (
                 <>
                   <ArrowForwardIcon style={{ fontSize: 16 }} className="text-muted-foreground" />
                   <Typography
@@ -562,13 +563,68 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
                     {ytDlpUpdateStatus === 'updating' ? 'Updating...' : 'Update'}
                   </Button>
                 </>
-              ) : (
+              ) : !isPlatformManaged.ytdlpUpdates ? (
                 <CheckCircleIcon color="success" fontSize="small" />
+              ) : null}
+              {isPlatformManaged.ytdlpUpdates && (
+                <Chip
+                  label={deploymentEnvironment.platform?.toLowerCase() === 'elfhosted' ? 'Managed by Elfhosted' : 'Platform Managed'}
+                  size="small"
+                />
               )}
             </Box>
-            <Typography variant="caption" color="text.secondary">
-              yt-dlp is the video download engine. If downloads are failing, try updating yt-dlp to the latest version.
-            </Typography>
+            {isPlatformManaged.ytdlpUpdates ? (
+              <Typography variant="caption" color="text.secondary">
+                yt-dlp is managed by {deploymentEnvironment.platform?.toLowerCase() === 'elfhosted' ? 'Elfhosted' : 'the platform'} and cannot be updated from Youtarr. Updates are applied automatically by the platform.
+              </Typography>
+            ) : (
+              <>
+                <Typography variant="caption" color="text.secondary">
+                  yt-dlp is the video download engine. If downloads are failing, try updating yt-dlp to the latest version.
+                </Typography>
+
+                <Box className="mt-4 flex items-center">
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        name="autoUpdateYtdlp"
+                        checked={!!config.autoUpdateYtdlp}
+                        onChange={handleCheckboxChange}
+                      />
+                    }
+                    label="Automatically update yt-dlp nightly"
+                  />
+                  <InfoTooltip
+                    text="Checks for a new yt-dlp release each night at 4:00 AM (server local time) and installs it automatically. Updates are skipped while a download is in progress and will be retried the following night. If an update fails, Youtarr keeps running on the previous version."
+                    onMobileClick={onMobileTooltipClick}
+                  />
+                </Box>
+
+                {(config.ytdlpLastChecked || config.ytdlpLastResult || config.ytdlpLastUpdated) && (
+                  <Box className="mt-1">
+                    {config.ytdlpLastChecked && (
+                      <Typography
+                        variant="caption"
+                        className="block"
+                        style={{ color: config.ytdlpLastResult?.status === 'error' ? 'var(--warning)' : undefined }}
+                        color={config.ytdlpLastResult?.status === 'error' ? undefined : 'text.secondary'}
+                      >
+                        Last checked: {formatDateTime(config.ytdlpLastChecked)}
+                        {config.ytdlpLastResult?.status === 'up-to-date' && ' — already up to date'}
+                        {config.ytdlpLastResult?.status === 'updated' && config.ytdlpLastResult.version && ` — updated to ${config.ytdlpLastResult.version}`}
+                        {config.ytdlpLastResult?.status === 'skipped' && ` — skipped: ${config.ytdlpLastResult.message || 'reason unknown'}`}
+                        {config.ytdlpLastResult?.status === 'error' && ` — update failed: ${config.ytdlpLastResult.message || 'reason unknown'}`}
+                      </Typography>
+                    )}
+                    {config.ytdlpLastUpdated && (
+                      <Typography variant="caption" color="text.secondary" className="block">
+                        Last updated: {formatDateTime(config.ytdlpLastUpdated)}
+                      </Typography>
+                    )}
+                  </Box>
+                )}
+              </>
+            )}
           </Box>
         </>
       )}

--- a/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.story.tsx
+++ b/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.story.tsx
@@ -39,7 +39,7 @@ const meta: Meta<typeof CoreSettingsSection> = {
   args: {
     token: 'storybook-token',
     deploymentEnvironment: { platform: null, isWsl: false },
-    isPlatformManaged: { plexUrl: false, authEnabled: true, useTmpForDownloads: false },
+    isPlatformManaged: { plexUrl: false, authEnabled: true, useTmpForDownloads: false, ytdlpUpdates: false },
     onMobileTooltipClick: fn(),
   },
 };

--- a/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
@@ -73,6 +73,7 @@ const createPlatformManagedState = (
   plexUrl: false,
   authEnabled: false,
   useTmpForDownloads: false,
+  ytdlpUpdates: false,
   ...overrides,
 });
 
@@ -1049,6 +1050,191 @@ describe('CoreSettingsSection Component', () => {
       await screen.findByText('No tracked channels are currently using Default Subfolder.');
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('yt-dlp Auto-Update Toggle', () => {
+    const ytDlpVersionInfo = {
+      currentVersion: '2026.04.10',
+      latestVersion: '2026.04.10',
+      updateAvailable: false,
+    };
+
+    test('does not render auto-update toggle when no yt-dlp version is available', () => {
+      const props = createSectionProps();
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(
+        screen.queryByRole('checkbox', { name: /Automatically update yt-dlp nightly/i })
+      ).not.toBeInTheDocument();
+    });
+
+    test('renders auto-update toggle when yt-dlp version info is provided', () => {
+      const props = createSectionProps({ ytDlpVersionInfo });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(
+        screen.getByRole('checkbox', { name: /Automatically update yt-dlp nightly/i })
+      ).toBeInTheDocument();
+    });
+
+    test('toggle reflects autoUpdateYtdlp false', () => {
+      const props = createSectionProps({
+        config: createConfig({ autoUpdateYtdlp: false }),
+        ytDlpVersionInfo,
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      const toggle = screen.getByRole('checkbox', { name: /Automatically update yt-dlp nightly/i });
+      expect(toggle).not.toBeChecked();
+    });
+
+    test('toggle reflects autoUpdateYtdlp true', () => {
+      const props = createSectionProps({
+        config: createConfig({ autoUpdateYtdlp: true }),
+        ytDlpVersionInfo,
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      const toggle = screen.getByRole('checkbox', { name: /Automatically update yt-dlp nightly/i });
+      expect(toggle).toBeChecked();
+    });
+
+    test('calls onConfigChange when toggled', async () => {
+      const user = userEvent.setup();
+      const onConfigChange = jest.fn();
+      const props = createSectionProps({
+        config: createConfig({ autoUpdateYtdlp: false }),
+        onConfigChange,
+        ytDlpVersionInfo,
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+
+      const toggle = screen.getByRole('checkbox', { name: /Automatically update yt-dlp nightly/i });
+      await user.click(toggle);
+
+      expect(onConfigChange).toHaveBeenCalledWith({ autoUpdateYtdlp: true });
+    });
+
+    test('does not render the status caption when no checks have run yet', () => {
+      const props = createSectionProps({ ytDlpVersionInfo });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(screen.queryByText(/Last checked:/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/Last updated:/i)).not.toBeInTheDocument();
+    });
+
+    test('renders "already up to date" caption after a successful no-op check', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          ytdlpLastChecked: '2026-04-25T04:00:00.000Z',
+          ytdlpLastResult: { status: 'up-to-date' },
+        }),
+        ytDlpVersionInfo,
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(screen.getByText(/Last checked:.*already up to date/i)).toBeInTheDocument();
+    });
+
+    test('renders "updated to <version>" caption and the last updated timestamp on a real update', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          ytdlpLastChecked: '2026-04-25T04:00:00.000Z',
+          ytdlpLastUpdated: '2026-04-25T04:00:00.000Z',
+          ytdlpLastResult: { status: 'updated', version: '2026.04.20' },
+        }),
+        ytDlpVersionInfo,
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(screen.getByText(/updated to 2026\.04\.20/i)).toBeInTheDocument();
+      expect(screen.getByText(/Last updated:/i)).toBeInTheDocument();
+    });
+
+    test('renders "skipped" caption when an auto-update was skipped', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          ytdlpLastChecked: '2026-04-25T04:00:00.000Z',
+          ytdlpLastResult: { status: 'skipped', message: 'Cannot update while downloads are in progress.' },
+        }),
+        ytDlpVersionInfo,
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(
+        screen.getByText(/skipped:.*downloads are in progress/i)
+      ).toBeInTheDocument();
+    });
+
+    test('renders "update failed" caption with message on error', () => {
+      const props = createSectionProps({
+        config: createConfig({
+          ytdlpLastChecked: '2026-04-25T04:00:00.000Z',
+          ytdlpLastResult: { status: 'error', message: 'Permission denied' },
+        }),
+        ytDlpVersionInfo,
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(screen.getByText(/update failed: Permission denied/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('yt-dlp Section on Platform-Managed Deployments', () => {
+    const ytDlpVersionInfo = {
+      currentVersion: '2026.04.10',
+      latestVersion: '2026.04.20',
+      updateAvailable: true,
+    };
+
+    test('hides the manual Update button when yt-dlp is platform-managed', () => {
+      const props = createSectionProps({
+        ytDlpVersionInfo,
+        isPlatformManaged: createPlatformManagedState({ ytdlpUpdates: true }),
+        deploymentEnvironment: createDeploymentEnvironment({ platform: 'elfhosted' }),
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(screen.queryByRole('button', { name: /^Update$/i })).not.toBeInTheDocument();
+    });
+
+    test('hides the auto-update toggle when yt-dlp is platform-managed', () => {
+      const props = createSectionProps({
+        ytDlpVersionInfo,
+        isPlatformManaged: createPlatformManagedState({ ytdlpUpdates: true }),
+        deploymentEnvironment: createDeploymentEnvironment({ platform: 'elfhosted' }),
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(
+        screen.queryByRole('checkbox', { name: /Automatically update yt-dlp nightly/i })
+      ).not.toBeInTheDocument();
+    });
+
+    test('shows the Elfhosted-specific managed message and chip', () => {
+      const props = createSectionProps({
+        ytDlpVersionInfo,
+        isPlatformManaged: createPlatformManagedState({ ytdlpUpdates: true }),
+        deploymentEnvironment: createDeploymentEnvironment({ platform: 'elfhosted' }),
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(screen.getByText('Managed by Elfhosted')).toBeInTheDocument();
+      expect(
+        screen.getByText(/yt-dlp is managed by Elfhosted and cannot be updated from Youtarr/i)
+      ).toBeInTheDocument();
+    });
+
+    test('shows a generic platform-managed message when platform is not Elfhosted', () => {
+      const props = createSectionProps({
+        ytDlpVersionInfo,
+        isPlatformManaged: createPlatformManagedState({ ytdlpUpdates: true }),
+        deploymentEnvironment: createDeploymentEnvironment({ platform: null }),
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(screen.getByText('Platform Managed')).toBeInTheDocument();
+      expect(
+        screen.getByText(/yt-dlp is managed by the platform and cannot be updated from Youtarr/i)
+      ).toBeInTheDocument();
+    });
+
+    test('still shows the current yt-dlp version when platform-managed', () => {
+      const props = createSectionProps({
+        ytDlpVersionInfo,
+        isPlatformManaged: createPlatformManagedState({ ytdlpUpdates: true }),
+        deploymentEnvironment: createDeploymentEnvironment({ platform: 'elfhosted' }),
+      });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      expect(screen.getByText('2026.04.10')).toBeInTheDocument();
     });
   });
 });

--- a/client/src/components/Configuration/sections/__tests__/PlexIntegrationSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/PlexIntegrationSection.test.tsx
@@ -18,6 +18,7 @@ const createPlatformManagedState = (
   plexUrl: false,
   authEnabled: false,
   useTmpForDownloads: false,
+  ytdlpUpdates: false,
   ...overrides,
 });
 

--- a/client/src/components/Configuration/types.ts
+++ b/client/src/components/Configuration/types.ts
@@ -71,6 +71,7 @@ export interface PlatformManagedState {
   plexUrl: boolean;
   authEnabled: boolean;
   useTmpForDownloads: boolean;
+  ytdlpUpdates: boolean;
 }
 
 export interface DeploymentEnvironment {

--- a/client/src/config/configSchema.ts
+++ b/client/src/config/configSchema.ts
@@ -105,6 +105,15 @@ export const CONFIG_FIELDS = {
   // API Keys
   apiKeyRateLimit: { default: 10, trackChanges: true },
 
+  // yt-dlp auto-update
+  autoUpdateYtdlp: { default: false, trackChanges: true },
+  ytdlpLastChecked: { default: null as string | null, trackChanges: false },
+  ytdlpLastUpdated: { default: null as string | null, trackChanges: false },
+  ytdlpLastResult: {
+    default: null as { status: 'updated' | 'up-to-date' | 'skipped' | 'error'; message?: string; version?: string } | null,
+    trackChanges: false,
+  },
+
   // System/internal fields (not tracked for changes)
   youtubeOutputDirectory: { default: '', trackChanges: false },
   uuid: { default: '', trackChanges: false },
@@ -165,6 +174,10 @@ export const DEFAULT_CONFIG: ConfigState = {
   darkModeEnabled: CONFIG_FIELDS.darkModeEnabled.default,
   channelVideosHotLoad: CONFIG_FIELDS.channelVideosHotLoad.default,
   apiKeyRateLimit: CONFIG_FIELDS.apiKeyRateLimit.default,
+  autoUpdateYtdlp: CONFIG_FIELDS.autoUpdateYtdlp.default,
+  ytdlpLastChecked: CONFIG_FIELDS.ytdlpLastChecked.default,
+  ytdlpLastUpdated: CONFIG_FIELDS.ytdlpLastUpdated.default,
+  ytdlpLastResult: CONFIG_FIELDS.ytdlpLastResult.default,
   youtubeOutputDirectory: CONFIG_FIELDS.youtubeOutputDirectory.default,
   uuid: CONFIG_FIELDS.uuid.default,
   envAuthApplied: CONFIG_FIELDS.envAuthApplied.default,

--- a/client/src/hooks/useConfig.ts
+++ b/client/src/hooks/useConfig.ts
@@ -28,7 +28,8 @@ export function useConfig(token: string | null): UseConfigResult {
   const [isPlatformManaged, setIsPlatformManaged] = useState<PlatformManagedState>({
     plexUrl: false,
     authEnabled: true,
-    useTmpForDownloads: false
+    useTmpForDownloads: false,
+    ytdlpUpdates: false
   });
   const [deploymentEnvironment, setDeploymentEnvironment] = useState<DeploymentEnvironment>({
     platform: null,

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -50,5 +50,9 @@
   "subtitleLanguage": "en",
   "darkModeEnabled": false,
   "uuid": "",
-  "apiKeyRateLimit": 10
+  "apiKeyRateLimit": 10,
+  "autoUpdateYtdlp": false,
+  "ytdlpLastChecked": null,
+  "ytdlpLastUpdated": null,
+  "ytdlpLastResult": null
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,6 +44,11 @@ services:
       - AUTH_ENABLED=${AUTH_ENABLED:-true}
       - AUTH_PRESET_USERNAME=${AUTH_PRESET_USERNAME:-}
       - AUTH_PRESET_PASSWORD=${AUTH_PRESET_PASSWORD:-}
+      # Platform-spoof env vars (used by ./scripts/start-dev.sh --as-elfhosted and full Elfhosted spoofs).
+      # Empty when unset on the host, so non-Elfhosted dev runs are unaffected.
+      - PLATFORM=${PLATFORM:-}
+      - DATA_PATH=${DATA_PATH:-}
+      - PLEX_URL=${PLEX_URL:-}
     depends_on:
       - youtarr-db
     # Use Node 18+'s built-in watch mode for auto-restart on server changes

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -16,6 +16,7 @@ These settings can be changed from the Configuration page in the web UI.
 - [Advanced Settings](#advanced-settings)
 - [Auto-Removal Settings](#auto-removal-settings)
 - [API Keys & External Access](#api-keys--external-access)
+- [yt-dlp Auto-Update](#yt-dlp-auto-update)
 - [Account & Security](#account--security)
 - [System Fields](#system-fields)
 - [Configuration Examples](#configuration-examples)
@@ -538,6 +539,47 @@ Settings for API key authentication used by bookmarklets, mobile shortcuts, and 
 - **Note**: Helps prevent abuse from external integrations. Each API key is rate-limited independently.
 
 For detailed information on creating and using API keys, see [API Integration Guide](API_INTEGRATION.md).
+
+## yt-dlp Auto-Update
+
+Youtarr can optionally check for and install yt-dlp updates on a nightly schedule. The toggle and its status display live next to the manual yt-dlp update button on the Core Settings page.
+
+### Auto-Update Enabled
+- **Config Key**: `autoUpdateYtdlp`
+- **Type**: `boolean`
+- **Default**: `false`
+- **Description**: When `true`, Youtarr runs `yt-dlp -U` at 4:00 AM (server local time, controlled by the `TZ` env var) every night.
+- **Behavior**:
+  - The update is skipped while any download job is in progress and is retried the next night.
+  - If the update process itself fails (e.g., permission denied on managed platforms, network error, timeout), the failure is logged and Youtarr continues to run on the previous yt-dlp version.
+  - On success, the in-process yt-dlp version cache is refreshed without requiring a server restart.
+
+### Last Checked Timestamp
+- **Config Key**: `ytdlpLastChecked`
+- **Type**: `string | null` (ISO 8601 timestamp)
+- **Default**: `null`
+- **Description**: Set automatically every time the nightly job runs (regardless of outcome). Surfaced in the UI as "Last checked: ...".
+- **Note**: Managed by the application; do not edit by hand.
+
+### Last Updated Timestamp
+- **Config Key**: `ytdlpLastUpdated`
+- **Type**: `string | null` (ISO 8601 timestamp)
+- **Default**: `null`
+- **Description**: Set automatically when the nightly job successfully installs a new yt-dlp version. Not updated when the check finds yt-dlp is already current.
+- **Note**: Managed by the application; do not edit by hand.
+
+### Last Run Result
+- **Config Key**: `ytdlpLastResult`
+- **Type**: `object | null`
+- **Default**: `null`
+- **Shape**: `{ status: 'updated' | 'up-to-date' | 'skipped' | 'error', message?: string, version?: string }`
+- **Description**: Records the outcome of the most recent nightly run. The UI uses this to render an inline status next to "Last checked".
+- **Statuses**:
+  - `updated` — a new version was installed; `version` holds the new version string.
+  - `up-to-date` — yt-dlp was already current.
+  - `skipped` — the run was deferred (for example, a download was in progress); `message` describes why.
+  - `error` — `yt-dlp -U` failed; `message` holds a short error description.
+- **Note**: Managed by the application; do not edit by hand.
 
 ## Account & Security
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -775,3 +775,9 @@ app.use((req, res, next) => {
 ### Frontend Profiling
 
 Use React DevTools Profiler to identify performance bottlenecks.
+
+## Platform-Specific Development
+
+When working on changes that interact with platform-managed deployments, see the dedicated developer guides:
+
+- [Elfhosted](development/ELFHOSTED.md) - environment variables, behavior switches, and how to spoof an Elfhosted deployment locally for testing.

--- a/docs/development/ELFHOSTED.md
+++ b/docs/development/ELFHOSTED.md
@@ -1,0 +1,239 @@
+# Elfhosted Developer Guide
+
+This guide is for developers working on Youtarr changes that interact with the Elfhosted platform deployment. It covers what makes a deployment "Elfhosted" from the code's perspective, the environment variables that toggle the related behavior, and how to spoof Elfhosted locally for testing.
+
+End-user, customer-facing Elfhosted documentation lives at https://docs.elfhosted.com/app/youtarr.
+
+## Table of Contents
+
+- [Why Elfhosted is Special](#why-elfhosted-is-special)
+- [The Four Environment Variables](#the-four-environment-variables)
+- [Behavior Matrix](#behavior-matrix)
+- [Spoofing Elfhosted Locally](#spoofing-elfhosted-locally)
+- [Code Touchpoints](#code-touchpoints)
+- [Testing Patterns](#testing-patterns)
+- [Common Pitfalls](#common-pitfalls)
+
+## Why Elfhosted is Special
+
+Elfhosted runs Youtarr as a managed app inside a Kubernetes-style platform. That means a few baseline assumptions normal self-hosters can rely on do not hold:
+
+- Authentication is handled by the platform (Cloudflare Access, Authelia, etc.), so Youtarr's built-in login flow gets in the way.
+- The video output directory is on slow rclone-backed remote storage, so downloads must be staged to fast local temp space first.
+- Persistent data needs to live under a single `/app/config/` mount instead of being scattered across `./config`, `./jobs`, and `./server/images`.
+- The yt-dlp binary is provisioned by the platform's image build, so Youtarr must not try to self-update it (the in-container update path lacks write permission and would silently fail).
+
+The codebase encodes these assumptions through four orthogonal environment variables. None of them are exclusive to Elfhosted, but Elfhosted is the canonical deployment that sets all four together.
+
+## The Four Environment Variables
+
+### `PLATFORM`
+
+The Elfhosted-specific switch. Detected by `configModule.isElfhostedPlatform()` in `server/modules/configModule.js:276` (case-insensitive `=== 'elfhosted'`). Also surfaced to the frontend as `deploymentEnvironment.platform` via `/getconfig` (`server/routes/config.js:73`).
+
+When `PLATFORM=elfhosted`:
+
+- **Backend, on every config save and reload:** `useTmpForDownloads` is forced to `true` and `tmpFilePath` is forced to `/app/config/temp_downloads` (`configModule.js:61, 322, 429`). These overrides are runtime-only; they are stripped from the persisted `config.json` so they do not survive a platform switch (`configModule.js:343`).
+- **Backend, on startup with `DATA_PATH` also set:** the temp downloads directory `/app/config/temp_downloads` is auto-created (`configModule.js:295`).
+- **Backend, nightly cron (4:00 AM):** the yt-dlp auto-update job no-ops, regardless of the `autoUpdateYtdlp` config toggle (`server/modules/cronJobs.js:116`).
+- **Backend, manual update route:** `POST /api/ytdlp/update` returns `403` with `{ success: false, message: 'yt-dlp is managed by the platform and cannot be updated from Youtarr.' }` (`server/routes/health.js:242`).
+- **Backend, `/getconfig` response:** the `isPlatformManaged` object exposes `useTmpForDownloads: true` and `ytdlpUpdates: true` so the frontend can disable the corresponding controls (`server/routes/config.js:68-69`).
+- **Frontend:** the Youtarr-version-update banner is suppressed (`client/src/App.tsx:89, 93`). When the `/tmp` directory warning fires, an Elfhosted setup-guide link is appended (`App.tsx:570-583`). In Settings, the "Use external temp directory" and "yt-dlp" sections show "Managed by Elfhosted" chips and platform-managed messages (`client/src/components/Configuration/sections/CoreSettingsSection.tsx:502, 571, 578`).
+
+### `AUTH_ENABLED`
+
+Independent of `PLATFORM`. When `AUTH_ENABLED=false`:
+
+- `/setup/status` returns `{ requiresSetup: false, isLocalhost: true, platformManaged: true, message: 'Authentication is managed by the platform' }` (`server/routes/setup.js:42-49`).
+- The frontend auto-logs in with the synthetic token `'platform-managed-auth'` and skips the login screen (`client/src/App.tsx:342-345`).
+- All API endpoints accept requests without a token. The bypass is implemented in two places: `verifyToken` short-circuits when `AUTH_ENABLED === 'false'` (`server/server.js:320`), and the local-login route does the same (`server/routes/auth.js:95`).
+- Login and logout buttons are hidden in the UI; `isPlatformManaged.authEnabled` is `false` in `/getconfig` (`server/routes/config.js:67`). The frontend logout button gates on the App-level `isPlatformManaged` boolean (`client/src/components/layout/NavHeaderActions.tsx:154`), and the Youtarr-version-update tooltip is suppressed by the same flag (`NavHeaderActions.tsx:42`).
+
+This is the standard way Elfhosted bypasses Youtarr's local-account flow. It can also be enabled in dev with the `--no-auth` flag to `start-dev.sh` (`scripts/_shared_start_tasks.sh:90-94`).
+
+### `DATA_PATH`
+
+Independent of `PLATFORM`. Detected by `configModule.isPlatformDeployment()` (`configModule.js:272`). When set:
+
+- The container reads/writes downloaded videos under `DATA_PATH` instead of the default `/usr/src/app/data` (`configModule.js:30, 533`).
+- Persistent data relocates from `./jobs` to `/app/config/jobs/`, and from `./server/images` to `/app/config/images/` (`configModule.js:304-316`).
+- `/getconfig` reports `isPlatformManaged.youtubeOutputDirectory: true` so the UI shows the path read-only (`server/routes/config.js:65`).
+- `youtubeOutputDirectory` in the UI resolves to `process.env.YOUTUBE_OUTPUT_DIR || process.env.DATA_PATH` (`server/routes/config.js:78`).
+
+`DATA_PATH` is documented in `docs/ENVIRONMENT_VARIABLES.md` and `docs/DOCKER.md`. Most self-hosters never need it.
+
+### `PLEX_URL`
+
+Independent of `PLATFORM`. When set:
+
+- The Plex IP, port, and HTTPS fields are disabled in the UI (`isPlatformManaged.plexUrl: true` from `server/routes/config.js:67`).
+- The value seeds `config.plexUrl` on first-run config creation (`configModule.js:228-231`).
+- `config.plexUrl` takes precedence over `plexIP`/`plexPort`/`plexViaHttps` everywhere it is consulted (see `docs/CONFIG.md`).
+
+Used by Elfhosted to point Youtarr at the bundled Plex instance.
+
+## Behavior Matrix
+
+| Variable | Sets `isElfhostedPlatform()` | Forces tmp downloads | Hides yt-dlp updates | Bypasses login | Relocates persistent data | Locks Plex URL |
+|---|---|---|---|---|---|---|
+| `PLATFORM=elfhosted` | yes | yes | yes | no | no | no |
+| `AUTH_ENABLED=false` | no | no | no | yes | no | no |
+| `DATA_PATH=<path>` | no | no | no | no | yes | no |
+| `PLEX_URL=<url>` | no | no | no | no | no | yes |
+
+A real Elfhosted deployment sets all four. Most local-test scenarios only need the one (or two) you are exercising.
+
+## Spoofing Elfhosted Locally
+
+The dev compose file (`docker-compose.dev.yml`) forwards all four Elfhosted-relevant env vars (`AUTH_ENABLED`, `PLATFORM`, `DATA_PATH`, `PLEX_URL`) using the `${VAR:-}` form, so they default to empty when unset on the host and have zero effect on normal dev runs. The `./scripts/start-dev.sh` script has an `--as-elfhosted` flag that handles the common cases for you.
+
+### Recipes
+
+**Minimum viable Elfhosted spoof — for most Elfhosted-related work:**
+
+```bash
+./scripts/start-dev.sh --as-elfhosted
+```
+
+This exports `PLATFORM=elfhosted` and `AUTH_ENABLED=false` for the run, prints a `yt-warn` summary of what is and is not spoofed, and otherwise behaves like `./scripts/start-dev.sh --no-auth`. It is enough to exercise:
+- yt-dlp update gating (cron skip and `POST /api/ytdlp/update` returning 403)
+- Auto-login with the synthetic `'platform-managed-auth'` token (no login screen)
+- The "Managed by Elfhosted" chips and platform-managed copy in Settings
+- Suppression of the Youtarr-version-update banner
+- The Elfhosted setup-guide link in the `/tmp` warning Snackbar
+- The `useTmpForDownloads` runtime override in `configModule.js` (downloads stage in `./config/temp_downloads/` on the host, auto-created on first download via `tempPathManager.cleanTempDirectory`)
+
+The flag does **not** set `DATA_PATH` or `PLEX_URL`, because those need real values, not constants. Without them:
+- Plex IP/port fields in Settings remain editable (no "Platform Managed" lock).
+- Persistent data stays in the normal dev locations (`./jobs/`, `./server/images/`) instead of relocating to `/app/config/jobs/` and `/app/config/images/`.
+- The `youtubeOutputDirectory` field shows the env-var-managed copy, not the platform-managed copy.
+
+That is fine for almost all dev work; downloads and the new yt-dlp gating both work end-to-end. Set the extra vars only when you specifically need to test code that consults `DATA_PATH` (storage-status path, persistent-data relocation, image/jobs directories) or `PLEX_URL` (Plex URL locking, `plexUrl` config seeding).
+
+**Full platform-deployment spoof — also relocates persistent data and locks the Plex URL:**
+
+Add to your `.env` for the duration of the test:
+
+```dotenv
+DATA_PATH=/usr/src/app/data
+PLEX_URL=http://your-plex:32400
+```
+
+Then run with the flag:
+
+```bash
+./scripts/start-dev.sh --as-elfhosted
+```
+
+The flag picks up `DATA_PATH` and `PLEX_URL` from `.env` automatically (because the dev compose forwards them) and the `yt-warn` output will reflect that they are now set. Note that with `DATA_PATH` set, persistent data moves under `/app/config/` inside the container, which is the bind-mounted `./config/` directory on the host; your existing `./jobs/` and `./server/images/` directories will not be read.
+
+### What `--as-elfhosted` cannot replicate
+
+Even with all four env vars set, the local spoof cannot stand in for everything Elfhosted handles:
+
+- **Cloudflare Access / Authelia / external auth** — Elfhosted relies on an upstream auth proxy. `AUTH_ENABLED=false` only tells Youtarr to trust the upstream; there is no upstream in dev.
+- **rclone-backed remote storage** — the production `DATA_PATH` points at network storage with its own latency profile. The dev mount is local disk.
+- **The platform's own yt-dlp build** — Elfhosted ships yt-dlp via its container image, not via Youtarr's update path. Locally you still have whatever `yt-dlp` is in the dev container.
+
+These limitations are by design. If you need to verify behavior under those conditions, do it on a real Elfhosted deployment.
+
+### What you should see
+
+After `./scripts/start-dev.sh --as-elfhosted`:
+
+- The startup log includes a `yt-warn` line "Spoofing Elfhosted deployment for this run." followed by what is and is not spoofed.
+- No login screen — the app auto-authenticates with the synthetic `'platform-managed-auth'` token (from the `AUTH_ENABLED=false` half of the spoof).
+- The logout button is hidden in the nav header (`NavHeaderActions.tsx:154`).
+- The Youtarr self-update banner does not appear, even when a newer Youtarr version is published to Docker Hub (suppressed via `isElfHosted` in `client/src/App.tsx:89, 93`).
+- Settings → Core Settings, in the **Use external temp directory** row: "Managed by Elfhosted" chip, the checkbox is disabled and forced on.
+- Settings → Core Settings, in the **yt-dlp** block: "Managed by Elfhosted" chip, no Update button, no auto-update toggle, replacement caption: "yt-dlp is managed by Elfhosted and cannot be updated from Youtarr. Updates are applied automatically by the platform."
+- `curl -i -X POST http://localhost:3087/api/ytdlp/update` returns `403` with the platform-managed message body.
+- Downloads still work; they stage in `./config/temp_downloads/` on the host (auto-created on first download).
+- If the `/tmp` warning fires (e.g., your `YOUTUBE_OUTPUT_DIR` resolves to a `/tmp` path), the warning Snackbar gets an extra "Elfhosted setup guide" link (`App.tsx:570-583`).
+
+Additional behavior only when you also set `DATA_PATH` in `.env`:
+
+- Settings → Core Settings, the `youtubeOutputDirectory` field's helper text changes to "This path is configured by your platform deployment and cannot be changed here." (`CoreSettingsSection.tsx:458`).
+- Persistent data is read from `/app/config/jobs/` and `/app/config/images/` (bind-mounted to `./config/jobs/` and `./config/images/` on the host) instead of `./jobs/` and `./server/images/`.
+
+Additional behavior only when you also set `PLEX_URL` in `.env`:
+
+- Settings → Plex Integration: the IP/port/HTTPS fields are disabled with helper text indicating the URL is platform-managed.
+
+### Reverting
+
+Just stop using the flag — `./scripts/start-dev.sh` (without `--as-elfhosted`) returns to normal behavior. The compose-file passthroughs are zero-impact when `PLATFORM`, `DATA_PATH`, and `PLEX_URL` are unset on the host (each forwards as an empty string, which all consumer code paths treat the same as undefined). If you set `DATA_PATH` or `PLEX_URL` in `.env` for a test, remove or comment those lines.
+
+## Code Touchpoints
+
+When you make a change that depends on Elfhosted detection, audit these locations:
+
+**Backend**
+
+- `server/modules/configModule.js`
+  - `isElfhostedPlatform()` (line 276) — the canonical check
+  - `isPlatformDeployment()` (line 272) — `DATA_PATH`-based, often paired with the above
+  - `getImagePath()`, `getJobsPath()`, `getStorageStatus()` — relocate paths when `DATA_PATH` is set
+  - The constructor and `updateConfig()` / `saveConfig()` / `watchConfig()` re-apply the temp-downloads override
+- `server/modules/cronJobs.js:116` — nightly yt-dlp auto-update skip
+- `server/routes/health.js:242` — `POST /api/ytdlp/update` returns 403
+- `server/routes/config.js:64-78` — `/getconfig` exposes `isPlatformManaged.{useTmpForDownloads, ytdlpUpdates, youtubeOutputDirectory, plexUrl, authEnabled}` and `deploymentEnvironment.platform`
+- `server/routes/setup.js:41-49` — `AUTH_ENABLED=false` short-circuits setup status (returns `platformManaged: true`)
+- `server/routes/auth.js:95` — local-login route is a no-op when `AUTH_ENABLED=false`
+- `server/server.js:320` — the `verifyToken` middleware bypasses auth when `AUTH_ENABLED=false`
+
+**Frontend**
+
+- `client/src/App.tsx`
+  - `isPlatformManaged` boolean state (line 74), set from the `/setup/status` response and threaded into the layout (lines 492, 509)
+  - `isElfHosted` (line 89) and version-banner suppression (line 93)
+  - `/setup/status` `platformManaged` handling and synthetic-token auto-login (lines 342-345)
+  - `/tmp` warning Elfhosted link (lines 570-583)
+- `client/src/hooks/useConfig.ts:28-66` — `isPlatformManaged` (the per-flag object) and `deploymentEnvironment` are split out of the `/getconfig` response and exposed via context to the rest of the app. Note: this is a different object from the App-level `isPlatformManaged` boolean above; both exist for historical reasons.
+- `client/src/components/layout/NavHeaderActions.tsx`
+  - Hides the logout button when the App-level `isPlatformManaged` boolean is true (line 154)
+  - Suppresses the Youtarr-version-update tooltip via the same flag (line 42)
+- `client/src/components/layout/NavHeader.tsx:28, 245` and `client/src/components/layout/AppShell.tsx:20, 202` — thread `isPlatformManaged` from `App.tsx` down to `NavHeaderActions.tsx`
+- `client/src/components/Settings/Settings.tsx`
+  - Uses `isPlatformManaged.plexUrl` to determine whether a Plex server is "configured" (line 65)
+  - Passes `isPlatformManaged` and `isPlatformManaged.authEnabled` into Plex and Account-Security sections (lines 247, 263, 341)
+- `client/src/components/Configuration/sections/CoreSettingsSection.tsx`
+  - YouTube Output Directory helper text branches on `deploymentEnvironment.platform === 'elfhosted'` (line 458)
+  - "Use external temp directory" chip and disabled state (lines 494-516)
+  - yt-dlp section: version display, Update button, auto-update toggle, platform-managed message and chip (lines 540-602)
+- `client/src/components/Configuration/sections/PlexIntegrationSection.tsx:149-167` — Plex URL field locking when `PLEX_URL` is set
+- `client/src/components/Configuration/types.ts:70-74` — `PlatformManagedState` type; add a new flag here when you add a new platform-managed control
+
+**Tests**
+
+- `server/modules/__tests__/configModule.test.js:407-560` — covers `isElfhostedPlatform()`, `isPlatformDeployment()`, and the temp-download override behavior. Uses `process.env.PLATFORM = 'elfhosted'` directly.
+- `server/modules/__tests__/cronJobs.test.js` — see the `'yt-dlp auto-update cron job (4:00 AM)'` describe block; `mockConfigModule.isElfhostedPlatform.mockReturnValue(true)` is the gating pattern.
+- `server/__tests__/server.routes.test.js` — `'server routes - configuration'` and `'server routes - yt-dlp update'` describe blocks; `configModuleMock.isElfhostedPlatform.mockReturnValue(true)` toggles platform mode per-test.
+- `client/src/App.test.tsx:435-540` — frontend Elfhosted-detection tests; injects `deploymentEnvironment: { platform: 'elfhosted' }` into the mocked `useConfig`.
+- `client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx` — `'yt-dlp Section on Platform-Managed Deployments'` describe block uses `createPlatformManagedState({ ytdlpUpdates: true })` and `createDeploymentEnvironment({ platform: 'elfhosted' })`.
+
+## Testing Patterns
+
+When you add a new behavior gated on Elfhosted, write tests at three layers:
+
+1. **Module-level**: prove the module's branch responds to `isElfhostedPlatform()` returning true. Mock `configModule` with a jest factory and toggle `isElfhostedPlatform` between tests.
+2. **Route-level**: prove `/getconfig` exposes any new `isPlatformManaged.*` flag, and any new gated route returns the right status. The `createServerModule` helper in `server/__tests__/server.routes.test.js` already mocks `configModule`; just call `configModuleMock.isElfhostedPlatform.mockReturnValue(true)` in the test.
+3. **UI**: prove the new control hides or disables when `isPlatformManaged.<your-flag>` is true. Use `createPlatformManagedState({ <yourFlag>: true })` and `createDeploymentEnvironment({ platform: 'elfhosted' })` in the section's test file.
+
+Always test the `false` case too — most regressions are "the control is now permanently disabled."
+
+## Common Pitfalls
+
+- **Forgetting to add the new flag to `PlatformManagedState`**. TypeScript will catch this at compile time, but you also have to update every test helper that constructs the type. `npm run lint:ts` will tell you which files.
+- **Persisting platform overrides to disk.** `useTmpForDownloads` and `tmpFilePath` are stripped from the saved `config.json` on Elfhosted (`configModule.js:343`). If you add a similar runtime-only override, follow the same pattern or it will leak into non-Elfhosted runs after a config save.
+- **Assuming `PLATFORM=elfhosted` implies `AUTH_ENABLED=false` (or vice versa).** They are independent. Test each toggle on its own.
+- **Hardcoding the `'elfhosted'` string in new code.** Prefer `configModule.isElfhostedPlatform()` on the backend and `isPlatformManaged.<flag>` on the frontend. The string-comparison is reserved for places that customize chip labels and copy ("Managed by Elfhosted" vs. "Platform Managed").
+- **Forgetting that `--no-auth` is a dev convenience for `AUTH_ENABLED=false`.** When debugging an Elfhosted-only login issue locally, use `--no-auth`; do not edit `.env` to flip `AUTH_ENABLED` permanently.
+- **Triggering the cron on a real Elfhosted environment.** The 4:00 AM yt-dlp auto-update job is the most recent gating addition. If you add another scheduled job that touches platform-owned binaries, gate it behind `isElfhostedPlatform()` the same way (`cronJobs.js:116`).
+
+## See Also
+
+- `docs/CONFIG.md` — config field reference (some fields are noted as platform-managed)
+- `docs/DOCKER.md` § Platform Deployment Configuration — operator-facing summary
+- `docs/ENVIRONMENT_VARIABLES.md` — full env var reference
+- `docs/AUTHENTICATION.md` — `AUTH_ENABLED=false` behavior

--- a/scripts/_shared_start_tasks.sh
+++ b/scripts/_shared_start_tasks.sh
@@ -20,6 +20,10 @@ Usage: $START_SCRIPT_NAME [--no-auth] [--debug] [--headless-auth] [--pull-latest
                      Warning: Dev builds contain unreleased features and may be unstable
   --arm              Force ARM compose file selection (useful for Apple Silicon / Raspberry Pi)
   --external-db      Use external database compose file (docker-compose.external-db.yml)
+  --as-elfhosted     (Dev only) Spoof an Elfhosted deployment by exporting PLATFORM=elfhosted
+                     and AUTH_ENABLED=false for this run. Implies --no-auth. Does not set
+                     DATA_PATH or PLEX_URL; add those to .env if you need to test code paths
+                     that depend on them. See docs/development/ELFHOSTED.md.
 EOF
 }
 
@@ -34,6 +38,21 @@ get_compose_command() {
         echo "Please install Docker Compose." >&2
         exit 1
     fi
+}
+
+get_env_or_dotenv_value() {
+  local key="$1"
+  local value="${!key:-}"
+
+  if [ -n "$value" ]; then
+    printf '%s' "$value"
+    return
+  fi
+
+  if [ -f ./.env ]; then
+    value=$(grep -E "^[[:space:]]*${key}[[:space:]]*=" ./.env | tail -n 1 | sed -E "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*//" | sed -E 's/[[:space:]]+#.*$//' | sed -E 's/^"(.*)"$/\1/' | sed -E "s/^'(.*)'$/\1/")
+    printf '%s' "$value"
+  fi
 }
 
 # Get the appropriate compose command
@@ -74,6 +93,10 @@ while [[ $# -gt 0 ]]; do
       USE_EXTERNAL_DB=true
       shift
       ;;
+    --as-elfhosted)
+      AS_ELFHOSTED=true
+      shift
+      ;;
     --help)
       print_usage
       exit 0
@@ -87,6 +110,31 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Command line flag overrides .env settings
+if [ "$AS_ELFHOSTED" = true ]; then
+  if [ "$DEV_MODE" != "true" ]; then
+    yt_error "--as-elfhosted is only supported by ./scripts/start-dev.sh."
+    exit 1
+  fi
+  export PLATFORM=elfhosted
+  export AUTH_ENABLED=false
+  yt_warn "Spoofing Elfhosted deployment for this run."
+  yt_detail "Exported: PLATFORM=elfhosted, AUTH_ENABLED=false (these overrides do not persist)."
+  yt_detail "Covers: yt-dlp update gating, auth bypass, Elfhosted UI chips, version-banner suppression."
+  DATA_PATH_FOR_SPOOF=$(get_env_or_dotenv_value "DATA_PATH")
+  PLEX_URL_FOR_SPOOF=$(get_env_or_dotenv_value "PLEX_URL")
+  if [ -z "$DATA_PATH_FOR_SPOOF" ] && [ -z "$PLEX_URL_FOR_SPOOF" ]; then
+    yt_detail "Not spoofed: DATA_PATH and PLEX_URL are unset, so persistent-data relocation"
+    yt_detail "  and Plex-URL locking will not be exercised. Set them in .env to test those paths."
+  elif [ -z "$DATA_PATH_FOR_SPOOF" ]; then
+    yt_detail "Not spoofed: DATA_PATH is unset (persistent-data relocation will not be exercised)."
+  elif [ -z "$PLEX_URL_FOR_SPOOF" ]; then
+    yt_detail "Not spoofed: PLEX_URL is unset (Plex-URL locking will not be exercised)."
+  else
+    yt_detail "Detected DATA_PATH and PLEX_URL from the shell or .env for full platform spoofing."
+  fi
+  yt_detail "A local spoof cannot replicate Cloudflare Access or rclone-backed storage."
+fi
+
 if [ "$NO_AUTH" = true ]; then
   export AUTH_ENABLED=false
   yt_warn "Authentication disabled via --no-auth flag."

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -363,6 +363,11 @@ const createServerModule = ({
         jest.doMock('../modules/notificationModule', () => ({
           sendTestNotification: jest.fn().mockResolvedValue({ success: true })
         }));
+        jest.doMock('../modules/ytdlpModule', () => ({
+          getLatestVersion: jest.fn().mockResolvedValue('2026.04.20'),
+          isUpdateAvailable: jest.fn(() => false),
+          performUpdate: jest.fn().mockResolvedValue({ success: true, reason: 'up-to-date', message: 'yt-dlp is already up to date' })
+        }));
         jest.doMock('../models/channelvideo', () => ({
           update: jest.fn().mockResolvedValue([1])
         }));
@@ -618,6 +623,36 @@ describe('server routes - configuration', () => {
       expect(res.body.isPlatformManaged).toBeDefined();
       expect(res.body.isPlatformManaged.useTmpForDownloads).toBe(true);
     });
+
+    test('includes ytdlpUpdates in isPlatformManaged when not elfhosted', async () => {
+      const { app, configModuleMock } = await createServerModule();
+      configModuleMock.isElfhostedPlatform.mockReturnValue(false);
+
+      const handlers = findRouteHandlers(app, 'get', '/getconfig');
+      const getConfigHandler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({ username: 'tester' });
+      const res = createMockResponse();
+
+      await getConfigHandler(req, res);
+
+      expect(res.body.isPlatformManaged.ytdlpUpdates).toBe(false);
+    });
+
+    test('includes ytdlpUpdates in isPlatformManaged when elfhosted', async () => {
+      const { app, configModuleMock } = await createServerModule();
+      configModuleMock.isElfhostedPlatform.mockReturnValue(true);
+
+      const handlers = findRouteHandlers(app, 'get', '/getconfig');
+      const getConfigHandler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({ username: 'tester' });
+      const res = createMockResponse();
+
+      await getConfigHandler(req, res);
+
+      expect(res.body.isPlatformManaged.ytdlpUpdates).toBe(true);
+    });
   });
 
   describe('POST /updateconfig', () => {
@@ -687,6 +722,38 @@ describe('server routes - configuration', () => {
       // The route preserves existing passwordHash and username
       expect(updateCall.passwordHash).toBe('hashed-password');
       expect(updateCall.username).toBe('tester');
+    });
+
+    test('preserves server-managed yt-dlp auto-update status fields', async () => {
+      const { app, configModuleMock } = await createServerModule({
+        configOverrides: {
+          ytdlpLastChecked: '2026-04-26T04:00:00.000Z',
+          ytdlpLastUpdated: '2026-04-26T04:00:00.000Z',
+          ytdlpLastResult: { status: 'updated', version: '2026.04.26' }
+        }
+      });
+
+      const handlers = findRouteHandlers(app, 'post', '/updateconfig');
+      const updateConfigHandler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({
+        body: {
+          plexApiKey: 'new-key',
+          ytdlpLastChecked: '2026-04-25T04:00:00.000Z',
+          ytdlpLastUpdated: null,
+          ytdlpLastResult: { status: 'error', message: 'stale client state' }
+        }
+      });
+      const res = createMockResponse();
+
+      await updateConfigHandler(req, res);
+
+      expect(configModuleMock.updateConfig).toHaveBeenCalled();
+      const updateCall = configModuleMock.updateConfig.mock.calls[0][0];
+      expect(updateCall.plexApiKey).toBe('new-key');
+      expect(updateCall.ytdlpLastChecked).toBe('2026-04-26T04:00:00.000Z');
+      expect(updateCall.ytdlpLastUpdated).toBe('2026-04-26T04:00:00.000Z');
+      expect(updateCall.ytdlpLastResult).toEqual({ status: 'updated', version: '2026.04.26' });
     });
   });
 });
@@ -1930,5 +1997,40 @@ describe('server routes - version', () => {
     expect(res.body.version).not.toMatch(/^dev/);
     // Should not return 'latest' tag
     expect(res.body.version).not.toBe('latest');
+  });
+});
+
+describe('server routes - yt-dlp update', () => {
+  test('POST /api/ytdlp/update returns 403 when on Elfhosted', async () => {
+    const { app, configModuleMock } = await createServerModule();
+    configModuleMock.isElfhostedPlatform.mockReturnValue(true);
+
+    const handlers = findRouteHandlers(app, 'post', '/api/ytdlp/update');
+    const updateHandler = handlers[handlers.length - 1];
+
+    const req = createMockRequest({ username: 'tester' });
+    const res = createMockResponse();
+
+    await updateHandler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/managed by the platform/i);
+  });
+
+  test('POST /api/ytdlp/update proceeds when not on Elfhosted', async () => {
+    const { app, configModuleMock } = await createServerModule();
+    configModuleMock.isElfhostedPlatform.mockReturnValue(false);
+
+    const handlers = findRouteHandlers(app, 'post', '/api/ytdlp/update');
+    const updateHandler = handlers[handlers.length - 1];
+
+    const req = createMockRequest({ username: 'tester' });
+    const res = createMockResponse();
+
+    await updateHandler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
   });
 });

--- a/server/modules/__tests__/cronJobs.test.js
+++ b/server/modules/__tests__/cronJobs.test.js
@@ -7,6 +7,9 @@ describe('CronJobs', () => {
   let mockVideosModule;
   let mockVideoDeletionModule;
   let mockLogger;
+  let mockYtdlpModule;
+  let mockConfigModule;
+  let mockConfigStore;
 
   beforeEach(() => {
     jest.resetModules();
@@ -63,6 +66,21 @@ describe('CronJobs', () => {
       sendAutoRemovalNotification: jest.fn().mockResolvedValue(undefined)
     }));
 
+    // Mock ytdlpModule
+    mockYtdlpModule = {
+      performUpdate: jest.fn()
+    };
+    jest.doMock('../ytdlpModule', () => mockYtdlpModule);
+
+    // Mock configModule with a tiny in-memory store so the auto-update job can read/write
+    mockConfigStore = { autoUpdateYtdlp: false };
+    mockConfigModule = {
+      getConfig: jest.fn(() => mockConfigStore),
+      updateConfig: jest.fn((next) => { mockConfigStore = next; }),
+      isElfhostedPlatform: jest.fn(() => false)
+    };
+    jest.doMock('../configModule', () => mockConfigModule);
+
     // Require the module after mocks are in place
     cronJobs = require('../cronJobs');
   });
@@ -76,13 +94,14 @@ describe('CronJobs', () => {
   });
 
   describe('initialize', () => {
-    test('should register all three cron jobs', () => {
+    test('should register all four cron jobs', () => {
       cronJobs.initialize();
 
-      expect(mockSchedule.schedule).toHaveBeenCalledTimes(3);
+      expect(mockSchedule.schedule).toHaveBeenCalledTimes(4);
       expect(mockSchedule.schedule).toHaveBeenCalledWith('0 2 * * *', expect.any(Function));
       expect(mockSchedule.schedule).toHaveBeenCalledWith('0 3 * * *', expect.any(Function));
       expect(mockSchedule.schedule).toHaveBeenCalledWith('30 3 * * *', expect.any(Function));
+      expect(mockSchedule.schedule).toHaveBeenCalledWith('0 4 * * *', expect.any(Function));
     });
 
     test('should log initialization messages', () => {
@@ -93,6 +112,7 @@ describe('CronJobs', () => {
       expect(mockLogger.info).toHaveBeenCalledWith('  - Automatic video cleanup: 2:00 AM daily');
       expect(mockLogger.info).toHaveBeenCalledWith('  - Session cleanup: 3:00 AM daily');
       expect(mockLogger.info).toHaveBeenCalledWith('  - Video metadata backfill: 3:30 AM daily');
+      expect(mockLogger.info).toHaveBeenCalledWith('  - yt-dlp auto-update: 4:00 AM daily (when enabled)');
     });
   });
 
@@ -346,6 +366,145 @@ describe('CronJobs', () => {
     });
   });
 
+  describe('yt-dlp auto-update cron job (4:00 AM)', () => {
+    let autoUpdateCallback;
+    let mockRefreshCache;
+
+    beforeEach(() => {
+      mockRefreshCache = jest.fn();
+      cronJobs.initialize({ refreshYtDlpVersionCache: mockRefreshCache });
+      autoUpdateCallback = mockSchedule.schedule.mock.calls[3][1];
+    });
+
+    test('does nothing when autoUpdateYtdlp is false', async () => {
+      mockConfigStore = { autoUpdateYtdlp: false };
+
+      await autoUpdateCallback();
+
+      expect(mockYtdlpModule.performUpdate).not.toHaveBeenCalled();
+      expect(mockConfigModule.updateConfig).not.toHaveBeenCalled();
+      expect(mockRefreshCache).not.toHaveBeenCalled();
+    });
+
+    test('does nothing on Elfhosted even when toggle is on', async () => {
+      mockConfigStore = { autoUpdateYtdlp: true };
+      mockConfigModule.isElfhostedPlatform.mockReturnValue(true);
+
+      await autoUpdateCallback();
+
+      expect(mockYtdlpModule.performUpdate).not.toHaveBeenCalled();
+      expect(mockConfigModule.updateConfig).not.toHaveBeenCalled();
+      expect(mockRefreshCache).not.toHaveBeenCalled();
+    });
+
+    test('records updated result and refreshes version cache on success with new version', async () => {
+      mockConfigStore = { autoUpdateYtdlp: true, otherField: 'preserved' };
+      mockYtdlpModule.performUpdate.mockResolvedValue({
+        success: true,
+        reason: 'updated',
+        message: 'Successfully updated to 2026.04.20',
+        newVersion: '2026.04.20'
+      });
+
+      await autoUpdateCallback();
+
+      expect(mockYtdlpModule.performUpdate).toHaveBeenCalled();
+      expect(mockConfigModule.updateConfig).toHaveBeenCalledTimes(1);
+
+      const writtenConfig = mockConfigModule.updateConfig.mock.calls[0][0];
+      expect(writtenConfig.otherField).toBe('preserved');
+      expect(writtenConfig.ytdlpLastChecked).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(writtenConfig.ytdlpLastUpdated).toBe(writtenConfig.ytdlpLastChecked);
+      expect(writtenConfig.ytdlpLastResult).toEqual({ status: 'updated', version: '2026.04.20' });
+
+      expect(mockRefreshCache).toHaveBeenCalledTimes(1);
+    });
+
+    test('records up-to-date result without setting lastUpdated when no new version', async () => {
+      mockConfigStore = { autoUpdateYtdlp: true };
+      mockYtdlpModule.performUpdate.mockResolvedValue({
+        success: true,
+        reason: 'up-to-date',
+        message: 'yt-dlp is already up to date'
+      });
+
+      await autoUpdateCallback();
+
+      const writtenConfig = mockConfigModule.updateConfig.mock.calls[0][0];
+      expect(writtenConfig.ytdlpLastChecked).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(writtenConfig.ytdlpLastUpdated).toBeUndefined();
+      expect(writtenConfig.ytdlpLastResult).toEqual({ status: 'up-to-date' });
+
+      expect(mockRefreshCache).toHaveBeenCalledTimes(1);
+    });
+
+    test('records skipped result when downloads are in progress', async () => {
+      mockConfigStore = { autoUpdateYtdlp: true };
+      mockYtdlpModule.performUpdate.mockResolvedValue({
+        success: false,
+        reason: 'skipped',
+        message: 'Update deferred by yt-dlp module.'
+      });
+
+      await autoUpdateCallback();
+
+      const writtenConfig = mockConfigModule.updateConfig.mock.calls[0][0];
+      expect(writtenConfig.ytdlpLastResult.status).toBe('skipped');
+      expect(writtenConfig.ytdlpLastResult.message).toBe('Update deferred by yt-dlp module.');
+      expect(mockRefreshCache).not.toHaveBeenCalled();
+    });
+
+    test('records error result on a real update failure', async () => {
+      mockConfigStore = { autoUpdateYtdlp: true };
+      mockYtdlpModule.performUpdate.mockResolvedValue({
+        success: false,
+        reason: 'error',
+        message: 'Update failed: Permission denied. On managed platforms, yt-dlp may be updated by the platform operator.'
+      });
+
+      await autoUpdateCallback();
+
+      const writtenConfig = mockConfigModule.updateConfig.mock.calls[0][0];
+      expect(writtenConfig.ytdlpLastResult.status).toBe('error');
+      expect(writtenConfig.ytdlpLastResult.message).toMatch(/Permission denied/);
+      expect(mockRefreshCache).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        { message: expect.any(String) },
+        'Nightly yt-dlp auto-update failed'
+      );
+    });
+
+    test('swallows unexpected errors so the cron keeps running', async () => {
+      mockConfigStore = { autoUpdateYtdlp: true };
+      mockYtdlpModule.performUpdate.mockRejectedValue(new Error('boom'));
+
+      await expect(autoUpdateCallback()).resolves.toBeUndefined();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Unexpected error in nightly yt-dlp auto-update'
+      );
+    });
+
+    test('tolerates a missing refreshYtDlpVersionCache dependency', async () => {
+      // Re-initialize without passing the dep to register a fresh callback
+      cronJobs.initialize();
+      const initialCallCount = mockSchedule.schedule.mock.calls.length;
+      const callbackNoDeps = mockSchedule.schedule.mock.calls[initialCallCount - 1][1];
+
+      mockConfigStore = { autoUpdateYtdlp: true };
+      mockYtdlpModule.performUpdate.mockResolvedValue({
+        success: true,
+        reason: 'updated',
+        message: 'Successfully updated to 2026.04.21',
+        newVersion: '2026.04.21'
+      });
+
+      await expect(callbackNoDeps()).resolves.toBeUndefined();
+      expect(mockConfigModule.updateConfig).toHaveBeenCalled();
+    });
+  });
+
   describe('cron schedule validation', () => {
     test('should use correct cron schedule for video cleanup (2:00 AM daily)', () => {
       cronJobs.initialize();
@@ -372,6 +531,16 @@ describe('CronJobs', () => {
 
       const scheduleCall = mockSchedule.schedule.mock.calls.find(
         call => call[0] === '30 3 * * *'
+      );
+
+      expect(scheduleCall).toBeDefined();
+    });
+
+    test('should use correct cron schedule for yt-dlp auto-update (4:00 AM daily)', () => {
+      cronJobs.initialize();
+
+      const scheduleCall = mockSchedule.schedule.mock.calls.find(
+        call => call[0] === '0 4 * * *'
       );
 
       expect(scheduleCall).toBeDefined();

--- a/server/modules/__tests__/ytdlpModule.test.js
+++ b/server/modules/__tests__/ytdlpModule.test.js
@@ -275,6 +275,7 @@ describe('ytdlpModule', () => {
 
       const result = await updatePromise;
       expect(result.success).toBe(true);
+      expect(result.reason).toBe('updated');
       expect(result.message).toBe('Successfully updated to 2024.01.20');
       expect(result.newVersion).toBe('2024.01.20');
     });
@@ -290,6 +291,7 @@ describe('ytdlpModule', () => {
 
       const result = await updatePromise;
       expect(result.success).toBe(true);
+      expect(result.reason).toBe('up-to-date');
       expect(result.message).toBe('yt-dlp is already up to date');
     });
 
@@ -304,6 +306,7 @@ describe('ytdlpModule', () => {
 
       const result = await updatePromise;
       expect(result.success).toBe(false);
+      expect(result.reason).toBe('error');
       expect(result.message).toContain('Permission denied');
     });
 
@@ -318,6 +321,7 @@ describe('ytdlpModule', () => {
 
       const result = await updatePromise;
       expect(result.success).toBe(false);
+      expect(result.reason).toBe('error');
       expect(result.message).toContain('Permission denied');
     });
 
@@ -332,6 +336,7 @@ describe('ytdlpModule', () => {
 
       const result = await updatePromise;
       expect(result.success).toBe(false);
+      expect(result.reason).toBe('error');
       expect(result.message).toContain('exit code 1');
     });
 
@@ -345,6 +350,7 @@ describe('ytdlpModule', () => {
 
       const result = await updatePromise;
       expect(result.success).toBe(false);
+      expect(result.reason).toBe('error');
       expect(result.message).toBe('Failed to start update process');
     });
 
@@ -361,6 +367,7 @@ describe('ytdlpModule', () => {
 
       const result = await updatePromise;
       expect(result.success).toBe(false);
+      expect(result.reason).toBe('error');
       expect(result.message).toBe('Update timed out. Please try again later.');
       expect(mockProcess.kill).toHaveBeenCalled();
 
@@ -378,6 +385,7 @@ describe('ytdlpModule', () => {
       const result2 = await ytdlpModule.performUpdate();
 
       expect(result2.success).toBe(false);
+      expect(result2.reason).toBe('skipped');
       expect(result2.message).toBe('An update is already in progress');
 
       // Complete the first update
@@ -394,6 +402,7 @@ describe('ytdlpModule', () => {
       const result = await ytdlpModule.performUpdate();
 
       expect(result.success).toBe(false);
+      expect(result.reason).toBe('skipped');
       expect(result.message).toBe('Cannot update while downloads are in progress. Please wait for downloads to complete.');
       expect(spawn).not.toHaveBeenCalled();
     });

--- a/server/modules/cronJobs.js
+++ b/server/modules/cronJobs.js
@@ -4,12 +4,18 @@ const logger = require('../logger');
 /**
  * Initialize all scheduled cron jobs for the application
  * This module centralizes all cron job definitions for better maintainability
+ *
+ * @param {Object} [deps]
+ * @param {Function} [deps.refreshYtDlpVersionCache] - Refreshes the cached yt-dlp version after a successful auto-update
  */
-function initialize() {
+function initialize(deps = {}) {
   const db = require('../db');
   const videosModule = require('./videosModule');
   const videoDeletionModule = require('./videoDeletionModule');
   const notificationModule = require('./notificationModule');
+  const ytdlpModule = require('./ytdlpModule');
+  const configModule = require('./configModule');
+  const { refreshYtDlpVersionCache } = deps;
 
   logger.info('Initializing scheduled cron jobs');
 
@@ -101,10 +107,71 @@ function initialize() {
     }
   });
 
+  // ============================================================================
+  // YT-DLP AUTO-UPDATE - 4:00 AM Daily (only when enabled in config)
+  // ============================================================================
+  schedule.schedule('0 4 * * *', async () => {
+    try {
+      // Skip on platforms that manage yt-dlp themselves (e.g., Elfhosted)
+      if (configModule.isElfhostedPlatform()) {
+        return;
+      }
+
+      const config = configModule.getConfig();
+      if (!config.autoUpdateYtdlp) {
+        return;
+      }
+
+      logger.info('Running nightly yt-dlp auto-update');
+      const checkedAt = new Date().toISOString();
+      const result = await ytdlpModule.performUpdate();
+
+      const updatedConfig = { ...configModule.getConfig(), ytdlpLastChecked: checkedAt };
+
+      const resultStatus = result.reason || (result.success ? (result.newVersion ? 'updated' : 'up-to-date') : 'error');
+
+      if (result.success) {
+        if (resultStatus === 'updated') {
+          updatedConfig.ytdlpLastUpdated = checkedAt;
+          updatedConfig.ytdlpLastResult = {
+            status: 'updated',
+            ...(result.newVersion ? { version: result.newVersion } : {})
+          };
+          logger.info({ newVersion: result.newVersion }, 'Nightly yt-dlp auto-update installed new version');
+        } else {
+          updatedConfig.ytdlpLastResult = { status: 'up-to-date' };
+          logger.info('Nightly yt-dlp auto-update: already up to date');
+        }
+        if (typeof refreshYtDlpVersionCache === 'function') {
+          try {
+            refreshYtDlpVersionCache();
+          } catch (err) {
+            logger.warn({ err }, 'Failed to refresh yt-dlp version cache after auto-update');
+          }
+        }
+      } else {
+        updatedConfig.ytdlpLastResult = {
+          status: resultStatus === 'skipped' ? 'skipped' : 'error',
+          message: result.message || 'Unknown error'
+        };
+        if (resultStatus === 'skipped') {
+          logger.info({ message: result.message }, 'Nightly yt-dlp auto-update skipped');
+        } else {
+          logger.warn({ message: result.message }, 'Nightly yt-dlp auto-update failed');
+        }
+      }
+
+      configModule.updateConfig(updatedConfig);
+    } catch (error) {
+      logger.error({ err: error }, 'Unexpected error in nightly yt-dlp auto-update');
+    }
+  });
+
   logger.info('Scheduled cron jobs initialized successfully');
   logger.info('  - Automatic video cleanup: 2:00 AM daily');
   logger.info('  - Session cleanup: 3:00 AM daily');
   logger.info('  - Video metadata backfill: 3:30 AM daily');
+  logger.info('  - yt-dlp auto-update: 4:00 AM daily (when enabled)');
 }
 
 module.exports = {

--- a/server/modules/ytdlpModule.js
+++ b/server/modules/ytdlpModule.js
@@ -146,13 +146,14 @@ function isDownloadInProgress() {
 
 /**
  * Performs yt-dlp self-update
- * @returns {Promise<{success: boolean, message: string, newVersion?: string}>}
+ * @returns {Promise<{success: boolean, reason: 'updated'|'up-to-date'|'skipped'|'error', message: string, newVersion?: string}>}
  */
 function performUpdate() {
   // Prevent concurrent updates
   if (updateInProgress) {
     return Promise.resolve({
       success: false,
+      reason: 'skipped',
       message: 'An update is already in progress',
     });
   }
@@ -161,6 +162,7 @@ function performUpdate() {
   if (isDownloadInProgress()) {
     return Promise.resolve({
       success: false,
+      reason: 'skipped',
       message: 'Cannot update while downloads are in progress. Please wait for downloads to complete.',
     });
   }
@@ -200,6 +202,7 @@ function performUpdate() {
           logger.warn({ output }, 'yt-dlp update failed: permission denied');
           resolve({
             success: false,
+            reason: 'error',
             message:
               'Update failed: Permission denied. On managed platforms, yt-dlp may be updated by the platform operator.',
           });
@@ -209,6 +212,7 @@ function performUpdate() {
         logger.error({ code, output }, 'yt-dlp update failed');
         resolve({
           success: false,
+          reason: 'error',
           message: `Update failed with exit code ${code}`,
         });
         return;
@@ -218,6 +222,7 @@ function performUpdate() {
         logger.info('yt-dlp is already up to date');
         resolve({
           success: true,
+          reason: 'up-to-date',
           message: 'yt-dlp is already up to date',
         });
         return;
@@ -232,6 +237,7 @@ function performUpdate() {
       logger.info({ newVersion, output }, 'yt-dlp updated successfully');
       resolve({
         success: true,
+        reason: 'updated',
         message: newVersion ? `Successfully updated to ${newVersion}` : 'Update completed successfully',
         newVersion,
       });
@@ -243,6 +249,7 @@ function performUpdate() {
       logger.error({ err }, 'Failed to spawn yt-dlp update process');
       resolve({
         success: false,
+        reason: 'error',
         message: 'Failed to start update process',
       });
     });
@@ -254,6 +261,7 @@ function performUpdate() {
       logger.warn('yt-dlp update timed out');
       resolve({
         success: false,
+        reason: 'error',
         message: 'Update timed out. Please try again later.',
       });
     }, timeout);

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -65,7 +65,8 @@ module.exports = function createConfigRoutes({ verifyToken, configModule, valida
       youtubeOutputDirectory: !!process.env.DATA_PATH,
       plexUrl: !!process.env.PLEX_URL,
       authEnabled: process.env.AUTH_ENABLED === 'false' ? false : true,
-      useTmpForDownloads: configModule.isElfhostedPlatform()
+      useTmpForDownloads: configModule.isElfhostedPlatform(),
+      ytdlpUpdates: configModule.isElfhostedPlatform()
     };
 
     safeConfig.deploymentEnvironment = {
@@ -129,6 +130,9 @@ module.exports = function createConfigRoutes({ verifyToken, configModule, valida
 
     updateData.passwordHash = currentConfig.passwordHash;
     updateData.username = currentConfig.username;
+    updateData.ytdlpLastChecked = currentConfig.ytdlpLastChecked;
+    updateData.ytdlpLastUpdated = currentConfig.ytdlpLastUpdated;
+    updateData.ytdlpLastResult = currentConfig.ytdlpLastResult;
 
     configModule.updateConfig(updateData);
 
@@ -388,4 +392,3 @@ module.exports = function createConfigRoutes({ verifyToken, configModule, valida
 
   return router;
 };
-

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -11,9 +11,10 @@ const ytdlpModule = require('../modules/ytdlpModule');
  * @param {Function} deps.getCachedYtDlpVersion - Function to get cached yt-dlp version
  * @param {Function} deps.refreshYtDlpVersionCache - Function to refresh yt-dlp version cache
  * @param {Function} deps.verifyToken - Authentication middleware
+ * @param {Object} deps.configModule - Configuration module
  * @returns {express.Router}
  */
-module.exports = function createHealthRoutes({ getCachedYtDlpVersion, refreshYtDlpVersionCache, verifyToken }) {
+module.exports = function createHealthRoutes({ getCachedYtDlpVersion, refreshYtDlpVersionCache, verifyToken, configModule }) {
   /**
    * @swagger
    * /api/health:
@@ -238,6 +239,13 @@ module.exports = function createHealthRoutes({ getCachedYtDlpVersion, refreshYtD
    */
   router.post('/api/ytdlp/update', verifyToken, async (req, res) => {
     try {
+      if (configModule.isElfhostedPlatform()) {
+        return res.status(403).json({
+          success: false,
+          message: 'yt-dlp is managed by the platform and cannot be updated from Youtarr.',
+        });
+      }
+
       const result = await ytdlpModule.performUpdate();
 
       // Refresh the cached version after update
@@ -257,4 +265,3 @@ module.exports = function createHealthRoutes({ getCachedYtDlpVersion, refreshYtD
 
   return router;
 };
-

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -42,7 +42,7 @@ function registerRoutes(app, deps) {
   } = deps;
 
   // Health routes (no auth required for health checks, but yt-dlp endpoints are authenticated)
-  app.use(createHealthRoutes({ getCachedYtDlpVersion, refreshYtDlpVersionCache, verifyToken }));
+  app.use(createHealthRoutes({ getCachedYtDlpVersion, refreshYtDlpVersionCache, verifyToken, configModule }));
 
   // Auth routes
   app.use(createAuthRoutes({ verifyToken, loginLimiter, configModule }));
@@ -82,4 +82,3 @@ function registerRoutes(app, deps) {
 }
 
 module.exports = { registerRoutes };
-

--- a/server/server.js
+++ b/server/server.js
@@ -580,7 +580,7 @@ const initialize = async () => {
         if (databaseHealth.isDatabaseHealthy()) {
           // Initialize cron jobs
           const cronJobs = require('./modules/cronJobs');
-          cronJobs.initialize();
+          cronJobs.initialize({ refreshYtDlpVersionCache });
 
           // Run folder_name migration for existing channels asynchronously
           // This populates folder_name from Video.filePath for channels that don't have it set


### PR DESCRIPTION
Add an opt-in 4:00 AM cron job that runs `yt-dlp -U` and records the outcome on the config (last checked, last updated, last result) so the Core Settings page can show inline status next to the existing manual Update button. The job is skipped while a download is in progress and skips on Elfhosted, where yt-dlp is owned by the platform image; the manual update endpoint also returns 403 on that platform.

Expose a new `isPlatformManaged.ytdlpUpdates` flag so the UI can hide the toggle and Update button on platform-managed deployments and show a "Managed by Elfhosted" chip instead.

Also add a `--as-elfhosted` flag to `./scripts/start-dev.sh` and a new docs/development/ELFHOSTED.md guide covering the four platform-related env vars and how to spoof the deployment locally for testing.

Refs: #539