### PR TITLE
feat: add manual rescan and recognize more formats

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 # Ignore database files
 database/
 database/*
+database.bind-mount-backup.*
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 ### Backend (server/)
 - `server.js`: Express entry point. `db.js`: Sequelize setup. `logger.js`: Pino logger with request correlation.
 - `models/`: Sequelize models (channel, video, job, jobvideo, jobvideodownload, channelvideo, session, apikey). Associations: Channel hasMany Videos, Job hasMany JobVideos.
-- `routes/`: API handlers (auth, channels, videos, videoDetail, videoSearch, config, jobs, plex, setup, subscriptions, apikeys, ytdlpOptions, health). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.
+- `routes/`: API handlers (auth, channels, videos, videoDetail, videoSearch, config, jobs, plex, setup, subscriptions, apikeys, ytdlpOptions, health, maintenance). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.
 - `modules/`: class-based singletons holding business logic. Top-level modules include `channelModule`, `downloadModule`, `plexModule`, `jobModule`, `configModule`, `videosModule`, `videoMetadataModule`, `videoSearchModule`, `webSocketServer`, `databaseHealthModule`, `notificationModule`, `channelSettingsModule`, `videoDeletionModule`, `nfoGenerator`, `cronJobs`, `apiKeyModule`, `ytdlpModule`, `messageEmitter`.
 - `modules/download/`: download orchestration (`downloadExecutor`, `ytdlpCommandBuilder`, `DownloadProgressMonitor`, `tempPathManager`, `videoMetadataProcessor`, `customArgsParser`, `ytdlpValidator`).
 - `modules/filesystem/`: path/file abstraction (`pathBuilder`, `directoryManager`, `fileOperations`, `sanitizer`, `constants`). Good example of the sub-module aggregator pattern.
@@ -44,7 +44,7 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 - `components/shared/`: reusable components used across multiple features (e.g. `VideoModal/` for the video detail modal, `ThumbnailClickOverlay` for clickable thumbnail hotspots, `DeleteVideosDialog`).
 - `components/ui/`: theme-neutral UI primitives (Button, Card, Dialog, Select, etc.) built on Radix and styled via CSS variables + Tailwind. Use these instead of Material-UI imports in new code.
 - `components/layout/`: app shell and navigation chrome. `AppShell.tsx` is the outer frame; `NavSidebar.tsx` / `NavHeader.tsx` own desktop and mobile nav; `navLayoutConstants.ts` holds shared sidebar/header sizing constants; `layoutFallback.css` provides fallback CSS variables for themes that skip layout overrides.
-- `components/Settings/`: Settings page wrapper and splash index (`SettingsIndex.tsx`) listing the per-section routes under `/settings/<key>`.
+- `components/Settings/`: Settings page wrapper and splash index (`SettingsIndex.tsx`) listing the per-section routes under `/settings/<key>`. `MaintenanceSection.tsx` hosts the manual filesystem rescan trigger.
 - `themes/`: theme definitions (`playful`, `linear`, `flat`), shared layout policy (`layoutPolicy.ts`), and the `ALL_THEMES` registry. New themes add an entry here and implement the required token surface.
 - `hooks/`: app-wide custom hooks for data fetching and state.
 - `contexts/` and `providers/`: React Context for cross-cutting concerns (auth token, WebSocket, theme). `contexts/ThemeEngineContext.tsx` owns the active theme mode, resolves the layout policy for the current viewport, and injects theme CSS variables onto the document root.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ https://github.com/user-attachments/assets/a80548fc-bcf9-4ad0-889c-dbd5aac250ee
 - **Metadata Generation**: NFO files, poster images and embedded MP4 metadata for all media servers
 - **Scheduled Downloads**: Configure automatic downloads on your schedule (cron-based)
 - **Auto-Cleanup**: Age and space-based removal of videos with dry-run previews
+- **Filesystem Rescan**: Move, rename, or convert downloaded files outside Youtarr (e.g., `.mp4` to `.mkv`) and trigger a rescan from Settings -> Maintenance to reconcile the database; daily and startup scans pick up changes automatically
 - **Discord Notifications**: Optional webhook alerts for new downloads
 - **Web Interface**: Manage everything through a responsive (PC or mobile) web UI
 - **Secure Access**: Built-in authentication with admin controls

--- a/client/src/components/Settings/MaintenanceSection.tsx
+++ b/client/src/components/Settings/MaintenanceSection.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Alert, Button, CircularProgress, Typography } from '../ui';
+import { ConfigurationCard } from '../Configuration/common/ConfigurationCard';
+import { useRescanStatus } from '../../hooks/useRescanStatus';
+import { formatDateTime } from '../../utils/formatters';
+
+interface MaintenanceSectionProps {
+  token: string | null;
+}
+
+export function MaintenanceSection({ token }: MaintenanceSectionProps) {
+  const { running, lastRun, loading, error, triggerRescan } = useRescanStatus(token);
+  const persistentError = !running && lastRun?.status === 'error' ? lastRun.errorMessage : null;
+  const transientError = error && error !== persistentError ? error : null;
+
+  let statusLine: React.ReactNode;
+  if (running) {
+    statusLine = (
+      <div className="flex items-center gap-2">
+        <CircularProgress size={16} />
+        <Typography variant="body2" color="text.secondary">
+          Rescan in progress...
+        </Typography>
+      </div>
+    );
+  } else if (lastRun) {
+    statusLine = (
+      <Typography variant="body2" color="text.secondary">
+        Last rescan: {formatDateTime(lastRun.completedAt)} ({lastRun.trigger}). Updated{' '}
+        {lastRun.videosUpdated} videos, marked {lastRun.videosMarkedMissing} missing.
+        {lastRun.status === 'timed-out' && ' (timed out; click to continue)'}
+      </Typography>
+    );
+  } else {
+    statusLine = (
+      <Typography variant="body2" color="text.secondary">
+        No rescan has run yet.
+      </Typography>
+    );
+  }
+
+  return (
+    <ConfigurationCard title="Rescan files on disk">
+      <div className="flex flex-col gap-4">
+        <Typography variant="body2" color="text.secondary">
+          Use this if you have moved or converted downloaded files outside of Youtarr - for
+          example, converting mp4 to mkv. The rescan walks your Youtarr downloads folder
+          and updates Youtarr&apos;s view of which files exist and where.
+        </Typography>
+
+        <div>
+          <Button
+            variant="contained"
+            disabled={running || loading}
+            onClick={() => {
+              void triggerRescan();
+            }}
+          >
+            Rescan files on disk
+          </Button>
+        </div>
+
+        {statusLine}
+
+        {transientError && (
+          <Alert severity="warning">{transientError}</Alert>
+        )}
+
+        {persistentError && (
+          <Alert severity="warning">{persistentError}</Alert>
+        )}
+      </div>
+    </ConfigurationCard>
+  );
+}
+
+export default MaintenanceSection;

--- a/client/src/components/Settings/Settings.tsx
+++ b/client/src/components/Settings/Settings.tsx
@@ -37,6 +37,7 @@ import { TRACKABLE_CONFIG_KEYS } from '../../config/configSchema';
 import { ConfigState, SnackbarState } from '../Configuration/types';
 import { validateConfig } from '../Configuration/utils/configValidation';
 import { SETTINGS_PAGES, SettingsIndex } from './SettingsIndex';
+import { MaintenanceSection } from './MaintenanceSection';
 
 interface SettingsProps {
   token: string | null;
@@ -374,6 +375,10 @@ export function Settings({ token }: SettingsProps) {
                 onTestKey={testYoutubeApiKey}
               />
             }
+          />
+          <Route
+            path="maintenance"
+            element={<MaintenanceSection token={token} />}
           />
 
           <Route path="*" element={<Navigate to="/settings" replace />} />

--- a/client/src/components/Settings/SettingsIndex.tsx
+++ b/client/src/components/Settings/SettingsIndex.tsx
@@ -11,6 +11,7 @@ export const SETTINGS_PAGES = [
   { key: 'appearance', title: 'Appearance', description: 'Theme, animations, and visual preferences.' },
   { key: 'autoremove', title: 'Auto Removal', description: 'Automated cleanup and retention policies.' },
   { key: 'cookies', title: 'Cookies', description: 'Cookie configuration and login helpers.' },
+  { key: 'maintenance', title: 'Maintenance', description: 'Rescan files on disk and other maintenance actions.' },
   { key: 'notifications', title: 'Notifications', description: 'Toast notifications and alert behavior.' },
   { key: 'plex', title: 'Plex', description: 'Plex integration and library configuration.' },
   { key: 'security', title: 'Account Security', description: 'Authentication and password management.' },

--- a/client/src/components/Settings/__tests__/MaintenanceSection.test.tsx
+++ b/client/src/components/Settings/__tests__/MaintenanceSection.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MaintenanceSection } from '../MaintenanceSection';
+import { UseRescanStatusReturn, RescanLastRun } from '../../../hooks/useRescanStatus';
+
+jest.mock('../../../hooks/useRescanStatus', () => ({
+  useRescanStatus: jest.fn()
+}));
+
+const { useRescanStatus } = require('../../../hooks/useRescanStatus') as {
+  useRescanStatus: jest.Mock<UseRescanStatusReturn, [string | null]>;
+};
+
+function setup(overrides: Partial<UseRescanStatusReturn> = {}) {
+  const triggerRescan = jest.fn().mockResolvedValue(undefined);
+  useRescanStatus.mockReturnValue({
+    running: false,
+    lastRun: null,
+    loading: false,
+    error: null,
+    triggerRescan,
+    ...overrides
+  });
+  render(<MaintenanceSection token="tok" />);
+  return { triggerRescan };
+}
+
+describe('MaintenanceSection', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('renders idle with no prior run', () => {
+    setup();
+    expect(screen.getByRole('button', { name: /rescan files on disk/i })).toBeEnabled();
+    expect(screen.getByText(/no rescan has run yet/i)).toBeInTheDocument();
+  });
+
+  test('renders idle with last-run summary', () => {
+    const lastRun: RescanLastRun = {
+      startedAt: '2026-05-04T15:00:00.000Z',
+      completedAt: '2026-05-04T15:01:00.000Z',
+      trigger: 'manual',
+      status: 'completed',
+      videosUpdated: 7,
+      videosMarkedMissing: 2,
+      videosScanned: 100,
+      filesFoundOnDisk: 98,
+      errorMessage: null
+    };
+    setup({ lastRun });
+    expect(screen.getByText(/updated 7 videos/i)).toBeInTheDocument();
+    expect(screen.getByText(/marked 2 missing/i)).toBeInTheDocument();
+  });
+
+  test('disables button while running', () => {
+    setup({ running: true });
+    expect(screen.getByRole('button', { name: /rescan files on disk/i })).toBeDisabled();
+    expect(screen.getByText(/rescan in progress/i)).toBeInTheDocument();
+  });
+
+  test('disables button while loading initial status', () => {
+    setup({ loading: true });
+    expect(screen.getByRole('button', { name: /rescan files on disk/i })).toBeDisabled();
+  });
+
+  test('clicking button calls triggerRescan', async () => {
+    const { triggerRescan } = setup();
+    await userEvent.click(screen.getByRole('button', { name: /rescan files on disk/i }));
+    await waitFor(() => expect(triggerRescan).toHaveBeenCalledTimes(1));
+  });
+
+  test('displays error string when error is set', () => {
+    setup({ error: 'Rescan already in progress' });
+    expect(screen.getByText(/rescan already in progress/i)).toBeInTheDocument();
+  });
+
+  test('displays errorMessage from a prior errored run', () => {
+    const lastRun: RescanLastRun = {
+      startedAt: '2026-05-04T15:00:00.000Z',
+      completedAt: '2026-05-04T15:01:00.000Z',
+      trigger: 'manual',
+      status: 'error',
+      videosUpdated: 0,
+      videosMarkedMissing: 0,
+      videosScanned: 0,
+      filesFoundOnDisk: 0,
+      errorMessage: 'Permission denied scanning /videos'
+    };
+    setup({ lastRun });
+    expect(screen.getByText(/permission denied scanning/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/config/configSchema.ts
+++ b/client/src/config/configSchema.ts
@@ -113,6 +113,20 @@ export const CONFIG_FIELDS = {
     default: null as { status: 'updated' | 'up-to-date' | 'skipped' | 'error'; message?: string; version?: string } | null,
     trackChanges: false,
   },
+  rescanLastRun: {
+    default: null as {
+      startedAt: string;
+      completedAt: string;
+      trigger: 'manual' | 'scheduled' | 'startup';
+      status: 'completed' | 'timed-out' | 'error';
+      videosUpdated: number;
+      videosMarkedMissing: number;
+      videosScanned: number;
+      filesFoundOnDisk: number;
+      errorMessage: string | null;
+    } | null,
+    trackChanges: false,
+  },
 
   // yt-dlp options (custom args, IP family, rate limit)
   ytdlpIpFamily: { default: 'ipv4' as 'ipv4' | 'ipv6' | 'auto', trackChanges: true },
@@ -183,6 +197,7 @@ export const DEFAULT_CONFIG: ConfigState = {
   ytdlpLastChecked: CONFIG_FIELDS.ytdlpLastChecked.default,
   ytdlpLastUpdated: CONFIG_FIELDS.ytdlpLastUpdated.default,
   ytdlpLastResult: CONFIG_FIELDS.ytdlpLastResult.default,
+  rescanLastRun: CONFIG_FIELDS.rescanLastRun.default,
   ytdlpIpFamily: CONFIG_FIELDS.ytdlpIpFamily.default,
   ytdlpDownloadRateLimit: CONFIG_FIELDS.ytdlpDownloadRateLimit.default,
   ytdlpCustomArgs: CONFIG_FIELDS.ytdlpCustomArgs.default,

--- a/client/src/hooks/__tests__/useRescanStatus.test.ts
+++ b/client/src/hooks/__tests__/useRescanStatus.test.ts
@@ -1,0 +1,216 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import axios from 'axios';
+import { useRescanStatus, RescanLastRun, RescanTrigger } from '../useRescanStatus';
+import WebSocketContext from '../../contexts/WebSocketContext';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  isAxiosError: (err: unknown): boolean =>
+    typeof err === 'object' && err !== null && 'response' in err
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+interface RescanStatusPayload {
+  running: boolean;
+  trigger?: RescanTrigger;
+  lastRun?: RescanLastRun | null;
+}
+
+interface RescanStatusEnvelope {
+  type: 'rescanStatus';
+  payload: RescanStatusPayload;
+}
+
+type Subscriber = {
+  filter: (msg: unknown) => boolean;
+  callback: (msg: unknown) => void;
+};
+
+function makeWrapper(subscribers: Subscriber[]) {
+  const value = {
+    socket: null,
+    subscribe: (filter: (msg: unknown) => boolean, callback: (msg: unknown) => void) => {
+      subscribers.push({ filter, callback });
+    },
+    unsubscribe: (callback: (msg: unknown) => void) => {
+      const idx = subscribers.findIndex((s) => s.callback === callback);
+      if (idx >= 0) subscribers.splice(idx, 1);
+    }
+  };
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(WebSocketContext.Provider, { value }, children);
+  }
+  return Wrapper;
+}
+
+describe('useRescanStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches initial status on mount', async () => {
+    const lastRun: RescanLastRun = {
+      startedAt: '2026-05-04T15:00:00.000Z',
+      completedAt: '2026-05-04T15:01:00.000Z',
+      trigger: 'manual',
+      status: 'completed',
+      videosUpdated: 3,
+      videosMarkedMissing: 1,
+      videosScanned: 100,
+      filesFoundOnDisk: 99,
+      errorMessage: null
+    };
+    mockedAxios.get.mockResolvedValueOnce({ data: { running: false, lastRun } });
+
+    const subscribers: Subscriber[] = [];
+    const { result } = renderHook(() => useRescanStatus('tok'), {
+      wrapper: makeWrapper(subscribers)
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.running).toBe(false);
+    expect(result.current.lastRun).toEqual(lastRun);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      '/api/maintenance/rescan-status',
+      expect.objectContaining({ headers: { 'x-access-token': 'tok' } })
+    );
+  });
+
+  test('updates state from WebSocket rescanStatus messages', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { running: false, lastRun: null } });
+
+    const subscribers: Subscriber[] = [];
+    const { result } = renderHook(() => useRescanStatus('tok'), {
+      wrapper: makeWrapper(subscribers)
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // WebSocketProvider passes the full message to filter() but only the
+    // payload to callback(); mirror that contract here.
+    act(() => {
+      const startMsg: RescanStatusEnvelope = {
+        type: 'rescanStatus',
+        payload: { running: true, trigger: 'manual' }
+      };
+      subscribers.forEach((s) => s.filter(startMsg) && s.callback(startMsg.payload));
+    });
+    expect(result.current.running).toBe(true);
+
+    const lastRun: RescanLastRun = {
+      startedAt: '2026-05-04T15:00:00.000Z',
+      completedAt: '2026-05-04T15:01:00.000Z',
+      trigger: 'manual',
+      status: 'completed',
+      videosUpdated: 0,
+      videosMarkedMissing: 0,
+      videosScanned: 0,
+      filesFoundOnDisk: 0,
+      errorMessage: null
+    };
+    act(() => {
+      const endMsg: RescanStatusEnvelope = {
+        type: 'rescanStatus',
+        payload: { running: false, lastRun }
+      };
+      subscribers.forEach((s) => s.filter(endMsg) && s.callback(endMsg.payload));
+    });
+    expect(result.current.running).toBe(false);
+    expect(result.current.lastRun).toEqual(lastRun);
+  });
+
+  test('triggerRescan POSTs and clears prior error', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { running: false, lastRun: null } });
+    mockedAxios.post.mockResolvedValueOnce({ status: 202, data: { status: 'started' } });
+
+    const { result } = renderHook(() => useRescanStatus('tok'), {
+      wrapper: makeWrapper([])
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.triggerRescan();
+    });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      '/api/maintenance/rescan-files',
+      undefined,
+      expect.objectContaining({ headers: { 'x-access-token': 'tok' } })
+    );
+    expect(result.current.error).toBeNull();
+    expect(result.current.running).toBe(true);
+  });
+
+  test('triggerRescan surfaces 409 as a user-friendly error', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { running: false, lastRun: null } });
+    const err = new Error('Conflict') as Error & {
+      response: { status: number; data: { error: string } };
+    };
+    err.response = { status: 409, data: { error: 'Rescan already in progress' } };
+    mockedAxios.post.mockRejectedValueOnce(err);
+
+    const { result } = renderHook(() => useRescanStatus('tok'), {
+      wrapper: makeWrapper([])
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.triggerRescan();
+    });
+
+    expect(result.current.error).toBe('Rescan already in progress');
+    expect(result.current.running).toBe(true);
+  });
+
+  test('triggerRescan reverts optimistic running state when start fails', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { running: false, lastRun: null } });
+    mockedAxios.post.mockRejectedValueOnce(new Error('Network Error'));
+
+    const { result } = renderHook(() => useRescanStatus('tok'), {
+      wrapper: makeWrapper([])
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.triggerRescan();
+    });
+
+    expect(result.current.running).toBe(false);
+    expect(result.current.error).toBe('Network Error');
+  });
+
+  test('clears transient errors when WebSocket status advances', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { running: false, lastRun: null } });
+    const err = new Error('Conflict') as Error & {
+      response: { status: number; data: { error: string } };
+    };
+    err.response = { status: 409, data: { error: 'Rescan already in progress' } };
+    mockedAxios.post.mockRejectedValueOnce(err);
+
+    const subscribers: Subscriber[] = [];
+    const { result } = renderHook(() => useRescanStatus('tok'), {
+      wrapper: makeWrapper(subscribers)
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.triggerRescan();
+    });
+    expect(result.current.error).toBe('Rescan already in progress');
+
+    act(() => {
+      const startMsg: RescanStatusEnvelope = {
+        type: 'rescanStatus',
+        payload: { running: true, trigger: 'scheduled' }
+      };
+      subscribers.forEach((s) => s.filter(startMsg) && s.callback(startMsg.payload));
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/client/src/hooks/useRescanStatus.ts
+++ b/client/src/hooks/useRescanStatus.ts
@@ -1,0 +1,110 @@
+import { useCallback, useContext, useEffect, useState } from 'react';
+import axios from 'axios';
+import WebSocketContext from '../contexts/WebSocketContext';
+
+export type RescanTrigger = 'manual' | 'scheduled' | 'startup';
+export type RescanStatus = 'completed' | 'timed-out' | 'error';
+
+export interface RescanLastRun {
+  startedAt: string;
+  completedAt: string;
+  trigger: RescanTrigger;
+  status: RescanStatus;
+  videosUpdated: number;
+  videosMarkedMissing: number;
+  videosScanned: number;
+  filesFoundOnDisk: number;
+  errorMessage: string | null;
+}
+
+interface RescanStatusResponse {
+  running: boolean;
+  lastRun: RescanLastRun | null;
+}
+
+interface RescanStatusPayload {
+  running: boolean;
+  trigger?: RescanTrigger;
+  lastRun?: RescanLastRun | null;
+}
+
+export interface UseRescanStatusReturn {
+  running: boolean;
+  lastRun: RescanLastRun | null;
+  loading: boolean;
+  error: string | null;
+  triggerRescan: () => Promise<void>;
+}
+
+export function useRescanStatus(token: string | null): UseRescanStatusReturn {
+  const [running, setRunning] = useState(false);
+  const [lastRun, setLastRun] = useState<RescanLastRun | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const ws = useContext(WebSocketContext);
+
+  useEffect(() => {
+    let cancelled = false;
+    const headers = token ? { 'x-access-token': token } : undefined;
+
+    axios
+      .get<RescanStatusResponse>('/api/maintenance/rescan-status', { headers })
+      .then((res) => {
+        if (cancelled) return;
+        setRunning(res.data.running);
+        setLastRun(res.data.lastRun);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : 'Failed to load rescan status';
+        setError(message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  useEffect(() => {
+    if (!ws) return undefined;
+    // Filter receives the full message envelope; callback receives only the
+    // payload (WebSocketProvider strips the envelope before invoking).
+    const filter = (msg: { type?: string }) => msg.type === 'rescanStatus';
+    const callback = (payload: RescanStatusPayload) => {
+      setRunning(payload.running);
+      if (payload.running) {
+        setError(null);
+      }
+      if (payload.lastRun !== undefined) {
+        setLastRun(payload.lastRun);
+        setError(null);
+      }
+    };
+    ws.subscribe(filter, callback);
+    return () => ws.unsubscribe(callback);
+  }, [ws]);
+
+  const triggerRescan = useCallback(async () => {
+    setError(null);
+    setRunning(true);
+    const headers = token ? { 'x-access-token': token } : undefined;
+    try {
+      await axios.post('/api/maintenance/rescan-files', undefined, { headers });
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err) && err.response?.status === 409) {
+        const data = err.response.data as { error?: string } | undefined;
+        setError(data?.error ?? 'Rescan already in progress');
+        return;
+      }
+      setRunning(false);
+      const message = err instanceof Error ? err.message : 'Failed to start rescan';
+      setError(message);
+    }
+  }, [token]);
+
+  return { running, lastRun, loading, error, triggerRescan };
+}

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -55,6 +55,7 @@
   "ytdlpLastChecked": null,
   "ytdlpLastUpdated": null,
   "ytdlpLastResult": null,
+  "rescanLastRun": null,
   "ytdlpIpFamily": "ipv4",
   "ytdlpDownloadRateLimit": "",
   "ytdlpCustomArgs": ""

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -606,6 +606,31 @@ Youtarr can optionally check for and install yt-dlp updates on a nightly schedul
   - `error` — `yt-dlp -U` failed; `message` holds a short error description.
 - **Note**: Managed by the application; do not edit by hand.
 
+## Filesystem Rescan
+
+For user-facing documentation on when and how to use the filesystem rescan (moving files, converting formats, supported extensions), see [Rescan Files on Disk](USAGE_GUIDE.md#rescan-files-on-disk).
+
+### Last Rescan Result
+- **Config Key**: `rescanLastRun`
+- **Type**: `object | null`
+- **Default**: `null`
+- **Shape**:
+  ```json
+  {
+    "startedAt": "2026-05-04T15:13:00.000Z",
+    "completedAt": "2026-05-04T15:14:32.000Z",
+    "trigger": "manual | scheduled | startup",
+    "status": "completed | timed-out | error",
+    "videosUpdated": 12,
+    "videosMarkedMissing": 3,
+    "videosScanned": 8421,
+    "filesFoundOnDisk": 8423,
+    "errorMessage": null
+  }
+  ```
+- **Description**: Records the outcome of the most recent filesystem reconciliation pass (the `backfillVideoMetadata` run). Written by the daily cron, the server-startup pass, and the manual "Rescan files on disk" action on the Maintenance settings page. Surfaced read-only on that page so users can see when the last scan ran and what it found or fixed.
+- **Note**: Managed by the application; do not edit by hand.
+
 ## Account & Security
 
 ### username

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -151,6 +151,22 @@ This creates a secure tunnel between your local machine's port 3087 and the serv
 - Check server logs around 2:00 AM for messages prefixed with `[CRON]` or `[Auto-Removal]` to confirm the job is executing (`docker compose logs -f youtarr`).
 - If errors appear in the logs (e.g., permission issues deleting files), resolve those first—the cron job will skip files it cannot delete.
 
+## Library / File Issues
+
+### Videos Show as "Missing" After I Moved or Renamed Files
+
+**Problem**: After moving downloaded files to a new location, renaming a folder, or restoring from backup, videos display with a cloud-off icon as if they were deleted.
+
+**Solution**: Open **Settings -> Maintenance** and click **Rescan files on disk**. Youtarr walks the downloads folder, matches files by the `[<youtube-id>]` segment in each filename, and updates the stored paths and "missing" flags. The same scan also runs daily on a schedule and at server startup.
+
+The rescan recognizes `.mp4`, `.webm`, `.mkv`, `.m4v`, `.avi`, and `.mp3`. Files that no longer have the `[<youtube-id>]` segment in their name (for example, if you renamed `Channel - Video [abc123XYZ01].mp4` to `My Movie.mp4`) cannot be matched and will continue to show as missing.
+
+### I Converted Videos to a Different Format and Youtarr Lost Them
+
+**Problem**: You used ffmpeg or another tool to convert downloaded `.mp4` videos to `.mkv` (or another container), and Youtarr now lists those videos as missing.
+
+**Solution**: Run **Settings -> Maintenance -> Rescan files on disk**. As long as the converted file kept the original `[<youtube-id>]` segment in its filename and uses one of the supported extensions (`.mp4`, `.webm`, `.mkv`, `.m4v`, `.avi`, `.mp3`), Youtarr will detect the new file, update the stored path, and clear the "missing" flag. See [Rescan Files on Disk](USAGE_GUIDE.md#rescan-files-on-disk) for full details on supported formats and limitations.
+
 ## Docker Issues
 
 ### "Empty section between colons" Error

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -11,6 +11,7 @@ This guide provides step-by-step instructions for common tasks in Youtarr. After
 - [Configure SponsorBlock](#configure-sponsorblock)
 - [Enable Download Notifications](#enable-download-notifications)
 - [Re-download Missing Videos](#re-download-missing-videos)
+- [Rescan Files on Disk](#rescan-files-on-disk)
 - [Organize Channels with Multi-Library Support](#organize-channels-with-multi-library-support)
 - [Browse and Filter Channel Videos](#browse-and-filter-channel-videos)
 - [Find Videos on YouTube](#find-videos-on-youtube)
@@ -228,7 +229,9 @@ Get Discord notifications when new videos finish downloading.
 
 ## Re-download Missing Videos
 
-Videos can become "missing" if they're manually deleted from disk or moved. This feature helps you recover them.
+Videos can become "missing" if they're manually deleted from disk. This feature helps you recover them by fetching the file from YouTube again.
+
+> **Note**: If the file still exists somewhere (you moved it, renamed its folder, or converted it to a different format), use [Rescan Files on Disk](#rescan-files-on-disk) instead. Rescan reconciles Youtarr's database with what's already on disk without re-downloading.
 
 1. **Identify missing videos**
    - Go to "Downloaded Videos" or a specific channel's video page
@@ -247,6 +250,27 @@ Videos can become "missing" if they're manually deleted from disk or moved. This
    - Click **Download Selected** and enable **Allow re-downloading previously fetched videos** in the dialog
    - Confirm with **Start Download**; the job will run through the normal downloads queue
    - Original metadata (watch status, etc.) is preserved
+
+## Rescan Files on Disk
+
+Use this when you've moved, renamed, or converted downloaded files outside Youtarr and want Youtarr's database to catch up with what's actually on disk. The rescan walks your downloads folder and updates Youtarr's view of which files exist and where; it does not re-download anything.
+
+Common cases:
+- You converted `.mp4` files to `.mkv` (or another supported container) using ffmpeg.
+- You restored a backup of your downloads folder to a different location.
+- You manually moved files between channel or subfolder directories.
+
+1. **Open Settings -> Maintenance**
+2. Click **Rescan files on disk**
+3. The page shows progress in real time and a summary of the last run (videos updated, files marked missing)
+
+A scan also runs daily on a schedule and once at server startup, so changes you make outside Youtarr will eventually be picked up even if you don't trigger a manual rescan.
+
+**Supported file extensions**: `.mp4`, `.webm`, `.mkv`, `.m4v`, `.avi` for video, plus `.mp3` for audio-only downloads. Youtarr only writes `.mp4` (or `.mp3` for audio-only), but the rescan recognizes any of these so transcoding outside Youtarr won't orphan your library. Files must keep the `[<youtube-id>]` segment in their filename (the 11-character ID in brackets that yt-dlp writes by default) for Youtarr to match them back to the database.
+
+**When to use this vs. Re-download Missing Videos**:
+- File is **gone** (deleted): use [Re-download Missing Videos](#re-download-missing-videos).
+- File **still exists somewhere** (moved, renamed, or converted): use Rescan.
 
 ## Organize Channels with Multi-Library Support
 

--- a/docs/YOUTARR_DOWNLOADS_FOLDER_STRUCTURE.md
+++ b/docs/YOUTARR_DOWNLOADS_FOLDER_STRUCTURE.md
@@ -72,3 +72,14 @@ YouTube Downloads/
 │       ├── Channel - Video [id].[lang].srt
 │       └── Channel - Video [id].jpg
 ```
+
+## Supported File Extensions (Reads vs. Writes)
+
+Youtarr **writes** downloaded media as `.mp4` for video and `.mp3` for audio-only downloads.
+
+Youtarr **reads** a wider set of extensions when reconciling the database with disk (during the daily scheduled scan, the server-startup scan, and the manual **Settings -> Maintenance -> Rescan files on disk** action):
+
+- **Video**: `.mp4`, `.webm`, `.mkv`, `.m4v`, `.avi`
+- **Audio**: `.mp3`
+
+This means you can safely convert downloaded videos to a different supported container outside Youtarr (for example, transcoding `.mp4` to `.mkv`) without losing track of them, as long as the `[<youtube-id>]` segment remains in the filename. Run a rescan from the Maintenance settings page after making changes to update Youtarr's view immediately, or wait for the next scheduled scan. See the [Usage Guide](USAGE_GUIDE.md#rescan-files-on-disk) for details.

--- a/server/modules/__tests__/fileCheckModule.test.js
+++ b/server/modules/__tests__/fileCheckModule.test.js
@@ -42,7 +42,7 @@ describe('FileCheckModule', () => {
         }
       ];
 
-      mockFs.stat.mockRejectedValueOnce({ code: 'ENOENT' });
+      mockFs.stat.mockRejectedValue({ code: 'ENOENT' });
 
       const result = await fileCheckModule.checkVideoFiles(videos);
 
@@ -189,10 +189,16 @@ describe('FileCheckModule', () => {
         }
       ];
 
-      mockFs.stat
-        .mockRejectedValueOnce({ code: 'ENOENT' }) // video1 not found
-        .mockResolvedValueOnce({ size: 2000 })     // video2 exists, size unchanged
-        .mockResolvedValueOnce({ size: 4000 });    // video4 exists, size changed
+      mockFs.stat.mockImplementation((p) => {
+        if (p === '/videos/channel/video2.mp4') {
+          return Promise.resolve({ size: 2000 });
+        }
+        if (p === '/videos/channel/video4.mp4') {
+          return Promise.resolve({ size: 4000 });
+        }
+        // video1 (and any same-dir extension fallbacks) all ENOENT
+        return Promise.reject({ code: 'ENOENT' });
+      });
 
       const result = await fileCheckModule.checkVideoFiles(videos);
 
@@ -229,7 +235,6 @@ describe('FileCheckModule', () => {
         { id: 2, removed: false },
         { id: 4, fileSize: 4000 }
       ]);
-      expect(mockFs.stat).toHaveBeenCalledTimes(3);
     });
 
     test('should handle non-ENOENT errors by not updating', async () => {
@@ -340,6 +345,105 @@ describe('FileCheckModule', () => {
       expect(result.updates).toEqual([
         { id: 1, fileSize: largeSize }
       ]);
+    });
+
+    test('should swap extension and update path when stored .mp4 is now .mkv at same dir', async () => {
+      const videos = [
+        {
+          id: 1,
+          youtubeId: 'abc123',
+          filePath: '/videos/channel/video [abc123].mp4',
+          fileSize: '1000',
+          removed: false
+        }
+      ];
+
+      // Original .mp4 is gone; .webm fails too; .mkv is found
+      mockFs.stat.mockImplementation((p) => {
+        if (p === '/videos/channel/video [abc123].mp4') {
+          return Promise.reject({ code: 'ENOENT' });
+        }
+        if (p === '/videos/channel/video [abc123].webm') {
+          return Promise.reject({ code: 'ENOENT' });
+        }
+        if (p === '/videos/channel/video [abc123].mkv') {
+          return Promise.resolve({ size: 5000 });
+        }
+        return Promise.reject({ code: 'ENOENT' });
+      });
+
+      const result = await fileCheckModule.checkVideoFiles(videos);
+
+      expect(result.updates).toEqual([
+        {
+          id: 1,
+          filePath: '/videos/channel/video [abc123].mkv',
+          fileSize: 5000
+        }
+      ]);
+    });
+
+    test('should leave filePath untouched when no extension variant exists', async () => {
+      const videos = [
+        {
+          id: 1,
+          youtubeId: 'abc123',
+          filePath: '/videos/channel/video [abc123].mp4',
+          fileSize: '1000',
+          removed: false
+        }
+      ];
+
+      mockFs.stat.mockRejectedValue({ code: 'ENOENT' });
+
+      const result = await fileCheckModule.checkVideoFiles(videos);
+
+      // Marked removed, but filePath/fileSize must NOT appear in the update
+      expect(result.updates).toHaveLength(1);
+      expect(result.updates[0]).toEqual({ id: 1, removed: true });
+      expect(result.updates[0].filePath).toBeUndefined();
+      expect(result.updates[0].fileSize).toBeUndefined();
+    });
+
+    test('should not flip removed status when stat fails with non-ENOENT error', async () => {
+      const videos = [
+        {
+          id: 1,
+          youtubeId: 'abc123',
+          filePath: '/videos/channel/video [abc123].mp4',
+          fileSize: '1000',
+          removed: false
+        }
+      ];
+
+      mockFs.stat.mockRejectedValue({ code: 'EACCES' });
+
+      const result = await fileCheckModule.checkVideoFiles(videos);
+
+      expect(result.updates).toEqual([]);
+    });
+
+    test('should mark removed when stored .mp3 is missing and no audio variant exists', async () => {
+      const videos = [
+        {
+          id: 1,
+          youtubeId: 'abc123',
+          audioFilePath: '/videos/channel/audio [abc123].mp3',
+          audioFileSize: '500',
+          removed: false
+        }
+      ];
+
+      // Today AUDIO_EXTENSIONS = ['.mp3'] only, so this test verifies that with a
+      // single-entry audio list, a missing .mp3 with no replacement marks removed
+      // without altering audioFilePath. (It also exercises the audio code path.)
+      mockFs.stat.mockRejectedValue({ code: 'ENOENT' });
+
+      const result = await fileCheckModule.checkVideoFiles(videos);
+
+      expect(result.updates).toHaveLength(1);
+      expect(result.updates[0]).toEqual({ id: 1, removed: true });
+      expect(result.updates[0].audioFilePath).toBeUndefined();
     });
   });
 
@@ -540,6 +644,21 @@ describe('FileCheckModule', () => {
       ).rejects.toThrow('Database connection failed');
     });
 
+    test('should set filePath and fileSize when both provided', async () => {
+      const updates = [
+        { id: 1, filePath: '/videos/channel/video [abc123].mkv', fileSize: 5000, removed: false }
+      ];
+
+      await fileCheckModule.applyVideoUpdates(mockSequelize, mockSequelizeLib, updates);
+
+      expect(mockSequelize.query).toHaveBeenCalledWith(
+        'UPDATE Videos SET filePath = ?, fileSize = ?, removed = ? WHERE id = ?',
+        expect.objectContaining({
+          replacements: ['/videos/channel/video [abc123].mkv', 5000, 0, 1]
+        })
+      );
+    });
+
     test('should continue with remaining updates if one fails', async () => {
       const updates = [
         { id: 1, fileSize: 2000 },
@@ -576,9 +695,13 @@ describe('FileCheckModule', () => {
         }
       ];
 
-      mockFs.stat
-        .mockResolvedValueOnce({ size: 1500 })     // video1 size changed
-        .mockRejectedValueOnce({ code: 'ENOENT' }); // video2 not found
+      mockFs.stat.mockImplementation((p) => {
+        if (p === '/videos/channel/video1.mp4') {
+          return Promise.resolve({ size: 1500 });
+        }
+        // video2 and any extension fallbacks all ENOENT
+        return Promise.reject({ code: 'ENOENT' });
+      });
 
       const mockSequelize = {
         query: jest.fn()

--- a/server/modules/__tests__/videosModule.test.js
+++ b/server/modules/__tests__/videosModule.test.js
@@ -10,6 +10,7 @@ describe('VideosModule', () => {
   let mockVideoValidationModule;
   let mockLogger;
   let mockNfoGenerator;
+  let mockMessageEmitter;
 
   beforeEach(() => {
     jest.resetModules();
@@ -43,7 +44,9 @@ describe('VideosModule', () => {
 
     // Mock configModule
     mockConfigModule = {
-      directoryPath: '/test/output/dir'
+      directoryPath: '/test/output/dir',
+      getConfig: jest.fn().mockReturnValue({}),
+      updateConfig: jest.fn()
     };
 
     mockVideoValidationModule = {
@@ -62,6 +65,10 @@ describe('VideosModule', () => {
 
     mockNfoGenerator = {
       writeVideoNfoFile: jest.fn()
+    };
+
+    mockMessageEmitter = {
+      emitMessage: jest.fn()
     };
 
     // Mock the database module
@@ -89,6 +96,8 @@ describe('VideosModule', () => {
     jest.doMock('../videoValidationModule', () => mockVideoValidationModule);
 
     jest.doMock('../nfoGenerator', () => mockNfoGenerator);
+
+    jest.doMock('../messageEmitter', () => mockMessageEmitter);
 
     // Mock logger
     jest.doMock('../../logger', () => mockLogger);
@@ -470,8 +479,9 @@ describe('VideosModule', () => {
       mockSequelize.query.mockResolvedValueOnce(); // Update query
       mockSequelize.query.mockResolvedValueOnce([]); // getAllUniqueChannels query
 
-      // Mock file does not exist
-      mockFs.stat.mockRejectedValueOnce({ code: 'ENOENT' });
+      // Mock file does not exist; fileCheckModule's same-dir fallback will
+      // also try .webm/.mkv/.m4v/.avi variants, all of which must ENOENT.
+      mockFs.stat.mockRejectedValue({ code: 'ENOENT' });
 
       const result = await VideosModule.getVideosPaginated();
 
@@ -684,6 +694,51 @@ describe('VideosModule', () => {
         'Error scanning directory'
       );
     });
+
+    test('should detect .mkv files', async () => {
+      mockFs.readdir.mockResolvedValueOnce([
+        { name: 'Channel - Title [vid12345abc].mkv', isDirectory: () => false, isFile: () => true }
+      ]);
+      mockFs.stat.mockResolvedValueOnce({ size: 9000 });
+
+      const { fileMap } = await VideosModule.scanForVideoFiles('/videos');
+
+      expect(fileMap.size).toBe(1);
+      expect(fileMap.get('vid12345abc')).toMatchObject({
+        videoFilePath: expect.stringMatching(/\.mkv$/),
+        videoFileSize: 9000
+      });
+    });
+
+    test('should detect .webm, .m4v, and .avi files', async () => {
+      mockFs.readdir.mockResolvedValueOnce([
+        { name: 'A [aaaaaaaaaaa].webm', isDirectory: () => false, isFile: () => true },
+        { name: 'B [bbbbbbbbbbb].m4v', isDirectory: () => false, isFile: () => true },
+        { name: 'C [ccccccccccc].avi', isDirectory: () => false, isFile: () => true }
+      ]);
+      mockFs.stat
+        .mockResolvedValueOnce({ size: 100 })
+        .mockResolvedValueOnce({ size: 200 })
+        .mockResolvedValueOnce({ size: 300 });
+
+      const { fileMap } = await VideosModule.scanForVideoFiles('/videos');
+
+      expect(fileMap.size).toBe(3);
+      expect(fileMap.get('aaaaaaaaaaa').videoFilePath).toMatch(/\.webm$/);
+      expect(fileMap.get('bbbbbbbbbbb').videoFilePath).toMatch(/\.m4v$/);
+      expect(fileMap.get('ccccccccccc').videoFilePath).toMatch(/\.avi$/);
+    });
+
+    test('should still ignore unsupported extensions like .txt', async () => {
+      mockFs.readdir.mockResolvedValueOnce([
+        { name: 'note [zzzzzzzzzzz].txt', isDirectory: () => false, isFile: () => true }
+      ]);
+
+      const { fileMap } = await VideosModule.scanForVideoFiles('/videos');
+
+      expect(fileMap.size).toBe(0);
+      expect(mockFs.stat).not.toHaveBeenCalled();
+    });
   });
 
   describe('backfillVideoMetadata', () => {
@@ -780,6 +835,34 @@ describe('VideosModule', () => {
       expect(result.updated).toBe(0);
     });
 
+    test('should clear removed flag when a previously-missing file reappears (raw row removed=1)', async () => {
+      // Sequelize raw mode returns BOOLEAN columns as 0/1, not true/false.
+      // This test exercises that path to ensure restoration is detected.
+      mockFs.readdir.mockResolvedValueOnce([
+        { name: 'video [restored1].mp4', isDirectory: () => false, isFile: () => true }
+      ]);
+      mockFs.stat.mockResolvedValueOnce({ size: 1000 });
+
+      mockVideo.count.mockResolvedValueOnce(1);
+
+      mockVideo.findAll.mockResolvedValueOnce([
+        {
+          id: 1,
+          youtubeId: 'restored1',
+          filePath: '/test/output/dir/video [restored1].mp4',
+          fileSize: '1000',
+          removed: 1
+        }
+      ]);
+
+      mockSequelize.query.mockResolvedValueOnce();
+
+      const result = await VideosModule.backfillVideoMetadata();
+
+      expect(result.updated).toBe(1);
+      expect(result.removed).toBe(0);
+    });
+
     test('should process videos in chunks', async () => {
       // Mock filesystem
       mockFs.readdir.mockResolvedValueOnce([]);
@@ -823,6 +906,134 @@ describe('VideosModule', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         { err: mockError },
         'Error during video metadata backfill'
+      );
+    });
+
+    test('should accept options object with timeLimit and trigger', async () => {
+      mockFs.readdir.mockResolvedValueOnce([]);
+      mockVideo.count.mockResolvedValueOnce(0);
+
+      const result = await VideosModule.backfillVideoMetadata({ timeLimit: 1000, trigger: 'manual' });
+
+      expect(result).toBeDefined();
+      expect(result.trigger).toBe('manual');
+    });
+
+    test('should still accept legacy positional timeLimit argument', async () => {
+      mockFs.readdir.mockResolvedValueOnce([]);
+      mockVideo.count.mockResolvedValueOnce(0);
+
+      const result = await VideosModule.backfillVideoMetadata(100);
+      expect(result).toBeDefined();
+      expect(result.trigger).toBe('scheduled');
+    });
+
+    test('should return skipped result when a backfill is already in progress', async () => {
+      VideosModule._backfillRunning = true;
+
+      const result = await VideosModule.backfillVideoMetadata({ trigger: 'manual' });
+
+      expect(result).toEqual({ skipped: true, reason: 'already-running' });
+      expect(VideosModule._backfillRunning).toBe(true);
+
+      VideosModule._backfillRunning = false;
+    });
+
+    test('should release lock on success', async () => {
+      mockFs.readdir.mockResolvedValueOnce([]);
+      mockVideo.count.mockResolvedValueOnce(0);
+
+      await VideosModule.backfillVideoMetadata({ trigger: 'manual' });
+
+      expect(VideosModule._backfillRunning).toBe(false);
+    });
+
+    test('should release lock on error', async () => {
+      const error = new Error('boom');
+      mockFs.readdir.mockResolvedValueOnce([]);
+      mockVideo.count.mockRejectedValueOnce(error);
+
+      await expect(VideosModule.backfillVideoMetadata({ trigger: 'manual' })).rejects.toThrow('boom');
+      expect(VideosModule._backfillRunning).toBe(false);
+    });
+
+    test('should write rescanLastRun to config on completion', async () => {
+      mockFs.readdir.mockResolvedValueOnce([]);
+      mockVideo.count.mockResolvedValueOnce(0);
+
+      await VideosModule.backfillVideoMetadata({ trigger: 'manual' });
+
+      expect(mockConfigModule.updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rescanLastRun: expect.objectContaining({
+            trigger: 'manual',
+            status: 'completed',
+            videosScanned: 0,
+            filesFoundOnDisk: 0,
+            videosUpdated: 0,
+            videosMarkedMissing: 0
+          })
+        })
+      );
+    });
+
+    test('should still emit completion when rescanLastRun persistence fails', async () => {
+      mockFs.readdir.mockResolvedValueOnce([]);
+      mockVideo.count.mockResolvedValueOnce(0);
+      mockConfigModule.updateConfig.mockImplementation(() => {
+        throw new Error('config write failed');
+      });
+
+      await VideosModule.backfillVideoMetadata({ trigger: 'manual' });
+
+      expect(mockMessageEmitter.emitMessage).toHaveBeenCalledWith(
+        'broadcast',
+        null,
+        'server',
+        'rescanStatus',
+        expect.objectContaining({ running: false, lastRun: expect.any(Object) })
+      );
+      expect(VideosModule._backfillRunning).toBe(false);
+    });
+
+    test('should release lock when no output directory and completion emit fails', async () => {
+      mockConfigModule.directoryPath = '';
+      mockMessageEmitter.emitMessage.mockImplementation((...args) => {
+        const payload = args[4];
+        if (payload?.running === false) {
+          throw new Error('websocket unavailable');
+        }
+      });
+
+      const result = await VideosModule.backfillVideoMetadata({ trigger: 'manual' });
+
+      expect(result).toBeUndefined();
+      expect(VideosModule._backfillRunning).toBe(false);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Failed to emit rescanStatus completion'
+      );
+    });
+
+    test('should emit rescanStatus WebSocket broadcasts on start and completion', async () => {
+      mockFs.readdir.mockResolvedValueOnce([]);
+      mockVideo.count.mockResolvedValueOnce(0);
+
+      await VideosModule.backfillVideoMetadata({ trigger: 'manual' });
+
+      expect(mockMessageEmitter.emitMessage).toHaveBeenCalledWith(
+        'broadcast',
+        null,
+        'server',
+        'rescanStatus',
+        expect.objectContaining({ running: true, trigger: 'manual' })
+      );
+      expect(mockMessageEmitter.emitMessage).toHaveBeenCalledWith(
+        'broadcast',
+        null,
+        'server',
+        'rescanStatus',
+        expect.objectContaining({ running: false, lastRun: expect.any(Object) })
       );
     });
   });
@@ -963,6 +1174,24 @@ describe('VideosModule', () => {
         videoInstance.filePath,
         expect.objectContaining({ normalized_rating: null })
       );
+    });
+  });
+
+  describe('tryStartBackfill', () => {
+    test('returns started: true when not running', () => {
+      VideosModule._backfillRunning = false;
+      const spy = jest.spyOn(VideosModule, 'backfillVideoMetadata').mockResolvedValue();
+      const result = VideosModule.tryStartBackfill({ trigger: 'manual' });
+      expect(result).toEqual({ started: true });
+      expect(spy).toHaveBeenCalledWith({ trigger: 'manual' });
+      spy.mockRestore();
+    });
+
+    test('returns started: false when already running', () => {
+      VideosModule._backfillRunning = true;
+      const result = VideosModule.tryStartBackfill();
+      expect(result).toEqual({ started: false, reason: 'already-running' });
+      VideosModule._backfillRunning = false;
     });
   });
 });

--- a/server/modules/cronJobs.js
+++ b/server/modules/cronJobs.js
@@ -91,7 +91,7 @@ function initialize(deps = {}) {
     logger.info('Starting scheduled video metadata backfill');
     try {
       // Run asynchronously without blocking - the method handles its own async flow
-      videosModule.backfillVideoMetadata()
+      videosModule.backfillVideoMetadata({ trigger: 'scheduled' })
         .then(result => {
           if (result && result.timedOut) {
             logger.info('Video metadata backfill reached time limit, will continue tomorrow');

--- a/server/modules/fileCheckModule.js
+++ b/server/modules/fileCheckModule.js
@@ -1,19 +1,57 @@
 const fs = require('fs').promises;
+const path = require('path');
+const { VIDEO_EXTENSIONS, AUDIO_EXTENSIONS } = require('./filesystem/constants');
 
 /**
  * Check file existence and update video metadata.
- * This shared module provides file existence checking for videos,
- * updating their 'removed' status and file size in real-time.
+ * Real-time per-page check: stats the stored path, falls back to same-dir
+ * same-basename files with any supported extension if the original is missing.
  */
 class FileCheckModule {
   /**
-   * Check file existence for an array of videos and prepare updates.
-   * Checks both video files (filePath) and audio files (audioFilePath).
-   * Only checks files that have a path stored to avoid incorrect marking.
+   * Try the original path; if missing, try same-dir variants with every
+   * extension in `extensionList`.
    *
-   * @param {Array} videos - Array of video objects with filePath and audioFilePath properties
-   * @returns {Promise<Object>} - Object with updated videos array and database updates array
+   * Returns:
+   *   { exists: true, replaced: false, path, size }     - original found
+   *   { exists: true, replaced: true,  path, size }     - variant found
+   *   { exists: false, statusKnown: true }              - definitively missing
+   *   { exists: false, statusKnown: false }             - non-ENOENT error
    */
+  async _findExistingMediaFile(originalPath, extensionList) {
+    try {
+      const stats = await fs.stat(originalPath);
+      return { exists: true, replaced: false, path: originalPath, size: stats.size };
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        return { exists: false, statusKnown: false };
+      }
+      // ENOENT on the stored path; fall through to the same-dir extension scan.
+    }
+
+    const dir = path.dirname(originalPath);
+    const ext = path.extname(originalPath);
+    const extLower = ext.toLowerCase();
+    const base = path.basename(originalPath, ext);
+
+    for (const candidateExt of extensionList) {
+      if (candidateExt.toLowerCase() === extLower) {
+        continue;
+      }
+      const candidatePath = path.join(dir, base + candidateExt);
+      try {
+        const stats = await fs.stat(candidatePath);
+        return { exists: true, replaced: true, path: candidatePath, size: stats.size };
+      } catch (err) {
+        if (err.code !== 'ENOENT') {
+          return { exists: false, statusKnown: false };
+        }
+      }
+    }
+
+    return { exists: false, statusKnown: true };
+  }
+
   async checkVideoFiles(videos) {
     const updates = [];
     const updatedVideos = [...videos];
@@ -24,69 +62,58 @@ class FileCheckModule {
       let hasUpdates = false;
       let videoFileExists = false;
       let audioFileExists = false;
-      // Track if we could definitively determine file status (not blocked by permission errors, etc.)
-      let videoFileStatusKnown = !video.filePath; // If no path, status is "known" (not applicable)
-      let audioFileStatusKnown = !video.audioFilePath; // If no path, status is "known" (not applicable)
+      let videoFileStatusKnown = !video.filePath;
+      let audioFileStatusKnown = !video.audioFilePath;
 
-      // Check video file (filePath)
       if (video.filePath) {
-        try {
-          const stats = await fs.stat(video.filePath);
+        const result = await this._findExistingMediaFile(video.filePath, VIDEO_EXTENSIONS);
+        if (result.exists) {
           videoFileExists = true;
           videoFileStatusKnown = true;
 
-          // File exists - update if size changed
-          if (video.fileSize !== stats.size.toString()) {
-            update.fileSize = stats.size;
+          if (result.replaced) {
+            update.filePath = result.path;
+            update.fileSize = result.size;
+            hasUpdates = true;
+          } else if (video.fileSize !== result.size.toString()) {
+            update.fileSize = result.size;
             hasUpdates = true;
           }
-        } catch (err) {
-          if (err.code === 'ENOENT') {
-            // Video file doesn't exist - definitively known
-            videoFileExists = false;
-            videoFileStatusKnown = true;
-          }
-          // For non-ENOENT errors (permissions, etc.), we can't determine status
-          // videoFileStatusKnown remains false, so we won't change removed status
+        } else {
+          videoFileExists = false;
+          videoFileStatusKnown = result.statusKnown;
         }
       }
 
-      // Check audio file (audioFilePath)
       if (video.audioFilePath) {
-        try {
-          const stats = await fs.stat(video.audioFilePath);
+        const result = await this._findExistingMediaFile(video.audioFilePath, AUDIO_EXTENSIONS);
+        if (result.exists) {
           audioFileExists = true;
           audioFileStatusKnown = true;
 
-          // File exists - update if size changed
-          if (video.audioFileSize !== stats.size.toString()) {
-            update.audioFileSize = stats.size;
+          if (result.replaced) {
+            update.audioFilePath = result.path;
+            update.audioFileSize = result.size;
+            hasUpdates = true;
+          } else if (video.audioFileSize !== result.size.toString()) {
+            update.audioFileSize = result.size;
             hasUpdates = true;
           }
-        } catch (err) {
-          if (err.code === 'ENOENT') {
-            // Audio file doesn't exist - definitively known
-            audioFileExists = false;
-            audioFileStatusKnown = true;
-          }
-          // For non-ENOENT errors (permissions, etc.), we can't determine status
-          // audioFileStatusKnown remains false, so we won't change removed status
+        } else {
+          audioFileExists = false;
+          audioFileStatusKnown = result.statusKnown;
         }
       }
 
-      // Determine removed status: removed only if NO files exist (both video and audio missing)
-      // Only update if we could definitively determine status for all paths
       const hasAnyPath = video.filePath || video.audioFilePath;
       const hasAnyFile = videoFileExists || audioFileExists;
       const canDetermineRemovedStatus = videoFileStatusKnown && audioFileStatusKnown;
 
       if (hasAnyPath && canDetermineRemovedStatus) {
         if (hasAnyFile && video.removed) {
-          // At least one file exists, mark as not removed
           update.removed = false;
           hasUpdates = true;
         } else if (!hasAnyFile && !video.removed) {
-          // No files exist, mark as removed
           update.removed = true;
           hasUpdates = true;
         }
@@ -94,30 +121,20 @@ class FileCheckModule {
 
       if (hasUpdates) {
         updates.push(update);
-        // Update the video object for immediate response
         updatedVideos[i] = {
           ...video,
+          ...(update.filePath !== undefined && { filePath: update.filePath }),
           ...(update.fileSize !== undefined && { fileSize: update.fileSize.toString() }),
+          ...(update.audioFilePath !== undefined && { audioFilePath: update.audioFilePath }),
           ...(update.audioFileSize !== undefined && { audioFileSize: update.audioFileSize.toString() }),
           ...(update.removed !== undefined && { removed: update.removed })
         };
       }
     }
-    // Intentionally NOT searching for videos without a filePath or audioFilePath
-    // This prevents incorrectly marking videos as removed when we can't find them quickly
-    // The backfill process will handle finding and updating these videos
 
     return { videos: updatedVideos, updates };
   }
 
-  /**
-   * Apply database updates for video file status changes.
-   *
-   * @param {Object} sequelize - Sequelize instance
-   * @param {Object} Sequelize - Sequelize library
-   * @param {Array} updates - Array of update objects with id, fileSize, audioFileSize, and/or removed properties
-   * @returns {Promise<void>}
-   */
   async applyVideoUpdates(sequelize, Sequelize, updates) {
     if (updates.length === 0) {
       return;
@@ -127,9 +144,17 @@ class FileCheckModule {
       const setClauses = [];
       const values = [];
 
+      if (update.filePath !== undefined) {
+        setClauses.push('filePath = ?');
+        values.push(update.filePath);
+      }
       if (update.fileSize !== undefined) {
         setClauses.push('fileSize = ?');
         values.push(update.fileSize);
+      }
+      if (update.audioFilePath !== undefined) {
+        setClauses.push('audioFilePath = ?');
+        values.push(update.audioFilePath);
       }
       if (update.audioFileSize !== undefined) {
         setClauses.push('audioFileSize = ?');

--- a/server/modules/videosModule.js
+++ b/server/modules/videosModule.js
@@ -5,9 +5,13 @@ const path = require('path');
 const configModule = require('./configModule');
 const fileCheckModule = require('./fileCheckModule');
 const logger = require('../logger');
+const messageEmitter = require('./messageEmitter');
+const { AUDIO_EXTENSIONS, MEDIA_EXTENSIONS } = require('./filesystem/constants');
 
 class VideosModule {
-  constructor() {}
+  constructor() {
+    this._backfillRunning = false;
+  }
 
   async getVideosPaginated(options = {}) {
     const {
@@ -349,51 +353,60 @@ class VideosModule {
         const fullPath = path.join(dir, entry.name);
 
         if (entry.isDirectory()) {
-          // Recursively scan subdirectories
           await this.scanForVideoFiles(fullPath, fileMap, duplicates);
-        } else if (entry.isFile() && (entry.name.endsWith('.mp4') || entry.name.endsWith('.mp3'))) {
-          // Extract YouTube ID from filename - matches files ending with [youtube_id].mp4 or [youtube_id].mp3
-          // Accepts ANY characters before the final [id].ext pattern
-          const match = entry.name.match(/\[([^[\]]+)\]\.(mp4|mp3)$/);
-          if (match) {
-            const youtubeId = match[1];
-            const ext = match[2]; // 'mp4' or 'mp3'
-            const isAudio = ext === 'mp3';
-            const stats = await fs.stat(fullPath);
+          continue;
+        }
 
-            // Get or create entry for this youtubeId
-            if (!fileMap.has(youtubeId)) {
-              fileMap.set(youtubeId, {
-                videoFilePath: null,
-                videoFileSize: null,
-                audioFilePath: null,
-                audioFileSize: null
-              });
-            }
+        if (!entry.isFile()) {
+          continue;
+        }
 
-            const existing = fileMap.get(youtubeId);
-            const pathKey = isAudio ? 'audioFilePath' : 'videoFilePath';
-            const sizeKey = isAudio ? 'audioFileSize' : 'videoFileSize';
+        const ext = path.extname(entry.name).toLowerCase();
+        if (!MEDIA_EXTENSIONS.includes(ext)) {
+          continue;
+        }
 
-            // Check for duplicates of the same type
-            if (existing[pathKey]) {
-              // Track duplicate for logging
-              if (!duplicates.has(youtubeId)) {
-                duplicates.set(youtubeId, []);
-              }
-              duplicates.get(youtubeId).push(fullPath);
+        // Match files ending with [<id>].<ext>; <id> is whatever yt-dlp wrote
+        // between the brackets at the end of the filename.
+        const match = entry.name.match(/\[([^[\]]+)\]\.[a-z0-9]+$/i);
+        if (!match) {
+          continue;
+        }
 
-              // Keep the larger file (likely the more complete download)
-              if (stats.size > existing[sizeKey]) {
-                logger.warn({ youtubeId, filePath: fullPath, size: stats.size, type: ext }, 'Duplicate found: keeping larger file');
-                existing[pathKey] = fullPath;
-                existing[sizeKey] = stats.size;
-              }
-            } else {
-              existing[pathKey] = fullPath;
-              existing[sizeKey] = stats.size;
-            }
+        const youtubeId = match[1];
+        const isAudio = AUDIO_EXTENSIONS.includes(ext);
+        const stats = await fs.stat(fullPath);
+
+        if (!fileMap.has(youtubeId)) {
+          fileMap.set(youtubeId, {
+            videoFilePath: null,
+            videoFileSize: null,
+            audioFilePath: null,
+            audioFileSize: null
+          });
+        }
+
+        const existing = fileMap.get(youtubeId);
+        const pathKey = isAudio ? 'audioFilePath' : 'videoFilePath';
+        const sizeKey = isAudio ? 'audioFileSize' : 'videoFileSize';
+
+        if (existing[pathKey]) {
+          if (!duplicates.has(youtubeId)) {
+            duplicates.set(youtubeId, []);
           }
+          duplicates.get(youtubeId).push(fullPath);
+
+          if (stats.size > existing[sizeKey]) {
+            logger.warn(
+              { youtubeId, filePath: fullPath, size: stats.size, type: ext },
+              'Duplicate found: keeping larger file'
+            );
+            existing[pathKey] = fullPath;
+            existing[sizeKey] = stats.size;
+          }
+        } else {
+          existing[pathKey] = fullPath;
+          existing[sizeKey] = stats.size;
         }
       }
     } catch (err) {
@@ -403,14 +416,38 @@ class VideosModule {
     return { fileMap, duplicates };
   }
 
-  async backfillVideoMetadata(timeLimit = 5 * 60 * 1000) { // Default 5 minutes
+  async backfillVideoMetadata(arg = {}) {
+    const opts = typeof arg === 'number' ? { timeLimit: arg } : arg;
+    const timeLimit = opts.timeLimit ?? 5 * 60 * 1000;
+    const trigger = opts.trigger ?? 'scheduled';
+
+    if (this._backfillRunning) {
+      logger.info({ trigger }, 'Backfill already running, skipping');
+      return { skipped: true, reason: 'already-running' };
+    }
+    this._backfillRunning = true;
+
     const startTime = Date.now();
+    const startedAtIso = new Date(startTime).toISOString();
     const logProgress = (message) => {
       const elapsed = Math.round((Date.now() - startTime) / 1000);
       logger.info({ elapsed, context: 'backfill' }, message);
     };
 
+    let totalProcessed = 0;
+    let totalUpdated = 0;
+    let totalRemoved = 0;
+    let fileMapSize = 0;
+    let result;
+
     try {
+      // Emit inside the try so a synchronous emit failure still triggers the
+      // finally block and clears the lock.
+      messageEmitter.emitMessage('broadcast', null, 'server', 'rescanStatus', {
+        running: true,
+        trigger
+      });
+
       logProgress('Starting video metadata backfill...');
       const outputDir = configModule.directoryPath;
 
@@ -429,6 +466,7 @@ class VideosModule {
       // First, scan filesystem for all video files
       logProgress('Scanning filesystem for video files...');
       const { fileMap, duplicates } = await this.scanForVideoFiles(outputDir);
+      fileMapSize = fileMap.size;
       logProgress(`Found ${fileMap.size} video files on disk`);
 
 
@@ -444,9 +482,6 @@ class VideosModule {
       // Process videos in chunks to avoid memory issues
       const VIDEO_CHUNK_SIZE = 1000; // Process 1000 videos at a time
       let offset = 0;
-      let totalProcessed = 0;
-      let totalUpdated = 0;
-      let totalRemoved = 0;
 
       // Get total count first
       const totalCount = await Video.count();
@@ -500,8 +535,10 @@ class VideosModule {
               // Check if we need to clear video fields (video file was deleted but audio exists)
               const videoFileRemoved = !hasVideoFile && hasAudioFile && (video.filePath || video.fileSize);
 
+              // Sequelize BOOLEAN columns come back as 0/1 in raw mode, so use a
+              // truthy check; `=== true` would never match the raw integer.
               if (videoPathChanged || videoSizeChanged || audioPathChanged || audioSizeChanged ||
-                  audioFileRemoved || videoFileRemoved || video.removed === true) {
+                  audioFileRemoved || videoFileRemoved || video.removed) {
                 const update = {
                   id: video.id,
                   removed: false
@@ -624,27 +661,111 @@ class VideosModule {
       logger.info({
         elapsed,
         totalProcessed,
-        filesOnDisk: fileMap.size,
+        filesOnDisk: fileMapSize,
         updated: totalUpdated,
         removed: totalRemoved
       }, 'Video metadata backfill completed');
 
-      return {
+      result = {
         processed: totalProcessed,
-        filesOnDisk: fileMap.size,
+        filesOnDisk: fileMapSize,
         updated: totalUpdated,
         removed: totalRemoved,
-        timeElapsed: elapsed
+        timeElapsed: elapsed,
+        trigger,
+        startedAt: startedAtIso,
+        completedAt: new Date().toISOString(),
+        status: 'completed'
       };
+      return result;
     } catch (err) {
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
       if (err.message && err.message.includes('Time limit exceeded')) {
-        const elapsed = Math.round((Date.now() - startTime) / 1000);
         logger.info({ elapsed }, 'Video metadata backfill stopped (time limit reached), will continue at next scheduled run');
-        return { timedOut: true, timeElapsed: elapsed };
+        result = {
+          timedOut: true,
+          timeElapsed: elapsed,
+          trigger,
+          startedAt: startedAtIso,
+          completedAt: new Date().toISOString(),
+          status: 'timed-out',
+          processed: totalProcessed,
+          filesOnDisk: fileMapSize,
+          updated: totalUpdated,
+          removed: totalRemoved
+        };
+        return result;
       }
       logger.error({ err }, 'Error during video metadata backfill');
+      result = {
+        trigger,
+        startedAt: startedAtIso,
+        completedAt: new Date().toISOString(),
+        status: 'error',
+        errorMessage: err.message || 'Unknown error',
+        processed: totalProcessed,
+        filesOnDisk: fileMapSize,
+        updated: totalUpdated,
+        removed: totalRemoved
+      };
       throw err;
+    } finally {
+      let lastRun = null;
+
+      if (result) {
+        lastRun = {
+          startedAt: result.startedAt,
+          completedAt: result.completedAt,
+          trigger: result.trigger,
+          status: result.status,
+          videosUpdated: result.updated || 0,
+          videosMarkedMissing: result.removed || 0,
+          videosScanned: result.processed || 0,
+          filesFoundOnDisk: result.filesOnDisk || 0,
+          errorMessage: result.errorMessage || null
+        };
+
+        try {
+          const currentConfig = configModule.getConfig();
+          configModule.updateConfig({ ...currentConfig, rescanLastRun: lastRun });
+        } catch (persistErr) {
+          logger.error({ err: persistErr }, 'Failed to persist rescanLastRun');
+        }
+      }
+
+      this._backfillRunning = false;
+
+      try {
+        messageEmitter.emitMessage('broadcast', null, 'server', 'rescanStatus', {
+          running: false,
+          lastRun
+        });
+      } catch (emitErr) {
+        logger.error({ err: emitErr }, 'Failed to emit rescanStatus completion');
+      }
     }
+  }
+
+  /**
+   * Atomically check the lock and kick off a backfill. Returns synchronously
+   * with `started: true` (caller should respond 202) or `started: false`
+   * (caller should respond 409). The actual backfill runs as a fire-and-forget
+   * task; errors are logged inside `backfillVideoMetadata` itself.
+   */
+  tryStartBackfill({ trigger = 'manual' } = {}) {
+    if (this._backfillRunning) {
+      return { started: false, reason: 'already-running' };
+    }
+    // backfillVideoMetadata sets the flag synchronously before its first await,
+    // so launching it here is race-free for in-process callers.
+    this.backfillVideoMetadata({ trigger }).catch((err) => {
+      logger.error({ err }, 'Manual backfill run failed');
+    });
+    return { started: true };
+  }
+
+  isBackfillRunning() {
+    return this._backfillRunning;
   }
 
   async setVideoProtection(id, protectedState) {

--- a/server/routes/__tests__/config.test.js
+++ b/server/routes/__tests__/config.test.js
@@ -20,6 +20,7 @@ function makeApp() {
       ytdlpLastChecked: null,
       ytdlpLastUpdated: null,
       ytdlpLastResult: null,
+      rescanLastRun: null,
     },
     getConfig: jest.fn(function () { return this._config; }),
     updateConfig: jest.fn(function (next) { this._config = next; }),
@@ -56,6 +57,31 @@ describe('POST /updateconfig', () => {
       .send({ ytdlpCustomArgs: '--no-mtime --concurrent-fragments 4' });
     expect(res.status).toBe(200);
     expect(configModule.updateConfig).toHaveBeenCalled();
+  });
+
+  test('preserves managed rescanLastRun when saving settings', async () => {
+    const { app, configModule } = makeApp();
+    const rescanLastRun = {
+      startedAt: '2026-05-04T15:00:00.000Z',
+      completedAt: '2026-05-04T15:01:00.000Z',
+      trigger: 'manual',
+      status: 'completed',
+      videosUpdated: 4,
+      videosMarkedMissing: 1,
+      videosScanned: 20,
+      filesFoundOnDisk: 19,
+      errorMessage: null
+    };
+    configModule._config.rescanLastRun = rescanLastRun;
+
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ ytdlpCustomArgs: '', rescanLastRun: null });
+
+    expect(res.status).toBe(200);
+    expect(configModule.updateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ rescanLastRun })
+    );
   });
 
   test('returns 400 with the offending flag when ytdlpCustomArgs contains a denylisted flag', async () => {

--- a/server/routes/__tests__/maintenance.test.js
+++ b/server/routes/__tests__/maintenance.test.js
@@ -1,0 +1,95 @@
+/* eslint-env jest */
+
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../../logger', () => ({
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn()
+}));
+
+describe('Maintenance routes', () => {
+  let app;
+  let mockVideosModule;
+  let mockConfigModule;
+  let mockVerifyToken;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    mockVideosModule = {
+      isBackfillRunning: jest.fn().mockReturnValue(false),
+      tryStartBackfill: jest.fn()
+    };
+    mockConfigModule = {
+      getConfig: jest.fn().mockReturnValue({})
+    };
+    mockVerifyToken = (req, res, next) => next();
+
+    const createMaintenanceRoutes = require('../maintenance');
+
+    app = express();
+    app.use(express.json());
+    app.use(createMaintenanceRoutes({
+      verifyToken: mockVerifyToken,
+      videosModule: mockVideosModule,
+      configModule: mockConfigModule
+    }));
+  });
+
+  describe('POST /api/maintenance/rescan-files', () => {
+    test('returns 202 when started', async () => {
+      mockVideosModule.tryStartBackfill.mockReturnValue({ started: true });
+
+      const res = await request(app).post('/api/maintenance/rescan-files');
+
+      expect(res.status).toBe(202);
+      expect(res.body).toEqual({ status: 'started', trigger: 'manual' });
+      expect(mockVideosModule.tryStartBackfill).toHaveBeenCalledWith({ trigger: 'manual' });
+    });
+
+    test('returns 409 when already running', async () => {
+      mockVideosModule.tryStartBackfill.mockReturnValue({ started: false, reason: 'already-running' });
+
+      const res = await request(app).post('/api/maintenance/rescan-files');
+
+      expect(res.status).toBe(409);
+      expect(res.body).toEqual({ error: 'Rescan already in progress' });
+    });
+  });
+
+  describe('GET /api/maintenance/rescan-status', () => {
+    test('returns running false and lastRun null when nothing has run', async () => {
+      mockVideosModule.isBackfillRunning.mockReturnValue(false);
+      mockConfigModule.getConfig.mockReturnValue({});
+
+      const res = await request(app).get('/api/maintenance/rescan-status');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ running: false, lastRun: null });
+    });
+
+    test('returns running true and lastRun from config', async () => {
+      mockVideosModule.isBackfillRunning.mockReturnValue(true);
+      const lastRun = {
+        startedAt: '2026-05-04T15:00:00.000Z',
+        completedAt: '2026-05-04T15:01:00.000Z',
+        trigger: 'manual',
+        status: 'completed',
+        videosUpdated: 1,
+        videosMarkedMissing: 0,
+        videosScanned: 5,
+        filesFoundOnDisk: 5,
+        errorMessage: null
+      };
+      mockConfigModule.getConfig.mockReturnValue({ rescanLastRun: lastRun });
+
+      const res = await request(app).get('/api/maintenance/rescan-status');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ running: true, lastRun });
+    });
+  });
+});

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -168,6 +168,7 @@ module.exports = function createConfigRoutes({ verifyToken, configModule, valida
     updateData.ytdlpLastChecked = currentConfig.ytdlpLastChecked;
     updateData.ytdlpLastUpdated = currentConfig.ytdlpLastUpdated;
     updateData.ytdlpLastResult = currentConfig.ytdlpLastResult;
+    updateData.rescanLastRun = currentConfig.rescanLastRun ?? null;
 
     configModule.updateConfig(updateData);
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -12,6 +12,7 @@ const createVideoDetailRoutes = require('./videoDetail');
 const createVideoSearchRoutes = require('./videoSearch');
 const createYoutubeApiKeyRoutes = require('./youtubeApiKey');
 const createYtdlpOptionsRoutes = require('./ytdlpOptions');
+const createMaintenanceRoutes = require('./maintenance');
 const videoMetadataModule = require('../modules/videoMetadataModule');
 const videoOembedEnricher = require('../modules/videoOembedEnricher');
 
@@ -84,6 +85,9 @@ function registerRoutes(app, deps) {
 
   // Video detail routes (metadata and streaming)
   app.use(createVideoDetailRoutes({ verifyToken, videoMetadataModule }));
+
+  // Maintenance routes
+  app.use(createMaintenanceRoutes({ verifyToken, videosModule, configModule }));
 }
 
 module.exports = { registerRoutes };

--- a/server/routes/maintenance.js
+++ b/server/routes/maintenance.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const logger = require('../logger');
+
+/**
+ * Maintenance routes.
+ * Hosts the manual "rescan files on disk" trigger and a status endpoint.
+ *
+ * @swagger
+ * tags:
+ *   name: Maintenance
+ *   description: Filesystem reconciliation actions
+ */
+function createMaintenanceRoutes({ verifyToken, videosModule, configModule }) {
+  const router = express.Router();
+
+  /**
+   * @swagger
+   * /api/maintenance/rescan-files:
+   *   post:
+   *     summary: Kick off a manual filesystem rescan
+   *     tags: [Maintenance]
+   *     responses:
+   *       202:
+   *         description: Rescan started
+   *       409:
+   *         description: A rescan is already in progress
+   */
+  router.post('/api/maintenance/rescan-files', verifyToken, (req, res) => {
+    try {
+      const result = videosModule.tryStartBackfill({ trigger: 'manual' });
+      if (!result.started) {
+        return res.status(409).json({ error: 'Rescan already in progress' });
+      }
+      return res.status(202).json({ status: 'started', trigger: 'manual' });
+    } catch (err) {
+      logger.error({ err }, 'Failed to start manual rescan');
+      return res.status(500).json({ error: 'Failed to start rescan' });
+    }
+  });
+
+  /**
+   * @swagger
+   * /api/maintenance/rescan-status:
+   *   get:
+   *     summary: Get current rescan running state and last-run summary
+   *     tags: [Maintenance]
+   *     responses:
+   *       200:
+   *         description: Status object
+   */
+  router.get('/api/maintenance/rescan-status', verifyToken, (req, res) => {
+    try {
+      const running = videosModule.isBackfillRunning();
+      const lastRun = configModule.getConfig().rescanLastRun ?? null;
+      return res.status(200).json({ running, lastRun });
+    } catch (err) {
+      logger.error({ err }, 'Failed to read rescan status');
+      return res.status(500).json({ error: 'Failed to read rescan status' });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createMaintenanceRoutes;

--- a/server/server.js
+++ b/server/server.js
@@ -612,7 +612,7 @@ const initialize = async () => {
           // Run video metadata backfill asynchronously after server starts
           setTimeout(() => {
             logger.info('Starting async video metadata backfill');
-            videosModule.backfillVideoMetadata()
+            videosModule.backfillVideoMetadata({ trigger: 'startup' })
               .then(() => {
                 logger.info('Video metadata backfill completed successfully');
               })


### PR DESCRIPTION
The video metadata backfill (previously only scheduled and on startup) can now be triggered from a new Settings -> Maintenance page. This lets users reconcile the database after moving, renaming, or converting downloaded files outside Youtarr without waiting for the daily scan.

Widen both the rescan and per-page file-existence checks to recognize .webm, .mkv, .m4v, and .avi alongside .mp4 and .mp3, and fall back to a same-directory same-basename lookup with any supported extension when the stored path is missing. This covers the common case of transcoding a .mp4 to .mkv outside Youtarr.

Persist a `rescanLastRun` summary (trigger, status, counts, error message) to config so the Maintenance page can show what the last scan did. A run lock and the existing time-limit handling guard against overlapping scans across the manual, scheduled, and startup paths.

Also loosen the backfill's row-update predicate to a truthy check on `removed`; the previous `=== true` comparison did not match raw-query integer booleans, so some recovered files stayed flagged missing.