### PR TITLE
fix(videos): handle ENOTEMPTY on SMB delete

### DIFF
--- a/server/modules/__tests__/videoDeletionModule.test.js
+++ b/server/modules/__tests__/videoDeletionModule.test.js
@@ -8,6 +8,7 @@ describe('VideoDeletionModule', () => {
   let mockVideo;
   let mockFs;
   let mockLogger;
+  let mockFilesystem;
 
   beforeEach(() => {
     jest.resetModules();
@@ -22,11 +23,24 @@ describe('VideoDeletionModule', () => {
       findOne: jest.fn()
     };
 
-    // Mock fs.promises
+    // Mock fs.promises (only the methods videoDeletionModule still calls directly,
+    // i.e. flat-mode readdir/unlink). The nested-mode rm path now goes through
+    // filesystem.removeDirectoryResilient and is mocked there.
     mockFs = {
-      rm: jest.fn(),
       readdir: jest.fn().mockResolvedValue([]),
       unlink: jest.fn()
+    };
+
+    // Mock the filesystem module (isVideoDirectory, cleanupEmptyChannelDirectory, etc.).
+    // removeDirectoryResilient defaults to success so existing tests don't need to
+    // wire it up explicitly; tests that need a failure path override per-test.
+    mockFilesystem = {
+      isVideoDirectory: jest.fn(() => true),
+      cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false),
+      cleanupEmptyParents: jest.fn().mockResolvedValue(),
+      isSubfolderDir: jest.fn((name) => name.startsWith('__')),
+      listSubdirectories: jest.fn().mockResolvedValue([]),
+      removeDirectoryResilient: jest.fn().mockResolvedValue()
     };
 
     // Mock the models
@@ -39,15 +53,7 @@ describe('VideoDeletionModule', () => {
       promises: mockFs
     }));
 
-    // Mock the filesystem module (isVideoDirectory, cleanupEmptyChannelDirectory, cleanupEmptyParents, etc.)
-    // Default to true (nested structure) for backwards compatibility with existing tests
-    jest.doMock('../filesystem', () => ({
-      isVideoDirectory: jest.fn(() => true),
-      cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false),
-      cleanupEmptyParents: jest.fn().mockResolvedValue(),
-      isSubfolderDir: jest.fn((name) => name.startsWith('__')),
-      listSubdirectories: jest.fn().mockResolvedValue([])
-    }));
+    jest.doMock('../filesystem', () => mockFilesystem);
 
     // Mock configModule for _tryCleanupChannelDirectory
     jest.doMock('../configModule', () => ({
@@ -69,14 +75,12 @@ describe('VideoDeletionModule', () => {
       };
 
       mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
-      mockFs.rm.mockResolvedValue();
 
       const result = await VideoDeletionModule.deleteVideoById(1);
 
       expect(mockVideo.findByPk).toHaveBeenCalledWith(1);
-      expect(mockFs.rm).toHaveBeenCalledWith(
-        '/test/output/Channel Name/Channel Name - Video Title - abc123',
-        { recursive: true, force: true }
+      expect(mockFilesystem.removeDirectoryResilient).toHaveBeenCalledWith(
+        '/test/output/Channel Name/Channel Name - Video Title - abc123'
       );
       expect(mockVideoRecord.update).toHaveBeenCalledWith({ removed: true });
       expect(result).toEqual({
@@ -100,7 +104,7 @@ describe('VideoDeletionModule', () => {
         videoId: 999,
         error: 'Video not found in database'
       });
-      expect(mockFs.rm).not.toHaveBeenCalled();
+      expect(mockFilesystem.removeDirectoryResilient).not.toHaveBeenCalled();
     });
 
     test('should return error when video already marked as removed', async () => {
@@ -120,7 +124,7 @@ describe('VideoDeletionModule', () => {
         videoId: 1,
         error: 'Video is already marked as removed'
       });
-      expect(mockFs.rm).not.toHaveBeenCalled();
+      expect(mockFilesystem.removeDirectoryResilient).not.toHaveBeenCalled();
     });
 
     test('should mark video as removed when no file path exists', async () => {
@@ -137,7 +141,7 @@ describe('VideoDeletionModule', () => {
       const result = await VideoDeletionModule.deleteVideoById(1);
 
       expect(mockVideoRecord.update).toHaveBeenCalledWith({ removed: true });
-      expect(mockFs.rm).not.toHaveBeenCalled();
+      expect(mockFilesystem.removeDirectoryResilient).not.toHaveBeenCalled();
       expect(result).toEqual({
         success: true,
         videoId: 1,
@@ -166,10 +170,12 @@ describe('VideoDeletionModule', () => {
         videoId: 1,
         error: 'Safety check failed: invalid file path'
       });
-      expect(mockFs.rm).not.toHaveBeenCalled();
+      expect(mockFilesystem.removeDirectoryResilient).not.toHaveBeenCalled();
     });
 
-    test('should handle ENOENT error when directory already deleted', async () => {
+    test('should report success when removeDirectoryResilient handles missing dir internally', async () => {
+      // removeDirectoryResilient swallows ENOENT and resolves cleanly, so
+      // videoDeletionModule still completes the DB update and reports success.
       const mockVideoRecord = {
         id: 1,
         youtubeId: 'abc123',
@@ -179,16 +185,12 @@ describe('VideoDeletionModule', () => {
       };
 
       mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
-
-      const enoentError = new Error('ENOENT: no such file or directory');
-      enoentError.code = 'ENOENT';
-      mockFs.rm.mockRejectedValue(enoentError);
+      mockFilesystem.removeDirectoryResilient.mockResolvedValue();
 
       const result = await VideoDeletionModule.deleteVideoById(1);
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        expect.objectContaining({ videoId: 1 }),
-        'Files already removed'
+      expect(mockFilesystem.removeDirectoryResilient).toHaveBeenCalledWith(
+        '/test/output/Channel/Channel - Video - abc123'
       );
       expect(mockVideoRecord.update).toHaveBeenCalledWith({ removed: true });
       expect(result).toEqual({
@@ -210,7 +212,7 @@ describe('VideoDeletionModule', () => {
 
       const permissionError = new Error('EACCES: permission denied');
       permissionError.code = 'EACCES';
-      mockFs.rm.mockRejectedValue(permissionError);
+      mockFilesystem.removeDirectoryResilient.mockRejectedValue(permissionError);
 
       const result = await VideoDeletionModule.deleteVideoById(1);
 
@@ -225,6 +227,29 @@ describe('VideoDeletionModule', () => {
       });
     });
 
+    test('delegates nested-mode directory removal to removeDirectoryResilient', async () => {
+      // The retry / AppleDouble sweep behavior is covered in directoryManager tests.
+      // Here we just verify videoDeletionModule routes through the helper instead
+      // of calling fs.rm directly.
+      const mockVideoRecord = {
+        id: 1,
+        youtubeId: 'abc123',
+        filePath: '/test/output/Channel/Channel - Video - abc123/video.mp4',
+        removed: false,
+        update: jest.fn().mockResolvedValue()
+      };
+
+      mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
+
+      const result = await VideoDeletionModule.deleteVideoById(1);
+
+      expect(mockFilesystem.removeDirectoryResilient).toHaveBeenCalledTimes(1);
+      expect(mockFilesystem.removeDirectoryResilient).toHaveBeenCalledWith(
+        '/test/output/Channel/Channel - Video - abc123'
+      );
+      expect(result.success).toBe(true);
+    });
+
     test('should handle database update errors', async () => {
       const mockVideoRecord = {
         id: 1,
@@ -235,7 +260,6 @@ describe('VideoDeletionModule', () => {
       };
 
       mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
-      mockFs.rm.mockResolvedValue();
 
       const result = await VideoDeletionModule.deleteVideoById(1);
 
@@ -280,12 +304,6 @@ describe('VideoDeletionModule', () => {
   });
 
   describe('_tryCleanupChannelDirectory', () => {
-    let mockFilesystem;
-
-    beforeEach(() => {
-      mockFilesystem = require('../filesystem');
-    });
-
     test('should call cleanupEmptyChannelDirectory with grandparent path for nested deletion', async () => {
       const mockVideoRecord = {
         id: 1,
@@ -296,7 +314,6 @@ describe('VideoDeletionModule', () => {
       };
 
       mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
-      mockFs.rm.mockResolvedValue();
 
       await VideoDeletionModule.deleteVideoById(1);
 
@@ -359,7 +376,7 @@ describe('VideoDeletionModule', () => {
 
       const permissionError = new Error('EACCES');
       permissionError.code = 'EACCES';
-      mockFs.rm.mockRejectedValue(permissionError);
+      mockFilesystem.removeDirectoryResilient.mockRejectedValue(permissionError);
 
       await VideoDeletionModule.deleteVideoById(1);
 
@@ -378,7 +395,6 @@ describe('VideoDeletionModule', () => {
       };
 
       mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
-      mockFs.rm.mockResolvedValue();
 
       const result = await VideoDeletionModule.deleteVideoById(1);
 
@@ -401,7 +417,6 @@ describe('VideoDeletionModule', () => {
       };
 
       mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
-      mockFs.rm.mockResolvedValue();
 
       await VideoDeletionModule.deleteVideoById(1);
 
@@ -423,7 +438,6 @@ describe('VideoDeletionModule', () => {
       };
 
       mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
-      mockFs.rm.mockResolvedValue();
 
       await VideoDeletionModule.deleteVideoById(1);
 
@@ -452,7 +466,6 @@ describe('VideoDeletionModule', () => {
       mockVideo.findByPk
         .mockResolvedValueOnce(mockVideo1)
         .mockResolvedValueOnce(mockVideo2);
-      mockFs.rm.mockResolvedValue();
 
       const result = await VideoDeletionModule.deleteVideos([1, 2]);
 
@@ -475,7 +488,6 @@ describe('VideoDeletionModule', () => {
       mockVideo.findByPk
         .mockResolvedValueOnce(mockVideo1)
         .mockResolvedValueOnce(null); // Second video not found
-      mockFs.rm.mockResolvedValue();
 
       const result = await VideoDeletionModule.deleteVideos([1, 2]);
 
@@ -547,7 +559,7 @@ describe('VideoDeletionModule', () => {
           return id === 1 ? mockVideo1 : mockVideo2;
         });
 
-      mockFs.rm.mockImplementation(async () => {
+      mockFilesystem.removeDirectoryResilient.mockImplementation(async () => {
         callOrder.push('rm');
       });
 
@@ -604,8 +616,6 @@ describe('VideoDeletionModule', () => {
         .mockResolvedValueOnce(mockVideo1)
         .mockResolvedValueOnce(mockVideo2);
 
-      mockFs.rm.mockResolvedValue();
-
       const result = await VideoDeletionModule.deleteVideosByYoutubeIds(['abc123', 'def456']);
 
       expect(mockVideo.findOne).toHaveBeenCalledWith({
@@ -653,8 +663,6 @@ describe('VideoDeletionModule', () => {
 
       // Mock findByPk for the successful deletion
       mockVideo.findByPk.mockResolvedValueOnce(mockVideo1);
-
-      mockFs.rm.mockResolvedValue();
 
       const result = await VideoDeletionModule.deleteVideosByYoutubeIds(['abc123', 'notfound456']);
 
@@ -1127,7 +1135,6 @@ describe('VideoDeletionModule', () => {
       };
 
       mockVideo.findByPk.mockResolvedValue(mockVideoRecord);
-      mockFs.rm.mockResolvedValue();
 
       const result = await VideoDeletionModule.performAutomaticCleanup({ dryRun: false });
 
@@ -1136,7 +1143,7 @@ describe('VideoDeletionModule', () => {
       expect(result.deletedByAge).toBe(1);
       expect(result.freedBytes).toBeGreaterThan(0);
       expect(result.plan.ageStrategy.deletedCount).toBe(1);
-      expect(mockFs.rm).toHaveBeenCalled();
+      expect(mockFilesystem.removeDirectoryResilient).toHaveBeenCalled();
     });
 
     test('should perform space-based cleanup in dry-run mode', async () => {
@@ -1339,8 +1346,6 @@ describe('VideoDeletionModule', () => {
         .mockResolvedValueOnce(mockVideoRecord1)
         .mockResolvedValueOnce(null); // Second video not found
 
-      mockFs.rm.mockResolvedValue();
-
       const result = await VideoDeletionModule.performAutomaticCleanup();
 
       expect(result.totalDeleted).toBe(1);
@@ -1351,12 +1356,6 @@ describe('VideoDeletionModule', () => {
   });
 
   describe('cleanupOrphanDirectories', () => {
-    let mockFilesystem;
-
-    beforeEach(() => {
-      mockFilesystem = require('../filesystem');
-    });
-
     test('should skip when no output directory is configured', async () => {
       jest.resetModules();
       jest.clearAllMocks();
@@ -1369,7 +1368,8 @@ describe('VideoDeletionModule', () => {
         cleanupEmptyChannelDirectory: jest.fn().mockResolvedValue(false),
         cleanupEmptyParents: jest.fn().mockResolvedValue(),
         isSubfolderDir: jest.fn((name) => name.startsWith('__')),
-        listSubdirectories: jest.fn().mockResolvedValue([])
+        listSubdirectories: jest.fn().mockResolvedValue([]),
+        removeDirectoryResilient: jest.fn().mockResolvedValue()
       }));
       jest.doMock('../configModule', () => ({
         directoryPath: null

--- a/server/modules/filesystem/__tests__/directoryManager.test.js
+++ b/server/modules/filesystem/__tests__/directoryManager.test.js
@@ -8,6 +8,7 @@ jest.mock('fs', () => ({
   promises: {
     readdir: jest.fn(),
     rmdir: jest.fn(),
+    rm: jest.fn(),
     access: jest.fn(),
     unlink: jest.fn()
   }
@@ -32,6 +33,8 @@ const {
   isChannelDirectory,
   isSubfolderDir,
   cleanupEmptyChannelDirectory,
+  removeDirectoryResilient,
+  isIgnorableEntry,
   listDirectory,
   listSubdirectories,
   isMainVideoFile
@@ -214,6 +217,57 @@ describe('filesystem/directoryManager', () => {
       const result = await isDirectoryEffectivelyEmpty('/path/channel');
 
       expect(result).toBe(false);
+    });
+
+    it('should return true for directory containing only AppleDouble sidecars', async () => {
+      fsPromises.readdir.mockResolvedValueOnce(['._video.mp4', '._poster.jpg']);
+
+      const result = await isDirectoryEffectivelyEmpty('/path/channel');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true for directory mixing AppleDouble and standard ignorables', async () => {
+      fsPromises.readdir.mockResolvedValueOnce(['._video.mp4', 'poster.jpg', '.DS_Store']);
+
+      const result = await isDirectoryEffectivelyEmpty('/path/channel');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when AppleDouble files coexist with real video', async () => {
+      fsPromises.readdir.mockResolvedValueOnce(['._video.mp4', 'video.mp4']);
+
+      const result = await isDirectoryEffectivelyEmpty('/path/channel');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isIgnorableEntry', () => {
+    it('returns true for entries in the ignorable list (case-insensitive)', () => {
+      expect(isIgnorableEntry('poster.jpg')).toBe(true);
+      expect(isIgnorableEntry('Poster.JPG')).toBe(true);
+      expect(isIgnorableEntry('.DS_Store')).toBe(true);
+      expect(isIgnorableEntry('Thumbs.db')).toBe(true);
+      expect(isIgnorableEntry('desktop.ini')).toBe(true);
+    });
+
+    it('returns true for AppleDouble sidecars', () => {
+      expect(isIgnorableEntry('._video.mp4')).toBe(true);
+      expect(isIgnorableEntry('._poster.jpg')).toBe(true);
+      expect(isIgnorableEntry('._.DS_Store')).toBe(true);
+    });
+
+    it('returns false for real video files', () => {
+      expect(isIgnorableEntry('video.mp4')).toBe(false);
+      expect(isIgnorableEntry('Channel - Title [abc123].mp4')).toBe(false);
+    });
+
+    it('returns false for null/undefined/empty', () => {
+      expect(isIgnorableEntry(null)).toBe(false);
+      expect(isIgnorableEntry(undefined)).toBe(false);
+      expect(isIgnorableEntry('')).toBe(false);
     });
   });
 
@@ -406,6 +460,135 @@ describe('filesystem/directoryManager', () => {
 
       expect(fsPromises.rmdir).not.toHaveBeenCalled();
       expect(result).toBe(false);
+    });
+
+    describe('with includeIgnorableFiles: true (race-safety + AppleDouble)', () => {
+      it('only unlinks ignorable entries even if a real file appears between reads', async () => {
+        fsPromises.access.mockResolvedValueOnce();
+        // First readdir for isDirectoryEffectivelyEmpty — only ignorables
+        fsPromises.readdir.mockResolvedValueOnce(['poster.jpg', '._poster.jpg']);
+        // Second readdir for the unlink loop — race: a real video file appeared
+        fsPromises.readdir.mockResolvedValueOnce(['poster.jpg', '._poster.jpg', 'real-video.mp4']);
+        fsPromises.unlink.mockResolvedValue();
+        fsPromises.rmdir.mockResolvedValueOnce();
+
+        await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir, {
+          includeIgnorableFiles: true
+        });
+
+        // The real video file must NOT be unlinked
+        expect(fsPromises.unlink).toHaveBeenCalledWith('/videos/ChannelName/poster.jpg');
+        expect(fsPromises.unlink).toHaveBeenCalledWith('/videos/ChannelName/._poster.jpg');
+        expect(fsPromises.unlink).not.toHaveBeenCalledWith('/videos/ChannelName/real-video.mp4');
+      });
+
+      it('sweeps AppleDouble files before rmdir', async () => {
+        fsPromises.access.mockResolvedValueOnce();
+        fsPromises.readdir.mockResolvedValueOnce(['._video.mp4', '._poster.jpg']);
+        fsPromises.readdir.mockResolvedValueOnce(['._video.mp4', '._poster.jpg']);
+        fsPromises.unlink.mockResolvedValue();
+        fsPromises.rmdir.mockResolvedValueOnce();
+
+        const result = await cleanupEmptyChannelDirectory('/videos/ChannelName', baseDir, {
+          includeIgnorableFiles: true
+        });
+
+        expect(fsPromises.unlink).toHaveBeenCalledWith('/videos/ChannelName/._video.mp4');
+        expect(fsPromises.unlink).toHaveBeenCalledWith('/videos/ChannelName/._poster.jpg');
+        expect(fsPromises.rmdir).toHaveBeenCalledWith('/videos/ChannelName');
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('removeDirectoryResilient', () => {
+    const dirPath = '/videos/Channel/Channel - Video - abc123';
+
+    it('resolves on the first attempt when fs.rm succeeds', async () => {
+      fsPromises.rm.mockResolvedValueOnce();
+
+      await expect(removeDirectoryResilient(dirPath)).resolves.toBeUndefined();
+
+      expect(fsPromises.rm).toHaveBeenCalledTimes(1);
+      expect(fsPromises.rm).toHaveBeenCalledWith(dirPath, { recursive: true, force: true });
+      expect(fsPromises.readdir).not.toHaveBeenCalled();
+    });
+
+    it('resolves cleanly when the directory is already gone (ENOENT)', async () => {
+      const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      fsPromises.rm.mockRejectedValueOnce(enoent);
+
+      await expect(removeDirectoryResilient(dirPath)).resolves.toBeUndefined();
+
+      expect(fsPromises.rm).toHaveBeenCalledTimes(1);
+    });
+
+    it('sweeps AppleDouble entries on ENOTEMPTY and retries successfully', async () => {
+      const enotempty = Object.assign(new Error('ENOTEMPTY'), { code: 'ENOTEMPTY' });
+      fsPromises.rm
+        .mockRejectedValueOnce(enotempty)
+        .mockResolvedValueOnce();
+      fsPromises.readdir.mockResolvedValueOnce(['._video.mp4', '._poster.jpg', 'real.mp4']);
+      fsPromises.unlink.mockResolvedValue();
+
+      await expect(removeDirectoryResilient(dirPath, { delayMs: 1 })).resolves.toBeUndefined();
+
+      expect(fsPromises.rm).toHaveBeenCalledTimes(2);
+      // Sweep only touches AppleDouble entries, not the real file
+      expect(fsPromises.unlink).toHaveBeenCalledWith(`${dirPath}/._video.mp4`);
+      expect(fsPromises.unlink).toHaveBeenCalledWith(`${dirPath}/._poster.jpg`);
+      expect(fsPromises.unlink).not.toHaveBeenCalledWith(`${dirPath}/real.mp4`);
+    });
+
+    it('treats ENOENT during the post-ENOTEMPTY readdir as already-gone', async () => {
+      const enotempty = Object.assign(new Error('ENOTEMPTY'), { code: 'ENOTEMPTY' });
+      const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      fsPromises.rm.mockRejectedValueOnce(enotempty);
+      fsPromises.readdir.mockRejectedValueOnce(enoent);
+
+      await expect(removeDirectoryResilient(dirPath, { delayMs: 1 })).resolves.toBeUndefined();
+
+      // No retry of fs.rm — we returned cleanly
+      expect(fsPromises.rm).toHaveBeenCalledTimes(1);
+      expect(fsPromises.unlink).not.toHaveBeenCalled();
+    });
+
+    it('rejects with the original error after exhausting retries on persistent ENOTEMPTY', async () => {
+      const enotempty = Object.assign(new Error('ENOTEMPTY'), { code: 'ENOTEMPTY' });
+      fsPromises.rm.mockRejectedValue(enotempty);
+      fsPromises.readdir.mockResolvedValue([]);
+
+      await expect(
+        removeDirectoryResilient(dirPath, { retries: 2, delayMs: 1 })
+      ).rejects.toMatchObject({ code: 'ENOTEMPTY' });
+
+      // initial attempt + 2 retries = 3 fs.rm calls
+      expect(fsPromises.rm).toHaveBeenCalledTimes(3);
+    });
+
+    it('rejects immediately for non-retryable errors (EACCES)', async () => {
+      const eacces = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      fsPromises.rm.mockRejectedValueOnce(eacces);
+
+      await expect(removeDirectoryResilient(dirPath, { delayMs: 1 })).rejects.toMatchObject({
+        code: 'EACCES'
+      });
+
+      expect(fsPromises.rm).toHaveBeenCalledTimes(1);
+      expect(fsPromises.readdir).not.toHaveBeenCalled();
+    });
+
+    it('propagates non-ENOENT readdir errors during sweep', async () => {
+      const enotempty = Object.assign(new Error('ENOTEMPTY'), { code: 'ENOTEMPTY' });
+      const eacces = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+      fsPromises.rm.mockRejectedValueOnce(enotempty);
+      fsPromises.readdir.mockRejectedValueOnce(eacces);
+
+      await expect(removeDirectoryResilient(dirPath, { delayMs: 1 })).rejects.toMatchObject({
+        code: 'EACCES'
+      });
+
+      expect(fsPromises.rm).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/server/modules/filesystem/constants.js
+++ b/server/modules/filesystem/constants.js
@@ -118,6 +118,15 @@ const CHANNEL_CLEANUP_IGNORABLE_FILES = [
   'desktop.ini',
 ];
 
+/**
+ * AppleDouble metadata files written by macOS SMB clients (e.g., "._video.mp4").
+ * These are sidecar metadata for an underlying file; once the underlying file
+ * is gone, the sidecar is orphaned junk and safe to remove. Mac SMB also tends
+ * to write these into a directory in response to other operations, which can
+ * race with rmdir and cause spurious ENOTEMPTY (issue #370).
+ */
+const APPLEDOUBLE_FILE_PATTERN = /^\._/;
+
 module.exports = {
   SUBFOLDER_PREFIX,
   GLOBAL_DEFAULT_SENTINEL,
@@ -135,5 +144,6 @@ module.exports = {
   MAIN_AUDIO_FILE_PATTERN,
   MAIN_MEDIA_FILE_PATTERN,
   FRAGMENT_FILE_PATTERN,
-  CHANNEL_CLEANUP_IGNORABLE_FILES
+  CHANNEL_CLEANUP_IGNORABLE_FILES,
+  APPLEDOUBLE_FILE_PATTERN
 };

--- a/server/modules/filesystem/directoryManager.js
+++ b/server/modules/filesystem/directoryManager.js
@@ -7,8 +7,22 @@ const fs = require('fs-extra');
 const fsPromises = require('fs').promises;
 const path = require('path');
 const logger = require('../../logger');
-const { YOUTUBE_ID_PATTERN, SUBFOLDER_PREFIX, MAIN_VIDEO_FILE_PATTERN, FRAGMENT_FILE_PATTERN, CHANNEL_CLEANUP_IGNORABLE_FILES } = require('./constants');
+const { YOUTUBE_ID_PATTERN, SUBFOLDER_PREFIX, MAIN_VIDEO_FILE_PATTERN, FRAGMENT_FILE_PATTERN, CHANNEL_CLEANUP_IGNORABLE_FILES, APPLEDOUBLE_FILE_PATTERN } = require('./constants');
 const { sleep } = require('./fileOperations');
+
+/**
+ * Decide whether a directory entry can be ignored when judging emptiness or
+ * sweeping junk before rmdir. Covers both the explicit ignore list (poster.jpg,
+ * .DS_Store, etc.) and AppleDouble sidecar files written by macOS SMB clients.
+ *
+ * @param {string} entryName - Bare file name (no path)
+ * @returns {boolean}
+ */
+function isIgnorableEntry(entryName) {
+  if (!entryName) return false;
+  if (APPLEDOUBLE_FILE_PATTERN.test(entryName)) return true;
+  return CHANNEL_CLEANUP_IGNORABLE_FILES.includes(entryName.toLowerCase());
+}
 
 /**
  * Ensure a directory exists, creating it if necessary
@@ -84,9 +98,7 @@ async function isDirectoryEffectivelyEmpty(dirPath) {
   try {
     const entries = await fsPromises.readdir(dirPath);
     if (entries.length === 0) return true;
-    return entries.every(entry =>
-      CHANNEL_CLEANUP_IGNORABLE_FILES.includes(entry.toLowerCase())
-    );
+    return entries.every(isIgnorableEntry);
   } catch (error) {
     logger.debug({ err: error, dirPath }, 'Cannot read directory (may not exist)');
     return false;
@@ -237,10 +249,13 @@ async function cleanupEmptyChannelDirectory(channelDir, baseDir, options = {}) {
       return false;
     }
 
-    // When includeIgnorableFiles is true, delete ignorable files before rmdir
+    // When includeIgnorableFiles is true, delete ignorable files before rmdir.
+    // Filter the second readdir explicitly via isIgnorableEntry so a real video
+    // file appearing between the emptiness check and this read isn't deleted.
     if (includeIgnorableFiles) {
       const entries = await fsPromises.readdir(channelDir);
       for (const entry of entries) {
+        if (!isIgnorableEntry(entry)) continue;
         const filePath = path.join(channelDir, entry);
         try {
           await fsPromises.unlink(filePath);
@@ -261,6 +276,66 @@ async function cleanupEmptyChannelDirectory(channelDir, baseDir, options = {}) {
     logger.error({ err: error, channelDir }, 'Error cleaning up empty channel directory');
     // Don't throw - this is a best-effort cleanup
     return false;
+  }
+}
+
+/**
+ * Recursively remove a directory and its contents, with resilience for
+ * macOS SMB shares that race-create AppleDouble (._*) sidecar files.
+ *
+ * Strategy: try fs.rm with recursive+force. If rmdir fails with ENOTEMPTY
+ * because junk reappeared after the recursive walk, sweep ignorable entries
+ * (AppleDouble + the standard ignore list) and retry with backoff.
+ *
+ * Behavior:
+ * - ENOENT (already gone): resolves cleanly.
+ * - ENOTEMPTY: sweep ignorable entries, retry up to `retries` times.
+ * - Other errors (EACCES, EPERM, etc.): rejects immediately, no retry.
+ *
+ * @param {string} dirPath - Directory to remove
+ * @param {Object} [options]
+ * @param {number} [options.retries=3] - Number of retry attempts after the initial try
+ * @param {number} [options.delayMs=150] - Base delay in ms; doubles each retry
+ * @returns {Promise<void>}
+ */
+async function removeDirectoryResilient(dirPath, { retries = 3, delayMs = 150 } = {}) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      await fsPromises.rm(dirPath, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        return;
+      }
+      if (err.code !== 'ENOTEMPTY' || attempt === retries) {
+        throw err;
+      }
+
+      // ENOTEMPTY: sweep junk that appeared after the recursive walk, then retry.
+      // The directory may also have disappeared by now, so tolerate ENOENT here.
+      try {
+        const entries = await fsPromises.readdir(dirPath);
+        for (const entry of entries) {
+          if (!isIgnorableEntry(entry)) continue;
+          try {
+            await fsPromises.unlink(path.join(dirPath, entry));
+          } catch (unlinkErr) {
+            if (unlinkErr.code !== 'ENOENT') {
+              logger.debug({ err: unlinkErr, dirPath, entry }, 'Failed to sweep ignorable entry before rmdir retry');
+            }
+          }
+        }
+      } catch (readErr) {
+        if (readErr.code === 'ENOENT') {
+          return;
+        }
+        throw readErr;
+      }
+
+      const backoff = delayMs * Math.pow(2, attempt);
+      logger.debug({ dirPath, attempt, backoff }, 'rmdir hit ENOTEMPTY, swept ignorable entries, retrying after backoff');
+      await sleep(backoff);
+    }
   }
 }
 
@@ -354,6 +429,8 @@ module.exports = {
   isSubfolderDir,
   cleanupEmptyChannelDirectory,
   cleanupEmptyParents,
+  removeDirectoryResilient,
+  isIgnorableEntry,
   listDirectory,
   listSubdirectories,
   isMainVideoFile

--- a/server/modules/videoDeletionModule.js
+++ b/server/modules/videoDeletionModule.js
@@ -2,7 +2,7 @@ const { Video } = require('../models');
 const fs = require('fs').promises;
 const path = require('path');
 const logger = require('../logger');
-const { isVideoDirectory, cleanupEmptyChannelDirectory, cleanupEmptyParents, isSubfolderDir, listSubdirectories } = require('./filesystem');
+const { isVideoDirectory, cleanupEmptyChannelDirectory, cleanupEmptyParents, isSubfolderDir, listSubdirectories, removeDirectoryResilient } = require('./filesystem');
 
 class VideoDeletionModule {
   constructor() {}
@@ -148,8 +148,10 @@ class VideoDeletionModule {
             }
           }
         } else {
-          // Nested structure: delete the entire video directory
-          await fs.rm(videoDirectory, { recursive: true, force: true });
+          // Nested structure: delete the entire video directory.
+          // Uses the resilient remover so SMB AppleDouble race conditions
+          // don't strand the directory with an ENOTEMPTY error (issue #370).
+          await removeDirectoryResilient(videoDirectory);
           logger.info({ videoId, videoDirectory }, 'Deleted video directory');
         }
       } catch (fsError) {


### PR DESCRIPTION
Deleting a video on an SMB-mounted output directory could fail at the rmdir step with ENOTEMPTY, leaving the directory on disk and the database record out of sync. Symptom matches macOS SMB clients writing AppleDouble (._*) sidecars into the directory as residue or as a race against rmdir.

Add a removeDirectoryResilient helper that, on ENOTEMPTY, sweeps AppleDouble files plus the existing ignorable list and retries fs.rm with short backoff. Wire it into the nested-mode delete. ENOENT from either the rm or the sweep readdir is treated as already-gone.

Also recognize ._* files as ignorable in the channel-directory cleanup pass, and filter the second readdir there through isIgnorableEntry so a real video file appearing between the emptiness check and the sweep is not unlinked.

Refs: #370