### PR TITLE
feat(auth): lower username minimum to 1 char

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -37,7 +37,7 @@ On first launch, Youtarr requires authentication setup from `localhost` for secu
    ```
 
 2. Complete the setup wizard:
-   - Enter desired username (3-32 characters)
+   - Enter desired username (1-32 characters)
    - Enter password (8-64 characters)
    - Confirm password
 
@@ -51,7 +51,7 @@ For remote or automated deployments:
 
 1. Add to `.env` file:
    ```bash
-   AUTH_PRESET_USERNAME=admin                 # Min 3 characters
+   AUTH_PRESET_USERNAME=admin                 # Min 1 character
    AUTH_PRESET_PASSWORD=your-secure-password  # Min 8 characters
    ```
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -587,7 +587,7 @@ Youtarr can optionally check for and install yt-dlp updates on a nightly schedul
 - **Type**: `string`
 - **Default**: Not set (must be configured)
 - **Description**: Login username for the web interface
-- **Validation**: 3-32 characters, no leading/trailing spaces
+- **Validation**: 1-32 characters, no leading/trailing spaces
 - **Note**: Set during initial setup or via AUTH_PRESET_USERNAME environment variable
 
 ### passwordHash

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -92,7 +92,7 @@ To use an external database:
 **Required**: No
 **Default**: None
 **Description**: Pre-configured admin username for automated deployments
-**Validation**: 3-32 characters, no leading/trailing spaces
+**Validation**: 1-32 characters, no leading/trailing spaces
 
 ### AUTH_PRESET_PASSWORD
 **Required**: No

--- a/docs/platforms/unraid.md
+++ b/docs/platforms/unraid.md
@@ -47,7 +47,7 @@ curl -L https://raw.githubusercontent.com/DialmasterOrg/unraid-templates/main/Yo
   - Map your persistent paths (for example `/mnt/user/appdata/youtarr` for `/app/config` and `/mnt/user/media/youtube` for `/data`) and supply the MariaDB connection variables before deploying.
   - Set both `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` to set credentials for login to Youtarr
   - **IMPORTANT**: `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` must meet these rules or they’ll be ignored:
-    - `AUTH_PRESET_USERNAME`: 3-32 characters in length
+    - `AUTH_PRESET_USERNAME`: 1-32 characters in length
     - `AUTH_PRESET_PASSWORD`: 8-64 characters in length
   Leaving them blank requires completing the setup wizard from the Unraid host's localhost (e.g., via SSH port forwarding), which most headless installs won't have handy.
 6. Click the "Apply" button to start Youtarr

--- a/scripts/_create-env.sh
+++ b/scripts/_create-env.sh
@@ -376,7 +376,7 @@ if [ "$AUTH_ENABLED" = true ]; then
       yt_info "Provide initial admin credentials for this headless deployment."
       yt_detail "Values will be written to .env as AUTH_PRESET_USERNAME and AUTH_PRESET_PASSWORD."
       while true; do
-      prompt_with_label "Initial admin username (3-32 characters) [admin]"
+      prompt_with_label "Initial admin username (1-32 characters) [admin]"
       read -r INITIAL_USERNAME
       INITIAL_USERNAME=${INITIAL_USERNAME:-admin}
       # Trim leading/trailing whitespace
@@ -387,11 +387,6 @@ if [ "$AUTH_ENABLED" = true ]; then
       fi
       if [ ${#INITIAL_USERNAME} -gt 32 ]; then
           yt_error "Username must be 32 characters or fewer."
-          continue
-      fi
-      # Must be 3 characters or more
-      if [ ${#INITIAL_USERNAME} -lt 3 ]; then
-          yt_error "Username must be 3 characters or more."
           continue
       fi
       break

--- a/server/__tests__/server.auth-sessions.test.js
+++ b/server/__tests__/server.auth-sessions.test.js
@@ -328,6 +328,21 @@ describe('auth preset bootstrap', () => {
     expect(bcryptMock.hash).not.toHaveBeenCalled();
     expect(configModuleMock.updateConfig).not.toHaveBeenCalledWith(expect.objectContaining({ username: 'admin' }));
   });
+
+  test('applies preset credentials when username is a single character', async () => {
+    const presetPassword = 'supersecret!';
+    const { configModuleMock, bcryptMock } = await createServerModule({
+      passwordHash: null,
+      configOverrides: { username: null },
+      authPreset: { username: 'a', password: presetPassword }
+    });
+
+    expect(bcryptMock.hash).toHaveBeenCalledWith(presetPassword, 10);
+    expect(configModuleMock.updateConfig).toHaveBeenCalledWith(expect.objectContaining({
+      username: 'a',
+      passwordHash: 'new-hashed-password'
+    }));
+  });
 });
 
 describe('server routes - cookies', () => {

--- a/server/server.js
+++ b/server/server.js
@@ -93,7 +93,7 @@ const databaseHealth = require('./modules/databaseHealthModule');
 const http = require('http');
 const bcrypt = require('bcrypt');
 const userNameMaxLength = 32;
-const userNameMinLength = 3;
+const userNameMinLength = 1;
 const passwordMaxLength = 64;
 const passwordMinLength = 8;
 
@@ -239,7 +239,7 @@ const initialize = async () => {
       logger.info('Applied ENV AUTH credentials and saved to config.json');
     } else if (process.env.AUTH_PRESET_USERNAME || process.env.AUTH_PRESET_PASSWORD) {
       // Credentials were provided but failed validation
-      logger.warn('Ignoring ENV AUTH credentials: both AUTH_PRESET_USERNAME and AUTH_PRESET_PASSWORD must be set and meet requirements (username: 3-32 chars, password: 8-64 chars)');
+      logger.warn('Ignoring ENV AUTH credentials: both AUTH_PRESET_USERNAME and AUTH_PRESET_PASSWORD must be set and meet requirements (username: 1-32 chars, password: 8-64 chars)');
     }
 
     channelModule.subscribe();


### PR DESCRIPTION
The AUTH_PRESET_USERNAME validator and headless setup script required 3 characters, which blocked users whose preferred username is shorter (e.g. 2-character handles) from using preset credentials and forced them to disable auth entirely.

Refs: #581