### PR TITLE
fix(downloads): tolerate expected yt-dlp skips

### DIFF
--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -1188,7 +1188,7 @@ describe('DownloadExecutor', () => {
       );
     });
 
-    it('should accumulate and persist grouped videos when yt-dlp exits non-zero', async () => {
+    it('should accumulate grouped videos without treating expected skips as failures', async () => {
       const existingVideo = { youtubeId: 'existing123', filePath: '/output/existing.mp4', fileSize: '2048' };
       const newVideo = { youtubeId: 'success1234', filePath: '/output/new.mp4', fileSize: '1024' };
       const existingFailedVideo = { youtubeId: 'oldfailed1', error: 'Old failure' };
@@ -1223,16 +1223,17 @@ describe('DownloadExecutor', () => {
         expect.objectContaining({
           data: expect.objectContaining({
             videos: [existingVideo, newVideo],
-            failedVideos: expect.arrayContaining([
-              existingFailedVideo,
-              expect.objectContaining({
-                youtubeId: 'failed12345',
-                error: 'This video is members-only'
-              })
-            ]),
+            failedVideos: [existingFailedVideo],
             cumulativeSkipped: 2
           })
         })
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          youtubeId: 'failed12345',
+          source: 'stdout'
+        }),
+        'Expected video skip from yt-dlp'
       );
       expect(jobModule.updateJob).not.toHaveBeenCalledWith(
         mockJobId,
@@ -1470,6 +1471,209 @@ describe('DownloadExecutor', () => {
         { error: 'Private video', currentVideoId: 'def456XYZ' },
         'Error detected in stderr'
       );
+    });
+
+    it('should treat members-only download errors as expected skips', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        {
+          youtubeId: 'success1234',
+          filePath: '/output/video.mp4',
+          fileSize: '1024',
+          youTubeVideoName: 'Downloaded Video',
+          youTubeChannelName: 'Channel'
+        }
+      ]);
+      archiveModule.getNewVideoUrlsSince.mockReturnValue(['https://youtu.be/success1234']);
+
+      setTimeout(() => {
+        mockProcess.stdout.emit('data', '[youtube] Extracting URL: https://youtube.com/watch?v=member12345\n');
+        mockProcess.stdout.emit('data', 'ERROR: [youtube] member12345: Join this channel to get access to members-only content like this video, and other exclusive perks.\n');
+        mockProcess.emit('exit', 1, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          youtubeId: 'member12345',
+          source: 'stdout'
+        }),
+        'Expected video skip from yt-dlp'
+      );
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.objectContaining({ currentVideoId: 'member12345' }),
+        'Error detected during download'
+      );
+      expect(archiveModule.removeVideoFromArchive).not.toHaveBeenCalledWith('member12345');
+      expect(jobModule.updateJob).toHaveBeenCalledWith(
+        mockJobId,
+        expect.objectContaining({
+          status: 'Complete',
+          data: expect.objectContaining({
+            videos: expect.arrayContaining([
+              expect.objectContaining({ youtubeId: 'success1234' })
+            ]),
+            failedVideos: []
+          })
+        })
+      );
+
+      const finalProgressCall = MessageEmitter.emitMessage.mock.calls.find(
+        call => call[3] === 'downloadProgress' && call[4]?.finalSummary
+      );
+      expect(finalProgressCall[4]).toEqual(expect.objectContaining({
+        text: 'Download completed: 1 video downloaded',
+        finalSummary: expect.objectContaining({
+          totalDownloaded: 1,
+          totalFailed: 0,
+          failedVideos: []
+        })
+      }));
+      expect(finalProgressCall[4]).not.toHaveProperty('warning');
+      expect(notificationModule.sendDownloadNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          finalSummary: expect.objectContaining({
+            totalFailed: 0,
+            failedVideos: []
+          })
+        })
+      );
+    });
+
+    it('should complete with zero-download summary when only upcoming live videos are skipped', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([]);
+      archiveModule.getNewVideoUrlsSince.mockReturnValue([]);
+
+      setTimeout(() => {
+        mockProcess.stdout.emit('data', '[youtube] Extracting URL: https://youtube.com/watch?v=live1234567\n');
+        mockProcess.stdout.emit('data', 'ERROR: [youtube] live1234567: This live event will begin in 21 hours.\n');
+        mockProcess.emit('exit', 1, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(jobModule.updateJob).toHaveBeenCalledWith(
+        mockJobId,
+        expect.objectContaining({
+          status: 'Complete',
+          data: expect.objectContaining({
+            videos: [],
+            failedVideos: []
+          })
+        })
+      );
+      // Notification module is invoked, but its own totalDownloaded === 0 guard
+      // keeps users from getting a "0 videos downloaded" message.
+      expect(notificationModule.sendDownloadNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          finalSummary: expect.objectContaining({
+            totalDownloaded: 0,
+            totalFailed: 0,
+            failedVideos: []
+          })
+        })
+      );
+
+      const finalProgressCall = MessageEmitter.emitMessage.mock.calls.find(
+        call => call[3] === 'downloadProgress' && call[4]?.finalSummary
+      );
+      expect(finalProgressCall[4]).toEqual(expect.objectContaining({
+        text: 'Download completed: No new videos to download',
+        finalSummary: expect.objectContaining({
+          totalDownloaded: 0,
+          totalFailed: 0,
+          failedVideos: []
+        })
+      }));
+      expect(finalProgressCall[4]).not.toHaveProperty('warning');
+    });
+
+    it('should not mark job Complete when an unassociated stdout error coexists with expected skips', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([]);
+      archiveModule.getNewVideoUrlsSince.mockReturnValue([]);
+
+      setTimeout(() => {
+        // Expected skip ERROR - suppressed by isExpectedYtdlpSkipMessage and
+        // does not increment unexpectedErrorCount.
+        mockProcess.stdout.emit('data', 'ERROR: This video is members-only\n');
+        // Real ERROR with no currentVideoId set. failedVideos.set is gated on
+        // currentVideoId so it never enters failedVideosList, but it must
+        // still bump unexpectedErrorCount so the job is not classified as
+        // "expected skips only".
+        mockProcess.stdout.emit('data', 'ERROR: Generic unexpected failure\n');
+        mockProcess.emit('exit', 1, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(jobModule.updateJob).not.toHaveBeenCalledWith(
+        mockJobId,
+        expect.objectContaining({ status: 'Complete' })
+      );
+
+      const finalProgressCall = MessageEmitter.emitMessage.mock.calls.find(
+        call => call[3] === 'downloadProgress' && call[4]?.finalSummary
+      );
+      expect(finalProgressCall[4]).not.toHaveProperty('warning');
+      expect(finalProgressCall[4]).toHaveProperty('error', true);
+    });
+
+    it('should not mark job Complete when an unassociated stderr error coexists with expected skips', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([]);
+      archiveModule.getNewVideoUrlsSince.mockReturnValue([]);
+
+      setTimeout(() => {
+        // Expected skip ERROR via stderr - matched by isExpectedYtdlpSkipMessage,
+        // increments expectedSkipCount only.
+        mockProcess.stderr.emit('data', 'ERROR: This video is members-only\n');
+        // Real ERROR via stderr with no currentVideoId. The stderr handler
+        // never calls monitor.processProgress, so monitor.hasError alone
+        // would miss this case; unexpectedErrorCount must catch it.
+        mockProcess.stderr.emit('data', 'ERROR: Generic unexpected failure\n');
+        mockProcess.emit('exit', 1, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(jobModule.updateJob).not.toHaveBeenCalledWith(
+        mockJobId,
+        expect.objectContaining({ status: 'Complete' })
+      );
+
+      const finalProgressCall = MessageEmitter.emitMessage.mock.calls.find(
+        call => call[3] === 'downloadProgress' && call[4]?.finalSummary
+      );
+      expect(finalProgressCall[4]).not.toHaveProperty('warning');
+      expect(finalProgressCall[4]).toHaveProperty('error', true);
+    });
+
+    it('should classify every ERROR line when a stderr chunk coalesces multiple lines', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([]);
+      archiveModule.getNewVideoUrlsSince.mockReturnValue([]);
+
+      setTimeout(() => {
+        // Node streams can deliver multiple newline-separated lines in one
+        // 'data' event. The stderr handler must classify each ERROR: line,
+        // not just the first match in the chunk.
+        mockProcess.stderr.emit(
+          'data',
+          'ERROR: This video is members-only\nERROR: Generic unexpected failure\n'
+        );
+        mockProcess.emit('exit', 1, null);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(jobModule.updateJob).not.toHaveBeenCalledWith(
+        mockJobId,
+        expect.objectContaining({ status: 'Complete' })
+      );
+
+      const finalProgressCall = MessageEmitter.emitMessage.mock.calls.find(
+        call => call[3] === 'downloadProgress' && call[4]?.finalSummary
+      );
+      expect(finalProgressCall[4]).not.toHaveProperty('warning');
+      expect(finalProgressCall[4]).toHaveProperty('error', true);
     });
 
     it('should track currentVideoId from destination path for main video files', async () => {
@@ -1907,6 +2111,29 @@ describe('DownloadExecutor', () => {
       // After exit, references should be cleared
       expect(executor.currentProcess).toBeNull();
       expect(executor.currentJobId).toBeNull();
+    });
+  });
+
+  describe('isExpectedYtdlpSkipMessage', () => {
+    it.each([
+      'ERROR: [youtube] abc123: Join this channel to get access to members-only content like this video, and other exclusive perks.',
+      'ERROR: [youtube] abc123: This video is available to this channel\'s members on level: Assistant (or any higher level).',
+      'ERROR: [youtube] abc123: This live event will begin in 21 hours.',
+      'WARNING: [youtube] This live event will begin in a few moments.',
+      'ERROR: [youtube] abc123: Premiere will begin shortly.',
+      'ERROR: [youtube] abc123: This pre-release video is not yet available.'
+    ])('should identify expected skip text: %s', (message) => {
+      expect(executor.isExpectedYtdlpSkipMessage(message)).toBe(true);
+    });
+
+    it.each([
+      'ERROR: [youtube] abc123: Private video. Sign in if you have been granted access.',
+      'ERROR: [youtube] abc123: Sign in to confirm you are not a bot.',
+      'ERROR: [youtube] abc123: HTTP Error 403: Forbidden',
+      'ERROR: [youtube] abc123: Video unavailable. This content is not available.',
+      'ERROR: [youtube] abc123: The following content is not available on this app.'
+    ])('should not classify real failures as expected skips: %s', (message) => {
+      expect(executor.isExpectedYtdlpSkipMessage(message)).toBe(false);
     });
   });
 

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -235,6 +235,25 @@ class DownloadExecutor {
     }
   }
 
+  isExpectedYtdlpSkipMessage(message = '') {
+    const normalized = String(message);
+    const expectedPatterns = [
+      /join this channel to get access to members-only content/i,
+      /available to this channel'?s members/i,
+      /members[- ]only/i,
+      /subscriber[_ -]?only/i,
+      /this live event will begin/i,
+      /will begin in (?:a few moments|\d+)/i,
+      /premiere (?:will begin|starts|is upcoming)/i,
+      /premieres? in \d+/i,
+      /pre[- ]release/i,
+      /this video is not yet available/i,
+      /release time of video is not known/i,
+    ];
+
+    return expectedPatterns.some(pattern => pattern.test(normalized));
+  }
+
   async persistCompletedVideosBeforeTerminalUpdate(jobId, videoData, failedVideosList) {
     if (!videoData || videoData.length === 0) {
       return;
@@ -637,8 +656,22 @@ class DownloadExecutor {
 
       // Track failed videos with their error messages
       const failedVideos = new Map(); // youtubeId -> { url, error, youtubeId }
+      // Count of yt-dlp errors that we treat as expected skips (members-only,
+      // upcoming live, premiere, etc.). Only the count drives downstream
+      // behavior; per-skip context goes to the structured log.
+      let expectedSkipCount = 0;
+      // Count of yt-dlp errors that are NOT expected skips. Incremented in
+      // both stdout and stderr handlers regardless of whether currentVideoId
+      // is known, so unassociated errors still block the
+      // "complete with only expected skips" classification.
+      let unexpectedErrorCount = 0;
       let currentVideoId = null; // Track the current video being processed
       let lastErrorMessage = null; // Store the last error message seen
+
+      const recordExpectedSkip = (reason, source) => {
+        expectedSkipCount += 1;
+        logger.info({ youtubeId: currentVideoId, reason, source }, 'Expected video skip from yt-dlp');
+      };
 
       const emitCookiesSuggestionMessage = () => {
         if (cookiesSuggestionEmitted) {
@@ -764,22 +797,33 @@ class DownloadExecutor {
             }
 
             // Detect and track ERROR messages
+            let suppressExpectedSkipLine = false;
             if (line.includes('ERROR:')) {
               const errorMatch = line.match(/ERROR:\s*(.+)/);
               if (errorMatch) {
                 lastErrorMessage = errorMatch[1].trim();
-                logger.warn({ error: lastErrorMessage, currentVideoId }, 'Error detected during download');
+                if (this.isExpectedYtdlpSkipMessage(lastErrorMessage)) {
+                  recordExpectedSkip(lastErrorMessage, 'stdout');
+                  suppressExpectedSkipLine = true;
+                } else {
+                  unexpectedErrorCount += 1;
+                  logger.warn({ error: lastErrorMessage, currentVideoId }, 'Error detected during download');
 
-                // Associate error with current video if we know which video is being processed
-                if (currentVideoId && !failedVideos.has(currentVideoId)) {
-                  failedVideos.set(currentVideoId, {
-                    youtubeId: currentVideoId,
-                    error: lastErrorMessage,
-                    url: null // Will be populated later from urlsToProcess
-                  });
-                  logger.info({ youtubeId: currentVideoId, error: lastErrorMessage }, 'Recorded video failure');
+                  // Associate error with current video if we know which video is being processed
+                  if (currentVideoId && !failedVideos.has(currentVideoId)) {
+                    failedVideos.set(currentVideoId, {
+                      youtubeId: currentVideoId,
+                      error: lastErrorMessage,
+                      url: null // Will be populated later from urlsToProcess
+                    });
+                    logger.info({ youtubeId: currentVideoId, error: lastErrorMessage }, 'Recorded video failure');
+                  }
                 }
               }
+            }
+
+            if (suppressExpectedSkipLine) {
+              return;
             }
 
             // Always try to process for state updates
@@ -821,23 +865,38 @@ class DownloadExecutor {
           emitCookiesSuggestionMessage();
         }
 
-        // Detect and track ERROR messages from stderr
+        // Detect and track ERROR messages from stderr. Node streams can
+        // coalesce multiple lines into one chunk, so iterate per line rather
+        // than running a single regex over the whole chunk (which would only
+        // catch the first ERROR: occurrence).
         if (dataStr.includes('ERROR:')) {
-          const errorMatch = dataStr.match(/ERROR:\s*(.+)/);
-          if (errorMatch) {
-            lastErrorMessage = errorMatch[1].trim();
-            logger.warn({ error: lastErrorMessage, currentVideoId }, 'Error detected in stderr');
+          dataStr
+            .split('\n')
+            .map(line => line.trim())
+            .filter(line => line.includes('ERROR:'))
+            .forEach(line => {
+              const errorMatch = line.match(/ERROR:\s*(.+)/);
+              if (!errorMatch) {
+                return;
+              }
+              lastErrorMessage = errorMatch[1].trim();
+              if (this.isExpectedYtdlpSkipMessage(lastErrorMessage)) {
+                recordExpectedSkip(lastErrorMessage, 'stderr');
+                return;
+              }
+              unexpectedErrorCount += 1;
+              logger.warn({ error: lastErrorMessage, currentVideoId }, 'Error detected in stderr');
 
-            // Associate error with current video if we know which video is being processed
-            if (currentVideoId && !failedVideos.has(currentVideoId)) {
-              failedVideos.set(currentVideoId, {
-                youtubeId: currentVideoId,
-                error: lastErrorMessage,
-                url: null // Will be populated later from urlsToProcess
-              });
-              logger.info({ youtubeId: currentVideoId, error: lastErrorMessage }, 'Recorded video failure from stderr');
-            }
-          }
+              // Associate error with current video if we know which video is being processed
+              if (currentVideoId && !failedVideos.has(currentVideoId)) {
+                failedVideos.set(currentVideoId, {
+                  youtubeId: currentVideoId,
+                  error: lastErrorMessage,
+                  url: null // Will be populated later from urlsToProcess
+                });
+                logger.info({ youtubeId: currentVideoId, error: lastErrorMessage }, 'Recorded video failure from stderr');
+              }
+            });
         }
 
         // Check for bot detection message (handle different quote types and patterns)
@@ -1042,6 +1101,19 @@ class DownloadExecutor {
 
         logger.info({ jobType, jobId }, 'Job complete (with or without errors)');
 
+        // yt-dlp exited with code 1 only because every error it emitted was an
+        // expected skip (members-only, upcoming live, premiere, etc.). Treat
+        // these as a clean completion rather than a failure. unexpectedErrorCount
+        // catches real ERRORs that miss failedVideosList because currentVideoId
+        // was null (covers both stdout and stderr). monitor.hasError on its own
+        // would only catch the stdout path.
+        const hasOnlyExpectedSkips = code === 1 &&
+          expectedSkipCount > 0 &&
+          failedVideosList.length === 0 &&
+          unexpectedErrorCount === 0 &&
+          !botDetected &&
+          !httpForbiddenDetected;
+
         let status = '';
         let output = '';
         let jobErrorCode;
@@ -1104,7 +1176,10 @@ class DownloadExecutor {
           let errorCode;
 
           // Provide more helpful error messages based on what we detected
-          if (httpForbiddenDetected) {
+          if (hasOnlyExpectedSkips) {
+            status = 'Complete';
+            output = `${videoCount} videos.`;
+          } else if (httpForbiddenDetected) {
             // Failed with 403 errors - likely authentication issue
             output = `${videoCount} videos. Error: YouTube returned HTTP 403 (Forbidden)`;
             notes = 'YouTube denied access (HTTP 403). Configure cookies in Settings to resolve this issue.';
@@ -1142,9 +1217,12 @@ class DownloadExecutor {
             );
           } else {
             await this.persistCompletedVideosBeforeTerminalUpdate(jobId, videoData, failedVideosList);
-            const terminalStatus = hasPartialSuccess
-              ? 'Complete with Warnings'
-              : status;
+            let terminalStatus = status;
+            if (hasOnlyExpectedSkips) {
+              terminalStatus = 'Complete';
+            } else if (hasPartialSuccess) {
+              terminalStatus = 'Complete with Warnings';
+            }
             await jobModule.updateJob(jobId, {
               status: terminalStatus,
               endDate: Date.now(),
@@ -1228,9 +1306,10 @@ class DownloadExecutor {
         const hasNonFatalPartialSuccess = code === 1 && hasSuccesses;
 
         let finalState;
-        if (code === 0 || isWarningOnly || hasNonFatalPartialSuccess) {
-          // Exit code was successful, but check for partial failures
-          finalState = (hasFailures || code !== 0) ? 'warning' : 'complete';
+        if (code === 0 || hasOnlyExpectedSkips) {
+          finalState = hasFailures ? 'warning' : 'complete';
+        } else if (isWarningOnly || hasNonFatalPartialSuccess) {
+          finalState = 'warning';
         } else {
           finalState = 'error';
         }
@@ -1244,6 +1323,9 @@ class DownloadExecutor {
           hasFailures,
           hasSuccesses,
           hasNonFatalPartialSuccess,
+          expectedSkipCount,
+          unexpectedErrorCount,
+          hasOnlyExpectedSkips,
           successCount: videoData.length,
           failureCount: failedVideosList.length,
           finalState


### PR DESCRIPTION
yt-dlp exits 1 with ERROR: lines for videos that were never downloadable (members-only, upcoming live, premieres, pre-release). Jobs ended as Error and fired download notifications.

Classify these via isExpectedYtdlpSkipMessage. Track expected and unexpected error counts in both stdout and stderr; mark the job Complete when exit 1 has only expected skips and no bot/403 detection. Split stderr chunks on newline so coalesced multi-line chunks are fully classified.