### PR TITLE
feat: add customizable video filename template

### DIFF
--- a/client/src/components/Configuration/sections/CoreSettingsSection.tsx
+++ b/client/src/components/Configuration/sections/CoreSettingsSection.tsx
@@ -31,6 +31,7 @@ import { YtDlpVersionInfo, YtDlpUpdateStatus } from '../hooks/useYtDlpUpdate';
 import { ConfigurationCard } from '../common/ConfigurationCard';
 import { InfoTooltip } from '../common/InfoTooltip';
 import SubtitleLanguageSelector from '../SubtitleLanguageSelector';
+import { VideoFilenameTemplate } from './components/VideoFilenameTemplate';
 import { SubfolderAutocomplete } from '../../shared/SubfolderAutocomplete';
 import { useSubfolders } from '../../../hooks/useSubfolders';
 import { ConfigState, DeploymentEnvironment, PlatformManagedState } from '../types';
@@ -513,6 +514,15 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
                           : 'Controls where downloads are staged before moving to final location. When enabled, uses external /tmp path (useful for slow network storage). When disabled, uses a hidden .youtarr_tmp/ folder in your output directory (faster for local/SSD storage). Both options hide in-progress files from media servers.'
                       }
                       onMobileClick={onMobileTooltipClick}
+                    />
+                  </Box>
+                </Grid>
+
+                <Grid item xs={12}>
+                  <Box className="border-t pt-3">
+                    <VideoFilenameTemplate
+                      value={config.videoFilenamePrefix}
+                      onChange={(newValue) => onConfigChange({ videoFilenamePrefix: newValue })}
                     />
                   </Box>
                 </Grid>

--- a/client/src/components/Configuration/sections/components/VideoFilenameTemplate.tsx
+++ b/client/src/components/Configuration/sections/components/VideoFilenameTemplate.tsx
@@ -1,0 +1,226 @@
+import React, { ChangeEvent, useMemo } from 'react';
+import {
+  Box,
+  TextField,
+  Typography,
+  Button,
+  Link,
+} from '../../../ui';
+import { renderForPreview } from '../../../../utils/filenameTemplate/renderer';
+import { SAMPLE_VIDEO_METADATA } from '../../../../utils/filenameTemplate/sampleInfoJson';
+import { FILENAME_PRESETS } from '../../../../utils/filenameTemplate/presets';
+import {
+  validatePrefix,
+  lengthSeverity,
+  hasUntruncatedTitle,
+  hasLockedSuffixToken,
+  hasOversizedTitleTruncation,
+} from '../../../../utils/filenameTemplate/validate';
+
+interface VideoFilenameTemplateProps {
+  value: string;
+  onChange: (newValue: string) => void;
+}
+
+const SEVERITY_TEXT: Record<'warn' | 'danger', string> = {
+  warn:
+    "Long filename. With deep subfolders or non-ASCII channel names, the full path may approach Windows' 260-character limit, which would cause downloads to fail.",
+  danger:
+    "Filename is very long. Downloads are likely to fail on Windows and SMB-mounted NAS shares (260-char path limit). Pure CJK or emoji content can also exceed Linux/macOS' 255-byte per-filename limit.",
+};
+
+export const VideoFilenameTemplate: React.FC<VideoFilenameTemplateProps> = ({
+  value,
+  onChange,
+}) => {
+  const validation = useMemo(() => validatePrefix(value), [value]);
+  const preview = useMemo(
+    () => renderForPreview(value, SAMPLE_VIDEO_METADATA),
+    [value]
+  );
+  // The full path includes both the per-video folder AND the file name; warn on the longer one.
+  const longerLength = Math.max(preview.fileLineLength, preview.folderLineLength);
+  const severity = lengthSeverity(longerLength);
+  const showStructural = hasUntruncatedTitle(value);
+  const showOversizedTitle = hasOversizedTitleTruncation(value);
+  const showLockedSuffixWarning = hasLockedSuffixToken(value);
+  const previewWarning = preview.warnings[0];
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <Box className="flex flex-col gap-3">
+      <Typography variant="subtitle2" className="font-bold">
+        Video Filename Template
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        How yt-dlp names downloaded video files and per-video folders. Youtarr always appends{' '}
+        <span className="font-mono px-1 py-0.5 rounded text-xs bg-muted">
+          [VIDEO_ID].EXT
+        </span>{' '}
+        to filenames and{' '}
+        <span className="font-mono px-1 py-0.5 rounded text-xs bg-muted">
+          - VIDEO_ID
+        </span>{' '}
+        to folder names so it can re-find your videos on disk. Only applies to new downloads.{' '}
+        <Link
+          href="https://github.com/yt-dlp/yt-dlp#output-template"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          See yt-dlp output template docs
+        </Link>
+        .
+      </Typography>
+
+      <TextField
+        fullWidth
+        label="Video Filename Template"
+        value={value}
+        onChange={handleChange as React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>}
+        error={!validation.ok}
+        helperText={validation.error}
+        inputProps={{ style: { fontFamily: 'monospace' } }}
+      />
+
+      <Box className="flex flex-wrap gap-2">
+        {FILENAME_PRESETS.map((preset) => (
+          <Button
+            key={preset.label}
+            variant="outlined"
+            size="small"
+            onClick={() => onChange(preset.prefix)}
+            title={preset.description}
+          >
+            {preset.label}
+          </Button>
+        ))}
+      </Box>
+
+      <Box className="rounded p-3 bg-muted">
+        <Typography variant="caption" color="text.secondary">
+          Preview (sample video)
+        </Typography>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          className="mt-2 block font-semibold"
+        >
+          Folder
+        </Typography>
+        <Typography
+          data-testid="filename-preview-folder"
+          variant="body2"
+          className="font-mono break-all"
+        >
+          {preview.folderLine}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" className="block">
+          {preview.folderLineLength} characters
+        </Typography>
+
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          className="mt-2 block font-semibold"
+        >
+          File
+        </Typography>
+        <Typography
+          data-testid="filename-preview-file"
+          variant="body2"
+          className="font-mono break-all"
+        >
+          {preview.fileLine}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" className="block">
+          {preview.fileLineLength} characters
+        </Typography>
+
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          className="mt-2 block italic"
+        >
+          Simulated against a sample video; actual filenames may vary slightly.
+        </Typography>
+        {previewWarning && (
+          <Typography
+            data-testid="filename-preview-warning"
+            variant="caption"
+            color="warning"
+            className="mt-2 block"
+          >
+            {previewWarning}
+          </Typography>
+        )}
+      </Box>
+
+      {severity !== 'ok' && (
+        <Box
+          data-testid="length-warning"
+          data-severity={severity}
+          className={
+            severity === 'danger'
+              ? 'rounded p-2 bg-destructive/10 text-destructive'
+              : 'rounded p-2 bg-warning/10 text-warning'
+          }
+        >
+          <Typography variant="caption">{SEVERITY_TEXT[severity]}</Typography>
+        </Box>
+      )}
+
+      {showStructural && (
+        <Typography variant="caption" color="text.secondary">
+          Untruncated{' '}
+          <span className="font-mono px-1 py-0.5 rounded text-xs bg-muted">
+            %(title)s
+          </span>{' '}
+          can produce arbitrarily long filenames depending on the video. Consider{' '}
+          <span className="font-mono px-1 py-0.5 rounded text-xs bg-muted">
+            %(title).76B
+          </span>
+          .
+        </Typography>
+      )}
+
+      {showOversizedTitle && (
+        <Typography
+          data-testid="oversized-title-warning"
+          variant="caption"
+          color="text.secondary"
+        >
+          Title byte truncation above{' '}
+          <span className="font-mono px-1 py-0.5 rounded text-xs bg-muted">
+            .76B
+          </span>{' '}
+          is not recommended. Larger values can push full paths past Windows{'’'} 260-character limit, especially with deep subfolders or non-ASCII channel names. Stick with{' '}
+          <span className="font-mono px-1 py-0.5 rounded text-xs bg-muted">
+            %(title).76B
+          </span>{' '}
+          or smaller.
+        </Typography>
+      )}
+
+      {showLockedSuffixWarning && (
+        <Typography
+          data-testid="locked-suffix-warning"
+          variant="caption"
+          color="text.secondary"
+        >
+          Video ID and extension are added automatically. Including{' '}
+          <span className="font-mono px-1 py-0.5 rounded text-xs bg-muted">
+            %(id)s
+          </span>{' '}
+          or{' '}
+          <span className="font-mono px-1 py-0.5 rounded text-xs bg-muted">
+            %(ext)s
+          </span>{' '}
+          in the prefix will duplicate them.
+        </Typography>
+      )}
+    </Box>
+  );
+};

--- a/client/src/components/Configuration/sections/components/__tests__/VideoFilenameTemplate.test.tsx
+++ b/client/src/components/Configuration/sections/components/__tests__/VideoFilenameTemplate.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { VideoFilenameTemplate } from '../VideoFilenameTemplate';
+
+const defaultPrefix = '%(uploader,channel,uploader_id).80B - %(title).76B';
+
+describe('VideoFilenameTemplate', () => {
+  it('renders the input with the current value', () => {
+    render(<VideoFilenameTemplate value={defaultPrefix} onChange={() => {}} />);
+    const input = screen.getByLabelText(/video filename template/i) as HTMLInputElement;
+    expect(input.value).toBe(defaultPrefix);
+  });
+
+  it('calls onChange when the user types', () => {
+    const handleChange = jest.fn();
+    render(<VideoFilenameTemplate value={defaultPrefix} onChange={handleChange} />);
+    const input = screen.getByLabelText(/video filename template/i);
+    fireEvent.change(input, { target: { value: '%(title)s' } });
+    expect(handleChange).toHaveBeenCalledWith('%(title)s');
+  });
+
+  it('renders all four presets and applies one when clicked', () => {
+    const handleChange = jest.fn();
+    render(<VideoFilenameTemplate value="" onChange={handleChange} />);
+    expect(screen.getByRole('button', { name: /default/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /date prefix/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /plex youtube-agent/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /title only/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /title only/i }));
+    expect(handleChange).toHaveBeenCalledWith('%(title).76B');
+  });
+
+  it('shows both folder and file preview lines', () => {
+    render(<VideoFilenameTemplate value={defaultPrefix} onChange={() => {}} />);
+    expect(screen.getByTestId('filename-preview-file')).toHaveTextContent(/\[.+\]\.\w+$/);
+    expect(screen.getByTestId('filename-preview-folder')).toHaveTextContent(/ - [A-Za-z0-9_-]{10,12}$/);
+  });
+
+  it('shows the simulated disclaimer and "only applies to new downloads" notice', () => {
+    render(<VideoFilenameTemplate value={defaultPrefix} onChange={() => {}} />);
+    expect(screen.getByText(/simulated/i)).toBeInTheDocument();
+    expect(screen.getByText(/only applies to new downloads/i)).toBeInTheDocument();
+  });
+
+  it('shows a yellow warning when rendered length is between 111 and 130 chars', () => {
+    // Add enough literal chars after a short token to push the longer line into the warn band.
+    const longPrefix = '%(uploader)s - ' + 'A'.repeat(90);
+    render(<VideoFilenameTemplate value={longPrefix} onChange={() => {}} />);
+    expect(screen.getByTestId('length-warning')).toHaveAttribute('data-severity', 'warn');
+  });
+
+  it('shows a red warning when rendered length exceeds 130 chars', () => {
+    const veryLongPrefix = '%(uploader)s - ' + 'A'.repeat(150);
+    render(<VideoFilenameTemplate value={veryLongPrefix} onChange={() => {}} />);
+    expect(screen.getByTestId('length-warning')).toHaveAttribute('data-severity', 'danger');
+  });
+
+  it('shows the structural warning when %(title)s lacks .NB truncation', () => {
+    render(<VideoFilenameTemplate value="%(title)s" onChange={() => {}} />);
+    expect(screen.getByText(/untruncated/i)).toBeInTheDocument();
+  });
+
+  it('shows the oversized-title warning when title byte truncation exceeds 76B', () => {
+    render(<VideoFilenameTemplate value="%(title).150B" onChange={() => {}} />);
+    expect(screen.getByTestId('oversized-title-warning')).toHaveTextContent(/76B/);
+  });
+
+  it('does not show the oversized-title warning at the recommended .76B', () => {
+    render(<VideoFilenameTemplate value="%(title).76B" onChange={() => {}} />);
+    expect(screen.queryByTestId('oversized-title-warning')).not.toBeInTheDocument();
+  });
+
+  it('shows a soft warning when the prefix includes locked suffix tokens', () => {
+    render(<VideoFilenameTemplate value="%(title).76B %(id)s" onChange={() => {}} />);
+    expect(screen.getByTestId('locked-suffix-warning')).toHaveTextContent(/added automatically/i);
+  });
+
+  it('shows a validation error when prefix is empty', () => {
+    render(<VideoFilenameTemplate value="" onChange={() => {}} />);
+    expect(screen.getByText(/may not be empty/i)).toBeInTheDocument();
+  });
+
+  it('shows a validation error when prefix contains a path separator', () => {
+    render(<VideoFilenameTemplate value="bad/value" onChange={() => {}} />);
+    expect(screen.getByText(/path separator/i)).toBeInTheDocument();
+  });
+
+  it('shows the first renderer warning when the preview cannot resolve a token', () => {
+    render(<VideoFilenameTemplate value="%(uploder)s" onChange={() => {}} />);
+    expect(screen.getByTestId('filename-preview-warning')).toHaveTextContent(/uploder/);
+  });
+
+  it('shows a validation error for invalid yt-dlp truncation syntax', () => {
+    render(<VideoFilenameTemplate value="%(title).40" onChange={() => {}} />);
+    expect(screen.getByText(/truncation/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/components/Configuration/utils/__tests__/configValidation.test.ts
+++ b/client/src/components/Configuration/utils/__tests__/configValidation.test.ts
@@ -85,4 +85,23 @@ describe('validateConfig', () => {
       expect(result).toMatch(/Cannot save:.*Invalid rate format/);
     }
   );
+
+  test('rejects an empty videoFilenamePrefix with a Cannot save error', () => {
+    const config = createConfig({ videoFilenamePrefix: '' });
+    const result = validateConfig(config);
+    expect(result).toMatch(/Cannot save:.*empty/i);
+  });
+
+  test('rejects a videoFilenamePrefix containing path separators', () => {
+    const config = createConfig({ videoFilenamePrefix: '%(uploader)s/%(title)s' });
+    const result = validateConfig(config);
+    expect(result).toMatch(/Cannot save:.*path separator/i);
+  });
+
+  test('accepts the default videoFilenamePrefix', () => {
+    const config = createConfig({
+      videoFilenamePrefix: '%(uploader,channel,uploader_id).80B - %(title).76B',
+    });
+    expect(validateConfig(config)).toBeNull();
+  });
 });

--- a/client/src/components/Configuration/utils/configValidation.ts
+++ b/client/src/components/Configuration/utils/configValidation.ts
@@ -1,5 +1,6 @@
 import { ConfigState } from '../types';
 import { validateRateLimit } from '../sections/ytdlpOptionsHelpers';
+import { validatePrefix } from '../../../utils/filenameTemplate/validate';
 
 /**
  * Validate proxy URL format
@@ -59,6 +60,12 @@ export const validateConfig = (config: ConfigState): string | null => {
   const rateLimitError = validateRateLimit(config.ytdlpDownloadRateLimit);
   if (rateLimitError) {
     return `Cannot save: ${rateLimitError}`;
+  }
+
+  // Video filename template prefix validation
+  const filenamePrefixResult = validatePrefix(config.videoFilenamePrefix);
+  if (!filenamePrefixResult.ok) {
+    return `Cannot save: ${filenamePrefixResult.error}`;
   }
 
   return null;

--- a/client/src/config/configSchema.ts
+++ b/client/src/config/configSchema.ts
@@ -28,6 +28,10 @@ export const CONFIG_FIELDS = {
   preferredResolution: { default: '1080', trackChanges: true },
   videoCodec: { default: 'default', trackChanges: true },
   defaultSubfolder: { default: '', trackChanges: true },
+  videoFilenamePrefix: {
+    default: '%(uploader,channel,uploader_id).80B - %(title).76B',
+    trackChanges: true,
+  },
 
   // Plex integration
   plexApiKey: { default: '', trackChanges: true },
@@ -158,6 +162,7 @@ export const DEFAULT_CONFIG: ConfigState = {
   preferredResolution: CONFIG_FIELDS.preferredResolution.default,
   videoCodec: CONFIG_FIELDS.videoCodec.default,
   defaultSubfolder: CONFIG_FIELDS.defaultSubfolder.default,
+  videoFilenamePrefix: CONFIG_FIELDS.videoFilenamePrefix.default,
   plexApiKey: CONFIG_FIELDS.plexApiKey.default,
   plexYoutubeLibraryId: CONFIG_FIELDS.plexYoutubeLibraryId.default,
   plexSubfolderLibraryMappings: CONFIG_FIELDS.plexSubfolderLibraryMappings.default,

--- a/client/src/utils/filenameTemplate/__tests__/presets.test.ts
+++ b/client/src/utils/filenameTemplate/__tests__/presets.test.ts
@@ -1,0 +1,21 @@
+import { FILENAME_PRESETS, DEFAULT_PRESET_PREFIX } from '../presets';
+
+describe('FILENAME_PRESETS', () => {
+  it('exports four presets in a stable order', () => {
+    expect(FILENAME_PRESETS).toHaveLength(4);
+    expect(FILENAME_PRESETS.map((p) => p.label)).toEqual([
+      'Default',
+      'Date prefix',
+      'Plex YouTube-Agent',
+      'Title only',
+    ]);
+  });
+
+  it('first preset matches DEFAULT_PRESET_PREFIX', () => {
+    expect(FILENAME_PRESETS[0].prefix).toBe(DEFAULT_PRESET_PREFIX);
+  });
+
+  it('default prefix is the legacy template prefix', () => {
+    expect(DEFAULT_PRESET_PREFIX).toBe('%(uploader,channel,uploader_id).80B - %(title).76B');
+  });
+});

--- a/client/src/utils/filenameTemplate/__tests__/renderer.test.ts
+++ b/client/src/utils/filenameTemplate/__tests__/renderer.test.ts
@@ -1,0 +1,155 @@
+/* eslint-disable testing-library/render-result-naming-convention */
+// `renderTemplate` is a pure string-template renderer, not a React render helper.
+import { renderTemplate, renderForPreview } from '../renderer';
+
+const sample = {
+  id: 'Cbq15X05wyY',
+  title: 'ESCAPING 99 Nights in the Forest IN REAL LIFE!',
+  uploader: 'Preston',
+  channel: 'Preston',
+  uploader_id: '@PrestonPlayz',
+  channel_id: 'UCu6mSoMNzHQiBIOCkHUa2Aw',
+  display_id: 'Cbq15X05wyY',
+  upload_date: '20251017',
+  ext: 'mp4',
+} as const;
+
+describe('renderTemplate - simple substitution', () => {
+  it('substitutes %(field)s tokens', () => {
+    const output = renderTemplate('%(title)s', sample);
+    expect(output.rendered).toBe('ESCAPING 99 Nights in the Forest IN REAL LIFE! [Cbq15X05wyY].mp4');
+  });
+
+  it('substitutes multiple tokens with literal text in between', () => {
+    const output = renderTemplate('%(uploader)s - %(title)s', sample);
+    expect(output.rendered).toBe('Preston - ESCAPING 99 Nights in the Forest IN REAL LIFE! [Cbq15X05wyY].mp4');
+  });
+
+  it('always appends the locked suffix', () => {
+    const output = renderTemplate('hello', sample);
+    expect(output.rendered).toBe('hello [Cbq15X05wyY].mp4');
+  });
+
+  it('uses leading-space-free suffix when prefix is empty for defensive preview rendering', () => {
+    const output = renderTemplate('', sample);
+    expect(output.rendered).toBe('[Cbq15X05wyY].mp4');
+  });
+
+  it('returns the literal token when field is missing and lists it as unsupported', () => {
+    const output = renderTemplate('%(nonexistent)s', sample);
+    expect(output.rendered).toContain('%(nonexistent)s');
+    expect(output.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('nonexistent'),
+    ]));
+  });
+});
+
+describe('renderTemplate - length', () => {
+  it('reports rendered character length', () => {
+    const output = renderTemplate('%(uploader)s', sample);
+    // 'Preston [Cbq15X05wyY].mp4' = 25 chars
+    expect(output.length).toBe(25);
+  });
+});
+
+describe('renderTemplate - date formatting', () => {
+  it('formats upload_date with %(field>strftime)s', () => {
+    const output = renderTemplate('%(upload_date>%Y-%m-%d)s', sample);
+    expect(output.rendered).toBe('2025-10-17 [Cbq15X05wyY].mp4');
+  });
+
+  it('handles underscore-separated date format', () => {
+    const output = renderTemplate('%(upload_date>%Y_%m_%d)s', sample);
+    expect(output.rendered).toBe('2025_10_17 [Cbq15X05wyY].mp4');
+  });
+
+  it('renders month name with %B', () => {
+    const output = renderTemplate('%(upload_date>%B %Y)s', sample);
+    expect(output.rendered).toBe('October 2025 [Cbq15X05wyY].mp4');
+  });
+});
+
+describe('renderTemplate - truncation', () => {
+  it('truncates with .NB byte limit', () => {
+    const longTitle = { ...sample, title: 'A'.repeat(200) };
+    const output = renderTemplate('%(title).76B', longTitle);
+    expect(output.rendered.startsWith('A'.repeat(76))).toBe(true);
+  });
+
+  it('respects UTF-8 byte boundaries', () => {
+    const emojiTitle = { ...sample, title: 'Hi! ' + '🎬'.repeat(20) }; // movie clapper emoji
+    const output = renderTemplate('%(title).10B', emojiTitle);
+    const stem = output.rendered.split(' [')[0];
+    expect(new TextEncoder().encode(stem).length).toBeLessThanOrEqual(10);
+  });
+
+  it('truncates with .Ns char limit', () => {
+    const longTitle = { ...sample, title: 'A'.repeat(200) };
+    const output = renderTemplate('%(title).40s', longTitle);
+    expect(output.rendered.startsWith('A'.repeat(40))).toBe(true);
+  });
+});
+
+describe('renderTemplate - fallback chains', () => {
+  it('uses comma-separated fallbacks', () => {
+    const noUploader = { ...sample, uploader: '' };
+    const output = renderTemplate('%(uploader,channel,uploader_id)s', noUploader);
+    expect(output.rendered).toBe('Preston [Cbq15X05wyY].mp4');
+  });
+
+  it('falls through to uploader_id when uploader and channel are empty', () => {
+    const onlyId = { ...sample, uploader: '', channel: '' };
+    const output = renderTemplate('%(uploader,channel,uploader_id)s', onlyId);
+    expect(output.rendered).toBe('@PrestonPlayz [Cbq15X05wyY].mp4');
+  });
+
+  it('uses |fallback when no field resolves', () => {
+    const output = renderTemplate('%(nonexistent|N\\A)s', sample);
+    expect(output.rendered).toBe('N\\A [Cbq15X05wyY].mp4');
+  });
+});
+
+describe('renderTemplate - Windows sanitization', () => {
+  it('replaces colons in titles', () => {
+    const colonTitle = { ...sample, title: 'Q&A: Best Tools?' };
+    const output = renderTemplate('%(title)s', colonTitle);
+    expect(output.rendered).toBe('Q&A： Best Tools？ [Cbq15X05wyY].mp4');
+  });
+});
+
+describe('renderTemplate - default prefix matches today\'s output', () => {
+  it('produces the legacy filename when given the default prefix', () => {
+    const output = renderTemplate('%(uploader,channel,uploader_id).80B - %(title).76B', sample);
+    expect(output.rendered).toBe('Preston - ESCAPING 99 Nights in the Forest IN REAL LIFE! [Cbq15X05wyY].mp4');
+  });
+});
+
+describe('renderForPreview', () => {
+  it('returns both folder and file lines using the default prefix', () => {
+    const result = renderForPreview(
+      '%(uploader,channel,uploader_id).80B - %(title).76B',
+      sample
+    );
+    expect(result.fileLine).toBe('Preston - ESCAPING 99 Nights in the Forest IN REAL LIFE! [Cbq15X05wyY].mp4');
+    expect(result.folderLine).toBe('Preston - ESCAPING 99 Nights in the Forest IN REAL LIFE! - Cbq15X05wyY');
+  });
+
+  it('handles empty prefix defensively for both preview lines', () => {
+    const result = renderForPreview('', sample);
+    expect(result.fileLine).toBe('[Cbq15X05wyY].mp4');
+    expect(result.folderLine).toBe('Cbq15X05wyY');
+  });
+
+  it('reports correct lengths', () => {
+    const result = renderForPreview('%(title)s', sample);
+    expect(result.fileLineLength).toBe(result.fileLine.length);
+    expect(result.folderLineLength).toBe(result.folderLine.length);
+  });
+
+  it('shares warnings between folder and file (one substitution pass)', () => {
+    const result = renderForPreview('%(nonexistent)s', sample);
+    expect(result.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('nonexistent'),
+    ]));
+  });
+});

--- a/client/src/utils/filenameTemplate/__tests__/sanitize.test.ts
+++ b/client/src/utils/filenameTemplate/__tests__/sanitize.test.ts
@@ -1,0 +1,24 @@
+import { sanitizeWindowsFilename } from '../sanitize';
+
+describe('sanitizeWindowsFilename', () => {
+  it('returns input unchanged when no reserved chars are present', () => {
+    expect(sanitizeWindowsFilename('Plain Title.mp4')).toBe('Plain Title.mp4');
+  });
+
+  it('replaces the seven yt-dlp --windows-filenames target characters', () => {
+    expect(sanitizeWindowsFilename('Q&A: Best Tools? <Live> "Stream"|2024*'))
+      .toBe('Q&A： Best Tools？ ＜Live＞ ＂Stream＂｜2024＊');
+  });
+
+  it('replaces colons in timestamp-like titles', () => {
+    expect(sanitizeWindowsFilename('Live at 09:30:00')).toBe('Live at 09：30：00');
+  });
+
+  it('handles empty string', () => {
+    expect(sanitizeWindowsFilename('')).toBe('');
+  });
+
+  it('does not modify path separators (those are blocked upstream by validation)', () => {
+    expect(sanitizeWindowsFilename('a/b\\c')).toBe('a/b\\c');
+  });
+});

--- a/client/src/utils/filenameTemplate/__tests__/validate.test.ts
+++ b/client/src/utils/filenameTemplate/__tests__/validate.test.ts
@@ -1,0 +1,171 @@
+import {
+  validatePrefix,
+  lengthSeverity,
+  hasUntruncatedTitle,
+  hasLockedSuffixToken,
+  hasOversizedTitleTruncation,
+} from '../validate';
+
+describe('validatePrefix', () => {
+  it('accepts the default prefix', () => {
+    const r = validatePrefix('%(uploader,channel,uploader_id).80B - %(title).76B');
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects an empty prefix', () => {
+    const r = validatePrefix('');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/empty/i);
+  });
+
+  it('rejects a whitespace-only prefix', () => {
+    const r = validatePrefix('   ');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/empty/i);
+  });
+
+  it('rejects forward slash', () => {
+    const r = validatePrefix('%(uploader)s/%(title)s');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/path separator/i);
+  });
+
+  it('rejects backslash', () => {
+    const r = validatePrefix('%(uploader)s\\%(title)s');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/path separator/i);
+  });
+
+  it('rejects path traversal sequence ..', () => {
+    const r = validatePrefix('..%(title)s');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/traversal/i);
+  });
+
+  it('rejects ASCII control chars', () => {
+    const r = validatePrefix('hello\x07world');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/control/i);
+  });
+
+  it('rejects NUL byte', () => {
+    const r = validatePrefix('hello\x00world');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects char truncation without a yt-dlp conversion char', () => {
+    const r = validatePrefix('%(title).40');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/truncation/i);
+  });
+
+  it('rejects incomplete yt-dlp tokens', () => {
+    const r = validatePrefix('%(title)');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/syntax/i);
+  });
+
+  it('rejects unescaped literal percent signs', () => {
+    const r = validatePrefix('100% done - %(title).76B');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/syntax/i);
+  });
+
+  it('accepts escaped literal percent signs', () => {
+    const r = validatePrefix('100%% done - %(title).76B');
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts char truncation with an explicit string conversion', () => {
+    const r = validatePrefix('%(title).40s');
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects overlong prefixes', () => {
+    const r = validatePrefix('a'.repeat(161));
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/160/);
+  });
+});
+
+describe('hasLockedSuffixToken', () => {
+  it('flags an explicit video ID token', () => {
+    expect(hasLockedSuffixToken('%(title).76B %(id)s')).toBe(true);
+  });
+
+  it('flags an explicit extension token', () => {
+    expect(hasLockedSuffixToken('%(title).76B.%(ext)s')).toBe(true);
+  });
+
+  it('flags %(display_id)s because it resolves to the same 11-char video ID as %(id)s', () => {
+    expect(hasLockedSuffixToken('%(display_id)s - %(title).76B')).toBe(true);
+  });
+
+  it('does not flag unrelated tokens', () => {
+    expect(hasLockedSuffixToken('%(channel_id)s - %(title).76B')).toBe(false);
+  });
+});
+
+describe('lengthSeverity', () => {
+  it('returns ok for short filenames', () => {
+    expect(lengthSeverity(50)).toBe('ok');
+    expect(lengthSeverity(110)).toBe('ok');
+  });
+
+  it('returns warn above 110', () => {
+    expect(lengthSeverity(111)).toBe('warn');
+    expect(lengthSeverity(130)).toBe('warn');
+  });
+
+  it('returns danger above 130', () => {
+    expect(lengthSeverity(131)).toBe('danger');
+  });
+});
+
+describe('hasUntruncatedTitle', () => {
+  it('flags a bare %(title)s', () => {
+    expect(hasUntruncatedTitle('%(title)s')).toBe(true);
+  });
+
+  it('does not flag truncated title', () => {
+    expect(hasUntruncatedTitle('%(title).76B')).toBe(false);
+  });
+
+  it('does not flag templates without title', () => {
+    expect(hasUntruncatedTitle('%(uploader)s')).toBe(false);
+  });
+});
+
+describe('hasOversizedTitleTruncation', () => {
+  it('flags %(title).100B', () => {
+    expect(hasOversizedTitleTruncation('%(uploader)s - %(title).100B')).toBe(true);
+  });
+
+  it('flags %(title).150B', () => {
+    expect(hasOversizedTitleTruncation('%(title).150B')).toBe(true);
+  });
+
+  it('does not flag the recommended %(title).76B', () => {
+    expect(hasOversizedTitleTruncation('%(title).76B')).toBe(false);
+  });
+
+  it('does not flag below the recommended limit', () => {
+    expect(hasOversizedTitleTruncation('%(title).50B')).toBe(false);
+  });
+
+  it('does not flag bare %(title)s (handled by hasUntruncatedTitle)', () => {
+    expect(hasOversizedTitleTruncation('%(title)s')).toBe(false);
+  });
+
+  it('does not flag character truncation', () => {
+    expect(hasOversizedTitleTruncation('%(title).200s')).toBe(false);
+  });
+
+  it('handles fallback chains', () => {
+    expect(hasOversizedTitleTruncation('%(title,description).200B')).toBe(true);
+  });
+
+  it('does not flag templates without title', () => {
+    expect(hasOversizedTitleTruncation('%(uploader).200B')).toBe(false);
+  });
+});

--- a/client/src/utils/filenameTemplate/__tests__/yt-dlp-parity.test.ts
+++ b/client/src/utils/filenameTemplate/__tests__/yt-dlp-parity.test.ts
@@ -1,0 +1,53 @@
+/* eslint-disable testing-library/render-result-naming-convention */
+// `renderTemplate` is a pure string-template renderer, not a React render helper.
+import { renderTemplate } from '../renderer';
+import sampleData from '../sample-video.info.json';
+
+const metadata = sampleData as Record<string, unknown>;
+
+describe('renderer parity with recorded yt-dlp output', () => {
+  const cases: { label: string; prefix: string; expected: string }[] = [
+    {
+      label: 'default',
+      prefix: '%(uploader,channel,uploader_id).80B - %(title).76B',
+      expected: 'TEDx Talks - How to Get Your Brain to Focus Even Better All The Time ｜ Chris Bailey ｜ TED [Hu4Yvq-g7_Y].webm',
+    },
+    {
+      label: 'date prefix',
+      prefix: '%(upload_date>%Y-%m-%d)s - %(title).76B',
+      expected: '2019-04-05 - How to Get Your Brain to Focus Even Better All The Time ｜ Chris Bailey ｜ TED [Hu4Yvq-g7_Y].webm',
+    },
+    {
+      label: 'plex youtube-agent',
+      prefix: '%(upload_date>%Y_%m_%d)s %(title).76B',
+      expected: '2019_04_05 How to Get Your Brain to Focus Even Better All The Time ｜ Chris Bailey ｜ TED [Hu4Yvq-g7_Y].webm',
+    },
+    {
+      label: 'title only',
+      prefix: '%(title).76B',
+      expected: 'How to Get Your Brain to Focus Even Better All The Time ｜ Chris Bailey ｜ TED [Hu4Yvq-g7_Y].webm',
+    },
+    {
+      label: 'empty prefix defensive rendering',
+      prefix: '',
+      expected: '[Hu4Yvq-g7_Y].webm',
+    },
+    {
+      label: 'channel id',
+      prefix: '%(channel)s [%(channel_id)s] %(title).50B',
+      expected: 'TEDx Talks [UCsT0YIqwnpJCM-mx7-gSA4Q] How to Get Your Brain to Focus Even Better All The [Hu4Yvq-g7_Y].webm',
+    },
+    {
+      label: 'month name',
+      prefix: '%(upload_date>%B %Y)s - %(title).50B',
+      expected: 'April 2019 - How to Get Your Brain to Focus Even Better All The [Hu4Yvq-g7_Y].webm',
+    },
+  ];
+
+  cases.forEach(({ label, prefix, expected }) => {
+    it(`matches recorded yt-dlp output for ${label}`, () => {
+      const ours = renderTemplate(prefix, metadata);
+      expect(ours.rendered).toBe(expected);
+    });
+  });
+});

--- a/client/src/utils/filenameTemplate/presets.ts
+++ b/client/src/utils/filenameTemplate/presets.ts
@@ -1,0 +1,30 @@
+export interface FilenamePreset {
+  label: string;
+  prefix: string;
+  description: string;
+}
+
+export const DEFAULT_PRESET_PREFIX = '%(uploader,channel,uploader_id).80B - %(title).76B';
+
+export const FILENAME_PRESETS: readonly FilenamePreset[] = [
+  {
+    label: 'Default',
+    prefix: DEFAULT_PRESET_PREFIX,
+    description: 'Channel name, hyphen, video title.',
+  },
+  {
+    label: 'Date prefix',
+    prefix: '%(upload_date>%Y-%m-%d)s - %(title).76B',
+    description: 'Upload date (YYYY-MM-DD), hyphen, video title.',
+  },
+  {
+    label: 'Plex YouTube-Agent',
+    prefix: '%(upload_date>%Y_%m_%d)s %(title).76B',
+    description: 'Compatible with Absolute-Series-Scanner / YouTube-Agent.bundle.',
+  },
+  {
+    label: 'Title only',
+    prefix: '%(title).76B',
+    description: 'Just the video title.',
+  },
+];

--- a/client/src/utils/filenameTemplate/renderer.ts
+++ b/client/src/utils/filenameTemplate/renderer.ts
@@ -1,0 +1,198 @@
+import { sanitizeWindowsFilename } from './sanitize';
+
+export interface RenderResult {
+  rendered: string;
+  length: number;
+  warnings: string[];
+}
+
+// yt-dlp template format: %(field_spec)[format_spec][conversion].
+// Supported truncation forms are `.NB` for byte limits and `.Ns` for character
+// limits; `.N` without a conversion char is rejected by yt-dlp and by validatePrefix.
+const TOKEN_RE = /%\(([^)]+)\)(?:(\.\d+B)|(\.\d+)?([sdjlqUDS]))/g;
+
+interface TokenSpec {
+  field: string;
+  fallbackChain: string[];
+  dateFormat: string | null;
+  byteLimit: number | null;
+  charLimit: number | null;
+  pipeFallback: string | null;
+}
+
+function parseSpec(rawInner: string, rawFormat: string): TokenSpec {
+  // rawInner = contents inside %(...) — e.g. 'title', 'uploader,channel,uploader_id',
+  //   'title|fallback', 'upload_date>%Y-%m-%d'.
+  // rawFormat = format specifier between `)` and conversion char — e.g. '.76B', '.40'.
+  let working = rawInner;
+  let pipeFallback: string | null = null;
+  if (working.includes('|')) {
+    const idx = working.indexOf('|');
+    pipeFallback = working.slice(idx + 1);
+    working = working.slice(0, idx);
+  }
+
+  let dateFormat: string | null = null;
+  if (working.includes('>')) {
+    const idx = working.indexOf('>');
+    dateFormat = working.slice(idx + 1);
+    working = working.slice(0, idx);
+  }
+
+  let byteLimit: number | null = null;
+  let charLimit: number | null = null;
+  const truncMatch = rawFormat.match(/\.(\d+)(B?)$/);
+  if (truncMatch) {
+    const n = Number(truncMatch[1]);
+    if (truncMatch[2] === 'B') byteLimit = n;
+    else charLimit = n;
+  }
+
+  const fallbackChain = working.split(',').map((s) => s.trim()).filter(Boolean);
+  const field = fallbackChain[0] ?? '';
+
+  return { field, fallbackChain, dateFormat, byteLimit, charLimit, pipeFallback };
+}
+
+function resolveValue(
+  spec: TokenSpec,
+  metadata: Record<string, unknown>,
+  warnings: string[],
+  rawToken: string
+): string | null {
+  for (const candidate of spec.fallbackChain) {
+    const value = metadata[candidate];
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+  }
+  if (spec.pipeFallback !== null) return spec.pipeFallback;
+  warnings.push(`Unsupported or missing field: ${rawToken}`);
+  return null;
+}
+
+const MONTHS_LONG = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+const MONTHS_SHORT = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+const DAYS_LONG = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+const DAYS_SHORT = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+
+function applyDateFormat(value: string, fmt: string): string {
+  // yt-dlp upload_date is 'YYYYMMDD'. Implement the strftime tokens it documents:
+  // %Y %y %m %d %H %M %S %j %B %b %A %a
+  const year = value.slice(0, 4);
+  const monthNum = value.slice(4, 6);
+  const day = value.slice(6, 8);
+  const monthIdx = Number(monthNum) - 1;
+  const dateObj = new Date(`${year}-${monthNum}-${day}T00:00:00Z`);
+  const map: Record<string, string> = {
+    '%Y': year,
+    '%y': year.slice(2),
+    '%m': monthNum,
+    '%d': day,
+    '%H': '00',
+    '%M': '00',
+    '%S': '00',
+    '%j': '001',
+    '%B': MONTHS_LONG[monthIdx] ?? '',
+    '%b': MONTHS_SHORT[monthIdx] ?? '',
+    '%A': isNaN(dateObj.getTime()) ? '' : DAYS_LONG[dateObj.getUTCDay()],
+    '%a': isNaN(dateObj.getTime()) ? '' : DAYS_SHORT[dateObj.getUTCDay()],
+  };
+  return fmt.replace(/%[YymdHMSjBbAa]/g, (tok) => map[tok] ?? tok);
+}
+
+function truncateBytes(value: string, limit: number): string {
+  // UTF-8 byte truncation matching yt-dlp's .NB behavior.
+  const enc = new TextEncoder();
+  const bytes = enc.encode(value);
+  if (bytes.length <= limit) return value;
+  // Walk back until we land on a complete UTF-8 character boundary
+  let cut = limit;
+  while (cut > 0 && (bytes[cut] & 0xc0) === 0x80) cut -= 1;
+  return new TextDecoder().decode(bytes.subarray(0, cut));
+}
+
+export interface PreviewResult {
+  fileLine: string;
+  folderLine: string;
+  fileLineLength: number;
+  folderLineLength: number;
+  warnings: string[];
+}
+
+interface SubstituteResult {
+  rendered: string;
+  warnings: string[];
+}
+
+function substituteAndSanitize(
+  prefix: string,
+  metadata: Record<string, unknown>
+): SubstituteResult {
+  const warnings: string[] = [];
+  const trimmedPrefix = prefix.replace(/\s+$/, '');
+
+  const substituted = trimmedPrefix.replace(TOKEN_RE, (full, rawInner, byteFormat, charFormat) => {
+    const rawFormat = String(byteFormat ?? charFormat ?? '');
+    const spec = parseSpec(String(rawInner), String(rawFormat));
+    const value = resolveValue(spec, metadata, warnings, full);
+    if (value === null) return full; // leave literal so user sees what failed
+
+    let out = value;
+    if (spec.dateFormat) out = applyDateFormat(out, spec.dateFormat);
+    if (spec.byteLimit !== null) out = truncateBytes(out, spec.byteLimit);
+    else if (spec.charLimit !== null) out = out.slice(0, spec.charLimit);
+    return out;
+  });
+
+  const sanitized = sanitizeWindowsFilename(substituted);
+  return { rendered: sanitized, warnings };
+}
+
+export function renderTemplate(
+  prefix: string,
+  metadata: Record<string, unknown>
+): RenderResult {
+  const { rendered: sanitized, warnings } = substituteAndSanitize(prefix, metadata);
+  const ext = String(metadata.ext ?? 'mp4');
+  const id = String(metadata.id ?? '???????????');
+  const suffix = `[${id}].${ext}`;
+  const rendered = sanitized.length === 0 ? suffix : `${sanitized} ${suffix}`;
+
+  return { rendered, length: rendered.length, warnings };
+}
+
+/**
+ * Render both the per-video folder name and the file name from the same prefix,
+ * mirroring the backend composers in `server/modules/filesystem/constants.js`:
+ *   - File:   `<prefix> [<id>].<ext>`  (or `[<id>].<ext>` when prefix is empty)
+ *   - Folder: `<prefix> - <id>`         (or `<id>` when prefix is empty)
+ * Empty prefixes are invalid in saved config, but the preview still renders
+ * them while the input displays its validation error.
+ *
+ * Both lines share a single substitution pass, so warnings are deduplicated
+ * across them.
+ */
+export function renderForPreview(
+  prefix: string,
+  metadata: Record<string, unknown>
+): PreviewResult {
+  const { rendered: sanitized, warnings } = substituteAndSanitize(prefix, metadata);
+  const ext = String(metadata.ext ?? 'mp4');
+  const id = String(metadata.id ?? '???????????');
+
+  const fileLine = sanitized.length === 0
+    ? `[${id}].${ext}`
+    : `${sanitized} [${id}].${ext}`;
+  const folderLine = sanitized.length === 0
+    ? id
+    : `${sanitized} - ${id}`;
+
+  return {
+    fileLine,
+    folderLine,
+    fileLineLength: fileLine.length,
+    folderLineLength: folderLine.length,
+    warnings,
+  };
+}

--- a/client/src/utils/filenameTemplate/sample-video.info.json
+++ b/client/src/utils/filenameTemplate/sample-video.info.json
@@ -1,0 +1,11 @@
+{
+  "id": "Hu4Yvq-g7_Y",
+  "title": "How to Get Your Brain to Focus Even Better All The Time | Chris Bailey | TEDxManchester Series Of TED Talks",
+  "uploader": "TEDx Talks",
+  "channel": "TEDx Talks",
+  "uploader_id": "@TEDx",
+  "channel_id": "UCsT0YIqwnpJCM-mx7-gSA4Q",
+  "display_id": "Hu4Yvq-g7_Y",
+  "upload_date": "20190405",
+  "ext": "webm"
+}

--- a/client/src/utils/filenameTemplate/sampleInfoJson.ts
+++ b/client/src/utils/filenameTemplate/sampleInfoJson.ts
@@ -1,0 +1,13 @@
+// Bundled at build time so the live preview has zero-network mock data.
+// Source of truth: client/src/utils/filenameTemplate/sample-video.info.json
+// Sanitized from `yt-dlp --skip-download --write-info-json -o ...` output.
+//
+// We override `ext` to 'mp4' because Youtarr always remuxes to MP4 on output
+// (see ytdlpCommandBuilder's --merge-output-format mp4), regardless of what
+// the source format's ext is in the captured fixture.
+import sampleData from './sample-video.info.json';
+
+export const SAMPLE_VIDEO_METADATA: Record<string, unknown> = {
+  ...(sampleData as Record<string, unknown>),
+  ext: 'mp4',
+};

--- a/client/src/utils/filenameTemplate/sanitize.ts
+++ b/client/src/utils/filenameTemplate/sanitize.ts
@@ -1,0 +1,15 @@
+const WINDOWS_REPLACEMENTS: Record<string, string> = {
+  '<': '＜',
+  '>': '＞',
+  ':': '：',
+  '"': '＂',
+  '|': '｜',
+  '?': '？',
+  '*': '＊',
+};
+
+const WINDOWS_REPLACEMENT_RE = /[<>:"|?*]/g;
+
+export function sanitizeWindowsFilename(input: string): string {
+  return input.replace(WINDOWS_REPLACEMENT_RE, (ch) => WINDOWS_REPLACEMENTS[ch] ?? ch);
+}

--- a/client/src/utils/filenameTemplate/validate.ts
+++ b/client/src/utils/filenameTemplate/validate.ts
@@ -1,0 +1,106 @@
+export type Severity = 'ok' | 'warn' | 'danger';
+
+export interface ValidationResult {
+  ok: boolean;
+  error?: string;
+}
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_RE = /[\x00-\x1f]/;
+const TRUNCATION_WITHOUT_CONVERSION_RE = /%\([^)]*\)\.\d+(?![\dBsdjlqUDS])/;
+// Keep in sync with server/routes/config.js and renderer.ts TOKEN_RE.
+const TEMPLATE_TOKEN_AT_START_RE = /^%\([^)]+\)(?:(?:\.\d+B)|(?:(?:\.\d+)?[sdjlqUDS]))/;
+const TEMPLATE_TOKEN_RE = /%\(([^)]+)\)(?:(?:\.\d+B)|(?:(?:\.\d+)?[sdjlqUDS]))/g;
+export const MAX_VIDEO_FILENAME_PREFIX_LENGTH = 160;
+
+function validatePercentSyntax(prefix: string): ValidationResult {
+  for (let i = 0; i < prefix.length; i += 1) {
+    if (prefix[i] !== '%') continue;
+    if (prefix[i + 1] === '%') {
+      i += 1;
+      continue;
+    }
+
+    const match = prefix.slice(i).match(TEMPLATE_TOKEN_AT_START_RE);
+    if (match) {
+      i += match[0].length - 1;
+      continue;
+    }
+
+    return {
+      ok: false,
+      error: 'Invalid yt-dlp template syntax. Use tokens like %(title)s or escape literal percent signs as %%.',
+    };
+  }
+
+  return { ok: true };
+}
+
+export function validatePrefix(prefix: string): ValidationResult {
+  const trimmedPrefix = prefix.replace(/\s+$/, '');
+  if (trimmedPrefix.trim().length === 0) {
+    return { ok: false, error: 'Prefix may not be empty.' };
+  }
+  if (trimmedPrefix.length > MAX_VIDEO_FILENAME_PREFIX_LENGTH) {
+    return {
+      ok: false,
+      error: `Prefix may not exceed ${MAX_VIDEO_FILENAME_PREFIX_LENGTH} characters.`,
+    };
+  }
+  if (trimmedPrefix.includes('/') || trimmedPrefix.includes('\\')) {
+    return { ok: false, error: 'Prefix may not contain path separators (/ or \\).' };
+  }
+  if (trimmedPrefix.includes('..')) {
+    return { ok: false, error: 'Prefix may not contain ".." (path traversal).' };
+  }
+  if (CONTROL_CHAR_RE.test(trimmedPrefix)) {
+    return { ok: false, error: 'Prefix may not contain ASCII control characters.' };
+  }
+  if (TRUNCATION_WITHOUT_CONVERSION_RE.test(trimmedPrefix)) {
+    return { ok: false, error: 'Truncation must use yt-dlp syntax like %(title).76B or %(title).40s.' };
+  }
+  return validatePercentSyntax(trimmedPrefix);
+}
+
+/**
+ * Length warnings use rendered JavaScript string length as path-length guidance.
+ * This is intentionally separate from yt-dlp's `.NB` UTF-8 byte truncation.
+ */
+export function lengthSeverity(length: number): Severity {
+  if (length > 130) return 'danger';
+  if (length > 110) return 'warn';
+  return 'ok';
+}
+
+export function hasUntruncatedTitle(prefix: string): boolean {
+  // Matches %(title)s without a trailing .NB or .Ns truncation modifier.
+  return /%\(title(?:[,|][^)]*)?\)s/.test(prefix) && !/%\(title[^)]*\.\d+B?\)s?/.test(prefix);
+}
+
+// 76 bytes is the validated-safe upper bound for the title token. yt-dlp's
+// channel template uses .80B and the locked suffix is 17 bytes; staying at .76B
+// keeps full paths within Windows' 260-char limit even for deep subfolders and
+// multi-byte titles. Past incidents (#404) showed character-based truncation
+// produced 200+ byte filenames in CJK locales - never widen this bound silently.
+export const RECOMMENDED_TITLE_BYTE_LIMIT = 76;
+
+export function hasOversizedTitleTruncation(prefix: string): boolean {
+  const matches = prefix.matchAll(/%\(title(?:[,|][^)]*)?\)\.(\d+)B/g);
+  for (const match of matches) {
+    if (Number(match[1]) > RECOMMENDED_TITLE_BYTE_LIMIT) return true;
+  }
+  return false;
+}
+
+export function hasLockedSuffixToken(prefix: string): boolean {
+  let match: RegExpExecArray | null;
+  TEMPLATE_TOKEN_RE.lastIndex = 0;
+  while ((match = TEMPLATE_TOKEN_RE.exec(prefix)) !== null) {
+    const fieldSpec = match[1].split('>')[0].split('|')[0];
+    const fields = fieldSpec.split(',').map((field) => field.trim());
+    if (fields.includes('id') || fields.includes('display_id') || fields.includes('ext')) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -6,6 +6,7 @@
   "preferredResolution": "1080",
   "videoCodec": "default",
   "defaultSubfolder": "",
+  "videoFilenamePrefix": "%(uploader,channel,uploader_id).80B - %(title).76B",
   "plexIP": "",
   "plexPort": "32400",
   "plexViaHttps": false,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -114,6 +114,21 @@ Configuration can be modified through:
   - Set a default location while allowing individual channels to override
   - Explicitly place specific channels in the root directory using "No Subfolder"
 
+### Video Filename Template
+- **Config Key**: `videoFilenamePrefix`
+- **Type**: `string`
+- **Default**: `"%(uploader,channel,uploader_id).80B - %(title).76B"` (matches the legacy fixed format byte-for-byte)
+- **Description**: User-customizable prefix for downloaded video filenames AND per-video directory names. Youtarr always appends ` [VIDEO_ID].EXT` to filenames and ` - VIDEO_ID` to per-video folder names so it can re-find your videos on disk; those suffixes are not configurable.
+- **Syntax**: Uses [yt-dlp's output template syntax](https://github.com/yt-dlp/yt-dlp#output-template). Common tokens: `%(title)s`, `%(uploader)s`, `%(channel)s`, `%(upload_date>%Y-%m-%d)s`, `%(channel_id)s`, `%(display_id)s`. Use `.NB` to byte-truncate values (e.g. `%(title).76B`) or `.Ns` for character truncation (e.g. `%(title).40s`); recommended to keep paths under Windows' 260-char limit.
+- **Validation**: Empty values, path separators (`/`, `\`), `..`, ASCII control characters, values longer than 160 characters, malformed yt-dlp percent syntax, and invalid truncation like `%(title).40` are rejected. Escape literal percent signs as `%%`. Trailing whitespace is trimmed on save.
+- **Scope**: Global setting. Applies only to NEW downloads; existing files are not renamed.
+- **Examples** (all paired with the locked suffixes):
+  - **Default**: `Preston - ESCAPING 99 Nights in the Forest IN REAL LIFE! [Cbq15X05wyY].mp4`
+  - **Date prefix** (`%(upload_date>%Y-%m-%d)s - %(title).76B`): `2025-10-17 - ESCAPING 99 Nights ... [Cbq15X05wyY].mp4`
+  - **Plex YouTube-Agent** (`%(upload_date>%Y_%m_%d)s %(title).76B`): `2025_10_17 ESCAPING 99 Nights ... [Cbq15X05wyY].mp4` (compatible with [Absolute-Series-Scanner](https://github.com/ZeroQI/Absolute-Series-Scanner) and [YouTube-Agent.bundle](https://github.com/ZeroQI/YouTube-Agent.bundle))
+  - **Title only** (`%(title).76B`): `ESCAPING 99 Nights ... [Cbq15X05wyY].mp4`
+- **UI**: A live preview in **Settings -> Core Settings -> File Structure Settings** shows the rendered folder and file names against a sample video, with length warnings (yellow > 110 chars, red > 130 chars on the rendered name).
+
 ### Enable Subtitles
 - **Config Key**: `subtitlesEnabled`
 - **Type**: `boolean`

--- a/server/modules/__tests__/channelDownloadGrouper.test.js
+++ b/server/modules/__tests__/channelDownloadGrouper.test.js
@@ -14,6 +14,7 @@ jest.mock('../configModule', () => ({
   config: {
     preferredResolution: '1080'
   },
+  getConfig: jest.fn().mockReturnValue({}),
   getDefaultSubfolder: jest.fn().mockReturnValue(null)
 }));
 
@@ -25,6 +26,8 @@ const path = require('path');
 describe('ChannelDownloadGrouper', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    configModule.getConfig.mockReturnValue({});
+    configModule.config.preferredResolution = '1080';
   });
 
   describe('ChannelFilterConfig', () => {
@@ -616,6 +619,17 @@ describe('ChannelDownloadGrouper', () => {
 
       expect(template).toContain('/mock/youtube/output');
     });
+
+    it('uses configured videoFilenamePrefix for grouped output paths', () => {
+      configModule.getConfig.mockReturnValue({
+        videoFilenamePrefix: '%(upload_date>%Y-%m-%d)s - %(title).76B'
+      });
+
+      const template = channelDownloadGrouper.buildOutputPathTemplate(null);
+
+      expect(template).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B - %(id)s');
+      expect(template).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B [%(id)s].%(ext)s');
+    });
   });
 
   describe('buildThumbnailPathTemplate', () => {
@@ -651,6 +665,17 @@ describe('ChannelDownloadGrouper', () => {
     it('should end path with poster folder', () => {
       const template = channelDownloadGrouper.buildThumbnailPathTemplate('Gaming');
 
+      expect(template).toMatch(/poster$/);
+    });
+
+    it('uses configured videoFilenamePrefix for grouped thumbnail folder paths', () => {
+      configModule.getConfig.mockReturnValue({
+        videoFilenamePrefix: '%(upload_date>%Y-%m-%d)s - %(title).76B'
+      });
+
+      const template = channelDownloadGrouper.buildThumbnailPathTemplate(null);
+
+      expect(template).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B - %(id)s');
       expect(template).toMatch(/poster$/);
     });
   });
@@ -808,6 +833,29 @@ describe('ChannelDownloadGrouper', () => {
       expect(groups[0].outputPath).toContain('__Tech');
       expect(groups[0].thumbnailPath).toContain('__Tech');
       expect(groups[0].thumbnailPath).toMatch(/poster$/);
+    });
+
+    it('includes configured videoFilenamePrefix in generated group paths', async () => {
+      const mockChannels = [
+        {
+          channel_id: 'channel1',
+          video_quality: '1080',
+          sub_folder: null,
+          min_duration: null,
+          max_duration: null,
+          title_filter_regex: null
+        }
+      ];
+
+      Channel.findAll.mockResolvedValue(mockChannels);
+      configModule.getConfig.mockReturnValue({
+        videoFilenamePrefix: '%(upload_date>%Y-%m-%d)s - %(title).76B'
+      });
+
+      const groups = await channelDownloadGrouper.generateDownloadGroups();
+
+      expect(groups[0].outputPath).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B [%(id)s].%(ext)s');
+      expect(groups[0].thumbnailPath).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B - %(id)s');
     });
 
     it('should handle empty channels array', async () => {

--- a/server/modules/channelDownloadGrouper.js
+++ b/server/modules/channelDownloadGrouper.js
@@ -136,7 +136,8 @@ class ChannelDownloadGrouper {
    * @returns {string} - Path template for yt-dlp -o argument
    */
   buildOutputPathTemplate(subFolder) {
-    return buildOutputTemplate(configModule.directoryPath, subFolder);
+    const prefix = configModule.getConfig().videoFilenamePrefix;
+    return buildOutputTemplate(configModule.directoryPath, subFolder, prefix);
   }
 
   /**
@@ -145,7 +146,8 @@ class ChannelDownloadGrouper {
    * @returns {string} - Thumbnail path template for yt-dlp
    */
   buildThumbnailPathTemplate(subFolder) {
-    return buildThumbnailTemplate(configModule.directoryPath, subFolder);
+    const prefix = configModule.getConfig().videoFilenamePrefix;
+    return buildThumbnailTemplate(configModule.directoryPath, subFolder, prefix);
   }
 
   /**

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -99,6 +99,7 @@ jest.mock('../../filesystem', () => {
       if (subfolder && subfolder.trim() !== '') return subfolder.trim();
       return null;
     }),
+    extractYoutubeIdFromPath: jest.fn(actualPathBuilder.extractYoutubeIdFromPath),
     extractSubfolderFromAbsPath: jest.fn(actualPathBuilder.extractSubfolderFromAbsPath),
   };
 });

--- a/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
+++ b/server/modules/download/__tests__/ytdlpCommandBuilder.test.js
@@ -303,6 +303,32 @@ describe('YtdlpCommandBuilder', () => {
       expect(result).toContain('/tmp/downloads');
       expect(result).toContain('GameChannel');
     });
+
+    it('uses configured videoFilenamePrefix when provided', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
+      configModule.getConfig.mockReturnValue({
+        videoFilenamePrefix: '%(upload_date>%Y-%m-%d)s - %(title).76B',
+      });
+      const result = YtdlpCommandBuilder.buildOutputPath();
+      expect(result).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B [%(id)s].%(ext)s');
+    });
+
+    it('falls back to default prefix when config is missing the field', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
+      configModule.getConfig.mockReturnValue({});
+      const result = YtdlpCommandBuilder.buildOutputPath();
+      expect(result).toContain('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s].%(ext)s');
+    });
+
+    it('uses configured videoFilenamePrefix for the per-video folder name as well', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
+      configModule.getConfig.mockReturnValue({
+        videoFilenamePrefix: '%(upload_date>%Y-%m-%d)s - %(title).76B',
+      });
+      const result = YtdlpCommandBuilder.buildOutputPath();
+      // Folder portion uses " - %(id)s" suffix (no brackets)
+      expect(result).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B - %(id)s');
+    });
   });
 
   describe('buildThumbnailPath', () => {
@@ -347,6 +373,25 @@ describe('YtdlpCommandBuilder', () => {
       // Thumbnail should have the same pattern as video file but without the .%(ext)s
       expect(outputPath).toContain('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s].%(ext)s');
       expect(thumbnailPath).toContain('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s]');
+    });
+
+    it('uses configured videoFilenamePrefix for the thumbnail stem', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
+      configModule.getConfig.mockReturnValue({
+        videoFilenamePrefix: '%(upload_date>%Y-%m-%d)s - %(title).76B',
+      });
+      const result = YtdlpCommandBuilder.buildThumbnailPath();
+      expect(result).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B [%(id)s]');
+      expect(result).not.toMatch(/\.%\(ext\)s$/);
+    });
+
+    it('uses configured videoFilenamePrefix for the per-video folder name as well', () => {
+      tempPathManager.getTempBasePath.mockReturnValue('/mock/youtube/output/.youtarr_tmp');
+      configModule.getConfig.mockReturnValue({
+        videoFilenamePrefix: '%(upload_date>%Y-%m-%d)s - %(title).76B',
+      });
+      const result = YtdlpCommandBuilder.buildThumbnailPath();
+      expect(result).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B - %(id)s');
     });
   });
 

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -46,26 +46,7 @@ class DownloadExecutor {
   // Helper function to extract YouTube ID from file path
   // Expects format: "...Channel - Title [VideoID].ext" or "...Channel - Title - VideoID/..."
   extractYoutubeIdFromPath(filePath) {
-    try {
-      const filename = path.basename(filePath);
-      // Try to extract from [VideoID].ext pattern
-      const bracketMatch = filename.match(/\[([a-zA-Z0-9_-]{10,12})\]/);
-      if (bracketMatch) {
-        return bracketMatch[1];
-      }
-
-      // Try to extract from directory name ending with " - VideoID"
-      const dirname = path.basename(path.dirname(filePath));
-      const dashMatch = dirname.match(/ - ([a-zA-Z0-9_-]{10,12})$/);
-      if (dashMatch) {
-        return dashMatch[1];
-      }
-
-      return null;
-    } catch (error) {
-      logger.error({ err: error, filePath }, 'Error extracting youtube ID from path');
-      return null;
-    }
+    return filesystem.extractYoutubeIdFromPath(filePath);
   }
 
   // Helper function to remove a channel directory if it's empty

--- a/server/modules/download/ytdlpCommandBuilder.js
+++ b/server/modules/download/ytdlpCommandBuilder.js
@@ -5,8 +5,9 @@ const logger = require('../../logger');
 const customArgsParser = require('./customArgsParser');
 const {
   CHANNEL_TEMPLATE,
-  VIDEO_FOLDER_TEMPLATE,
-  VIDEO_FILE_TEMPLATE
+  composeVideoFileTemplate,
+  composeThumbnailFilename,
+  composeVideoFolderName,
 } = require('../filesystem/constants');
 
 class YtdlpCommandBuilder {
@@ -20,12 +21,15 @@ class YtdlpCommandBuilder {
   static buildOutputPath(subFolder = null, skipVideoFolder = false) {
     // Always use temp path - downloads are staged before moving to final location
     const baseOutputPath = tempPathManager.getTempBasePath();
+    const prefix = configModule.getConfig().videoFilenamePrefix;
+    const videoFolderName = composeVideoFolderName(prefix);
+    const videoFileTemplate = composeVideoFileTemplate(prefix);
 
     const segments = [baseOutputPath];
     if (subFolder) segments.push(subFolder);
     segments.push(CHANNEL_TEMPLATE);
-    if (!skipVideoFolder) segments.push(VIDEO_FOLDER_TEMPLATE);
-    segments.push(VIDEO_FILE_TEMPLATE);
+    if (!skipVideoFolder) segments.push(videoFolderName);
+    segments.push(videoFileTemplate);
 
     return path.join(...segments);
   }
@@ -40,14 +44,14 @@ class YtdlpCommandBuilder {
   static buildThumbnailPath(subFolder = null, skipVideoFolder = false) {
     // Always use temp path - thumbnails are staged with videos
     const baseOutputPath = tempPathManager.getTempBasePath();
-
-    // Use same filename as video file (without extension - yt-dlp adds .jpg)
-    const thumbnailFilename = `${CHANNEL_TEMPLATE} - %(title).76B [%(id)s]`;
+    const prefix = configModule.getConfig().videoFilenamePrefix;
+    const videoFolderName = composeVideoFolderName(prefix);
+    const thumbnailFilename = composeThumbnailFilename(prefix);
 
     const segments = [baseOutputPath];
     if (subFolder) segments.push(subFolder);
     segments.push(CHANNEL_TEMPLATE);
-    if (!skipVideoFolder) segments.push(VIDEO_FOLDER_TEMPLATE);
+    if (!skipVideoFolder) segments.push(videoFolderName);
     segments.push(thumbnailFilename);
 
     return path.join(...segments);

--- a/server/modules/filesystem/__tests__/constants.test.js
+++ b/server/modules/filesystem/__tests__/constants.test.js
@@ -65,7 +65,7 @@ describe('filesystem/constants', () => {
     });
 
     it('should match IDs with underscores and hyphens', () => {
-      // YouTube IDs are exactly 11 characters
+      // This parser accepts the same defensive 10-12 character window as YOUTUBE_ID_PATTERN.
       const match = 'Video [a_b-c_d-e_f].mp4'.match(YOUTUBE_ID_BRACKET_PATTERN);
       expect(match).not.toBeNull();
       expect(match[1]).toBe('a_b-c_d-e_f');
@@ -156,6 +156,108 @@ describe('filesystem/constants', () => {
       expect(CHANNEL_CLEANUP_IGNORABLE_FILES).toContain('.ds_store');
       expect(CHANNEL_CLEANUP_IGNORABLE_FILES).toContain('thumbs.db');
       expect(CHANNEL_CLEANUP_IGNORABLE_FILES).toContain('desktop.ini');
+    });
+  });
+
+  const {
+    DEFAULT_VIDEO_FILENAME_PREFIX,
+    VIDEO_FILENAME_SUFFIX,
+    composeVideoFileTemplate,
+    composeThumbnailFilename,
+    composeVideoFolderName,
+  } = require('../constants');
+
+  describe('DEFAULT_VIDEO_FILENAME_PREFIX', () => {
+    it('matches the legacy file template prefix exactly', () => {
+      expect(DEFAULT_VIDEO_FILENAME_PREFIX).toBe('%(uploader,channel,uploader_id).80B - %(title).76B');
+    });
+  });
+
+  describe('VIDEO_FILENAME_SUFFIX', () => {
+    it('is the locked id+ext suffix', () => {
+      expect(VIDEO_FILENAME_SUFFIX).toBe('[%(id)s].%(ext)s');
+    });
+  });
+
+  describe('composeVideoFileTemplate', () => {
+    it('produces the legacy template when given the default prefix', () => {
+      expect(composeVideoFileTemplate(DEFAULT_VIDEO_FILENAME_PREFIX))
+        .toBe('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s].%(ext)s');
+    });
+
+    it('inserts a single space between non-empty prefix and suffix', () => {
+      expect(composeVideoFileTemplate('%(title)s'))
+        .toBe('%(title)s [%(id)s].%(ext)s');
+    });
+
+    it('omits the leading space when the prefix is empty as defensive fallback behavior', () => {
+      expect(composeVideoFileTemplate('')).toBe('[%(id)s].%(ext)s');
+    });
+
+    it('treats whitespace-only prefix as empty as defensive fallback behavior', () => {
+      expect(composeVideoFileTemplate('   ')).toBe('[%(id)s].%(ext)s');
+    });
+
+    it('falls back to default when prefix is null or undefined', () => {
+      expect(composeVideoFileTemplate(null))
+        .toBe('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s].%(ext)s');
+      expect(composeVideoFileTemplate(undefined))
+        .toBe('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s].%(ext)s');
+    });
+  });
+
+  describe('composeThumbnailFilename', () => {
+    it('produces the legacy thumbnail template when given the default prefix', () => {
+      expect(composeThumbnailFilename(DEFAULT_VIDEO_FILENAME_PREFIX))
+        .toBe('%(uploader,channel,uploader_id).80B - %(title).76B [%(id)s]');
+    });
+
+    it('drops the .%(ext)s tail relative to the file template', () => {
+      expect(composeThumbnailFilename('%(title)s')).toBe('%(title)s [%(id)s]');
+    });
+
+    it('omits the leading space when the prefix is empty as defensive fallback behavior', () => {
+      expect(composeThumbnailFilename('')).toBe('[%(id)s]');
+    });
+  });
+
+  describe('VIDEO_FILE_TEMPLATE backward compatibility', () => {
+    it('still equals the composed default (legacy callers keep working)', () => {
+      const { VIDEO_FILE_TEMPLATE } = require('../constants');
+      expect(VIDEO_FILE_TEMPLATE).toBe(composeVideoFileTemplate(DEFAULT_VIDEO_FILENAME_PREFIX));
+    });
+  });
+
+  describe('composeVideoFolderName', () => {
+    it('produces the legacy folder template when given the default prefix', () => {
+      expect(composeVideoFolderName(DEFAULT_VIDEO_FILENAME_PREFIX))
+        .toBe('%(uploader,channel,uploader_id).80B - %(title).76B - %(id)s');
+    });
+
+    it('inserts " - " between non-empty prefix and id', () => {
+      expect(composeVideoFolderName('%(title)s')).toBe('%(title)s - %(id)s');
+    });
+
+    it('omits the leading " - " when the prefix is empty as defensive fallback behavior', () => {
+      expect(composeVideoFolderName('')).toBe('%(id)s');
+    });
+
+    it('treats whitespace-only prefix as empty as defensive fallback behavior', () => {
+      expect(composeVideoFolderName('   ')).toBe('%(id)s');
+    });
+
+    it('falls back to default when prefix is null or undefined', () => {
+      expect(composeVideoFolderName(null))
+        .toBe('%(uploader,channel,uploader_id).80B - %(title).76B - %(id)s');
+      expect(composeVideoFolderName(undefined))
+        .toBe('%(uploader,channel,uploader_id).80B - %(title).76B - %(id)s');
+    });
+  });
+
+  describe('VIDEO_FOLDER_TEMPLATE backward compatibility', () => {
+    it('still equals the composed default folder name (legacy callers keep working)', () => {
+      const { VIDEO_FOLDER_TEMPLATE } = require('../constants');
+      expect(VIDEO_FOLDER_TEMPLATE).toBe(composeVideoFolderName(DEFAULT_VIDEO_FILENAME_PREFIX));
     });
   });
 });

--- a/server/modules/filesystem/__tests__/pathBuilder.test.js
+++ b/server/modules/filesystem/__tests__/pathBuilder.test.js
@@ -166,6 +166,12 @@ describe('filesystem/pathBuilder', () => {
       expect(template).toContain('__MyFolder');
       expect(template).toContain('%(uploader,channel,uploader_id).80B');
     });
+
+    it('uses provided videoFilenamePrefix when supplied', () => {
+      const template = buildOutputTemplate(baseDir, null, '%(upload_date>%Y-%m-%d)s - %(title).76B');
+      expect(template).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B - %(id)s');
+      expect(template).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B [%(id)s].%(ext)s');
+    });
   });
 
   describe('buildThumbnailTemplate', () => {
@@ -180,6 +186,12 @@ describe('filesystem/pathBuilder', () => {
     it('should build thumbnail template with subfolder', () => {
       const template = buildThumbnailTemplate(baseDir, 'MyFolder');
       expect(template).toContain('__MyFolder');
+      expect(template).toContain('poster');
+    });
+
+    it('uses provided videoFilenamePrefix for the folder name when supplied', () => {
+      const template = buildThumbnailTemplate(baseDir, null, '%(upload_date>%Y-%m-%d)s - %(title).76B');
+      expect(template).toContain('%(upload_date>%Y-%m-%d)s - %(title).76B - %(id)s');
       expect(template).toContain('poster');
     });
   });

--- a/server/modules/filesystem/constants.js
+++ b/server/modules/filesystem/constants.js
@@ -47,28 +47,83 @@ const MEDIA_EXTENSIONS = [...VIDEO_EXTENSIONS, ...AUDIO_EXTENSIONS];
 const CHANNEL_TEMPLATE = '%(uploader,channel,uploader_id).80B';
 
 /**
- * yt-dlp output template for video folder name
- * Format: "ChannelName - VideoTitle - VideoID"
- * Title is truncated to 76 bytes (not characters) to avoid path length issues with UTF-8
- * Using .NB syntax for byte-based truncation instead of .Ns for character-based
- * Note: 76 bytes keeps same safety margin as before for Windows path limits (entire path must be <260)
+ * Default prefix for the user-customizable video filename template.
+ * Composed with VIDEO_FILENAME_SUFFIX to produce the full yt-dlp -o template.
+ * Matches the legacy fixed template byte-for-byte so existing installs are
+ * unchanged until the user touches the setting.
  */
-const VIDEO_FOLDER_TEMPLATE = `${CHANNEL_TEMPLATE} - %(title).76B - %(id)s`;
+const DEFAULT_VIDEO_FILENAME_PREFIX = `${CHANNEL_TEMPLATE} - %(title).76B`;
 
 /**
- * yt-dlp output template for video file name
- * Format: "ChannelName - VideoTitle [VideoID].ext"
- * Title is truncated to 76 bytes (not characters) to avoid path length issues with UTF-8
- * Using .NB syntax for byte-based truncation instead of .Ns for character-based
- * Note: 76 bytes keeps same safety margin as before for Windows path limits (entire path must be <260)
+ * Locked suffix appended to every user-customized video filename.
+ * Required for Youtarr's file-to-DB matching (see YOUTUBE_ID_BRACKET_PATTERN).
  */
-const VIDEO_FILE_TEMPLATE = `${CHANNEL_TEMPLATE} - %(title).76B [%(id)s].%(ext)s`;
+const VIDEO_FILENAME_SUFFIX = '[%(id)s].%(ext)s';
+
+/**
+ * Normalize a user-supplied filename prefix: fall back to the default when
+ * null/undefined, then strip trailing whitespace. Shared by the three
+ * filename composers below.
+ */
+function normalizePrefix(prefix) {
+  const effective = prefix == null ? DEFAULT_VIDEO_FILENAME_PREFIX : prefix;
+  return effective.replace(/\s+$/, '');
+}
+
+/**
+ * Compose the full yt-dlp video file template from a user-supplied prefix.
+ * Inserts a single space between non-empty prefix and suffix; emits suffix
+ * alone when the prefix is empty/whitespace as defensive fallback behavior.
+ * User-facing config validation rejects empty prefixes. Null/undefined falls
+ * back to the default prefix so callers without config still produce a valid template.
+ */
+function composeVideoFileTemplate(prefix) {
+  const trimmed = normalizePrefix(prefix);
+  return trimmed.length === 0
+    ? VIDEO_FILENAME_SUFFIX
+    : `${trimmed} ${VIDEO_FILENAME_SUFFIX}`;
+}
+
+/**
+ * Compose the thumbnail filename template (no extension; yt-dlp adds .jpg via
+ * --convert-thumbnails). Mirrors the video file template so the post-processor
+ * can pair thumbnail + video by stem.
+ */
+function composeThumbnailFilename(prefix) {
+  const trimmed = normalizePrefix(prefix);
+  return trimmed.length === 0 ? '[%(id)s]' : `${trimmed} [%(id)s]`;
+}
+
+/**
+ * Compose the per-video directory name from a user-supplied prefix.
+ * Non-empty prefixes get " - %(id)s"; empty prefixes use "%(id)s" alone.
+ * User-facing config validation rejects empty prefixes, so the empty form is
+ * defensive fallback behavior for older/hand-edited configs.
+ * The non-empty form matches YOUTUBE_ID_DASH_PATTERN for directory ID extraction.
+ * Same composition rules as composeVideoFileTemplate.
+ */
+function composeVideoFolderName(prefix) {
+  const trimmed = normalizePrefix(prefix);
+  return trimmed.length === 0 ? '%(id)s' : `${trimmed} - %(id)s`;
+}
+
+/**
+ * Legacy-compatible folder template. Kept so existing imports of
+ * VIDEO_FOLDER_TEMPLATE continue to work byte-identically.
+ */
+const VIDEO_FOLDER_TEMPLATE = composeVideoFolderName(DEFAULT_VIDEO_FILENAME_PREFIX);
+
+/**
+ * Legacy-compatible full template. Kept so existing imports of
+ * VIDEO_FILE_TEMPLATE (e.g. tests, future callers) continue to work.
+ */
+const VIDEO_FILE_TEMPLATE = composeVideoFileTemplate(DEFAULT_VIDEO_FILENAME_PREFIX);
 
 /**
  * Pattern to extract YouTube video ID from filename
- * Matches [VideoID] where VideoID is 11 alphanumeric characters (including - and _)
+ * Matches [VideoID] where VideoID is 10-12 alphanumeric characters (including - and _)
  */
-const YOUTUBE_ID_BRACKET_PATTERN = /\[([a-zA-Z0-9_-]{11})\]/;
+const YOUTUBE_ID_BRACKET_PATTERN = /\[([a-zA-Z0-9_-]{10,12})\]/;
 
 /**
  * Pattern to extract YouTube video ID from directory name
@@ -137,6 +192,11 @@ module.exports = {
   CHANNEL_TEMPLATE,
   VIDEO_FOLDER_TEMPLATE,
   VIDEO_FILE_TEMPLATE,
+  DEFAULT_VIDEO_FILENAME_PREFIX,
+  VIDEO_FILENAME_SUFFIX,
+  composeVideoFileTemplate,
+  composeThumbnailFilename,
+  composeVideoFolderName,
   YOUTUBE_ID_BRACKET_PATTERN,
   YOUTUBE_ID_DASH_PATTERN,
   YOUTUBE_ID_PATTERN,

--- a/server/modules/filesystem/pathBuilder.js
+++ b/server/modules/filesystem/pathBuilder.js
@@ -9,8 +9,8 @@ const {
   GLOBAL_DEFAULT_SENTINEL,
   ROOT_SENTINEL,
   CHANNEL_TEMPLATE,
-  VIDEO_FOLDER_TEMPLATE,
-  VIDEO_FILE_TEMPLATE,
+  composeVideoFolderName,
+  composeVideoFileTemplate,
   YOUTUBE_ID_BRACKET_PATTERN,
   YOUTUBE_ID_DASH_PATTERN,
   YOUTUBE_ID_PATTERN
@@ -126,28 +126,37 @@ function buildVideoPath(baseDir, subfolder, channelFolderName, videoFolderName) 
  * Build yt-dlp output template for video files
  * @param {string} baseDir - The base output directory
  * @param {string|null} subfolder - The subfolder name (without prefix) or null
+ * @param {string|null} videoFilenamePrefix - User-supplied prefix for the
+ *   per-video folder and file names. When null, the default legacy template
+ *   is used (byte-identical to the pre-customization output).
  * @returns {string} - Path template for yt-dlp -o argument
  */
-function buildOutputTemplate(baseDir, subfolder) {
+function buildOutputTemplate(baseDir, subfolder, videoFilenamePrefix = null) {
+  const folderName = composeVideoFolderName(videoFilenamePrefix);
+  const fileTemplate = composeVideoFileTemplate(videoFilenamePrefix);
   if (subfolder) {
     const subfolderSegment = buildSubfolderSegment(subfolder);
-    return path.join(baseDir, subfolderSegment, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, VIDEO_FILE_TEMPLATE);
+    return path.join(baseDir, subfolderSegment, CHANNEL_TEMPLATE, folderName, fileTemplate);
   }
-  return path.join(baseDir, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, VIDEO_FILE_TEMPLATE);
+  return path.join(baseDir, CHANNEL_TEMPLATE, folderName, fileTemplate);
 }
 
 /**
  * Build yt-dlp thumbnail output template
  * @param {string} baseDir - The base output directory
  * @param {string|null} subfolder - The subfolder name (without prefix) or null
+ * @param {string|null} videoFilenamePrefix - User-supplied prefix for the
+ *   per-video folder name. The thumbnail filename itself is always 'poster'
+ *   in this code path. When null, the default legacy folder template is used.
  * @returns {string} - Thumbnail path template for yt-dlp
  */
-function buildThumbnailTemplate(baseDir, subfolder) {
+function buildThumbnailTemplate(baseDir, subfolder, videoFilenamePrefix = null) {
+  const folderName = composeVideoFolderName(videoFilenamePrefix);
   if (subfolder) {
     const subfolderSegment = buildSubfolderSegment(subfolder);
-    return path.join(baseDir, subfolderSegment, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, 'poster');
+    return path.join(baseDir, subfolderSegment, CHANNEL_TEMPLATE, folderName, 'poster');
   }
-  return path.join(baseDir, CHANNEL_TEMPLATE, VIDEO_FOLDER_TEMPLATE, 'poster');
+  return path.join(baseDir, CHANNEL_TEMPLATE, folderName, 'poster');
 }
 
 /**

--- a/server/routes/__tests__/config.test.js
+++ b/server/routes/__tests__/config.test.js
@@ -140,3 +140,130 @@ describe('POST /updateconfig', () => {
     );
   });
 });
+
+describe('POST /updateconfig - videoFilenamePrefix validation', () => {
+  test('accepts the default prefix', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: '%(uploader,channel,uploader_id).80B - %(title).76B' });
+    expect(res.status).toBe(200);
+  });
+
+  test('rejects an empty prefix with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: '' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/empty/i);
+  });
+
+  test('rejects a whitespace-only prefix with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: '   ' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/empty/i);
+  });
+
+  test('trims trailing whitespace before persisting', async () => {
+    const { app, configModule } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: '%(title).76B   ' });
+    expect(res.status).toBe(200);
+    expect(configModule.updateConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ videoFilenamePrefix: '%(title).76B' })
+    );
+  });
+
+  test('rejects forward slash with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: '%(uploader)s/%(title)s' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/path separator/i);
+  });
+
+  test('rejects backslash with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: 'a\\b' });
+    expect(res.status).toBe(400);
+  });
+
+  test('rejects path traversal .. with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: '..%(title)s' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/traversal/i);
+  });
+
+  test('rejects ASCII control characters with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: 'hello\x07world' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/control/i);
+  });
+
+  test('rejects non-string values with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: {} });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/string/i);
+  });
+
+  test('rejects overlong values with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: 'a'.repeat(161) });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/160/);
+  });
+
+  test('rejects invalid yt-dlp truncation syntax with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: '%(title).40' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/truncation/i);
+  });
+
+  test('rejects incomplete yt-dlp tokens with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: '%(title)' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/syntax/i);
+  });
+
+  test('rejects unescaped literal percent signs with 400', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: '100% done - %(title).76B' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/syntax/i);
+  });
+
+  test('accepts escaped literal percent signs', async () => {
+    const { app } = makeApp();
+    const res = await supertest(app)
+      .post('/updateconfig')
+      .send({ videoFilenamePrefix: '100%% done - %(title).76B' });
+    expect(res.status).toBe(200);
+  });
+});

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -5,6 +5,30 @@ const customArgsParser = require('../modules/download/customArgsParser');
 // Mirror of the frontend RATE_LIMIT_REGEX. Matches yt-dlp's --limit-rate
 // format: digits with optional decimal, optional K/M/G suffix.
 const RATE_LIMIT_REGEX = /^\d+(\.\d+)?[KkMmGg]?$/;
+const MAX_VIDEO_FILENAME_PREFIX_LENGTH = 160;
+const TRUNCATION_WITHOUT_CONVERSION_RE = /%\([^)]*\)\.\d+(?![\dBsdjlqUDS])/;
+// Keep in sync with client/src/utils/filenameTemplate/validate.ts and renderer.ts TOKEN_RE.
+const TEMPLATE_TOKEN_AT_START_RE = /^%\([^)]+\)(?:(?:\.\d+B)|(?:(?:\.\d+)?[sdjlqUDS]))/;
+
+function validateTemplatePercentSyntax(prefix) {
+  for (let i = 0; i < prefix.length; i++) {
+    if (prefix[i] !== '%') continue;
+    if (prefix[i + 1] === '%') {
+      i++;
+      continue;
+    }
+
+    const match = prefix.slice(i).match(TEMPLATE_TOKEN_AT_START_RE);
+    if (match) {
+      i += match[0].length - 1;
+      continue;
+    }
+
+    return 'Invalid yt-dlp template syntax. Use tokens like %(title)s or escape literal percent signs as %%.';
+  }
+
+  return null;
+}
 
 // Configure multer for cookie file upload
 const cookieUpload = multer({
@@ -158,6 +182,54 @@ module.exports = function createConfigRoutes({ verifyToken, configModule, valida
           error: 'Invalid download rate limit format. Use e.g. 5M, 500K, 1.5G',
         });
       }
+    }
+
+    // Video filename template prefix validation
+    if (Object.prototype.hasOwnProperty.call(updateData, 'videoFilenamePrefix')) {
+      if (typeof updateData.videoFilenamePrefix !== 'string') {
+        return res.status(400).json({
+          error: 'videoFilenamePrefix must be a string.',
+        });
+      }
+      const prefix = updateData.videoFilenamePrefix;
+      const trimmedPrefix = prefix.replace(/\s+$/, '');
+      if (trimmedPrefix.trim().length === 0) {
+        return res.status(400).json({
+          error: 'videoFilenamePrefix may not be empty.',
+        });
+      }
+      if (trimmedPrefix.length > MAX_VIDEO_FILENAME_PREFIX_LENGTH) {
+        return res.status(400).json({
+          error: `videoFilenamePrefix may not exceed ${MAX_VIDEO_FILENAME_PREFIX_LENGTH} characters.`,
+        });
+      }
+      if (trimmedPrefix.includes('/') || trimmedPrefix.includes('\\')) {
+        return res.status(400).json({
+          error: 'videoFilenamePrefix may not contain path separators (/ or \\).',
+        });
+      }
+      if (trimmedPrefix.includes('..')) {
+        return res.status(400).json({
+          error: 'videoFilenamePrefix may not contain ".." (path traversal).',
+        });
+      }
+      // eslint-disable-next-line no-control-regex
+      if (/[\x00-\x1f]/.test(trimmedPrefix)) {
+        return res.status(400).json({
+          error: 'videoFilenamePrefix may not contain ASCII control characters.',
+        });
+      }
+      if (TRUNCATION_WITHOUT_CONVERSION_RE.test(trimmedPrefix)) {
+        return res.status(400).json({
+          error: 'videoFilenamePrefix truncation must use yt-dlp syntax like %(title).76B or %(title).40s.',
+        });
+      }
+      const syntaxError = validateTemplatePercentSyntax(trimmedPrefix);
+      if (syntaxError) {
+        return res.status(400).json({ error: syntaxError });
+      }
+      // Trim trailing whitespace before persisting
+      updateData.videoFilenamePrefix = trimmedPrefix;
     }
 
     delete updateData.passwordHash;


### PR DESCRIPTION
Add `videoFilenamePrefix` config field so users can customize the prefix portion of downloaded video filenames and per-video folder names via yt-dlp's output template syntax. Default matches the legacy fixed format byte-for-byte so existing installs are unchanged until the user touches the setting.

Youtarr always appends a locked suffix (` [VIDEO_ID].EXT` to filenames, ` - VIDEO_ID` to folders) so file-to-DB matching keeps working regardless of the configured prefix.

Validation on both client and server rejects empty prefixes, path separators, `..`, ASCII control characters, oversize values (>160 chars), and malformed percent syntax. Trailing whitespace is trimmed on save.

A new live-preview UI under Settings -> Core Settings -> File Structure renders sample folder and file names against a sample video, with length warnings as paths approach the Windows 260-char limit.

<img width="1608" height="548" alt="image" src="https://github.com/user-attachments/assets/2e8fc237-3447-4895-9dd7-63c160d77590" />


Refs: #369