### PR TITLE
feat(find-videos): add filter and bulk download

### DIFF
--- a/client/src/components/FindVideos/__tests__/FindVideos.test.tsx
+++ b/client/src/components/FindVideos/__tests__/FindVideos.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('axios', () => ({
   post: jest.fn(),
@@ -18,29 +19,71 @@ jest.mock('../../shared/VideoModal', () => ({
   },
 }));
 
+jest.mock('../../../hooks/useConfig', () => ({
+  useConfig: () => ({ config: { preferredResolution: '1080' } }),
+}));
+
+const mockTriggerDownloads = jest.fn().mockResolvedValue(true);
+jest.mock('../../../hooks/useTriggerDownloads', () => ({
+  useTriggerDownloads: () => ({ triggerDownloads: mockTriggerDownloads, loading: false, error: null }),
+}));
+
+jest.mock('../../DownloadManager/ManualDownload/DownloadSettingsDialog', () => ({
+  __esModule: true,
+  default: function MockDownloadDialog(props: {
+    open: boolean;
+    onConfirm: (s: null) => void;
+    onClose: () => void;
+    videoCount?: number;
+    missingVideoCount?: number;
+  }) {
+    const React = require('react');
+    if (!props.open) return null;
+    return React.createElement(
+      'div',
+      { 'data-testid': 'mock-download-dialog' },
+      React.createElement('div', { 'data-testid': 'dialog-video-count' }, String(props.videoCount ?? 0)),
+      React.createElement('div', { 'data-testid': 'dialog-missing-count' }, String(props.missingVideoCount ?? 0)),
+      React.createElement(
+        'button',
+        { onClick: () => props.onConfirm(null), 'data-testid': 'dialog-confirm' },
+        'Confirm'
+      ),
+      React.createElement('button', { onClick: props.onClose, 'data-testid': 'dialog-close' }, 'Close')
+    );
+  },
+}));
+
 const axios = require('axios');
 const FindVideos = require('../index').default;
 
-beforeAll(() => {
-  if (!window.matchMedia) {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: (query: string) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        addListener: () => {},
-        removeListener: () => {},
-        dispatchEvent: () => false,
-      }),
-    });
-  }
-});
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
 
 describe('FindVideos page', () => {
-  beforeEach(() => { jest.clearAllMocks(); });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTriggerDownloads.mockResolvedValue(true);
+    mockMatchMedia(false);
+    window.localStorage.clear();
+  });
 
   test('submitting a search renders results', async () => {
     axios.post.mockResolvedValueOnce({
@@ -51,7 +94,7 @@ describe('FindVideos page', () => {
       }] },
     });
 
-    render(<FindVideos token="t" />);
+    renderWithRouter(<FindVideos token="t" />);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hello' } });
     fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
 
@@ -67,13 +110,214 @@ describe('FindVideos page', () => {
       }] },
     });
 
-    render(<FindVideos token="t" />);
+    renderWithRouter(<FindVideos token="t" />);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'x' } });
     fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
     expect(await screen.findByText('Pick me')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /open pick me/i }));
     expect(screen.getByTestId('mock-video-modal')).toHaveTextContent('Pick me');
+  });
+
+  test('applies persisted minimum duration filter and shows "X of Y" count', async () => {
+    window.localStorage.setItem('findVideos.minDuration', '60');
+    axios.post.mockResolvedValueOnce({
+      data: { results: [
+        { youtubeId: 'short000001', title: 'Tiny Short', channelName: 'C', channelId: null, duration: 30, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+        { youtubeId: 'long0000001', title: 'Long Video', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+      ] },
+    });
+
+    renderWithRouter(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'q' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+
+    expect(await screen.findByText('Long Video')).toBeInTheDocument();
+    expect(screen.queryByText('Tiny Short')).not.toBeInTheDocument();
+    expect(screen.getByText(/showing 1 of 2 results/i)).toBeInTheDocument();
+  });
+
+  test('shows a filter-aware empty message when filter hides everything', async () => {
+    window.localStorage.setItem('findVideos.minDuration', '1200');
+    axios.post.mockResolvedValueOnce({
+      data: { results: [
+        { youtubeId: 'short000001', title: 'Short A', channelName: 'C', channelId: null, duration: 30, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+        { youtubeId: 'short000002', title: 'Short B', channelName: 'C', channelId: null, duration: 45, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+      ] },
+    });
+
+    renderWithRouter(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'q' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+
+    expect(await screen.findByText(/all 2 results were hidden/i)).toBeInTheDocument();
+    expect(screen.queryByText('Short A')).not.toBeInTheDocument();
+    expect(screen.queryByText(/no videos found for/i)).not.toBeInTheDocument();
+  });
+
+  test('keeps results with null duration even when filter is active', async () => {
+    window.localStorage.setItem('findVideos.minDuration', '60');
+    axios.post.mockResolvedValueOnce({
+      data: { results: [
+        { youtubeId: 'unknownmeta', title: 'Unknown duration', channelName: 'C', channelId: null, duration: null, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+        { youtubeId: 'short000001', title: 'Tiny', channelName: 'C', channelId: null, duration: 10, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+      ] },
+    });
+
+    renderWithRouter(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'q' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+
+    expect(await screen.findByText('Unknown duration')).toBeInTheDocument();
+    expect(screen.queryByText('Tiny')).not.toBeInTheDocument();
+  });
+
+  test('eligible videos render a select checkbox; downloaded videos do not', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: { results: [
+        { youtubeId: 'never000001', title: 'Never', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+        { youtubeId: 'missing0001', title: 'Missing', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'missing' },
+        { youtubeId: 'downloaded1', title: 'Done', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'downloaded' },
+      ] },
+    });
+
+    renderWithRouter(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'q' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    expect(await screen.findByText('Never')).toBeInTheDocument();
+
+    expect(screen.getByTestId('select-never000001')).toBeInTheDocument();
+    expect(screen.getByTestId('select-missing0001')).toBeInTheDocument();
+    expect(screen.queryByTestId('select-downloaded1')).not.toBeInTheDocument();
+  });
+
+  test('selecting eligible videos and confirming dialog calls triggerDownloads with URLs', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: { results: [
+        { youtubeId: 'never000001', title: 'Never', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+        { youtubeId: 'missing0001', title: 'Missing', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'missing' },
+      ] },
+    });
+
+    renderWithRouter(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'q' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    await screen.findByText('Never');
+
+    fireEvent.click(screen.getByTestId('select-never000001'));
+    fireEvent.click(screen.getByTestId('select-missing0001'));
+
+    fireEvent.click(screen.getByTestId('video-list-selection-pill'));
+    fireEvent.click(await screen.findByTestId('selection-menu-download'));
+
+    expect(await screen.findByTestId('mock-download-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('dialog-video-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('dialog-missing-count')).toHaveTextContent('1');
+
+    fireEvent.click(screen.getByTestId('dialog-confirm'));
+
+    await waitFor(() => expect(mockTriggerDownloads).toHaveBeenCalledTimes(1));
+    expect(mockTriggerDownloads).toHaveBeenCalledWith({
+      urls: [
+        'https://www.youtube.com/watch?v=never000001',
+        'https://www.youtube.com/watch?v=missing0001',
+      ],
+      overrideSettings: undefined,
+    });
+  });
+
+  test('failed download queue keeps selection and shows an error', async () => {
+    mockTriggerDownloads.mockResolvedValueOnce(false);
+    axios.post.mockResolvedValueOnce({
+      data: { results: [
+        { youtubeId: 'never000001', title: 'Never', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+      ] },
+    });
+
+    renderWithRouter(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'q' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    await screen.findByText('Never');
+
+    fireEvent.click(screen.getByTestId('select-never000001'));
+    fireEvent.click(screen.getByTestId('video-list-selection-pill'));
+    fireEvent.click(await screen.findByTestId('selection-menu-download'));
+    fireEvent.click(await screen.findByTestId('dialog-confirm'));
+
+    expect(await screen.findByText(/failed to queue selected videos/i)).toBeInTheDocument();
+    expect(screen.getByTestId('video-list-selection-pill')).toBeInTheDocument();
+  });
+
+  test('selected hidden missing videos still count as missing in the download dialog', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: { results: [
+        { youtubeId: 'missing0001', title: 'Missing', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'missing' },
+        { youtubeId: 'long0000001', title: 'Long', channelName: 'C', channelId: null, duration: 1800, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+      ] },
+    });
+
+    renderWithRouter(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'q' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    await screen.findByTestId('select-missing0001');
+
+    fireEvent.click(screen.getByTestId('select-missing0001'));
+    fireEvent.mouseDown(screen.getByText('Any length'));
+    fireEvent.click(await screen.findByText('20+ min'));
+
+    expect(screen.queryByTestId('select-missing0001')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('video-list-selection-pill'));
+    fireEvent.click(await screen.findByTestId('selection-menu-download'));
+
+    expect(await screen.findByTestId('mock-download-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('dialog-missing-count')).toHaveTextContent('1');
+  });
+
+  test('mobile selection action opens the download dialog', async () => {
+    mockMatchMedia(true);
+    axios.post.mockResolvedValueOnce({
+      data: { results: [
+        { youtubeId: 'never000001', title: 'Never', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+      ] },
+    });
+
+    renderWithRouter(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'q' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    await screen.findByText('Never');
+
+    fireEvent.click(screen.getByTestId('select-mobile-never000001'));
+    fireEvent.click(screen.getByTestId('selection-action-download'));
+
+    expect(await screen.findByTestId('mock-download-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('dialog-video-count')).toHaveTextContent('1');
+  });
+
+  test('starting a new search clears prior selection so stale ids cannot be downloaded', async () => {
+    axios.post
+      .mockResolvedValueOnce({
+        data: { results: [
+          { youtubeId: 'first0000001', title: 'First', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+        ] },
+      })
+      .mockResolvedValueOnce({
+        data: { results: [
+          { youtubeId: 'second000001', title: 'Second', channelName: 'C', channelId: null, duration: 600, thumbnailUrl: null, publishedAt: null, viewCount: null, status: 'never_downloaded' },
+        ] },
+      });
+
+    renderWithRouter(<FindVideos token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'one' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    await screen.findByText('First');
+    fireEvent.click(screen.getByTestId('select-first0000001'));
+    expect(screen.getByTestId('video-list-selection-pill')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'two' } });
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    await screen.findByText('Second');
+
+    expect(screen.queryByTestId('video-list-selection-pill')).not.toBeInTheDocument();
   });
 
   test('toggling to Table View switches results to a table and row click opens modal', async () => {
@@ -85,7 +329,7 @@ describe('FindVideos page', () => {
       }] },
     });
 
-    render(<FindVideos token="t" />);
+    renderWithRouter(<FindVideos token="t" />);
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'x' } });
     fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
     expect(await screen.findByText('Row Pick')).toBeInTheDocument();

--- a/client/src/components/FindVideos/components/ResultCard.tsx
+++ b/client/src/components/FindVideos/components/ResultCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Card, CardActionArea, Typography, Chip } from '../../ui';
+import { Box, Card, CardActionArea, Checkbox, Typography, Chip } from '../../ui';
 import { CalendarToday as CalendarTodayIcon } from '../../../lib/icons';
 import {
   getStatusColor,
@@ -11,16 +11,19 @@ import {
 } from '../../../utils/videoStatus';
 import { SHARED_THEMED_CHIP_SMALL_STYLE } from '../../shared/chipStyles';
 import { formatDurationClock } from '../../../utils';
-import { SearchResult } from '../types';
+import { isSelectableForDownload, ResultSelection, SearchResult } from '../types';
 
 interface ResultCardProps {
   result: SearchResult;
   onClick: () => void;
+  selection?: ResultSelection;
 }
 
-export default function ResultCard({ result, onClick }: ResultCardProps) {
+export default function ResultCard({ result, onClick, selection }: ResultCardProps) {
   const status: VideoStatus = result.status;
   const durationLabel = formatDurationClock(result.duration);
+  const selectable = Boolean(selection) && isSelectableForDownload(result.status);
+  const checked = selectable && selection!.isChecked(result.youtubeId);
 
   return (
     <Card className="cursor-pointer overflow-hidden hover:shadow-md transition-shadow">
@@ -36,6 +39,29 @@ export default function ResultCard({ result, onClick }: ResultCardProps) {
               className="w-full h-full object-cover"
               loading="lazy"
             />
+          )}
+          {selectable && (
+            <Box
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                position: 'absolute',
+                top: 4,
+                left: 4,
+                padding: 4,
+                borderRadius: 'var(--radius-ui)',
+                backgroundColor: 'var(--media-overlay-background)',
+                zIndex: 3,
+              }}
+            >
+              <Checkbox
+                checked={checked}
+                onChange={() => selection!.toggle(result.youtubeId)}
+                inputProps={{
+                  'aria-label': `Select ${result.title} for download`,
+                  'data-testid': `select-${result.youtubeId}`,
+                }}
+              />
+            </Box>
           )}
           {durationLabel && (
             <Chip

--- a/client/src/components/FindVideos/components/ResultsGrid.tsx
+++ b/client/src/components/FindVideos/components/ResultsGrid.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Typography, Alert, Button, Skeleton } from '../../ui';
 import { useMediaQuery } from '../../../hooks/useMediaQuery';
-import { SearchResult, PageSize, ViewMode } from '../types';
+import { ResultSelection, SearchResult, PageSize, ViewMode } from '../types';
 import ResultCard from './ResultCard';
 import ResultsTable from './ResultsTable';
 import ResultsListMobile from './ResultsListMobile';
@@ -16,10 +16,11 @@ interface ResultsGridProps {
   viewMode: ViewMode;
   onResultClick: (result: SearchResult) => void;
   onRetry: () => void;
+  selection?: ResultSelection;
 }
 
 export default function ResultsGrid({
-  results, loading, error, hasSearched, lastQuery, pageSize, viewMode, onResultClick, onRetry,
+  results, loading, error, hasSearched, lastQuery, pageSize, viewMode, onResultClick, onRetry, selection,
 }: ResultsGridProps) {
   const isMobile = useMediaQuery('(max-width: 767px)');
 
@@ -66,14 +67,19 @@ export default function ResultsGrid({
 
   if (viewMode === 'table') {
     return isMobile
-      ? <ResultsListMobile results={results} onResultClick={onResultClick} />
-      : <ResultsTable results={results} onResultClick={onResultClick} />;
+      ? <ResultsListMobile results={results} onResultClick={onResultClick} selection={selection} />
+      : <ResultsTable results={results} onResultClick={onResultClick} selection={selection} />;
   }
 
   return (
     <Box className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
       {results.map((r) => (
-        <ResultCard key={r.youtubeId} result={r} onClick={() => onResultClick(r)} />
+        <ResultCard
+          key={r.youtubeId}
+          result={r}
+          onClick={() => onResultClick(r)}
+          selection={selection}
+        />
       ))}
     </Box>
   );

--- a/client/src/components/FindVideos/components/ResultsListMobile.tsx
+++ b/client/src/components/FindVideos/components/ResultsListMobile.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography, Chip } from '../../ui';
+import { Checkbox, Typography, Chip } from '../../ui';
 import { CalendarToday as CalendarTodayIcon } from '../../../lib/icons';
 import {
   getStatusColor,
@@ -11,7 +11,13 @@ import {
 } from '../../../utils/videoStatus';
 import { SHARED_THEMED_CHIP_SMALL_STYLE } from '../../shared/chipStyles';
 import { formatDurationClock } from '../../../utils';
-import { SearchResult, THUMB_WIDTH, THUMB_HEIGHT } from '../types';
+import {
+  isSelectableForDownload,
+  ResultSelection,
+  SearchResult,
+  THUMB_WIDTH,
+  THUMB_HEIGHT,
+} from '../types';
 
 function StatusChip({ status }: { status: VideoStatus }) {
   return (
@@ -32,14 +38,17 @@ function StatusChip({ status }: { status: VideoStatus }) {
 interface ResultsListMobileProps {
   results: SearchResult[];
   onResultClick: (result: SearchResult) => void;
+  selection?: ResultSelection;
 }
 
-export default function ResultsListMobile({ results, onResultClick }: ResultsListMobileProps) {
+export default function ResultsListMobile({ results, onResultClick, selection }: ResultsListMobileProps) {
   return (
     <div className="flex flex-col">
       {results.map((result) => {
         const status: VideoStatus = result.status;
         const durationLabel = formatDurationClock(result.duration);
+        const selectable = Boolean(selection) && isSelectableForDownload(result.status);
+        const checked = selectable && selection!.isChecked(result.youtubeId);
         const published = result.publishedAt
           ? new Date(result.publishedAt).toLocaleDateString(undefined, {
               month: 'short',
@@ -62,6 +71,21 @@ export default function ResultsListMobile({ results, onResultClick }: ResultsLis
             }}
             className="flex gap-3 py-2 px-1 border-b border-border cursor-pointer items-start"
           >
+            {selectable && (
+              <div
+                onClick={(e) => e.stopPropagation()}
+                className="flex items-center pt-1"
+              >
+                <Checkbox
+                  checked={checked}
+                  onChange={() => selection!.toggle(result.youtubeId)}
+                  inputProps={{
+                    'aria-label': `Select ${result.title} for download`,
+                    'data-testid': `select-mobile-${result.youtubeId}`,
+                  }}
+                />
+              </div>
+            )}
             <div
               className="relative shrink-0 overflow-hidden bg-[var(--media-placeholder-background)] rounded-[var(--radius-thumb)]"
               style={{ width: THUMB_WIDTH, height: THUMB_HEIGHT }}

--- a/client/src/components/FindVideos/components/ResultsTable.tsx
+++ b/client/src/components/FindVideos/components/ResultsTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Checkbox,
   Typography,
   Chip,
   TableContainer,
@@ -20,7 +21,13 @@ import {
 } from '../../../utils/videoStatus';
 import { SHARED_THEMED_CHIP_SMALL_STYLE } from '../../shared/chipStyles';
 import { formatDurationClock } from '../../../utils';
-import { SearchResult, THUMB_WIDTH, THUMB_HEIGHT } from '../types';
+import {
+  isSelectableForDownload,
+  ResultSelection,
+  SearchResult,
+  THUMB_WIDTH,
+  THUMB_HEIGHT,
+} from '../types';
 
 function StatusChip({ status }: { status: VideoStatus }) {
   return (
@@ -41,14 +48,16 @@ function StatusChip({ status }: { status: VideoStatus }) {
 interface ResultsTableProps {
   results: SearchResult[];
   onResultClick: (result: SearchResult) => void;
+  selection?: ResultSelection;
 }
 
-export default function ResultsTable({ results, onResultClick }: ResultsTableProps) {
+export default function ResultsTable({ results, onResultClick, selection }: ResultsTableProps) {
   return (
     <TableContainer>
       <Table size="small" className="table-fixed">
         <TableHead>
           <TableRow>
+            {selection && <TableCell component="th" className="w-[40px]" aria-label="Select" />}
             <TableCell component="th" className="w-[140px]">Thumbnail</TableCell>
             <TableCell component="th" className="w-[40%]">Title</TableCell>
             <TableCell component="th" className="w-[22%]">Channel</TableCell>
@@ -60,6 +69,8 @@ export default function ResultsTable({ results, onResultClick }: ResultsTablePro
         <TableBody>
           {results.map((result) => {
             const status: VideoStatus = result.status;
+            const selectable = Boolean(selection) && isSelectableForDownload(result.status);
+            const checked = selectable && selection!.isChecked(result.youtubeId);
             return (
               <TableRow
                 key={result.youtubeId}
@@ -68,6 +79,20 @@ export default function ResultsTable({ results, onResultClick }: ResultsTablePro
                 className="cursor-pointer"
                 aria-label={`Open ${result.title}`}
               >
+                {selection && (
+                  <TableCell onClick={(e) => e.stopPropagation()}>
+                    {selectable ? (
+                      <Checkbox
+                        checked={checked}
+                        onChange={() => selection.toggle(result.youtubeId)}
+                        inputProps={{
+                          'aria-label': `Select ${result.title} for download`,
+                          'data-testid': `select-row-${result.youtubeId}`,
+                        }}
+                      />
+                    ) : null}
+                  </TableCell>
+                )}
                 <TableCell>
                   <div
                     className="relative inline-block overflow-hidden bg-[var(--media-placeholder-background)] rounded-[var(--radius-thumb)]"

--- a/client/src/components/FindVideos/components/SearchBar.tsx
+++ b/client/src/components/FindVideos/components/SearchBar.tsx
@@ -1,23 +1,32 @@
 import React from 'react';
 import { Box, Button, TextField, Select, MenuItem } from '../../ui';
 import { Loader2, LayoutGrid as ViewModuleIcon, Rows as TableChartIcon } from '../../../lib/icons';
-import { PAGE_SIZES, PageSize, ViewMode } from '../types';
+import {
+  PAGE_SIZES,
+  PageSize,
+  ViewMode,
+  MinDuration,
+  MIN_DURATIONS,
+  MIN_DURATION_LABELS,
+} from '../types';
 
 interface SearchBarProps {
   query: string;
   pageSize: PageSize;
+  minDuration: MinDuration;
   loading: boolean;
   viewMode: ViewMode;
   onQueryChange: (q: string) => void;
   onPageSizeChange: (s: PageSize) => void;
+  onMinDurationChange: (d: MinDuration) => void;
   onViewModeChange: (v: ViewMode) => void;
   onSearch: () => void;
   onCancel: () => void;
 }
 
 export default function SearchBar({
-  query, pageSize, loading, viewMode,
-  onQueryChange, onPageSizeChange, onViewModeChange, onSearch, onCancel,
+  query, pageSize, minDuration, loading, viewMode,
+  onQueryChange, onPageSizeChange, onMinDurationChange, onViewModeChange, onSearch, onCancel,
 }: SearchBarProps) {
   const trimmed = query.trim();
   const canSearch = !loading && trimmed.length > 0;
@@ -43,6 +52,16 @@ export default function SearchBar({
       >
         {PAGE_SIZES.map((n) => (
           <MenuItem key={n} value={String(n)}>{n} results</MenuItem>
+        ))}
+      </Select>
+      <Select
+        value={String(minDuration)}
+        onValueChange={(v) => onMinDurationChange(Number(v) as MinDuration)}
+        disabled={loading}
+        aria-label="Minimum duration"
+      >
+        {MIN_DURATIONS.map((d) => (
+          <MenuItem key={d} value={String(d)}>{MIN_DURATION_LABELS[d]}</MenuItem>
         ))}
       </Select>
       {loading ? (

--- a/client/src/components/FindVideos/components/__tests__/SearchBar.test.tsx
+++ b/client/src/components/FindVideos/components/__tests__/SearchBar.test.tsx
@@ -5,10 +5,12 @@ import SearchBar from '../SearchBar';
 const baseProps = {
   query: '',
   pageSize: 25 as const,
+  minDuration: 0 as const,
   loading: false,
   viewMode: 'grid' as const,
   onQueryChange: () => {},
   onPageSizeChange: () => {},
+  onMinDurationChange: () => {},
   onViewModeChange: () => {},
   onSearch: () => {},
   onCancel: () => {},

--- a/client/src/components/FindVideos/hooks/__tests__/useVideoSearch.test.ts
+++ b/client/src/components/FindVideos/hooks/__tests__/useVideoSearch.test.ts
@@ -24,23 +24,50 @@ describe('useVideoSearch', () => {
     expect(result.current.error).toBeNull();
   });
 
-  test('single in-flight: second search while loading is ignored', async () => {
-    let resolveFirst: (v: unknown) => void = () => {};
-    axios.post.mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }));
+  test('second search while loading aborts the first and runs the new one', async () => {
+    const firstSignals: AbortSignal[] = [];
+    axios.post.mockImplementationOnce((_url: string, _body: unknown, opts: { signal?: AbortSignal }) => {
+      if (opts.signal) firstSignals.push(opts.signal);
+      return new Promise((_resolve, reject) => {
+        opts.signal?.addEventListener('abort', () => reject(new axios.CanceledError()));
+      });
+    });
+    axios.post.mockResolvedValueOnce({ data: { results: [{ youtubeId: 'b', title: 'B' }] } });
 
     const { result } = renderHook(() => useVideoSearch('token'));
 
     act(() => { result.current.search('first', 25); });
     await waitFor(() => expect(result.current.loading).toBe(true));
 
+    await act(async () => { await result.current.search('second', 25); });
+
+    expect(axios.post).toHaveBeenCalledTimes(2);
+    expect(firstSignals[0].aborted).toBe(true);
+    expect(result.current.results).toEqual([{ youtubeId: 'b', title: 'B' }]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  test('starting a new search clears stale results so they do not persist on screen', async () => {
+    axios.post.mockResolvedValueOnce({ data: { results: [{ youtubeId: 'old', title: 'Old' }] } });
+    let resolveSecond: (v: unknown) => void = () => {};
+    axios.post.mockImplementationOnce(() => new Promise((resolve) => { resolveSecond = resolve; }));
+
+    const { result } = renderHook(() => useVideoSearch('token'));
+    await act(async () => { await result.current.search('first', 25); });
+    expect(result.current.results).toEqual([{ youtubeId: 'old', title: 'Old' }]);
+
     act(() => { result.current.search('second', 25); });
-    expect(axios.post).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    // While the second search is in flight, the old results must be gone.
+    expect(result.current.results).toEqual([]);
 
     await act(async () => {
-      resolveFirst({ data: { results: [] } });
+      resolveSecond({ data: { results: [{ youtubeId: 'new', title: 'New' }] } });
       await Promise.resolve();
     });
     await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.results).toEqual([{ youtubeId: 'new', title: 'New' }]);
   });
 
   test('cancel aborts the request and clears state without setting error', async () => {

--- a/client/src/components/FindVideos/hooks/useVideoSearch.ts
+++ b/client/src/components/FindVideos/hooks/useVideoSearch.ts
@@ -21,11 +21,16 @@ export function useVideoSearch(token: string | null): UseVideoSearchResult {
   }, []);
 
   const search = useCallback(async (query: string, count: PageSize) => {
-    if (controllerRef.current) return;
+    // Cancel any in-flight search so a stale response cannot overwrite a newer
+    // one and leave the prior search's results stuck on the page.
+    if (controllerRef.current) {
+      controllerRef.current.abort();
+    }
     const controller = new AbortController();
     controllerRef.current = controller;
     setLoading(true);
     setError(null);
+    setResults([]);
 
     try {
       const res = await axios.post(
@@ -36,18 +41,22 @@ export function useVideoSearch(token: string | null): UseVideoSearchResult {
           signal: controller.signal,
         }
       );
+      // Late-arriving response from a superseded search: drop it.
+      if (controllerRef.current !== controller) return;
       setResults(res.data.results || []);
     } catch (err: unknown) {
       if (axios.isCancel(err)) {
-        // user canceled; do not surface as error
-      } else {
+        // user canceled or superseded; do not surface as error
+      } else if (controllerRef.current === controller) {
         const message = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
           || 'Search failed';
         setError(message);
       }
     } finally {
-      controllerRef.current = null;
-      setLoading(false);
+      if (controllerRef.current === controller) {
+        controllerRef.current = null;
+        setLoading(false);
+      }
     }
   }, [token]);
 

--- a/client/src/components/FindVideos/index.tsx
+++ b/client/src/components/FindVideos/index.tsx
@@ -1,12 +1,43 @@
-import React, { useCallback, useRef, useState } from 'react';
-import { Box, Typography } from '../ui';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Alert, Box, Typography } from '../ui';
+import { Download as DownloadIcon } from '../../lib/icons';
 import VideoModal from '../shared/VideoModal';
 import { VideoModalData } from '../shared/VideoModal/types';
 import { useMediaQuery } from '../../hooks/useMediaQuery';
+import { useConfig } from '../../hooks/useConfig';
+import { useTriggerDownloads } from '../../hooks/useTriggerDownloads';
+import { useVideoSelection } from '../shared/VideoList/hooks/useVideoSelection';
+import VideoListSelectionPill from '../shared/VideoList/VideoListSelectionPill';
+import { SelectionAction } from '../shared/VideoList/types';
+import DownloadSettingsDialog from '../DownloadManager/ManualDownload/DownloadSettingsDialog';
+import { DownloadSettings } from '../DownloadManager/ManualDownload/types';
 import SearchBar from './components/SearchBar';
 import ResultsGrid from './components/ResultsGrid';
 import { useVideoSearch } from './hooks/useVideoSearch';
-import { DEFAULT_PAGE_SIZE, PageSize, SearchResult, ViewMode } from './types';
+import {
+  DEFAULT_MIN_DURATION,
+  DEFAULT_PAGE_SIZE,
+  isSelectableForDownload,
+  MIN_DURATIONS,
+  MIN_DURATION_STORAGE_KEY,
+  MinDuration,
+  PageSize,
+  ResultSelection,
+  SearchResult,
+  ViewMode,
+} from './types';
+
+function readStoredMinDuration(): MinDuration {
+  try {
+    const raw = window.localStorage.getItem(MIN_DURATION_STORAGE_KEY);
+    if (raw === null) return DEFAULT_MIN_DURATION;
+    const parsed = Number(raw) as MinDuration;
+    return MIN_DURATIONS.includes(parsed) ? parsed : DEFAULT_MIN_DURATION;
+  } catch {
+    return DEFAULT_MIN_DURATION;
+  }
+}
 
 interface FindVideosProps {
   token: string | null;
@@ -39,19 +70,39 @@ function toModalData(r: SearchResult): VideoModalData {
 
 export default function FindVideos({ token }: FindVideosProps) {
   const isMobile = useMediaQuery('(max-width: 767px)');
+  const navigate = useNavigate();
   const [query, setQuery] = useState('');
   const [pageSize, setPageSize] = useState<PageSize>(DEFAULT_PAGE_SIZE);
+  const [minDuration, setMinDuration] = useState<MinDuration>(readStoredMinDuration);
   const [hasSearched, setHasSearched] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>(isMobile ? 'table' : 'grid');
   const [modalVideo, setModalVideo] = useState<VideoModalData | null>(null);
+  const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
   const lastQueryRef = useRef('');
   const lastPageSizeRef = useRef<PageSize>(DEFAULT_PAGE_SIZE);
 
   const { results, loading, error, search, cancel } = useVideoSearch(token);
+  const { config } = useConfig(token);
+  const { triggerDownloads } = useTriggerDownloads(token);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(MIN_DURATION_STORAGE_KEY, String(minDuration));
+    } catch {
+      // localStorage unavailable (private mode, quota); filter still works in-session.
+    }
+  }, [minDuration]);
+
+  const filteredResults = useMemo(() => {
+    if (minDuration === 0) return results;
+    return results.filter((r) => r.duration === null || r.duration >= minDuration);
+  }, [results, minDuration]);
 
   const doSearch = useCallback(() => {
     const trimmed = query.trim();
     if (!trimmed) return;
+    setDownloadError(null);
     lastQueryRef.current = trimmed;
     lastPageSizeRef.current = pageSize;
     setHasSearched(true);
@@ -63,30 +114,138 @@ export default function FindVideos({ token }: FindVideosProps) {
     search(lastQueryRef.current, lastPageSizeRef.current);
   }, [search]);
 
+  const showFilterCount =
+    hasSearched && !loading && !error && minDuration !== 0 && results.length > 0;
+  const allFilteredOut =
+    showFilterCount && results.length > 0 && filteredResults.length === 0;
+
+  const downloadActions: SelectionAction<string>[] = useMemo(
+    () => [
+      {
+        id: 'download',
+        label: 'Download',
+        icon: <DownloadIcon size={14} />,
+        intent: 'success',
+        onClick: () => {
+          setDownloadError(null);
+          setDownloadDialogOpen(true);
+        },
+      },
+    ],
+    []
+  );
+
+  const selection = useVideoSelection<string>({ actions: downloadActions });
+
+  // Drop selected ids that are no longer eligible (e.g. their status changed,
+  // or a new search wiped them from the results list).
+  useEffect(() => {
+    if (selection.selectedIds.length === 0) return;
+    const eligibleIds = new Set(
+      results.filter((r) => isSelectableForDownload(r.status)).map((r) => r.youtubeId)
+    );
+    const stillValid = selection.selectedIds.filter((id) => eligibleIds.has(id));
+    if (stillValid.length !== selection.selectedIds.length) selection.set(stillValid);
+  }, [results, selection.selectedIds, selection.set]);
+
+  const resultSelection: ResultSelection = useMemo(
+    () => ({
+      isChecked: (id: string) => selection.isSelected(id),
+      toggle: (id: string) => selection.toggle(id),
+    }),
+    [selection.isSelected, selection.toggle]
+  );
+
+  const handleDownloadConfirm = useCallback(
+    async (settings: DownloadSettings | null) => {
+      setDownloadDialogOpen(false);
+      const ids = selection.selectedIds;
+      if (ids.length === 0) return;
+      const urls = ids.map((id) => `https://www.youtube.com/watch?v=${id}`);
+      const overrideSettings = settings
+        ? {
+            resolution: settings.resolution,
+            allowRedownload: settings.allowRedownload,
+            subfolder: settings.subfolder,
+            audioFormat: settings.audioFormat,
+            rating: settings.rating,
+            skipVideoFolder: settings.skipVideoFolder,
+          }
+        : undefined;
+      const success = await triggerDownloads({ urls, overrideSettings });
+      if (!success) {
+        setDownloadError('Failed to queue selected videos. Please try again.');
+        return;
+      }
+      selection.clear();
+      navigate('/downloads/activity');
+    },
+    [selection, triggerDownloads, navigate]
+  );
+
+  const missingVideoCount = useMemo(
+    () => results.filter((r) => selection.isSelected(r.youtubeId) && r.status === 'missing').length,
+    [results, selection.isSelected]
+  );
+  const defaultResolution = config.preferredResolution || '1080';
+
   return (
     <Box className="flex flex-col gap-4 py-4">
       <Typography variant="h5">Find on YouTube</Typography>
       <SearchBar
         query={query}
         pageSize={pageSize}
+        minDuration={minDuration}
         loading={loading}
         viewMode={viewMode}
         onQueryChange={setQuery}
         onPageSizeChange={setPageSize}
+        onMinDurationChange={setMinDuration}
         onViewModeChange={setViewMode}
         onSearch={doSearch}
         onCancel={cancel}
       />
-      <ResultsGrid
-        results={results}
-        loading={loading}
-        error={error}
-        hasSearched={hasSearched}
-        lastQuery={lastQueryRef.current}
-        pageSize={pageSize}
-        viewMode={viewMode}
-        onResultClick={(r) => setModalVideo(toModalData(r))}
-        onRetry={onRetry}
+      {showFilterCount && (
+        <Typography variant="body2" className="text-muted-foreground">
+          Showing {filteredResults.length} of {results.length} results (
+          {results.length - filteredResults.length} hidden by minimum duration filter)
+        </Typography>
+      )}
+      {downloadError && (
+        <Alert severity="error" onClose={() => setDownloadError(null)}>
+          {downloadError}
+        </Alert>
+      )}
+      {allFilteredOut ? (
+        <Typography variant="body2" className="text-muted-foreground">
+          All {results.length} results were hidden by the minimum duration filter. Try
+          lowering it to see more.
+        </Typography>
+      ) : (
+        <ResultsGrid
+          results={filteredResults}
+          loading={loading}
+          error={error}
+          hasSearched={hasSearched}
+          lastQuery={lastQueryRef.current}
+          pageSize={pageSize}
+          viewMode={viewMode}
+          onResultClick={(r) => setModalVideo(toModalData(r))}
+          onRetry={onRetry}
+          selection={resultSelection}
+        />
+      )}
+      <VideoListSelectionPill selection={selection} isMobile={isMobile} />
+      <DownloadSettingsDialog
+        open={downloadDialogOpen}
+        onClose={() => setDownloadDialogOpen(false)}
+        onConfirm={handleDownloadConfirm}
+        videoCount={selection.selectedIds.length}
+        missingVideoCount={missingVideoCount}
+        defaultResolution={defaultResolution}
+        defaultResolutionSource="global"
+        mode="manual"
+        token={token}
       />
       {modalVideo && (
         <VideoModal

--- a/client/src/components/FindVideos/types.ts
+++ b/client/src/components/FindVideos/types.ts
@@ -21,11 +21,40 @@ export interface SearchResult {
   ratingSource?: string | null;
 }
 
-export type PageSize = 10 | 25 | 50;
-export const PAGE_SIZES: PageSize[] = [10, 25, 50];
+export type PageSize = 10 | 25 | 50 | 100;
+export const PAGE_SIZES: PageSize[] = [10, 25, 50, 100];
 export const DEFAULT_PAGE_SIZE: PageSize = 25;
 
 export type ViewMode = 'grid' | 'table';
 
+// Minimum-duration filter applied client-side. 0 = no filter, show everything
+// (including Shorts). Other values are minimum seconds.
+export type MinDuration = 0 | 60 | 180 | 300 | 600 | 900 | 1200;
+export const MIN_DURATIONS: MinDuration[] = [0, 60, 180, 300, 600, 900, 1200];
+export const DEFAULT_MIN_DURATION: MinDuration = 0;
+export const MIN_DURATION_LABELS: Record<MinDuration, string> = {
+  0: 'Any length',
+  60: '1+ min',
+  180: '3+ min',
+  300: '5+ min',
+  600: '10+ min',
+  900: '15+ min',
+  1200: '20+ min',
+};
+
+export const MIN_DURATION_STORAGE_KEY = 'findVideos.minDuration';
+
 export const THUMB_WIDTH = 120;
 export const THUMB_HEIGHT = 67;
+
+export interface ResultSelection {
+  isChecked: (id: string) => boolean;
+  toggle: (id: string) => void;
+}
+
+// Eligible to multi-select for download. Includes 'missing' so users can bulk
+// re-download videos whose files are gone; the DownloadSettingsDialog already
+// surfaces the allow-redownload toggle for that case.
+export function isSelectableForDownload(status: SearchResultStatus): boolean {
+  return status === 'never_downloaded' || status === 'missing';
+}

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -353,10 +353,11 @@ Search YouTube from inside Youtarr and see which results you already have, which
 1. **Open Find on YouTube**
    - In the sidebar, expand **Videos** and click **Find on YouTube**
    - Enter a search query (up to 200 characters)
-   - Pick a result count (10, 25, or 50) and click Search
+   - Pick a result count (10, 25, 50, or 100), optionally choose a minimum duration, and click Search
 
 2. **Results**
    - Sorted newest-to-oldest by YouTube's approximate publish date (accurate to within a day or two, same fidelity as the channel videos page)
+   - If a minimum duration is selected, shorter results are hidden in the browser and the page shows how many results were filtered out
    - Each card shows the channel, duration, upload date, and a status chip:
      - **Downloaded**: already in your library
      - **Missing**: previously downloaded but removed from disk

--- a/server/modules/videoSearchModule.js
+++ b/server/modules/videoSearchModule.js
@@ -5,7 +5,7 @@ const { Video } = require('../models');
 const youtubeApi = require('./youtubeApi');
 
 const SEARCH_TIMEOUT_MS = 60_000;
-const ALLOWED_COUNTS = [10, 25, 50];
+const ALLOWED_COUNTS = [10, 25, 50, 100];
 
 class SearchCanceledError extends Error {
   constructor() { super('Search canceled'); this.name = 'SearchCanceledError'; }
@@ -63,12 +63,16 @@ class VideoSearchModule {
   _parseNdjson(stdout, query) {
     const lines = stdout.split('\n');
     const results = [];
+    const seenIds = new Set();
     for (const line of lines) {
       const trimmed = line.trim();
       if (!trimmed) continue;
       try {
         const entry = JSON.parse(trimmed);
-        results.push(this._normalize(entry));
+        const normalized = this._normalize(entry);
+        if (normalized.youtubeId && seenIds.has(normalized.youtubeId)) continue;
+        if (normalized.youtubeId) seenIds.add(normalized.youtubeId);
+        results.push(normalized);
       } catch (err) {
         logger.warn({ err, query, line: trimmed.slice(0, 200) }, 'skipping unparseable yt-dlp line');
       }

--- a/server/modules/youtubeApi/__tests__/client.test.js
+++ b/server/modules/youtubeApi/__tests__/client.test.js
@@ -512,7 +512,7 @@ describe('youtubeApi/client', () => {
       );
     });
 
-    test('filters out Shorts shorter than 60 seconds after enrichment', async () => {
+    test('does not drop Shorts; frontend filter owns that policy now', async () => {
       axios.get.mockResolvedValueOnce({
         status: 200,
         data: {
@@ -536,8 +536,138 @@ describe('youtubeApi/client', () => {
 
       const results = await client.searchVideos('api-key', 'q', 10);
 
-      // 60s is kept (boundary), 45s is dropped, 10m is kept.
-      expect(results.map((r) => r.youtubeId)).toEqual(['exact60sss1', 'longvideo01']);
+      expect(results.map((r) => r.youtubeId)).toEqual(['short000001', 'exact60sss1', 'longvideo01']);
+      expect(results.map((r) => r.duration)).toEqual([45, 60, 600]);
+    });
+
+    test('paginates search.list when caller requests more than one page', async () => {
+      const firstPageItems = Array.from({ length: 50 }, (_, i) => ({
+        id: { kind: 'youtube#video', videoId: `firstpag${String(i).padStart(3, '0')}` },
+        snippet: { title: `P1-${i}`, publishedAt: '2024-01-01T00:00:00Z' },
+      }));
+      const secondPageItems = Array.from({ length: 50 }, (_, i) => ({
+        id: { kind: 'youtube#video', videoId: `secondpg${String(i).padStart(3, '0')}` },
+        snippet: { title: `P2-${i}`, publishedAt: '2024-01-01T00:00:00Z' },
+      }));
+
+      axios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { items: firstPageItems, nextPageToken: 'TOKEN-2' },
+      });
+      axios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { items: secondPageItems },
+      });
+      // videos.list batches: 50 per call, so 100 IDs = 2 batches.
+      const allIds = [...firstPageItems, ...secondPageItems].map((it) => it.id.videoId);
+      axios.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          items: allIds.slice(0, 50).map((id) => ({
+            id,
+            contentDetails: { duration: 'PT5M' },
+            statistics: { viewCount: '10' },
+          })),
+        },
+      });
+      axios.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          items: allIds.slice(50).map((id) => ({
+            id,
+            contentDetails: { duration: 'PT5M' },
+            statistics: { viewCount: '10' },
+          })),
+        },
+      });
+
+      const results = await client.searchVideos('api-key', 'q', 100);
+
+      expect(results).toHaveLength(100);
+      // Second search.list call carries the pageToken from the first response.
+      expect(axios.get).toHaveBeenNthCalledWith(
+        2,
+        'https://www.googleapis.com/youtube/v3/search',
+        expect.objectContaining({
+          params: expect.objectContaining({ pageToken: 'TOKEN-2' }),
+        })
+      );
+    });
+
+    test('deduplicates videoIds that appear on multiple search.list pages', async () => {
+      const sharedItem = {
+        id: { kind: 'youtube#video', videoId: 'sharedid001' },
+        snippet: { title: 'Shared', publishedAt: '2024-01-01T00:00:00Z' },
+      };
+      const uniqueItem = {
+        id: { kind: 'youtube#video', videoId: 'uniqueid002' },
+        snippet: { title: 'Unique', publishedAt: '2024-01-01T00:00:00Z' },
+      };
+      axios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { items: [sharedItem], nextPageToken: 'TOKEN-2' },
+      });
+      axios.get.mockResolvedValueOnce({
+        status: 200,
+        data: { items: [sharedItem, uniqueItem] },
+      });
+      axios.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          items: [
+            { id: 'sharedid001', contentDetails: { duration: 'PT5M' }, statistics: { viewCount: '10' } },
+            { id: 'uniqueid002', contentDetails: { duration: 'PT5M' }, statistics: { viewCount: '10' } },
+          ],
+        },
+      });
+
+      const results = await client.searchVideos('api-key', 'q', 100);
+
+      expect(results.map((r) => r.youtubeId)).toEqual(['sharedid001', 'uniqueid002']);
+    });
+
+    test('stops paginating when nextPageToken is missing even if below requested count', async () => {
+      const items = Array.from({ length: 30 }, (_, i) => ({
+        id: { kind: 'youtube#video', videoId: `onlypage${String(i).padStart(3, '0')}` },
+        snippet: { title: `O-${i}`, publishedAt: '2024-01-01T00:00:00Z' },
+      }));
+      axios.get.mockResolvedValueOnce({ status: 200, data: { items } });
+      axios.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          items: items.map((it) => ({
+            id: it.id.videoId,
+            contentDetails: { duration: 'PT5M' },
+            statistics: { viewCount: '10' },
+          })),
+        },
+      });
+
+      const results = await client.searchVideos('api-key', 'q', 100);
+
+      expect(results).toHaveLength(30);
+      // Only 1 search.list call + 1 videos.list call = 2 axios calls.
+      expect(axios.get).toHaveBeenCalledTimes(2);
+    });
+
+    test('caps pagination when pages contain no usable video results', async () => {
+      axios.get
+        .mockResolvedValueOnce({ status: 200, data: { items: [], nextPageToken: 'TOKEN-2' } })
+        .mockResolvedValueOnce({ status: 200, data: { items: [], nextPageToken: 'TOKEN-3' } })
+        .mockResolvedValueOnce({ status: 200, data: { items: [], nextPageToken: 'TOKEN-4' } })
+        .mockResolvedValueOnce({ status: 200, data: { items: [], nextPageToken: 'TOKEN-5' } });
+
+      const results = await client.searchVideos('api-key', 'q', 100);
+
+      expect(results).toEqual([]);
+      expect(axios.get).toHaveBeenCalledTimes(3);
+      expect(axios.get).toHaveBeenNthCalledWith(
+        3,
+        'https://www.googleapis.com/youtube/v3/search',
+        expect.objectContaining({
+          params: expect.objectContaining({ pageToken: 'TOKEN-3' }),
+        })
+      );
     });
 
     test('keeps items whose enrichment row is missing so gaps do not silently drop videos', async () => {

--- a/server/modules/youtubeApi/client.js
+++ b/server/modules/youtubeApi/client.js
@@ -13,18 +13,17 @@ const {
 // Reference video for key validation: a permanently public, well-known video.
 const TEST_VIDEO_ID = 'dQw4w9WgXcQ';
 
-// searchVideos filters client-side to approximate yt-dlp's ytsearch behavior,
-// which uses YouTube's "Videos" result filter and excludes Shorts/live streams.
-// The Data API has no equivalent query-side filter, so:
-//   - We always request the API's max page size (cost is flat at 100 units
-//     regardless of maxResults), giving headroom to drop Shorts/live and still
-//     satisfy the caller's requested count.
-//   - Live/upcoming broadcasts are identified by snippet.liveBroadcastContent
-//     on the raw search response, so this filter applies even if enrichment fails.
-//   - Shorts are identified by duration strictly under 60s. Past-livestreams
-//     return 'none' in liveBroadcastContent and will pass through.
+// search.list caps maxResults at 50 per page. To support caller counts above 50
+// (or simply to fill a 50 result page after server-side filters drop a few),
+// we paginate via nextPageToken. Each page costs 100 quota units flat regardless
+// of maxResults, so we always request the max page size.
+//
+// We do NOT filter Shorts server-side; the frontend exposes a user-controlled
+// minimum-duration filter so users can opt into long-form-only when they want
+// it. Live/upcoming broadcasts are still dropped here because they have no
+// playable file and would surface a useless result card.
 const SEARCH_LIST_MAX_RESULTS = 50;
-const SEARCH_MIN_DURATION_SECONDS = 60;
+const SEARCH_LIST_EXTRA_PAGE_BUFFER = 1;
 
 // Per-tab auto-generated playlist prefixes. UU is all uploads combined;
 // UULF/UUSH/UULV are the same content partitioned by media type and correspond
@@ -250,73 +249,80 @@ async function getChannelInfo(apiKey, channelUrl, { signal } = {}) {
 }
 
 async function searchVideos(apiKey, query, maxResults, { signal } = {}) {
-  const data = await apiGet(
-    apiKey,
-    ENDPOINTS.search,
-    {
+  const baseResults = [];
+  // YouTube's search.list can return the same videoId across pages when
+  // paginated, so we dedupe defensively to avoid showing the same card twice.
+  const seenIds = new Set();
+  let pageToken;
+  let pagesFetched = 0;
+  const maxPages = Math.ceil(maxResults / SEARCH_LIST_MAX_RESULTS) + SEARCH_LIST_EXTRA_PAGE_BUFFER;
+
+  while (baseResults.length < maxResults && pagesFetched < maxPages) {
+    const params = {
       q: query,
       type: 'video',
       part: 'snippet',
       maxResults: SEARCH_LIST_MAX_RESULTS,
-    },
-    { signal }
-  );
+    };
+    if (pageToken) params.pageToken = pageToken;
 
-  if (!Array.isArray(data.items)) return [];
+    // eslint-disable-next-line no-await-in-loop
+    const data = await apiGet(apiKey, ENDPOINTS.search, params, { signal });
+    pagesFetched += 1;
 
-  const baseResults = data.items
-    .filter((item) => item?.id?.kind === 'youtube#video' && item?.id?.videoId)
-    .filter((item) => {
-      const live = item?.snippet?.liveBroadcastContent;
-      return live !== 'live' && live !== 'upcoming';
-    })
-    .map((item) => {
-      const snippet = item.snippet || {};
-      return {
-        youtubeId: item.id.videoId,
-        title: snippet.title || '',
-        channelId: snippet.channelId || null,
-        channelName: snippet.channelTitle || '',
-        publishedAt: snippet.publishedAt ? new Date(snippet.publishedAt).toISOString() : null,
-        thumbnailUrl: snippet.thumbnails?.high?.url
-          || snippet.thumbnails?.medium?.url
-          || snippet.thumbnails?.default?.url
-          || null,
-        duration: null,
-        viewCount: null,
-        status: 'never_downloaded',
-      };
-    });
+    if (Array.isArray(data.items)) {
+      for (const item of data.items) {
+        if (item?.id?.kind !== 'youtube#video' || !item?.id?.videoId) continue;
+        if (seenIds.has(item.id.videoId)) continue;
+        const live = item?.snippet?.liveBroadcastContent;
+        if (live === 'live' || live === 'upcoming') continue;
+        const snippet = item.snippet || {};
+        seenIds.add(item.id.videoId);
+        baseResults.push({
+          youtubeId: item.id.videoId,
+          title: snippet.title || '',
+          channelId: snippet.channelId || null,
+          channelName: snippet.channelTitle || '',
+          publishedAt: snippet.publishedAt ? new Date(snippet.publishedAt).toISOString() : null,
+          thumbnailUrl: snippet.thumbnails?.high?.url
+            || snippet.thumbnails?.medium?.url
+            || snippet.thumbnails?.default?.url
+            || null,
+          duration: null,
+          viewCount: null,
+          status: 'never_downloaded',
+        });
+      }
+    }
+
+    if (!data.nextPageToken) break;
+    pageToken = data.nextPageToken;
+  }
 
   if (baseResults.length === 0) return baseResults;
 
+  const trimmed = baseResults.slice(0, maxResults);
+
   // search.list returns snippet only - duration and view count are not in it.
   // A follow-up videos.list batch (1 unit per 50 IDs, vs the 100-unit search
-  // call above) fills them in so result cards and the VideoModal can render
-  // duration, and lets us drop Shorts by duration. If enrichment fails, fall
-  // back to the pre-enrichment results (which have already had live/upcoming
-  // filtered out) rather than failing the whole search.
+  // call above) fills them in so result cards can render duration. Batching
+  // happens inside getVideoMetadata. If enrichment fails, fall back to the
+  // pre-enrichment results rather than failing the whole search.
   try {
-    const videoIds = baseResults.map((r) => r.youtubeId);
+    const videoIds = trimmed.map((r) => r.youtubeId);
     const metadata = await getVideoMetadata(apiKey, videoIds, { signal });
     const byId = new Map(metadata.map((m) => [m.id, m]));
-    const enriched = baseResults.map((r) => {
+    return trimmed.map((r) => {
       const m = byId.get(r.youtubeId);
       if (!m) return r;
       return { ...r, duration: m.duration ?? null, viewCount: m.viewCount ?? null };
     });
-    // Keep videos with unknown duration (enrichment gap) so a missing item
-    // never silently disappears; drop only videos we know are Shorts.
-    const filtered = enriched.filter(
-      (r) => r.duration === null || r.duration >= SEARCH_MIN_DURATION_SECONDS
-    );
-    return filtered.slice(0, maxResults);
   } catch (err) {
     if (err && err.code === YoutubeApiErrorCode.CANCELED) {
       throw err;
     }
     logger.warn({ err, code: err?.code }, 'YouTube API searchVideos metadata enrichment failed');
-    return baseResults.slice(0, maxResults);
+    return trimmed;
   }
 }
 

--- a/server/routes/__tests__/videoSearch.test.js
+++ b/server/routes/__tests__/videoSearch.test.js
@@ -14,7 +14,7 @@ class SearchCanceledError extends Error {
 
 function buildApp({ verifyToken, searchVideos }) {
   const videoSearchModule = {
-    ALLOWED_COUNTS: [10, 25, 50],
+    ALLOWED_COUNTS: [10, 25, 50, 100],
     SearchTimeoutError,
     SearchCanceledError,
     searchVideos: searchVideos || jest.fn(),

--- a/server/routes/videoSearch.js
+++ b/server/routes/videoSearch.js
@@ -58,7 +58,7 @@ function createVideoSearchRoutes({ verifyToken, videoSearchModule }) {
    *                 example: "Minecraft"
    *               count:
    *                 type: integer
-   *                 enum: [10, 25, 50]
+   *                 enum: [10, 25, 50, 100]
    *                 default: 25
    *                 description: Number of results to fetch from YouTube.
    *     responses:


### PR DESCRIPTION
Move the Shorts cutoff out of the YouTube API client so users can choose their own minimum duration. The new client-side filter (persisted via localStorage) covers Any length, 1+, 3+, 5+, 10+, 15+, and 20+ minutes; results below the threshold are hidden in the browser and the page surfaces "X of Y" plus a filter-aware empty state.

Add a 100-result page size. The Data API search.list caps each page at 50 items and the same videoId can appear on multiple pages, so the client now paginates via nextPageToken and dedupes by id; the yt-dlp ndjson path also dedupes defensively. Live and upcoming broadcasts are still dropped server-side because they have no downloadable file.

Add multi-select checkboxes to grid, table, and mobile list views, wired to the shared VideoListSelectionPill. Eligible statuses are never_downloaded and missing; downloaded results render no checkbox. Confirming the selection opens the existing download settings dialog and routes to /downloads/activity. Starting a new search aborts any in-flight request, clears stale results so they cannot remain on screen, and drops selected ids that are no longer eligible.