### PR TITLE
fix(setup): replace localhost gate with one-time token

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@ database/
 database/*
 database.bind-mount-backup.*
 
+# Ignore local setup secrets
+config/setup-token

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@
 # Example Windows: C:/Media/YouTube (use forward slashes)
 YOUTUBE_OUTPUT_DIR=./downloads
 
+# Host port for the Youtarr web interface. The container still listens on 3011.
+# If you change this, start scripts will print and poll the matching setup URL.
+# YOUTARR_HOST_PORT=3087
+
 
 # ==============================================================================
 # DATABASE CONFIGURATION
@@ -78,15 +82,22 @@ AUTH_ENABLED=true
 # And they will be saved to config/config.json (password hashed)
 #
 # Useful for container orchestration platforms (Kubernetes, automated deployments)
-# where the UI may not be accessible via localhost
+# where you want to skip the one-time setup-token wizard
 # NOTE: If set, these values OVERRIDE any username and password previously set through the WEB UI
 #       and will continue to do so on each startup
 # These must meet the following validation criteria or they will be ignored:
-#   Username: 3-32 characters (no leading/trailing spaces)
+#   Username: 1-32 characters (no leading/trailing spaces)
 #   Password: 8-64 characters
 
 # AUTH_PRESET_USERNAME=admin
 # AUTH_PRESET_PASSWORD=changeme
+
+# Proxy trust
+# Leave unset to preserve Express's historical proxy-header trust behavior.
+# Rate limits use the direct peer IP until TRUST_PROXY is explicitly configured.
+# Set TRUST_PROXY=false when exposing Youtarr directly without a reverse proxy.
+# Set TRUST_PROXY=1 or a trusted subnet when a reverse proxy should supply client IPs.
+# TRUST_PROXY=false
 
 # Logging Configuration
 # Options: warn, info (default), debug

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ config/jobs.json
 config/config.json
 config/config.json.*
 config/cookies.user.txt
+config/setup-token
 config/*.env
 database
 server/images

--- a/client/src/__tests__/App.story.tsx
+++ b/client/src/__tests__/App.story.tsx
@@ -32,7 +32,6 @@ const meta: Meta<typeof App> = {
         http.get('/setup/status', () => {
           return HttpResponse.json({
             requiresSetup: false,
-            isLocalhost: true,
             platformManaged: false,
           });
         }),
@@ -129,7 +128,6 @@ export const DatabaseError: Story = {
         http.get('/setup/status', () => {
           return HttpResponse.json({
             requiresSetup: false,
-            isLocalhost: true,
             platformManaged: false,
           });
         }),
@@ -186,7 +184,6 @@ export const RequiresSetup: Story = {
         http.get('/setup/status', () => {
           return HttpResponse.json({
             requiresSetup: true,
-            isLocalhost: true,
             platformManaged: false,
           });
         }),

--- a/client/src/components/AuthSplash.tsx
+++ b/client/src/components/AuthSplash.tsx
@@ -57,12 +57,14 @@ export const AuthSplash: React.FC<AuthSplashProps> = ({ setToken }) => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [showPasswordResetHelp, setShowPasswordResetHelp] = useState(false);
   const [loading, setLoading] = useState(false);
   const showPlainTitle = !showHeaderWordmark;
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setShowPasswordResetHelp(false);
     setLoading(true);
 
     try {
@@ -76,9 +78,11 @@ export const AuthSplash: React.FC<AuthSplashProps> = ({ setToken }) => {
       setToken(token);
       window.location.href = '/channels';
     } catch (err: unknown) {
+      const shouldShowPasswordResetHelp = axios.isAxiosError(err) && err.response?.status === 401;
       const nextError = getAxiosErrorMessage(err);
       if (nextError) {
         setError(nextError);
+        setShowPasswordResetHelp(shouldShowPasswordResetHelp);
       }
     } finally {
       setLoading(false);
@@ -177,6 +181,26 @@ export const AuthSplash: React.FC<AuthSplashProps> = ({ setToken }) => {
               >
                 {error}
               </Alert>
+            )}
+
+            {showPasswordResetHelp && (
+              <details className="mt-4 rounded-[var(--radius-ui)] border border-[var(--border)] bg-[var(--muted)] px-3.5 py-3 text-[var(--foreground)]">
+                <summary className="cursor-pointer font-semibold">
+                  Forgot your password?
+                </summary>
+                <div className="mt-2.5">
+                  <Typography variant="body2" className="mb-2">
+                    If you have access to the Youtarr host, stop Youtarr, set{' '}
+                    <code>AUTH_PRESET_USERNAME</code> and <code>AUTH_PRESET_PASSWORD</code> in your{' '}
+                    <code>.env</code> file, then restart Youtarr and log in with those credentials.
+                  </Typography>
+                  <Typography variant="body2">
+                    Advanced fallback: stop Youtarr, remove <code>username</code> and{' '}
+                    <code>passwordHash</code> from <code>config/config.json</code>, restart, then
+                    complete setup again with the one-time setup token.
+                  </Typography>
+                </div>
+              </details>
             )}
 
             <Button

--- a/client/src/components/ChannelPage.tsx
+++ b/client/src/components/ChannelPage.tsx
@@ -89,11 +89,83 @@ function ChannelPage({ token }: ChannelPageProps) {
     setDescriptionExpanded(false);
   }, [channel?.description]);
 
-  function textToHTML(text: string) {
-    return text
+  function renderDescriptionText(text: string): React.ReactNode[] {
+    const nodes: React.ReactNode[] = [];
+    const tokenPattern = /(https?:\/\/[^\s]+)|(\r\n|\r|\n)/g;
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
 
-      .replace(/(https?:\/\/[^\s]+)/g, '<a href="$1">$1</a>')
-      .replace(/(?:\r\n|\r|\n)/g, '<br />'); // replace newlines with <br />
+    const splitUrlTrailingPunctuation = (rawUrl: string): [string, string] => {
+      let url = rawUrl;
+      let suffix = '';
+
+      const stripFromUrl = (count: number) => {
+        suffix = url.slice(-count) + suffix;
+        url = url.slice(0, -count);
+      };
+
+      const stripTrailingSentencePunctuation = () => {
+        const punctuationMatch = url.match(/[.,!?;:]+$/);
+        if (punctuationMatch) {
+          stripFromUrl(punctuationMatch[0].length);
+        }
+      };
+
+      stripTrailingSentencePunctuation();
+
+      const bracketPairs = [
+        ['(', ')'],
+        ['[', ']'],
+        ['{', '}'],
+      ];
+
+      let strippedBracket = true;
+      while (strippedBracket) {
+        strippedBracket = false;
+
+        for (const [open, close] of bracketPairs) {
+          if (!url.endsWith(close)) continue;
+
+          const openCount = url.split(open).length - 1;
+          const closeCount = url.split(close).length - 1;
+          if (closeCount > openCount) {
+            stripFromUrl(1);
+            stripTrailingSentencePunctuation();
+            strippedBracket = true;
+          }
+        }
+      }
+
+      return [url, suffix];
+    };
+
+    while ((match = tokenPattern.exec(text)) !== null) {
+      if (match.index > lastIndex) {
+        nodes.push(text.slice(lastIndex, match.index));
+      }
+
+      if (match[1]) {
+        const [url, suffix] = splitUrlTrailingPunctuation(match[1]);
+        nodes.push(
+          <a key={`link-${match.index}`} href={url} target="_blank" rel="noopener noreferrer">
+            {url}
+          </a>
+        );
+        if (suffix) {
+          nodes.push(suffix);
+        }
+      } else {
+        nodes.push(<br key={`br-${match.index}`} />);
+      }
+
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < text.length) {
+      nodes.push(text.slice(lastIndex));
+    }
+
+    return nodes;
   }
 
   const chipHeight = isMobile ? 22 : 26;
@@ -333,8 +405,9 @@ function ChannelPage({ token }: ChannelPageProps) {
                     align="left"
                     color="text.secondary"
                     style={{ lineHeight: 1.6 }}
-                    dangerouslySetInnerHTML={{ __html: textToHTML(displayedDescription) }}
-                  />
+                  >
+                    {renderDescriptionText(displayedDescription)}
+                  </Typography>
                 </Box>
                 {shouldShowExpandButton && (
                   <Button

--- a/client/src/components/InitialSetup.tsx
+++ b/client/src/components/InitialSetup.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   TextField,
   Button,
@@ -25,22 +25,21 @@ interface InitialSetupProps {
 }
 
 const InitialSetup: React.FC<InitialSetupProps> = ({ onSetupComplete }) => {
+  const [setupToken, setSetupToken] = useState('');
   const [username, setUsername] = useState('admin');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [isLocalhost, setIsLocalhost] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    axios.get('/setup/status')
-      .then(response => {
-        setIsLocalhost(response.data.isLocalhost);
-      })
-      .catch(err => {
-        console.error('Setup status check failed:', err);
-      });
-  }, []);
+  const hostname = typeof window === 'undefined' ? '' : window.location.hostname;
+  const isLoopbackHost = hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname === '[::1]';
+  const showInsecureRemoteWarning =
+    typeof window !== 'undefined' &&
+    window.location.protocol !== 'https:' &&
+    !isLoopbackHost;
 
   const passwordStrength = (pwd: string): string => {
     if (pwd.length < 8) return 'Too short';
@@ -52,6 +51,11 @@ const InitialSetup: React.FC<InitialSetupProps> = ({ onSetupComplete }) => {
   const handleSetup = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+
+    if (!setupToken.trim()) {
+      setError('Setup token is required');
+      return;
+    }
 
     if (password !== confirmPassword) {
       setError('Passwords do not match');
@@ -67,53 +71,29 @@ const InitialSetup: React.FC<InitialSetupProps> = ({ onSetupComplete }) => {
 
     try {
       const response = await axios.post('/setup/create-auth', {
+        token: setupToken.trim(),
         username,
-        password
+        password,
       });
 
       localStorage.setItem('authToken', response.data.token);
       onSetupComplete(response.data.token);
-    } catch (err: any) {
-      setError(err.response?.data?.error || 'Setup failed');
+    } catch (err: unknown) {
+      const message =
+        (axios.isAxiosError(err) && err.response?.data?.error) ||
+        'Setup failed';
+      setError(message);
     } finally {
       setLoading(false);
     }
   };
 
-  if (isLocalhost === false) {
-    return (
-      <div style={AUTH_VIEWPORT_STYLE}>
-        <div style={AUTH_CONTAINER_STYLE}>
-          <Paper elevation={0} style={AUTH_SURFACE_STYLE}>
-            <Typography variant="h5" color="error" gutterBottom>
-              🔒 Security Protection Active
-            </Typography>
-            <Typography variant="body1" paragraph>
-              Initial password setup must be performed from the server itself.
-            </Typography>
-            <Alert severity="info">
-              http://localhost:3087
-            </Alert>
-            <Typography variant="body2" style={{ marginTop: 16 }}>
-              This security measure prevents unauthorized users from claiming your Youtarr instance.
-            </Typography>
-          </Paper>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div style={AUTH_VIEWPORT_STYLE}>
       <div style={AUTH_CONTAINER_STYLE}>
         <Paper elevation={0} style={AUTH_SURFACE_STYLE}>
-          {/* Branding */}
           <div style={{ textAlign: 'center', marginBottom: 24 }}>
-            <Typography
-              variant="h3"
-              component="h1"
-              style={AUTH_TITLE_STYLE}
-            >
+            <Typography variant="h3" component="h1" style={AUTH_TITLE_STYLE}>
               Welcome to Youtarr Setup
             </Typography>
             <Typography
@@ -125,26 +105,47 @@ const InitialSetup: React.FC<InitialSetupProps> = ({ onSetupComplete }) => {
             </Typography>
           </div>
 
-          {/* Info alert */}
           <Alert severity="info" style={{ marginBottom: 24, borderRadius: 'var(--radius-ui)' }}>
-            <AlertTitle>Important</AlertTitle>
+            <AlertTitle>Setup token required</AlertTitle>
             <Typography variant="body2">
-              Youtarr uses local authentication by default. Initial setup requires access via localhost.
+              Find your one-time setup token in the container logs (<code>docker logs youtarr</code>)
+              or in the <code>config/setup-token</code> file inside your Youtarr data volume.
+            </Typography>
+            <Typography variant="body2" style={{ marginTop: 8 }}>
+              If you are running headless and cannot retrieve the token, set <code>AUTH_PRESET_USERNAME</code> and{' '}
+              <code>AUTH_PRESET_PASSWORD</code> in your <code>.env</code> file, then restart Youtarr.
             </Typography>
           </Alert>
 
-          {/* Form */}
-          <form onSubmit={handleSetup}>
+          {showInsecureRemoteWarning && (
+            <Alert severity="warning" style={{ marginBottom: 24, borderRadius: 'var(--radius-ui)' }}>
+              <AlertTitle>Trusted network only</AlertTitle>
+              <Typography variant="body2">
+                This page is using plain HTTP. Continue only from your private LAN, VPN, or SSH tunnel;
+                use HTTPS before exposing Youtarr outside your network.
+              </Typography>
+            </Alert>
+          )}
+
+          <form onSubmit={handleSetup} style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+            <TextField
+              fullWidth
+              label="Setup Token"
+              value={setupToken}
+              onChange={(e) => setSetupToken(e.target.value)}
+              required
+              helperText="Paste the 64-character token from your container logs or config/setup-token"
+              inputProps={{ autoCapitalize: 'off', autoComplete: 'off' }}
+            />
+
             <TextField
               fullWidth
               label="Username"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              margin="normal"
               required
               helperText="Choose a username for login"
               inputProps={{ autoCapitalize: 'off' }}
-              style={{ marginBottom: '16px' }}
             />
 
             <TextField
@@ -153,10 +154,8 @@ const InitialSetup: React.FC<InitialSetupProps> = ({ onSetupComplete }) => {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              margin="normal"
               required
               helperText={`Password strength: ${password ? passwordStrength(password) : 'Enter password'}`}
-              style={{ marginBottom: '16px' }}
             />
 
             <TextField
@@ -165,14 +164,13 @@ const InitialSetup: React.FC<InitialSetupProps> = ({ onSetupComplete }) => {
               type="password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
-              margin="normal"
               required
             />
 
             {error && (
               <Alert
                 severity="error"
-                style={{ marginTop: 16, borderRadius: 'var(--radius-ui)', border: '1px solid var(--destructive)' }}
+                style={{ borderRadius: 'var(--radius-ui)', border: '1px solid var(--destructive)' }}
               >
                 {error}
               </Alert>
@@ -183,22 +181,21 @@ const InitialSetup: React.FC<InitialSetupProps> = ({ onSetupComplete }) => {
               fullWidth
               variant="contained"
               size="large"
-              disabled={loading || isLocalhost === null}
+              disabled={loading}
               style={AUTH_PRIMARY_BUTTON_STYLE}
             >
               {loading ? 'Setting up...' : 'Complete Setup'}
             </Button>
 
-            {loading && <LinearProgress style={{ marginTop: 16, borderRadius: 'var(--radius-ui)' }} />}
+            {loading && <LinearProgress style={{ borderRadius: 'var(--radius-ui)' }} />}
           </form>
 
-          {/* Footer */}
           <Typography
             variant="caption"
             color="text.secondary"
             style={AUTH_FOOTER_STYLE}
           >
-            After setup, you can access Youtarr from anywhere.
+            After setup, you can access Youtarr normally.
           </Typography>
           <Typography
             variant="caption"

--- a/client/src/components/LocalLogin.tsx
+++ b/client/src/components/LocalLogin.tsx
@@ -14,11 +14,13 @@ const LocalLogin: React.FC<LocalLoginProps> = ({ setToken }) => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [showPasswordResetHelp, setShowPasswordResetHelp] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setShowPasswordResetHelp(false);
     setLoading(true);
 
     try {
@@ -40,6 +42,7 @@ const LocalLogin: React.FC<LocalLoginProps> = ({ setToken }) => {
       } else if (err.response?.status === 401) {
         // Invalid credentials
         setError('Invalid username or password');
+        setShowPasswordResetHelp(true);
       } else if (err.response?.data?.error) {
         // Other server errors with specific messages
         setError(err.response.data.error);
@@ -91,6 +94,26 @@ const LocalLogin: React.FC<LocalLoginProps> = ({ setToken }) => {
         >
           {error}
         </div>
+      )}
+
+      {showPasswordResetHelp && (
+        <details className="rounded-md border border-[var(--border)] bg-[var(--muted)] px-3 py-2 text-sm text-[var(--muted-foreground)]">
+          <summary className="cursor-pointer font-medium text-[var(--foreground)]">
+            Forgot your password?
+          </summary>
+          <div className="mt-2 space-y-2">
+            <p>
+              If you have access to the Youtarr host, stop Youtarr, set{' '}
+              <code>AUTH_PRESET_USERNAME</code> and <code>AUTH_PRESET_PASSWORD</code> in your{' '}
+              <code>.env</code> file, then restart Youtarr and log in with those credentials.
+            </p>
+            <p>
+              Advanced fallback: stop Youtarr, remove <code>username</code> and{' '}
+              <code>passwordHash</code> from <code>config/config.json</code>, restart, then complete
+              setup again with the one-time setup token.
+            </p>
+          </div>
+        </details>
       )}
 
       <button

--- a/client/src/components/__tests__/AuthSplash.test.tsx
+++ b/client/src/components/__tests__/AuthSplash.test.tsx
@@ -178,6 +178,29 @@ describe('AuthSplash', () => {
     });
   });
 
+  test('shows password reset disclosure after invalid credentials', async () => {
+    axios.isAxiosError.mockReturnValue(true);
+    axios.post.mockRejectedValueOnce({ response: { status: 401, data: {} } });
+    render(<AuthSplash setToken={setToken} />);
+
+    expect(screen.queryByText(/forgot your password/i)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'a' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'b' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/forgot your password/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText(/forgot your password/i));
+
+    expect(screen.getByText(/AUTH_PRESET_USERNAME/)).toBeInTheDocument();
+    expect(screen.getByText(/AUTH_PRESET_PASSWORD/)).toBeInTheDocument();
+    expect(screen.getByText(/passwordHash/)).toBeInTheDocument();
+    expect(screen.getByText(/one-time setup token/i)).toBeInTheDocument();
+  });
+
   test('shows server-provided error message when response.data.error is present', async () => {
     axios.isAxiosError.mockReturnValue(true);
     axios.post.mockRejectedValueOnce({

--- a/client/src/components/__tests__/ChannelPage.test.tsx
+++ b/client/src/components/__tests__/ChannelPage.test.tsx
@@ -849,6 +849,32 @@ describe('ChannelPage Component', () => {
       });
     });
 
+    test('does not include trailing punctuation in description links', async () => {
+      const channelWithUrl = {
+        ...mockChannel,
+        description: 'Check out https://example.com).'
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(channelWithUrl)
+      });
+
+      render(
+        <BrowserRouter>
+          <ChannelPage token={mockToken} />
+        </BrowserRouter>
+      );
+
+      await screen.findByText('Tech Channel');
+
+      await waitFor(() => {
+        const link = screen.getByRole('link', { name: 'https://example.com' });
+        expect(link).toHaveAttribute('href', 'https://example.com');
+      });
+      expect(document.body).toHaveTextContent('Check out https://example.com).');
+    });
+
     test('converts newlines to br tags in description', async () => {
       const channelWithNewlines = {
         ...mockChannel,
@@ -1062,7 +1088,7 @@ describe('ChannelPage Component', () => {
     });
   });
 
-  describe('textToHTML Helper Function', () => {
+  describe('description rendering', () => {
     test('handles complex text transformations', async () => {
       const complexDescription = {
         ...mockChannel,
@@ -1090,6 +1116,29 @@ describe('ChannelPage Component', () => {
 
       const link2 = screen.getByRole('link', { name: 'http://test.org' });
       expect(link2).toHaveAttribute('href', 'http://test.org');
+    });
+
+    test('renders HTML-like channel descriptions as text, not executable markup', async () => {
+      const maliciousDescription = {
+        ...mockChannel,
+        description: '<img src=x onerror="window.__xss=true"> https://example.com'
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(maliciousDescription)
+      });
+
+      render(
+        <BrowserRouter>
+          <ChannelPage token={mockToken} />
+        </BrowserRouter>
+      );
+
+      await screen.findByText('Tech Channel');
+
+      expect(screen.getByText(/<img src=x onerror=/)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'https://example.com' })).toHaveAttribute('href', 'https://example.com');
     });
 
     test('handles empty description gracefully', async () => {

--- a/client/src/components/__tests__/InitialSetup.story.tsx
+++ b/client/src/components/__tests__/InitialSetup.story.tsx
@@ -12,10 +12,7 @@ const meta: Meta<typeof InitialSetup> = {
   parameters: {
     msw: {
       handlers: [
-        http.get('/setup/status', () =>
-          HttpResponse.json({ requiresSetup: true, isLocalhost: true })
-        ),
-        http.post('/setup/create-auth', () => HttpResponse.json({ token: 'setup-token' })),
+        http.post('/setup/create-auth', () => HttpResponse.json({ token: 'session-token' })),
       ],
     },
   },
@@ -28,10 +25,7 @@ export const PasswordMismatch: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await waitFor(() =>
-      expect(canvas.getByRole('button', { name: /complete setup/i })).toBeEnabled()
-    );
-
+    await userEvent.type(canvas.getByLabelText(/setup token/i), 'sample-setup-token');
     await userEvent.type(canvas.getByLabelText(/^password/i), 'password123');
     await userEvent.type(canvas.getByLabelText(/confirm password/i), 'password456');
 
@@ -45,20 +39,12 @@ export const SuccessfulSetup: Story = {
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
-    await waitFor(() =>
-      expect(canvas.getByRole('button', { name: /complete setup/i })).toBeEnabled()
-    );
-
-    const password = canvas.getByLabelText(/^password/i);
-    const confirmPassword = canvas.getByLabelText(/confirm password/i);
-
-    await userEvent.clear(password);
-    await userEvent.type(password, 'password123');
-    await userEvent.clear(confirmPassword);
-    await userEvent.type(confirmPassword, 'password123');
+    await userEvent.type(canvas.getByLabelText(/setup token/i), 'sample-setup-token');
+    await userEvent.type(canvas.getByLabelText(/^password/i), 'password123');
+    await userEvent.type(canvas.getByLabelText(/confirm password/i), 'password123');
 
     await userEvent.click(canvas.getByRole('button', { name: /complete setup/i }));
 
-    await waitFor(() => expect(args.onSetupComplete).toHaveBeenCalledWith('setup-token'));
+    await waitFor(() => expect(args.onSetupComplete).toHaveBeenCalledWith('session-token'));
   },
 };

--- a/client/src/components/__tests__/InitialSetup.test.tsx
+++ b/client/src/components/__tests__/InitialSetup.test.tsx
@@ -4,15 +4,15 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import InitialSetup from '../InitialSetup';
 
-// Mock axios
+// Mock axios. Include isAxiosError so the component's narrowing works.
 jest.mock('axios', () => ({
   get: jest.fn(),
-  post: jest.fn()
+  post: jest.fn(),
+  isAxiosError: jest.fn((err: unknown) => Boolean((err as { isAxiosError?: boolean })?.isAxiosError)),
 }));
 
 const axios = require('axios');
 
-// Mock localStorage
 const localStorageMock = {
   getItem: jest.fn(),
   setItem: jest.fn(),
@@ -31,391 +31,217 @@ describe('InitialSetup Component', () => {
     jest.clearAllMocks();
   });
 
-  describe('Initial Status Check', () => {
-    test('checks setup status on component mount', async () => {
-      axios.get.mockResolvedValueOnce({
-        data: { isLocalhost: true }
-      });
-
+  describe('Setup form rendering', () => {
+    test('renders all required fields including the setup token field', () => {
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith('/setup/status');
-      });
-    });
-
-    test('handles setup status check failure gracefully', async () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-      axios.get.mockRejectedValueOnce(new Error('Network error'));
-
-      render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
-
-      await waitFor(() => {
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-          'Setup status check failed:',
-          expect.any(Error)
-        );
-      });
-
-      consoleErrorSpy.mockRestore();
-    });
-  });
-
-  describe('Non-localhost Access', () => {
-    test('displays security warning when accessing from non-localhost', async () => {
-      axios.get.mockResolvedValueOnce({
-        data: { isLocalhost: false }
-      });
-
-      render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
-
-      await waitFor(() => {
-        expect(screen.getByText('🔒 Security Protection Active')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText(/initial password setup must be performed from the server itself/i)).toBeInTheDocument();
-      expect(screen.getByText('http://localhost:3087')).toBeInTheDocument();
-      expect(screen.getByText(/this security measure prevents unauthorized users/i)).toBeInTheDocument();
-    });
-
-    test('does not show setup form when not on localhost', async () => {
-      axios.get.mockResolvedValueOnce({
-        data: { isLocalhost: false }
-      });
-
-      render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
-
-      await waitFor(() => {
-        expect(screen.getByText('🔒 Security Protection Active')).toBeInTheDocument();
-      });
-
-      expect(screen.queryByLabelText(/username/i)).not.toBeInTheDocument();
-      expect(screen.queryByLabelText(/password/i)).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /complete setup/i })).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Localhost Setup Form', () => {
-    beforeEach(() => {
-      axios.get.mockResolvedValueOnce({
-        data: { isLocalhost: true }
-      });
-    });
-
-    test('renders setup form with all required fields', async () => {
-      render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
-
-      // Wait for the form to be rendered after axios call
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
-
-      // Check all form fields are present
-      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/^Password/i)).toBeInTheDocument();
+      expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
+      expect(screen.getByLabelText(/setup token/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^username/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^password/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /complete setup/i })).toBeInTheDocument();
     });
 
-    test('shows important changes alert with information', async () => {
+    test('displays setup-token alert with reference to logs and config file', () => {
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      await waitFor(() => {
-        expect(screen.getByText('Important')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText(/youtarr uses local authentication by default/i)).toBeInTheDocument();
-      expect(screen.getByText(/initial setup requires access via localhost/i)).toBeInTheDocument();
+      expect(screen.getByText('Setup token required')).toBeInTheDocument();
+      expect(screen.getAllByText(/docker logs youtarr/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/config\/setup-token/).length).toBeGreaterThan(0);
+      expect(screen.getByText(/AUTH_PRESET_USERNAME/)).toBeInTheDocument();
+      expect(screen.getByText(/AUTH_PRESET_PASSWORD/)).toBeInTheDocument();
+      expect(screen.getByText(/restart Youtarr/i)).toBeInTheDocument();
     });
 
-    test('has admin as default username', async () => {
+    test('uses admin as the default username', () => {
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      await waitFor(() => {
-        const usernameInput = screen.getByLabelText(/username/i);
-        expect(usernameInput).toHaveValue('admin');
-      });
+      expect(screen.getByLabelText(/^username/i)).toHaveValue('admin');
     });
 
-    test('updates input values when user types', async () => {
-      const user = userEvent.setup();
+    test('does not call /setup/status', () => {
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
-      });
-
-      const usernameInput = screen.getByLabelText(/username/i);
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
-
-      await user.clear(usernameInput);
-      await user.type(usernameInput, 'newuser');
-      await user.type(passwordInput, 'testpassword123');
-      await user.type(confirmPasswordInput, 'testpassword123');
-
-      expect(usernameInput).toHaveValue('newuser');
-      expect(passwordInput).toHaveValue('testpassword123');
-      expect(confirmPasswordInput).toHaveValue('testpassword123');
+      expect(axios.get).not.toHaveBeenCalled();
     });
 
-    test('submit button is disabled while checking localhost status', () => {
-      axios.get.mockImplementationOnce(() => new Promise(() => {})); // Never resolves
-
+    test('all four input fields are marked as required', () => {
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      const submitButton = screen.getByRole('button', { name: /complete setup/i });
-      expect(submitButton).toBeDisabled();
+      expect(screen.getByLabelText(/setup token/i)).toHaveAttribute('required');
+      expect(screen.getByLabelText(/^username/i)).toHaveAttribute('required');
+      expect(screen.getByLabelText(/^password/i)).toHaveAttribute('required');
+      expect(screen.getByLabelText(/confirm password/i)).toHaveAttribute('required');
+    });
+
+    test('submit button is enabled by default', () => {
+      render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
+
+      expect(screen.getByRole('button', { name: /complete setup/i })).toBeEnabled();
     });
   });
 
-  describe('Password Strength Indicator', () => {
-    beforeEach(() => {
-      axios.get.mockResolvedValueOnce({
-        data: { isLocalhost: true }
-      });
-    });
-
-    test('shows password strength as "Too short" for passwords under 8 characters', async () => {
+  describe('Password strength indicator', () => {
+    test('shows "Too short" for passwords under 8 characters', async () => {
       const user = userEvent.setup();
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
-
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      await user.type(passwordInput, 'short');
+      await user.type(screen.getByLabelText(/^password/i), 'short');
 
       expect(screen.getByText(/password strength: too short/i)).toBeInTheDocument();
     });
 
-    test('shows password strength as "Fair" for 8-11 character passwords', async () => {
+    test('shows "Fair" for 8-11 character passwords', async () => {
       const user = userEvent.setup();
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
-
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      await user.type(passwordInput, 'fairpass');
+      await user.type(screen.getByLabelText(/^password/i), 'fairpass');
 
       expect(screen.getByText(/password strength: fair/i)).toBeInTheDocument();
     });
 
-    test('shows password strength as "Good" for 12-15 character passwords', async () => {
+    test('shows "Good" for 12-15 character passwords', async () => {
       const user = userEvent.setup();
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
-
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      await user.type(passwordInput, 'goodpassword');
+      await user.type(screen.getByLabelText(/^password/i), 'goodpassword');
 
       expect(screen.getByText(/password strength: good/i)).toBeInTheDocument();
     });
 
-    test('shows password strength as "Strong" for 16+ character passwords', async () => {
+    test('shows "Strong" for 16+ character passwords', async () => {
       const user = userEvent.setup();
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
-
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      await user.type(passwordInput, 'verystrongpassword123');
+      await user.type(screen.getByLabelText(/^password/i), 'verystrongpassword123');
 
       expect(screen.getByText(/password strength: strong/i)).toBeInTheDocument();
     });
 
-    test('shows "Enter password" when password field is empty', async () => {
+    test('shows "Enter password" when the password field is empty', () => {
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      await waitFor(() => {
-        expect(screen.getByText(/password strength: enter password/i)).toBeInTheDocument();
-      });
+      expect(screen.getByText(/password strength: enter password/i)).toBeInTheDocument();
     });
   });
 
-  describe('Form Validation', () => {
-    beforeEach(() => {
-      axios.get.mockResolvedValueOnce({
-        data: { isLocalhost: true }
-      });
+  describe('Form validation', () => {
+    const fillTokenAndPasswords = async (user: ReturnType<typeof userEvent.setup>) => {
+      await user.type(screen.getByLabelText(/setup token/i), 'sample-token');
+    };
+
+    test('does not submit when token is only whitespace', async () => {
+      const user = userEvent.setup();
+      render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
+
+      await user.type(screen.getByLabelText(/setup token/i), '   ');
+      await user.type(screen.getByLabelText(/^password/i), 'password123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'password123');
+      await user.click(screen.getByRole('button', { name: /complete setup/i }));
+
+      expect(await screen.findByText('Setup token is required')).toBeInTheDocument();
+      expect(axios.post).not.toHaveBeenCalled();
+      expect(mockOnSetupComplete).not.toHaveBeenCalled();
     });
 
     test('shows error when passwords do not match', async () => {
       const user = userEvent.setup();
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
+      await fillTokenAndPasswords(user);
+      await user.type(screen.getByLabelText(/^password/i), 'password123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'different');
+      await user.click(screen.getByRole('button', { name: /complete setup/i }));
 
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
-      const submitButton = screen.getByRole('button', { name: /complete setup/i });
-
-      await user.type(passwordInput, 'password123');
-      await user.type(confirmPasswordInput, 'differentpassword');
-      await user.click(submitButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
-      });
-
+      expect(await screen.findByText(/passwords do not match/i)).toBeInTheDocument();
       expect(axios.post).not.toHaveBeenCalled();
     });
 
-    test('shows error when password is less than 8 characters', async () => {
+    test('shows error when password is shorter than 8 chars', async () => {
       const user = userEvent.setup();
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
+      await fillTokenAndPasswords(user);
+      await user.type(screen.getByLabelText(/^password/i), 'short');
+      await user.type(screen.getByLabelText(/confirm password/i), 'short');
+      await user.click(screen.getByRole('button', { name: /complete setup/i }));
 
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
-      const submitButton = screen.getByRole('button', { name: /complete setup/i });
-
-      await user.type(passwordInput, 'short');
-      await user.type(confirmPasswordInput, 'short');
-      await user.click(submitButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Password must be at least 8 characters')).toBeInTheDocument();
-      });
-
+      expect(await screen.findByText(/password must be at least 8 characters/i)).toBeInTheDocument();
       expect(axios.post).not.toHaveBeenCalled();
     });
 
-    test('clears error when submitting again', async () => {
+    test('clears the inline error when the next submission succeeds', async () => {
       const user = userEvent.setup();
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
+      await fillTokenAndPasswords(user);
+      await user.type(screen.getByLabelText(/^password/i), 'short');
+      await user.type(screen.getByLabelText(/confirm password/i), 'short');
+      await user.click(screen.getByRole('button', { name: /complete setup/i }));
 
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
-      const submitButton = screen.getByRole('button', { name: /complete setup/i });
+      await screen.findByText(/password must be at least 8 characters/i);
 
-      // First submission with error
-      await user.type(passwordInput, 'short');
-      await user.type(confirmPasswordInput, 'short');
-      await user.click(submitButton);
+      await user.clear(screen.getByLabelText(/^password/i));
+      await user.clear(screen.getByLabelText(/confirm password/i));
+      await user.type(screen.getByLabelText(/^password/i), 'validpassword123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'validpassword123');
 
-      await waitFor(() => {
-        expect(screen.getByText('Password must be at least 8 characters')).toBeInTheDocument();
-      });
+      axios.post.mockResolvedValueOnce({ data: { token: 'session-token' } });
 
-      // Second submission with valid data
-      await user.clear(passwordInput);
-      await user.clear(confirmPasswordInput);
-      await user.type(passwordInput, 'validpassword123');
-      await user.type(confirmPasswordInput, 'validpassword123');
-
-      axios.post.mockResolvedValueOnce({
-        data: { token: 'test-token' }
-      });
-
-      await user.click(submitButton);
+      await user.click(screen.getByRole('button', { name: /complete setup/i }));
 
       await waitFor(() => {
-        expect(screen.queryByText('Password must be at least 8 characters')).not.toBeInTheDocument();
+        expect(screen.queryByText(/password must be at least 8 characters/i)).not.toBeInTheDocument();
       });
     });
   });
 
-  describe('Successful Setup', () => {
-    beforeEach(() => {
-      axios.get.mockResolvedValueOnce({
-        data: { isLocalhost: true }
-      });
-    });
-
-    test('handles successful setup and calls onSetupComplete', async () => {
+  describe('Successful setup', () => {
+    test('posts the token, username, and password and calls onSetupComplete', async () => {
       const user = userEvent.setup();
-      const mockToken = 'test-auth-token';
+      const sessionToken = 'returned-session-token';
 
-      axios.post.mockResolvedValueOnce({
-        data: { token: mockToken }
-      });
+      axios.post.mockResolvedValueOnce({ data: { token: sessionToken } });
 
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      await waitFor(() => {
-        expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
-      });
-
-      const usernameInput = screen.getByLabelText(/username/i);
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
-      const submitButton = screen.getByRole('button', { name: /complete setup/i });
-
-      await user.clear(usernameInput);
-      await user.type(usernameInput, 'testuser');
-      await user.type(passwordInput, 'testpassword123');
-      await user.type(confirmPasswordInput, 'testpassword123');
-      await user.click(submitButton);
+      await user.type(screen.getByLabelText(/setup token/i), '  my-setup-token  ');
+      await user.clear(screen.getByLabelText(/^username/i));
+      await user.type(screen.getByLabelText(/^username/i), 'newuser');
+      await user.type(screen.getByLabelText(/^password/i), 'password123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'password123');
+      await user.click(screen.getByRole('button', { name: /complete setup/i }));
 
       await waitFor(() => {
         expect(axios.post).toHaveBeenCalledWith('/setup/create-auth', {
-          username: 'testuser',
-          password: 'testpassword123'
+          token: 'my-setup-token',
+          username: 'newuser',
+          password: 'password123',
         });
       });
 
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('authToken', mockToken);
-      expect(mockOnSetupComplete).toHaveBeenCalledWith(mockToken);
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('authToken', sessionToken);
+      expect(mockOnSetupComplete).toHaveBeenCalledWith(sessionToken);
     });
 
-    test('shows loading state during setup', async () => {
+    test('shows the loading state while the request is in flight', async () => {
       const user = userEvent.setup();
-
-      // Create a promise we can control
-      let resolveSetup: any;
-      const setupPromise = new Promise((resolve) => {
-        resolveSetup = resolve;
-      });
-
+      let resolveSetup: (value: unknown) => void = () => {};
+      const setupPromise = new Promise((resolve) => { resolveSetup = resolve; });
       axios.post.mockReturnValueOnce(setupPromise);
 
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
+      await user.type(screen.getByLabelText(/setup token/i), 'token');
+      await user.type(screen.getByLabelText(/^password/i), 'password123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'password123');
+      await user.click(screen.getByRole('button', { name: /complete setup/i }));
 
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
-      const submitButton = screen.getByRole('button', { name: /complete setup/i });
-
-      await user.type(passwordInput, 'testpassword123');
-      await user.type(confirmPasswordInput, 'testpassword123');
-      await user.click(submitButton);
-
-      // Check loading state
       expect(screen.getByRole('button', { name: /setting up/i })).toBeDisabled();
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
 
-      // Resolve the setup
-      resolveSetup({ data: { token: 'test-token' } });
+      resolveSetup({ data: { token: 'tok' } });
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /complete setup/i })).not.toBeDisabled();
@@ -423,137 +249,72 @@ describe('InitialSetup Component', () => {
     });
   });
 
-  describe('Setup Failure', () => {
-    beforeEach(() => {
-      axios.get.mockResolvedValueOnce({
-        data: { isLocalhost: true }
-      });
-    });
-
-    test('displays server error message when setup fails', async () => {
+  describe('Setup failure', () => {
+    test('surfaces the server "Invalid setup token" error', async () => {
       const user = userEvent.setup();
-
-      axios.post.mockRejectedValueOnce({
-        response: {
-          data: { error: 'Database connection failed' }
-        }
-      });
+      const axiosError = { isAxiosError: true, response: { status: 401, data: { error: 'Invalid setup token' } } };
+      axios.isAxiosError.mockImplementation((err: unknown) => Boolean((err as typeof axiosError)?.isAxiosError));
+      axios.post.mockRejectedValueOnce(axiosError);
 
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
+      await user.type(screen.getByLabelText(/setup token/i), 'wrong-token');
+      await user.type(screen.getByLabelText(/^password/i), 'password123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'password123');
+      await user.click(screen.getByRole('button', { name: /complete setup/i }));
 
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
-      const submitButton = screen.getByRole('button', { name: /complete setup/i });
-
-      await user.type(passwordInput, 'testpassword123');
-      await user.type(confirmPasswordInput, 'testpassword123');
-      await user.click(submitButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Database connection failed')).toBeInTheDocument();
-      });
-
+      expect(await screen.findByText('Invalid setup token')).toBeInTheDocument();
       expect(mockOnSetupComplete).not.toHaveBeenCalled();
       expect(localStorageMock.setItem).not.toHaveBeenCalled();
     });
 
-    test('displays generic error message for unknown errors', async () => {
+    test('surfaces a generic "Setup failed" message for non-axios errors', async () => {
       const user = userEvent.setup();
-
       axios.post.mockRejectedValueOnce(new Error('Network error'));
 
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
+      await user.type(screen.getByLabelText(/setup token/i), 'token');
+      await user.type(screen.getByLabelText(/^password/i), 'password123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'password123');
+      await user.click(screen.getByRole('button', { name: /complete setup/i }));
 
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
-      const submitButton = screen.getByRole('button', { name: /complete setup/i });
-
-      await user.type(passwordInput, 'testpassword123');
-      await user.type(confirmPasswordInput, 'testpassword123');
-      await user.click(submitButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Setup failed')).toBeInTheDocument();
-      });
-
+      expect(await screen.findByText('Setup failed')).toBeInTheDocument();
       expect(mockOnSetupComplete).not.toHaveBeenCalled();
     });
 
-    test('re-enables button after failed setup', async () => {
+    test('re-enables the submit button after a failed attempt', async () => {
       const user = userEvent.setup();
-
-      axios.post.mockRejectedValueOnce({
-        response: {
-          data: { error: 'Setup error' }
-        }
-      });
+      const axiosError = { isAxiosError: true, response: { status: 500, data: { error: 'Server error' } } };
+      axios.isAxiosError.mockImplementation((err: unknown) => Boolean((err as typeof axiosError)?.isAxiosError));
+      axios.post.mockRejectedValueOnce(axiosError);
 
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      // Wait for form to render
-      await waitFor(() => {
-        expect(screen.getByText('Welcome to Youtarr Setup')).toBeInTheDocument();
-      });
+      await user.type(screen.getByLabelText(/setup token/i), 'token');
+      await user.type(screen.getByLabelText(/^password/i), 'password123');
+      await user.type(screen.getByLabelText(/confirm password/i), 'password123');
+      await user.click(screen.getByRole('button', { name: /complete setup/i }));
 
-      const passwordInput = screen.getByLabelText(/^Password/i);
-      const confirmPasswordInput = screen.getByLabelText(/confirm password/i);
-      const submitButton = screen.getByRole('button', { name: /complete setup/i });
+      await screen.findByText('Server error');
 
-      await user.type(passwordInput, 'testpassword123');
-      await user.type(confirmPasswordInput, 'testpassword123');
-      await user.click(submitButton);
-
-      await waitFor(() => {
-        expect(screen.getByText('Setup error')).toBeInTheDocument();
-      });
-
-      expect(submitButton).not.toBeDisabled();
-      expect(submitButton).toHaveTextContent('Complete Setup');
+      const button = screen.getByRole('button', { name: /complete setup/i });
+      expect(button).not.toBeDisabled();
+      expect(button).toHaveTextContent('Complete Setup');
     });
   });
 
-  describe('UI Elements', () => {
-    beforeEach(() => {
-      axios.get.mockResolvedValueOnce({
-        data: { isLocalhost: true }
-      });
-    });
-
-    test('displays helper text for username field', async () => {
+  describe('Helper UI text', () => {
+    test('displays the username helper text', () => {
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      await waitFor(() => {
-        expect(screen.getByText('Choose a username for login')).toBeInTheDocument();
-      });
+      expect(screen.getByText('Choose a username for login')).toBeInTheDocument();
     });
 
-    test('displays footer message about post-setup access', async () => {
+    test('displays the post-setup access footer', () => {
       render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
 
-      await waitFor(() => {
-        expect(screen.getByText(/after setup, you can access youtarr from anywhere/i)).toBeInTheDocument();
-      });
-    });
-
-    test('all input fields are marked as required', async () => {
-      render(<InitialSetup onSetupComplete={mockOnSetupComplete} />);
-
-      await waitFor(() => {
-        expect(screen.getByLabelText(/username/i)).toHaveAttribute('required');
-      });
-
-      expect(screen.getByLabelText(/^Password/i)).toHaveAttribute('required');
-      expect(screen.getByLabelText(/confirm password/i)).toHaveAttribute('required');
+      expect(screen.getByText(/after setup, you can access youtarr normally/i)).toBeInTheDocument();
     });
   });
 });

--- a/client/src/components/__tests__/LocalLogin.test.tsx
+++ b/client/src/components/__tests__/LocalLogin.test.tsx
@@ -110,6 +110,35 @@ describe('LocalLogin Component', () => {
     });
   });
 
+  test('shows password reset disclosure only after invalid credentials', async () => {
+    const user = userEvent.setup();
+
+    axios.post.mockRejectedValueOnce({
+      response: {
+        status: 401,
+        data: { error: 'Unauthorized' }
+      }
+    });
+
+    render(<LocalLogin setToken={mockSetToken} />);
+
+    expect(screen.queryByText(/forgot your password/i)).not.toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/username/i), 'wronguser');
+    await user.type(screen.getByLabelText(/password/i), 'wrongpass');
+    await user.click(screen.getByRole('button', { name: /login/i }));
+
+    const summary = await screen.findByText(/forgot your password/i);
+    expect(summary).toBeInTheDocument();
+
+    await user.click(summary);
+
+    expect(screen.getByText(/AUTH_PRESET_USERNAME/)).toBeInTheDocument();
+    expect(screen.getByText(/AUTH_PRESET_PASSWORD/)).toBeInTheDocument();
+    expect(screen.getByText(/passwordHash/)).toBeInTheDocument();
+    expect(screen.getByText(/one-time setup token/i)).toBeInTheDocument();
+  });
+
   test('displays rate limit error (429)', async () => {
     const user = userEvent.setup();
     

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,10 +17,10 @@ services:
       dockerfile: Dockerfile
     image: ${YOUTARR_IMAGE:-youtarr-dev:latest}
     container_name: youtarr-dev
-    # Expose backend on host port 3087 (container still listens on 3011).
+    # Expose backend on host port 3087 by default (container still listens on 3011).
     # The Vite dev server proxies to http://127.0.0.1:3087 by default.
     ports:
-      - "3087:3011"
+      - "${YOUTARR_HOST_PORT:-3087}:3011"
     volumes:
       - ${YOUTUBE_OUTPUT_DIR:-./downloads}:/usr/src/app/data
       - ./server/images:/app/server/images
@@ -44,6 +44,7 @@ services:
       - AUTH_ENABLED=${AUTH_ENABLED:-true}
       - AUTH_PRESET_USERNAME=${AUTH_PRESET_USERNAME:-}
       - AUTH_PRESET_PASSWORD=${AUTH_PRESET_PASSWORD:-}
+      - TRUST_PROXY=${TRUST_PROXY:-}
       # Platform-spoof env vars (used by ./scripts/start-dev.sh --as-elfhosted and full Elfhosted spoofs).
       # Empty when unset on the host, so non-Elfhosted dev runs are unaffected.
       - PLATFORM=${PLATFORM:-}

--- a/docker-compose.external-db.yml
+++ b/docker-compose.external-db.yml
@@ -42,6 +42,8 @@ services:
       # Optional: Seed initial admin credentials for headless deployments
       AUTH_PRESET_USERNAME: ${AUTH_PRESET_USERNAME:-}
       AUTH_PRESET_PASSWORD: ${AUTH_PRESET_PASSWORD:-}
+      # Optional: Configure Express proxy header trust
+      TRUST_PROXY: ${TRUST_PROXY:-}
       # Logging configuration
       LOG_LEVEL: ${LOG_LEVEL:-info}
       # This is just informational and lets the app know where the videos will be stored on the host
@@ -51,7 +53,7 @@ services:
       # DATA_PATH: /storage/rclone/storagebox/youtube
 
     ports:
-      - "3087:3011"
+      - "${YOUTARR_HOST_PORT:-3087}:3011"
     volumes:
       - ${YOUTUBE_OUTPUT_DIR}:/usr/src/app/data
       - ./server/images:/app/server/images

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,8 @@ services:
       # Optional: Seed initial admin credentials for headless deployments
       AUTH_PRESET_USERNAME: ${AUTH_PRESET_USERNAME:-}
       AUTH_PRESET_PASSWORD: ${AUTH_PRESET_PASSWORD:-}
+      # Optional: Configure Express proxy header trust
+      TRUST_PROXY: ${TRUST_PROXY:-}
       # Logging configuration
       LOG_LEVEL: ${LOG_LEVEL:-info}
       # This is just informational and lets the app know where the videos will be stored on the host
@@ -81,7 +83,7 @@ services:
       # DATA_PATH: /storage/rclone/storagebox/youtube
 
     ports:
-      - "3087:3011"
+      - "${YOUTARR_HOST_PORT:-3087}:3011"
     volumes:
       - ${YOUTUBE_OUTPUT_DIR}:/usr/src/app/data
       - ./server/images:/app/server/images

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -27,21 +27,31 @@ Youtarr implements a secure authentication system to protect your instance from 
 
 ## Initial Setup
 
-### Method 1: Web UI Setup (Localhost Only)
+### Method 1: Web UI Setup with One-Time Token
 
-On first launch, Youtarr requires authentication setup from `localhost` for security:
+On first launch, Youtarr generates a one-time setup token and surfaces it through two channels: your container logs and a file in your data volume. You can complete setup from localhost, your trusted LAN, a VPN, or an SSH tunnel.
 
-1. Access Youtarr from the same machine:
-   ```
-   http://localhost:3087
-   ```
+1. Retrieve the setup token. Either:
+   - **From container logs:** `docker logs youtarr` (look for the "Youtarr initial setup required" log entry; the token-bearing entry is emitted at `LOG_LEVEL=info`), or
+   - **From the data volume:** read `config/setup-token` on the host (mounted from the container's `/app/config/setup-token`). The file is written with mode `0600`, so if your container runs as a UID that does not match your host user (for example, the container runs as root or as `YOUTARR_UID=1000` while you log in as a different user), the read will fail with "Permission denied". Use `sudo cat /path/to/youtarr/config/setup-token`, or fall back to the container-logs path above.
 
-2. Complete the setup wizard:
+2. Open Youtarr in a browser, e.g. `http://localhost:3087` or `http://<your-LAN-IP>:3087`.
+
+3. Complete the setup wizard:
+   - Paste the setup token (64 hex characters)
    - Enter desired username (1-32 characters)
    - Enter password (8-64 characters)
    - Confirm password
 
-3. Credentials are saved to `config/config.json`
+4. The token is consumed on success. Credentials are saved to `config/config.json`.
+
+Knowledge of the token requires either Docker access (for the logs) or filesystem access to the data volume (for the file), both of which already imply admin status on the host. The token survives container restarts while setup is incomplete, so you have time to fetch it.
+
+If you wipe or recreate the `config/` volume, Youtarr loses the saved credentials and setup token state; run initial setup again on the next boot.
+
+Plain HTTP is intended for localhost and private LAN/VPN access only. Do not expose Youtarr setup or login directly to the internet over HTTP; put it behind HTTPS and normal network controls first.
+
+Treat startup logs as sensitive while setup is incomplete. If you ship container logs to Loki, Splunk, CloudWatch, or another external system, redact or drop the `setupToken` field/log entry until the one-time setup token has been consumed. When `LOG_LEVEL=warn`, Youtarr logs setup guidance without the token; use `config/setup-token` to retrieve the token in that mode.
 
 ### Method 2: Environment Variables (Headless/Automated)
 
@@ -248,11 +258,13 @@ DELETE FROM Sessions;
 3. Restart:
    `./start.sh` or `docker compose up -d`
 
-4. Access from localhost to set new credentials
+4. Open Youtarr and set new credentials with the one-time setup token from the container logs or `config/setup-token`
 
 ### Remote Access for Initial Setup
 
 #### SSH Port Forwarding
+
+> SSH port forwarding is no longer required for security reasons (the localhost gate has been removed). It remains useful as a way to retrieve the setup token over a secure channel if you don't want to enable HTTPS for your Youtarr instance yet.
 
 **From Windows:**
 ```bash
@@ -329,20 +341,30 @@ If OAuth fails, get token manually:
 
 ### Network Security
 
-1. **Use HTTPS with reverse proxy**:
+1. **Keep HTTP local**:
+   - Plain HTTP is acceptable for localhost, a private LAN, VPN, or SSH tunnel
+   - Do not port-forward Youtarr directly to the internet over HTTP
+
+2. **Use HTTPS with reverse proxy for external access**:
    - Nginx/Caddy/Traefik with SSL
    - Let's Encrypt certificates
 
-2. **Firewall rules**:
+3. **Firewall rules**:
    ```bash
    # Allow only local network
    iptables -A INPUT -p tcp --dport 3087 -s 192.168.0.0/16 -j ACCEPT
    iptables -A INPUT -p tcp --dport 3087 -j DROP
    ```
 
-3. **VPN Access**:
+4. **VPN Access**:
    - Use WireGuard/OpenVPN for remote access
    - Avoid exposing to internet directly
+
+5. **Proxy trust**:
+   - Youtarr keeps the historical `TRUST_PROXY=true` default for compatibility with existing reverse-proxy installs
+   - Youtarr's own rate-limit, session, and setup audit IPs use the direct peer IP until `TRUST_PROXY` is explicitly configured
+   - Set `TRUST_PROXY=false` when exposing the app directly without a reverse proxy
+   - Set `TRUST_PROXY` to a specific hop count or trusted subnet when your reverse proxy setup needs forwarded client IPs
 
 ### Authentication Hardening
 
@@ -356,14 +378,16 @@ If OAuth fails, get token manually:
 
 ## Troubleshooting
 
-### Cannot Access Initial Setup
+### Cannot Find the Setup Token
 
-**Problem**: "Initial setup can only be performed from localhost" error
+**Problem**: First-time setup wizard asks for a token and you don't know where to find it.
 
 **Solutions**:
-1. Use SSH port forwarding (see above)
-2. Use environment variables for headless setup
-3. Access from Docker host machine directly
+1. **Container logs:** `docker logs youtarr | grep -A5 "initial setup required"`. The token-bearing setup log entry is emitted at `LOG_LEVEL=info` on every startup until setup completes.
+2. **Data volume:** the token is also written to `config/setup-token` (mode 0600) in your data volume. From the host: `cat /path/to/youtarr/config/setup-token`. If you see "Permission denied", the container is running as a UID that does not match your host user; use `sudo cat ...` or retrieve the token from the container logs (option 1 above) instead.
+3. **Lost before setup is complete?** Stop Youtarr, delete `config/setup-token`, restart. A new token will be generated and logged.
+4. **Already completed setup and need to reset?** Stop Youtarr, remove `username` and `passwordHash` from `config/config.json`, restart, then complete setup again with the newly generated token.
+5. **Headless without log access?** Use the env-var path instead: set `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` in `.env` (see Method 2 above).
 
 ### Invalid Credentials Error
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -219,7 +219,8 @@ vim .env  # or nano, or your preferred editor
 
 **Optional settings:**
 - `TZ` - Your timezone (e.g., `America/New_York`, `Europe/London`). Defaults to `UTC`. Set this if scheduled downloads and nightly cleanup should run in your local time.
-- `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` - For headless setups where you cannot reach the initial-setup wizard via localhost.
+- `YOUTARR_HOST_PORT` - Host port for the web interface. Defaults to `3087`; change this if another service already uses that port.
+- `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` - Seed login credentials and skip the setup-token wizard for headless or automated deployments.
 - `YOUTARR_UID` / `YOUTARR_GID` - Run the container as a non-root user (recommended for security, see step 5 below).
 - **Changing bundled-database credentials?** If you want to customize the MariaDB password, set BOTH `DB_PASSWORD` **and** `DB_ROOT_PASSWORD` to the same value. Setting only one of them will cause the app to fail to connect because the app uses `DB_PASSWORD` while MariaDB's root account is initialized from `DB_ROOT_PASSWORD`. This only applies to the bundled database; external-DB users set `DB_PASSWORD` to match their existing database.
 - See [ENVIRONMENT_VARIABLES.md](ENVIRONMENT_VARIABLES.md) for the full reference.
@@ -517,7 +518,7 @@ See: [ENVIRONMENT_VARIABLES](ENVIRONMENT_VARIABLES.md) for more details
 
 ### Platform Deployment Configuration
 
-Youtarr supports platform-managed deployments (Elfhosted, Kubernetes, etc.) with three special environment variables:
+Youtarr supports platform-managed deployments (Elfhosted, Kubernetes, etc.) with four special environment variables:
 
 #### Environment Variables
 
@@ -525,18 +526,19 @@ Youtarr supports platform-managed deployments (Elfhosted, Kubernetes, etc.) with
 |----------|-------------|---------|
 | `DATA_PATH` | Video storage path inside container (only really needed for Elfhosted) | `/storage/rclone/storagebox/youtube` |
 | `AUTH_ENABLED` | Set to `false` to bypass internal authentication | `false` |
+| `TRUST_PROXY` | Controls whether Youtarr trusts proxy headers. Set `false` for direct exposure without a reverse proxy. | `false` |
 | `PLEX_URL` | Pre-configured Plex server URL, overrides plexIp and plexPort from config.json | `http://plex:32400` |
 
 ### Preset Credentials for Headless Deployments
 
-For platforms where you cannot access `http://localhost:3087` (Unraid, Kubernetes, etc.), you can seed the initial login without touching the UI by setting both environment variables below. These values will override and overwrite existing values in config.json
+For platforms where you cannot access `http://localhost:3087` (Unraid, Kubernetes, etc.), you can either use the one-time setup token from container logs or seed the initial login without touching the UI by setting both environment variables below. These values will override and overwrite existing values in config.json
 
 | Variable | Description |
 |----------|-------------|
 | `AUTH_PRESET_USERNAME` | Initial admin username. Trimmed and must be ≤ 32 characters. |
 | `AUTH_PRESET_PASSWORD` | Initial admin password (8–64 characters). Stored as a hash on first boot. |
 
-If only one variable is present, or the values fall outside the validation rules, the preset is ignored and the localhost-only setup wizard remains active.
+If only one variable is present, or the values fall outside the validation rules, the preset is ignored and the setup-token wizard remains active.
 
 #### What Happens in Platform Mode
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -4,6 +4,7 @@ This document provides a comprehensive reference for all environment variables s
 
 ## Table of Contents
 - [Required Variables](#required-variables)
+- [Application Access](#application-access)
 - [Database Configuration](#database-configuration)
 - [Authentication](#authentication)
 - [User and Permissions](#user-and-permissions)
@@ -26,6 +27,15 @@ This document provides a comprehensive reference for all environment variables s
 - This path must exist on your host system before starting the containers
 - Ensure the directory has appropriate write permissions for the configured UID/GID
 - For network storage, mount the storage before starting Youtarr
+
+## Application Access
+
+### YOUTARR_HOST_PORT
+**Required**: No
+**Default**: `3087`
+**Description**: Host port mapped to the Youtarr web interface. The container still listens on port `3011`.
+**Example**: `YOUTARR_HOST_PORT=8087`
+**Note**: The bundled start scripts use this value when polling `/setup/status` and printing first-time setup URLs.
 
 ## Database Configuration
 
@@ -102,9 +112,20 @@ To use an external database:
 
 **Important Notes**:
 - These override any existing credentials in config.json
-- If not set, credentials must be configured through the web UI on first access via `localhost`
-- Useful for deployment environments where you may not have access to `localhost`
-  via a browser as this removes the requirement to set your initial login credentials via the web UI.
+- If not set, credentials must be configured through the web UI using the one-time setup token from the logs or `config/setup-token`
+- Useful for deployment environments where you want to skip the browser setup wizard entirely.
+
+### TRUST_PROXY
+**Required**: No
+**Default**: `true` (backwards-compatible with existing reverse-proxy deployments)
+**Options**: `true`, `false`, a hop count such as `1`, or an Express trust-proxy value such as `loopback`
+**Description**: Controls whether Express trusts proxy headers such as `X-Forwarded-For`
+
+**Recommendations**:
+- Set `TRUST_PROXY=false` when Youtarr is exposed directly without a reverse proxy
+- Leave unset only if you want the historical Express proxy-header trust behavior; Youtarr's rate-limit, session, and setup audit IPs will still key on the direct peer IP until `TRUST_PROXY` is explicitly configured
+- Set `TRUST_PROXY=1` when Youtarr is behind one trusted reverse proxy and you want per-client rate limits
+- Prefer a specific hop count or trusted subnet over broad `true` when exposing Youtarr through a proxy you control
 
 ## User and Permissions
 
@@ -204,9 +225,11 @@ These variables are used by docker-compose.yml but not directly by the applicati
 ### Security
 1. **Always change default passwords** in production
 2. **Never disable AUTH_ENABLED** for internet-exposed instances
-3. **Use non-root UID/GID** (set YOUTARR_UID=1000)
+3. **Use HTTPS/VPN for remote access**; plain HTTP is intended for localhost and trusted LAN access only
+4. **Set TRUST_PROXY=false** when directly exposing Youtarr without a reverse proxy
+5. **Use non-root UID/GID** (set YOUTARR_UID=1000)
     - Existing Youtarr users that were previously using the default root GID/UID (0:0) will need to completely stop Youtarr and ensure that directory permissions are updated if they want to switch from root UID/GID to non-root
-4. **Secure your .env file** with appropriate permissions:
+6. **Secure your .env file** with appropriate permissions:
    ```bash
    chmod 600 .env
    ```

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -39,8 +39,7 @@ Choose your preferred installation method
    Open your browser and navigate to `http://localhost:3087`
 
 4. **Complete initial setup**:
-   - On first access from localhost, you'll be prompted to create an admin account
-     - **IMPORTANT**: This requires access via `localhost`
+   - On first access, you'll be prompted to create an admin account. Paste the setup token from `docker logs youtarr` or `config/setup-token` in your data volume.
    - Choose a strong password (minimum 8 characters required)
    - This account will be used for all future logins and can be changed in the web UI
 
@@ -70,8 +69,12 @@ If you prefer to use standard `docker compose up` commands:
    ```
 
    Optionally configure other settings:
-   - `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` - For headless deployments (e.g., Unraid)
+   - `YOUTARR_HOST_PORT=3087` - Change this if you need the web interface on a different host port
+   - For **headless deployments** (e.g., Unraid, NAS, remote VPS), you have two options:
+     - **One-time setup token:** open the web UI from localhost, your trusted LAN, VPN, or SSH tunnel and paste the token from `docker logs youtarr` or `config/setup-token`.
+     - **Pre-set credentials via env vars:** set `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` in your `.env` (see [Authentication](AUTHENTICATION.md)).
    - `AUTH_ENABLED=false` - Only if behind external authentication (VPN, reverse proxy)
+   - `TRUST_PROXY=false` - Recommended when exposing Youtarr directly without a reverse proxy. Leave unset for the current backwards-compatible default.
    - `LOG_LEVEL` - Set to `debug` for troubleshooting, `info` for normal/production use (default), `warn` for minimal logging
 
    See: [ENVIRONMENT VARIABLES](ENVIRONMENT_VARIABLES.md) for more details
@@ -88,9 +91,9 @@ If you prefer to use standard `docker compose up` commands:
    > If you already have data in `./database/`, use `./scripts/migrate-to-named-volume.sh` instead. See [Database Management](DATABASE.md#migrating-from-bind-mount-to-named-volume) and [Troubleshooting](TROUBLESHOOTING.md#docker-desktop--arm-incorrect-information-in-file-errors) for details.
 
 5. **Access the web interface**:
-   - Navigate to `http://localhost:3087`
+   - Navigate to `http://localhost:3087` (or your server's LAN IP)
    - If you set preset credentials in .env, use those to log in
-   - If not, you'll create your admin account on first access, which will require access via `localhost`
+   - If not, you'll be prompted to complete the setup wizard using the one-time token from `docker logs youtarr` or `config/setup-token`
    - Configure Plex and other settings from the Configuration page
 
 > **Important**: Ensure the path you assign to `YOUTUBE_OUTPUT_DIR` already exists on the host and is writable before starting the stack. Otherwise Docker will create it as root-owned and the container may not be able to write downloads.
@@ -110,7 +113,7 @@ Most users should use Method 1 or 2 above for the best experience and easiest up
 See [AUTHENTICATION.md](AUTHENTICATION.md)
 
 ### Important Notes:
-- Initial setup can **only** be performed from localhost for security reasons
+- Initial setup requires the one-time setup token from `docker logs youtarr` or `config/setup-token`; plain HTTP setup is intended for localhost, private LAN, VPN, or SSH tunnel access only
 - If you need to reset your admin password, see the [Troubleshooting Guide](TROUBLESHOOTING.md#reset-admin-password)
 
 ## Configuration
@@ -185,15 +188,15 @@ Youtarr fully supports platform-managed deployments with automatic configuration
 
 ## Network Access
 
-To access Youtarr from other devices on your network:
+To access Youtarr from other devices on your private network:
 
 1. Configure your firewall to allow port 3087
 2. Access using your server's IP address: `http://[server-ip]:3087`
 
-For external access, you'll need to:
-- Set up port forwarding on your router
-- Consider using a reverse proxy for security
-- Implement HTTPS for secure remote access
+For external access:
+- Do not expose Youtarr directly to the internet over plain HTTP
+- Use a reverse proxy with HTTPS, or use a VPN/SSH tunnel instead of port forwarding the app directly
+- Keep `AUTH_ENABLED=true` unless an upstream authentication layer protects every request
 
 ## Upgrading
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,38 +2,11 @@
 
 ## Login Issues
 
-### Cannot Access Initial Setup
+### Cannot Find the Setup Token
 
-**Problem**: Unable to access the initial setup page or getting "Initial setup can only be performed from localhost" error.
+**Problem**: First-time setup wizard asks for a token and you don't know where to find it.
 
-**Solution**:
-- Initial setup must be done from the same machine running Youtarr unless you seed credentials via environment variables
-- For headless/remote setups, run `./start.sh --headless-auth` which will prompt for credentials and save them to your `.env` file
-- Alternatively, manually add `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` to your `.env` file before first startup
-- If you prefer to use the UI wizard, access the setup using `http://localhost:3087` (not the machine's IP address)
-- When running in Docker, make sure you browse from the host machine or forward the port securely as described below
-
-#### Accessing from a Headless/Remote Server
-
-If you're running Youtarr on a headless server (no GUI) or remote machine, you can use SSH port forwarding to access the initial setup:
-
-**From Windows:**
-```bash
-# Open an elevated Command Prompt or PowerShell
-ssh -L 3087:localhost:3087 username@<server-ip-address>
-# Then open http://localhost:3087 in your browser
-```
-
-**From Linux/Mac:**
-```bash
-# In terminal
-ssh -L 3087:localhost:3087 username@<server-ip-address>
-# Then open http://localhost:3087 in your browser
-```
-
-This creates a secure tunnel between your local machine's port 3087 and the server's port 3087, allowing you to complete the initial setup as if you were on localhost. After completing the setup, you can access Youtarr normally using the server's IP address.
-
-> Tip: If you cannot use SSH port forwarding, provide `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` in your container environment (or via `./start.sh`) before the first boot. Youtarr will hash the password and skip the localhost-only wizard.
+See [Authentication - Cannot Find the Setup Token](AUTHENTICATION.md#cannot-find-the-setup-token) for the full list of solutions.
 
 ### Forgotten Admin Password {#reset-admin-password}
 
@@ -73,9 +46,7 @@ This creates a secure tunnel between your local machine's port 3087 and the serv
    ./start.sh
    ```
 
-4. Access `http://localhost:3087` to create new credentials via the UI setup wizard
-   - **Important**: This must be done from localhost (or via SSH port forwarding as described above)
-   - You will be prompted to create a new admin account on first access
+4. Open Youtarr in any browser. You will be prompted to create a new admin account using the one-time setup token from `docker logs youtarr` or `config/setup-token`.
 
 ### Session Expired
 

--- a/docs/development/ELFHOSTED.md
+++ b/docs/development/ELFHOSTED.md
@@ -44,7 +44,7 @@ When `PLATFORM=elfhosted`:
 
 Independent of `PLATFORM`. When `AUTH_ENABLED=false`:
 
-- `/setup/status` returns `{ requiresSetup: false, isLocalhost: true, platformManaged: true, message: 'Authentication is managed by the platform' }` (`server/routes/setup.js:42-49`).
+- `/setup/status` returns `{ requiresSetup: false, platformManaged: true, message: 'Authentication is managed by the platform' }` (`server/routes/setup.js`).
 - The frontend auto-logs in with the synthetic token `'platform-managed-auth'` and skips the login screen (`client/src/App.tsx:342-345`).
 - All API endpoints accept requests without a token. The bypass is implemented in two places: `verifyToken` short-circuits when `AUTH_ENABLED === 'false'` (`server/server.js:320`), and the local-login route does the same (`server/routes/auth.js:95`).
 - Login and logout buttons are hidden in the UI; `isPlatformManaged.authEnabled` is `false` in `/getconfig` (`server/routes/config.js:67`). The frontend logout button gates on the App-level `isPlatformManaged` boolean (`client/src/components/layout/NavHeaderActions.tsx:154`), and the Youtarr-version-update tooltip is suppressed by the same flag (`NavHeaderActions.tsx:42`).

--- a/docs/platforms/external-db.md
+++ b/docs/platforms/external-db.md
@@ -49,7 +49,7 @@ If your platform limits wildcard access, replace `'%'` with the container's IP o
    ./start-with-external-db.sh
    ```
    - Add `--no-auth` if you are fronting Youtarr with your own authentication layer
-   - Provide `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` (either via .env or via your platform's UI) when you need to bypass the localhost-only setup wizard
+   - Provide `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` (either via .env or via your platform's UI) when you need to bypass the setup-token wizard
 
 To revert to the bundled database, simply run `./start.sh` without the flag.
 

--- a/docs/platforms/synology.md
+++ b/docs/platforms/synology.md
@@ -309,7 +309,7 @@ Edit the file to configure your settings. At minimum, set the `YOUTUBE_OUTPUT_DI
 YOUTUBE_OUTPUT_DIR=/volume1/media/youtube
 
 # Optional: Set initial admin credentials
-# Recommended for headless setup since you must otherwise set your initial login credentials via localhost
+# Use this when you want to skip the setup-token wizard
 AUTH_PRESET_USERNAME=admin
 AUTH_PRESET_PASSWORD=YourSecurePassword123
 
@@ -384,7 +384,7 @@ http://your-nas-ip:3087
 
 **First-time setup**:
 - If you set `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` in `.env`, log in with those credentials
-- If you didn't set credentials, you'll be prompted to create an admin account (only accessible from localhost - requires SSH port forwarding)
+- If you didn't set credentials, you'll be prompted to create an admin account with the one-time token from `docker compose logs youtarr` or `config/setup-token`
 
 **After logging in**:
 1. Navigate to **Configuration** page
@@ -641,11 +641,22 @@ docker ps
 
 ### Cannot Login - Setup Wizard Required
 
-**Symptom**: Browser shows "Initial setup required" but you can't access from remote IP.
+**Symptom**: Browser shows "Initial setup required" and asks for a setup token.
 
-**Cause**: Initial setup must be completed from localhost for security.
+**Cause**: Initial credentials have not been configured yet.
 
-**Solution A: Set preset credentials** (recommended):
+**Solution A: Use the setup token**:
+```bash
+cd /volume1/docker/Youtarr
+docker compose logs youtarr | grep -A5 "initial setup required"
+
+# Or read the token file directly:
+cat config/setup-token
+```
+
+Paste the token into the setup wizard and create your admin account.
+
+**Solution B: Set preset credentials**:
 ```bash
 # Edit .env file
 vi /volume1/docker/Youtarr/.env
@@ -660,15 +671,6 @@ docker compose up -d
 ```
 
 > **Tip**: If you prefer `nano` and have installed it, replace `vi` with `nano` in the command above. In `vi`, press `Esc`, type `:wq`, then press `Enter` to save and exit.
-
-**Solution B: SSH port forwarding**:
-```bash
-# From your local computer, create SSH tunnel:
-ssh -L 3087:localhost:3087 yourusername@your-nas-ip
-
-# Then access http://localhost:3087 on your computer
-# Complete setup wizard
-```
 
 ### Database Connection Errors
 

--- a/docs/platforms/unraid.md
+++ b/docs/platforms/unraid.md
@@ -54,7 +54,7 @@ curl -L https://raw.githubusercontent.com/DialmasterOrg/unraid-templates/main/Yo
   - **IMPORTANT**: `AUTH_PRESET_USERNAME` and `AUTH_PRESET_PASSWORD` must meet these rules or they’ll be ignored:
     - `AUTH_PRESET_USERNAME`: 1-32 characters in length
     - `AUTH_PRESET_PASSWORD`: 8-64 characters in length
-  Leaving them blank requires completing the setup wizard from the Unraid host's localhost (e.g., via SSH port forwarding), which most headless installs won't have handy.
+  Leaving them blank uses the setup-token wizard; retrieve the token from the container logs or the mapped `config/setup-token` file.
 6. Click the "Apply" button to start Youtarr
 
 Once the container is running, open http://<your-unraid-ip>:3087 in your browser to access Youtarr.

--- a/scripts/_create-env.sh
+++ b/scripts/_create-env.sh
@@ -419,9 +419,8 @@ if [ "$AUTH_ENABLED" = true ]; then
       yt_info "Username and password are now managed via .env and cannot be changed via the web UI in headless auth mode."
   else
     if [ "$EXISTING_CONFIG" = false ]; then
-      yt_info "Authentication is enabled. You'll be prompted to create credentials on first web login (localhost required)."
-      yt_info "Your authentication settings will be saved in config/config.json after first login and can be changed via the web UI."
-      yt_detail "For headless setups, set AUTH_PRESET_USERNAME and AUTH_PRESET_PASSWORD manually in .env."
+      yt_info "Authentication is enabled. First-time setup instructions will be shown after services start."
+      yt_detail "For fully headless deployments, set AUTH_PRESET_USERNAME and AUTH_PRESET_PASSWORD in .env to skip the wizard."
     else
       yt_info "Authentication is enabled. Existing config.json will retain existing login credentials."
       yt_detail "If you wish to change credentials, you can do so via the web UI after logging in."

--- a/scripts/_shared_start_tasks.sh
+++ b/scripts/_shared_start_tasks.sh
@@ -8,6 +8,179 @@ source "$SHARED_SCRIPT_DIR/_console_output.sh"
 # shellcheck source=scripts/_env_helpers.sh
 source "$SHARED_SCRIPT_DIR/_env_helpers.sh"
 
+SETUP_TOKEN_PATTERN='[0-9a-f]{64}'
+
+get_youtarr_host_port() {
+  local host_port="${YOUTARR_HOST_PORT:-}"
+
+  if [ -z "$host_port" ]; then
+    host_port=$(youtarr_get_env_file_value "./.env" "YOUTARR_HOST_PORT" "3087")
+  fi
+
+  printf '%s' "${host_port:-3087}"
+}
+
+extract_setup_token_from_text() {
+  local text="$1"
+
+  printf '%s' "$text" \
+    | grep -Eo "setupToken['\"]?[[:space:]]*[:=][[:space:]]*['\"]?$SETUP_TOKEN_PATTERN['\"]?" \
+    | head -n 1 \
+    | grep -Eo "$SETUP_TOKEN_PATTERN" \
+    | head -n 1
+}
+
+read_setup_token_from_file() {
+  local token_file="./config/setup-token"
+  local token
+
+  if [ ! -r "$token_file" ]; then
+    return 1
+  fi
+
+  token=$(tr -d '[:space:]' < "$token_file" 2>/dev/null || true)
+  if printf '%s' "$token" | grep -Eq "^$SETUP_TOKEN_PATTERN$"; then
+    printf '%s' "$token"
+    return 0
+  fi
+
+  return 1
+}
+
+read_setup_token_from_logs() {
+  local provided_logs="${1:-}"
+  local logs token
+
+  if [ -n "$provided_logs" ]; then
+    token=$(extract_setup_token_from_text "$provided_logs")
+    if [ -n "$token" ]; then
+      printf '%s' "$token"
+      return 0
+    fi
+  fi
+
+  # shellcheck disable=SC2086 # COMPOSE_CMD and COMPOSE_FILES intentionally word-split.
+  logs=$($COMPOSE_CMD $COMPOSE_FILES logs --tail 300 --no-log-prefix youtarr 2>/dev/null || true)
+  token=$(extract_setup_token_from_text "$logs")
+  if [ -n "$token" ]; then
+    printf '%s' "$token"
+    return 0
+  fi
+
+  return 1
+}
+
+read_initial_setup_token() {
+  local provided_logs="${1:-}"
+
+  read_setup_token_from_file && return 0
+  read_setup_token_from_logs "$provided_logs" && return 0
+
+  return 1
+}
+
+print_initial_setup_guidance() {
+  local provided_logs="${1:-}"
+  local setup_token host_port
+  host_port=$(get_youtarr_host_port)
+
+  yt_section "Initial Setup Required"
+  yt_info "Authentication is not yet configured. Complete first-time setup with the one-time token."
+
+  if setup_token=$(read_initial_setup_token "$provided_logs"); then
+    yt_info "Setup token:"
+    yt_detail "$setup_token"
+    yt_warn "Treat this token as sensitive. It is single-use and will be removed after setup."
+  else
+    yt_info "Retrieve the token with:"
+    yt_detail "$COMPOSE_CMD $COMPOSE_FILES logs youtarr | grep -A5 'initial setup required'"
+    yt_detail "Or read config/setup-token in your Youtarr data volume."
+  fi
+
+  yt_info "Open the setup page in any browser and paste the token:"
+  yt_detail "http://localhost:${host_port}/setup     (or http://<your-LAN-IP>:${host_port}/setup)"
+  yt_detail "The token is also written to config/setup-token in your Youtarr data volume."
+  yt_warn "Only use plain HTTP setup on localhost, your trusted LAN, VPN, or SSH tunnel."
+}
+
+has_valid_auth_preset() {
+  local username="$1"
+  local password="$2"
+  local trimmed_username
+
+  trimmed_username=$(printf '%s' "$username" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+
+  [ -n "$trimmed_username" ] &&
+    [ "${#trimmed_username}" -le 32 ] &&
+    [ -n "$password" ] &&
+    [ "${#password}" -ge 8 ] &&
+    [ "${#password}" -le 64 ]
+}
+
+print_setup_guidance_if_needed() {
+  local env_file="./.env"
+
+  local auth_enabled auth_preset_username auth_preset_password
+  auth_enabled=$(youtarr_get_env_file_value "$env_file" "AUTH_ENABLED" "true")
+  auth_preset_username=$(youtarr_get_env_file_value "$env_file" "AUTH_PRESET_USERNAME" "")
+  auth_preset_password=$(youtarr_get_env_file_value "$env_file" "AUTH_PRESET_PASSWORD" "")
+
+  # Platform-managed auth: setup wizard is bypassed.
+  if [ "$auth_enabled" = "false" ]; then
+    return 0
+  fi
+
+  # Headless preset will bootstrap creds on container start; no wizard needed.
+  if has_valid_auth_preset "$auth_preset_username" "$auth_preset_password"; then
+    return 0
+  fi
+
+  # Prefer the app's setup-status endpoint once it is reachable. This avoids
+  # racing the startup logs on first boot, where MariaDB/app initialization can
+  # take longer than the shell helper's polling window.
+  local i logs setup_status setup_token host_port
+  host_port=$(get_youtarr_host_port)
+  for i in $(seq 1 60); do
+    if command -v curl >/dev/null 2>&1; then
+      setup_status=$(curl --silent --max-time 1 "http://localhost:${host_port}/setup/status" 2>/dev/null || true)
+      if printf '%s' "$setup_status" | grep -q '"requiresSetup"[[:space:]]*:[[:space:]]*true'; then
+        print_initial_setup_guidance
+        return 0
+      fi
+      if printf '%s' "$setup_status" | grep -q '"requiresSetup"[[:space:]]*:[[:space:]]*false'; then
+        return 0
+      fi
+    fi
+
+    # Fall back to logs for systems without curl or while the HTTP endpoint is
+    # still coming up. Include COMPOSE_FILES so dev/external-db starts inspect
+    # the same stack that was just launched.
+    # shellcheck disable=SC2086 # COMPOSE_CMD and COMPOSE_FILES intentionally word-split.
+    logs=$($COMPOSE_CMD $COMPOSE_FILES logs --tail 300 --no-log-prefix youtarr 2>/dev/null)
+    if printf '%s' "$logs" | grep -q 'initial setup required'; then
+      print_initial_setup_guidance "$logs"
+      return 0
+    fi
+    if ! command -v curl >/dev/null 2>&1 && printf '%s' "$logs" | grep -q 'Server started and listening'; then
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  yt_section "Startup Next Steps"
+  yt_info "Youtarr is still starting or the setup-status endpoint is not reachable yet."
+  yt_info "Open http://localhost:${host_port} after the container finishes starting."
+  yt_detail "If this is a first-time install, the setup page will ask for the one-time token."
+  if setup_token=$(read_initial_setup_token "$logs"); then
+    yt_info "Setup token:"
+    yt_detail "$setup_token"
+    yt_warn "Treat this token as sensitive. It is single-use and will be removed after setup."
+  else
+    yt_detail "Token command: $COMPOSE_CMD $COMPOSE_FILES logs youtarr | grep -A5 'initial setup required'"
+  fi
+  return 0
+}
+
 print_usage() {
   cat <<EOF
 Usage: $START_SCRIPT_NAME [--no-auth] [--debug] [--headless-auth] [--pull-latest] [--dev]

--- a/scripts/_start_template.sh
+++ b/scripts/_start_template.sh
@@ -53,3 +53,5 @@ yt_section "Environment"
 yt_info "Youtarr services are starting."
 yt_detail "Follow logs : $COMPOSE_CMD logs -f"
 yt_detail "Stop stack  : $COMPOSE_CMD down"
+
+print_setup_guidance_if_needed

--- a/server/__tests__/server.additional-routes.test.js
+++ b/server/__tests__/server.additional-routes.test.js
@@ -319,6 +319,21 @@ const createServerModule = ({
         jest.doMock('child_process', () => childProcessMock);
         jest.doMock('pino-http', () => pinoHttpMock);
 
+        const setupTokenModuleMock = {
+          setTokenPath: jest.fn(),
+          reset: jest.fn(),
+          getToken: jest.fn(() => 'mock-token-value'),
+          ensureToken: jest.fn(),
+          verify: jest.fn((provided) => provided === 'mock-token-value'),
+          consume: jest.fn(),
+          claimForSetup: jest.fn((provided) => provided === 'mock-token-value'),
+          releaseSetupClaim: jest.fn(),
+          clearStaleFile: jest.fn(),
+          logBanner: jest.fn()
+        };
+
+        jest.doMock('../modules/setupTokenModule', () => setupTokenModuleMock);
+
         const serverModule = require('../server');
 
         state.app = serverModule.app;
@@ -332,6 +347,7 @@ const createServerModule = ({
         state.videosModuleMock = videosModuleMock;
         state.httpsMock = httpsMock;
         state.bcryptMock = bcryptMock;
+        state.setupTokenModuleMock = setupTokenModuleMock;
         state.sessionUpdateMock = effectiveSession?.update || defaultSessionUpdate;
 
         const finalize = () => resolve(state);

--- a/server/__tests__/server.apikeys.test.js
+++ b/server/__tests__/server.apikeys.test.js
@@ -336,6 +336,21 @@ const createServerModule = ({
           jest.doMock('../modules/apiKeyModule', () => apiKeyModuleMock);
         }
 
+        const setupTokenModuleMock = {
+          setTokenPath: jest.fn(),
+          reset: jest.fn(),
+          getToken: jest.fn(() => 'mock-token-value'),
+          ensureToken: jest.fn(),
+          verify: jest.fn((provided) => provided === 'mock-token-value'),
+          consume: jest.fn(),
+          claimForSetup: jest.fn((provided) => provided === 'mock-token-value'),
+          releaseSetupClaim: jest.fn(),
+          clearStaleFile: jest.fn(),
+          logBanner: jest.fn()
+        };
+
+        jest.doMock('../modules/setupTokenModule', () => setupTokenModuleMock);
+
         const serverModule = require('../server');
 
         state.app = serverModule.app;
@@ -343,6 +358,7 @@ const createServerModule = ({
         state.dbMock = dbMock;
         state.configModuleMock = configModuleMock;
         state.apiKeyModuleMock = apiKeyModuleMock;
+        state.setupTokenModuleMock = setupTokenModuleMock;
         state.sessionUpdateMock = effectiveSession?.update || defaultSessionUpdate;
 
         const finalize = () => resolve(state);

--- a/server/__tests__/server.auth-sessions.test.js
+++ b/server/__tests__/server.auth-sessions.test.js
@@ -263,8 +263,22 @@ const createServerModule = ({
         jest.doMock('express-rate-limit', () => jest.fn(() => (req, res, next) => next()));
         jest.doMock('https', () => ({ get: jest.fn() }));
 
+        const setupTokenModuleMock = {
+          setTokenPath: jest.fn(),
+          reset: jest.fn(),
+          getToken: jest.fn(() => 'mock-token-value'),
+          ensureToken: jest.fn(),
+          verify: jest.fn((provided) => provided === 'mock-token-value'),
+          consume: jest.fn(),
+          claimForSetup: jest.fn((provided) => provided === 'mock-token-value'),
+          releaseSetupClaim: jest.fn(),
+          clearStaleFile: jest.fn(),
+          logBanner: jest.fn()
+        };
+
         jest.doMock('../db', () => dbMock);
         jest.doMock('../modules/configModule', () => configModuleMock);
+        jest.doMock('../modules/setupTokenModule', () => setupTokenModuleMock);
         jest.doMock('bcrypt', () => bcryptMock);
         jest.doMock('uuid', () => uuidMock);
         jest.doMock('fs', () => fsMock);
@@ -276,6 +290,7 @@ const createServerModule = ({
         state.serverModule = serverModule;
         state.dbMock = dbMock;
         state.configModuleMock = configModuleMock;
+        state.setupTokenModuleMock = setupTokenModuleMock;
         state.bcryptMock = bcryptMock;
         state.uuidMock = uuidMock;
         state.fsMock = fsMock;
@@ -300,6 +315,7 @@ afterEach(() => {
   delete process.env.AUTH_ENABLED;
   delete process.env.AUTH_PRESET_USERNAME;
   delete process.env.AUTH_PRESET_PASSWORD;
+  delete process.env.TRUST_PROXY;
 });
 
 describe('auth preset bootstrap', () => {
@@ -662,80 +678,77 @@ describe('server routes - session management', () => {
 
 describe('server routes - setup', () => {
   describe('GET /setup/status', () => {
-    test('returns setup required when not configured', async () => {
+    test('returns requiresSetup=true with no isLocalhost field when unconfigured', async () => {
       const { app } = await createServerModule({ passwordHash: null });
-
       const handlers = findRouteHandlers(app, 'get', '/setup/status');
-      const statusHandler = handlers[handlers.length - 1];
+      const handler = handlers[handlers.length - 1];
 
-      const req = createMockRequest({
-        ip: '127.0.0.1'
-      });
+      const req = createMockRequest({});
       const res = createMockResponse();
 
-      await statusHandler(req, res);
+      await handler(req, res);
 
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
         requiresSetup: true,
-        isLocalhost: true,
+        platformManaged: false,
         message: null
       });
+      expect(res.body).not.toHaveProperty('isLocalhost');
     });
 
-    test('returns setup not required when configured', async () => {
+    test('returns requiresSetup=false when configured', async () => {
       const { app } = await createServerModule();
-
       const handlers = findRouteHandlers(app, 'get', '/setup/status');
-      const statusHandler = handlers[handlers.length - 1];
+      const handler = handlers[handlers.length - 1];
 
       const req = createMockRequest({});
       const res = createMockResponse();
 
-      await statusHandler(req, res);
+      await handler(req, res);
 
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
         requiresSetup: false,
-        isLocalhost: true,
+        platformManaged: false,
         message: null
       });
     });
 
-    test('detects non-localhost access', async () => {
-      const { app } = await createServerModule({ passwordHash: null });
-
-      const handlers = findRouteHandlers(app, 'get', '/setup/status');
-      const statusHandler = handlers[handlers.length - 1];
-
-      const req = createMockRequest({
-        ip: '192.168.1.100'
+    test('returns requiresSetup=true when username is missing even if passwordHash exists', async () => {
+      const { app } = await createServerModule({
+        passwordHash: 'existing-hash',
+        configOverrides: { username: null }
       });
-      const res = createMockResponse();
-
-      await statusHandler(req, res);
-
-      expect(res.statusCode).toBe(200);
-      expect(res.body.requiresSetup).toBe(true);
-      // isLocalhost will be falsy but may be undefined depending on the isLocalhostIP implementation
-      expect(res.body.message).toBe('Setup must be performed from localhost');
-    });
-
-    test('handles platform managed auth', async () => {
-      const { app } = await createServerModule({ authEnabled: 'false' });
-
       const handlers = findRouteHandlers(app, 'get', '/setup/status');
-      const statusHandler = handlers[handlers.length - 1];
+      const handler = handlers[handlers.length - 1];
 
       const req = createMockRequest({});
       const res = createMockResponse();
 
-      await statusHandler(req, res);
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({
+        requiresSetup: true,
+        platformManaged: false,
+        message: null
+      });
+    });
+
+    test('returns platformManaged=true when AUTH_ENABLED=false', async () => {
+      const { app } = await createServerModule({ authEnabled: 'false' });
+      const handlers = findRouteHandlers(app, 'get', '/setup/status');
+      const handler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({});
+      const res = createMockResponse();
+
+      await handler(req, res);
 
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
         requiresSetup: false,
-        isLocalhost: true,
         platformManaged: true,
         message: 'Authentication is managed by the platform'
       });
@@ -743,174 +756,293 @@ describe('server routes - setup', () => {
   });
 
   describe('POST /setup/create-auth', () => {
-    test('creates initial authentication successfully', async () => {
-      const { app, bcryptMock, dbMock, configModuleMock } = await createServerModule({
-        passwordHash: null
-      });
-
+    test('rejects request with no token', async () => {
+      const { app } = await createServerModule({ passwordHash: null });
       const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
-      const createAuthHandler = handlers[handlers.length - 1];
+      const handler = handlers[handlers.length - 1];
 
       const req = createMockRequest({
-        body: {
-          username: 'newuser',
-          password: 'password123'
-        },
-        ip: '127.0.0.1',
-        headers: {
-          'user-agent': 'Mozilla/5.0'
-        }
+        body: { username: 'admin', password: 'password123' }
       });
       const res = createMockResponse();
 
-      await createAuthHandler(req, res);
+      await handler(req, res);
 
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toEqual({ error: 'Invalid setup token' });
+    });
+
+    test('rejects request with wrong token', async () => {
+      const { app, setupTokenModuleMock } = await createServerModule({ passwordHash: null });
+      setupTokenModuleMock.verify.mockReturnValueOnce(false);
+
+      const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
+      const handler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({
+        body: { token: 'wrong', username: 'admin', password: 'password123' }
+      });
+      const res = createMockResponse();
+
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toEqual({ error: 'Invalid setup token' });
+    });
+
+    test('accepts correct token, creates user, consumes token', async () => {
+      const { app, bcryptMock, configModuleMock, dbMock, setupTokenModuleMock } =
+        await createServerModule({ passwordHash: null });
+
+      const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
+      const handler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({
+        body: { token: 'mock-token-value', username: 'newuser', password: 'password123' },
+        headers: { 'user-agent': 'Mozilla/5.0' }
+      });
+      const res = createMockResponse();
+
+      await handler(req, res);
+
+      expect(setupTokenModuleMock.verify).toHaveBeenCalledWith('mock-token-value');
       expect(bcryptMock.hash).toHaveBeenCalledWith('password123', 10);
       expect(configModuleMock.updateConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          username: 'newuser',
-          passwordHash: 'new-hashed-password'
-        })
+        expect.objectContaining({ username: 'newuser', passwordHash: 'new-hashed-password' })
       );
       expect(dbMock.Session.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          session_token: 'test-uuid-token',
-          username: 'newuser'
-        })
+        expect.objectContaining({ username: 'newuser' })
+      );
+      expect(setupTokenModuleMock.claimForSetup).toHaveBeenCalledWith('mock-token-value');
+      expect(setupTokenModuleMock.consume).toHaveBeenCalledTimes(1);
+      expect(dbMock.Session.create.mock.invocationCallOrder[0]).toBeLessThan(
+        setupTokenModuleMock.consume.mock.invocationCallOrder[0]
       );
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({
         token: 'test-uuid-token',
-        message: 'Setup complete! You can now access Youtarr from anywhere.',
+        message: 'Setup complete! You can now access Youtarr normally.',
         username: 'newuser'
       });
     });
 
-    test('blocks setup from non-localhost', async () => {
-      const { app } = await createServerModule({ passwordHash: null });
+    test('reports partial setup success when session creation fails after credentials are saved', async () => {
+      const { app, dbMock, setupTokenModuleMock } = await createServerModule({ passwordHash: null });
+      dbMock.Session.create.mockRejectedValueOnce(new Error('database unavailable'));
 
       const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
-      const createAuthHandler = handlers[handlers.length - 1];
+      const handler = handlers[handlers.length - 1];
 
       const req = createMockRequest({
-        body: {
-          username: 'newuser',
-          password: 'password123'
-        },
-        ip: '192.168.1.100'
+        body: { token: 'mock-token-value', username: 'newuser', password: 'password123' },
+        headers: { 'user-agent': 'Mozilla/5.0' }
       });
       const res = createMockResponse();
 
-      await createAuthHandler(req, res);
+      await handler(req, res);
 
-      expect(res.statusCode).toBe(403);
-      expect(res.body.error).toContain('Initial setup can only be performed from localhost');
+      expect(setupTokenModuleMock.claimForSetup).toHaveBeenCalledWith('mock-token-value');
+      expect(setupTokenModuleMock.consume).toHaveBeenCalledTimes(1);
+      expect(setupTokenModuleMock.releaseSetupClaim).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(500);
+      expect(res.body).toEqual({
+        error: 'Setup saved your credentials but the session could not be created. Please log in with the credentials you just entered.'
+      });
     });
 
-    test('prevents setup when already configured', async () => {
-      const { app } = await createServerModule();
+    test('rolls back in-memory auth fields when config persistence fails', async () => {
+      const { app, configModuleMock, setupTokenModuleMock } = await createServerModule({ passwordHash: null });
+      configModuleMock.updateConfig.mockImplementationOnce(() => {
+        throw new Error('disk full');
+      });
 
       const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
-      const createAuthHandler = handlers[handlers.length - 1];
+      const handler = handlers[handlers.length - 1];
+
+      const firstReq = createMockRequest({
+        body: { token: 'mock-token-value', username: 'newuser', password: 'password123' },
+        headers: { 'user-agent': 'Mozilla/5.0' }
+      });
+      const firstRes = createMockResponse();
+
+      await handler(firstReq, firstRes);
+
+      expect(firstRes.statusCode).toBe(500);
+      expect(firstRes.body).toEqual({ error: 'Setup failed' });
+      expect(configModuleMock.getConfig()).toEqual(
+        expect.objectContaining({ username: null, passwordHash: null })
+      );
+      expect(setupTokenModuleMock.releaseSetupClaim).toHaveBeenCalledTimes(1);
+      expect(setupTokenModuleMock.consume).not.toHaveBeenCalled();
+
+      const secondReq = createMockRequest({
+        body: { token: 'mock-token-value', username: 'newuser', password: 'password123' },
+        headers: { 'user-agent': 'Mozilla/5.0' }
+      });
+      const secondRes = createMockResponse();
+
+      await handler(secondReq, secondRes);
+
+      expect(secondRes.statusCode).toBe(200);
+      expect(configModuleMock.updateConfig).toHaveBeenCalledTimes(2);
+    });
+
+    test('rejects concurrent submit with valid token when setup is already in progress', async () => {
+      const { app, setupTokenModuleMock } = await createServerModule({ passwordHash: null });
+      setupTokenModuleMock.claimForSetup.mockReturnValueOnce(false);
+
+      const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
+      const handler = handlers[handlers.length - 1];
 
       const req = createMockRequest({
-        body: {
-          username: 'newuser',
-          password: 'password123'
-        },
-        ip: '127.0.0.1'
+        body: { token: 'mock-token-value', username: 'newuser', password: 'password123' },
+        headers: { 'user-agent': 'Mozilla/5.0' }
       });
       const res = createMockResponse();
 
-      await createAuthHandler(req, res);
+      await handler(req, res);
+
+      expect(setupTokenModuleMock.verify).toHaveBeenCalledWith('mock-token-value');
+      expect(setupTokenModuleMock.claimForSetup).toHaveBeenCalledWith('mock-token-value');
+      expect(setupTokenModuleMock.consume).not.toHaveBeenCalled();
+      expect(setupTokenModuleMock.releaseSetupClaim).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toEqual({ error: 'Invalid setup token' });
+    });
+
+    test('rejects when already configured', async () => {
+      const { app } = await createServerModule();
+      const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
+      const handler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({
+        body: { token: 'mock-token-value', username: 'newuser', password: 'password123' }
+      });
+      const res = createMockResponse();
+
+      await handler(req, res);
 
       expect(res.statusCode).toBe(400);
       expect(res.body).toEqual({ error: 'Authentication already configured' });
     });
 
-    test('validates username requirements', async () => {
-      const { app } = await createServerModule({ passwordHash: null });
-
+    test('returns invalid setup token for tokenless probes even when already configured', async () => {
+      const { app } = await createServerModule();
       const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
-      const createAuthHandler = handlers[handlers.length - 1];
+      const handler = handlers[handlers.length - 1];
 
       const req = createMockRequest({
-        body: {
-          username: '',
-          password: 'password123'
-        },
-        ip: '127.0.0.1'
+        body: { username: 'newuser', password: 'password123' }
       });
       const res = createMockResponse();
 
-      await createAuthHandler(req, res);
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toEqual({ error: 'Invalid setup token' });
+    });
+
+    test('validates username is required', async () => {
+      const { app } = await createServerModule({ passwordHash: null });
+      const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
+      const handler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({
+        body: { token: 'mock-token-value', username: '', password: 'password123' }
+      });
+      const res = createMockResponse();
+
+      await handler(req, res);
 
       expect(res.statusCode).toBe(400);
       expect(res.body).toEqual({ error: 'Username is required' });
     });
 
-    test('validates password requirements', async () => {
-      const { app } = await createServerModule({ passwordHash: null });
-
+    test('validates username length after trimming whitespace', async () => {
+      const { app, configModuleMock, dbMock } = await createServerModule({ passwordHash: null });
       const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
-      const createAuthHandler = handlers[handlers.length - 1];
+      const handler = handlers[handlers.length - 1];
 
       const req = createMockRequest({
-        body: {
-          username: 'newuser',
-          password: 'short'
-        },
-        ip: '127.0.0.1'
+        body: { token: 'mock-token-value', username: `admin${' '.repeat(28)}`, password: 'password123' }
       });
       const res = createMockResponse();
 
-      await createAuthHandler(req, res);
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(configModuleMock.updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ username: 'admin' })
+      );
+      expect(dbMock.Session.create).toHaveBeenCalledWith(
+        expect.objectContaining({ username: 'admin' })
+      );
+    });
+
+    test('validates password length', async () => {
+      const { app } = await createServerModule({ passwordHash: null });
+      const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
+      const handler = handlers[handlers.length - 1];
+
+      const req = createMockRequest({
+        body: { token: 'mock-token-value', username: 'admin', password: 'short' }
+      });
+      const res = createMockResponse();
+
+      await handler(req, res);
 
       expect(res.statusCode).toBe(400);
       expect(res.body).toEqual({ error: 'Password must be at least 8 characters' });
     });
+  });
+});
 
-    test('validates maximum username length', async () => {
-      const { app } = await createServerModule({ passwordHash: null });
+describe('setup token wiring on initialize', () => {
+  test('ensures a token when passwordHash is missing and AUTH_PRESET is not set', async () => {
+    const { setupTokenModuleMock } = await createServerModule({ passwordHash: null });
 
-      const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
-      const createAuthHandler = handlers[handlers.length - 1];
+    expect(setupTokenModuleMock.ensureToken).toHaveBeenCalledTimes(1);
+    expect(setupTokenModuleMock.logBanner).toHaveBeenCalledTimes(1);
+    expect(setupTokenModuleMock.clearStaleFile).not.toHaveBeenCalled();
+  });
 
-      const req = createMockRequest({
-        body: {
-          username: 'a'.repeat(33),
-          password: 'password123'
-        },
-        ip: '127.0.0.1'
-      });
-      const res = createMockResponse();
-
-      await createAuthHandler(req, res);
-
-      expect(res.statusCode).toBe(400);
-      expect(res.body).toEqual({ error: 'Username is too long (max 32 characters)' });
+  test('clears stale token file when AUTH_PRESET applies', async () => {
+    const { setupTokenModuleMock } = await createServerModule({
+      passwordHash: null,
+      authPreset: { username: 'admin', password: 'longenough' }
     });
 
-    test('validates maximum password length', async () => {
-      const { app } = await createServerModule({ passwordHash: null });
+    expect(setupTokenModuleMock.clearStaleFile).toHaveBeenCalledTimes(1);
+    expect(setupTokenModuleMock.ensureToken).not.toHaveBeenCalled();
+  });
 
-      const handlers = findRouteHandlers(app, 'post', '/setup/create-auth');
-      const createAuthHandler = handlers[handlers.length - 1];
+  test('clears stale token file when passwordHash is already set (defensive cleanup)', async () => {
+    const { setupTokenModuleMock } = await createServerModule({ passwordHash: 'existing-hash' });
 
-      const req = createMockRequest({
-        body: {
-          username: 'newuser',
-          password: 'a'.repeat(65)
-        },
-        ip: '127.0.0.1'
-      });
-      const res = createMockResponse();
+    expect(setupTokenModuleMock.clearStaleFile).toHaveBeenCalledTimes(1);
+    expect(setupTokenModuleMock.ensureToken).not.toHaveBeenCalled();
+  });
 
-      await createAuthHandler(req, res);
-
-      expect(res.statusCode).toBe(400);
-      expect(res.body).toEqual({ error: 'Password is too long' });
+  test('ensures a token when config is partially configured with passwordHash but no username', async () => {
+    const { setupTokenModuleMock } = await createServerModule({
+      passwordHash: 'existing-hash',
+      configOverrides: { username: null }
     });
+
+    expect(setupTokenModuleMock.ensureToken).toHaveBeenCalledTimes(1);
+    expect(setupTokenModuleMock.logBanner).toHaveBeenCalledTimes(1);
+    expect(setupTokenModuleMock.clearStaleFile).not.toHaveBeenCalled();
+  });
+
+  test('does nothing for the token when AUTH_ENABLED=false', async () => {
+    const { setupTokenModuleMock } = await createServerModule({
+      authEnabled: 'false',
+      passwordHash: null
+    });
+
+    expect(setupTokenModuleMock.ensureToken).not.toHaveBeenCalled();
+    expect(setupTokenModuleMock.clearStaleFile).not.toHaveBeenCalled();
+    expect(setupTokenModuleMock.logBanner).not.toHaveBeenCalled();
   });
 });
 

--- a/server/__tests__/server.core.test.js
+++ b/server/__tests__/server.core.test.js
@@ -49,7 +49,8 @@ const createServerModule = ({
   passwordHash = 'hashed-password',
   session,
   skipInitialize = false,
-  configOverrides = {}
+  configOverrides = {},
+  trustProxy
 } = {}) => {
   jest.resetModules();
   jest.clearAllMocks();
@@ -64,6 +65,12 @@ const createServerModule = ({
           delete process.env.AUTH_ENABLED;
         } else {
           process.env.AUTH_ENABLED = authEnabled;
+        }
+
+        if (trustProxy === undefined) {
+          delete process.env.TRUST_PROXY;
+        } else {
+          process.env.TRUST_PROXY = trustProxy;
         }
 
         const defaultSessionUpdate = jest.fn().mockResolvedValue();
@@ -277,23 +284,38 @@ const createServerModule = ({
 
 afterEach(() => {
   delete process.env.AUTH_ENABLED;
-});
-
-describe('isLocalhostIP', () => {
-  test.each([
-    ['127.0.0.1', true],
-    ['::1', true],
-    ['::ffff:127.0.0.1', true],
-    ['localhost', true],
-    ['192.168.1.10', false],
-    [null, false]
-  ])('returns %s for %s', async (input, expected) => {
-    const { serverModule } = await createServerModule({ skipInitialize: true });
-    expect(serverModule.isLocalhostIP(input)).toBe(expected);
-  });
+  delete process.env.TRUST_PROXY;
 });
 
 describe('server initialization', () => {
+  test('normalizes named TRUST_PROXY values for Express', async () => {
+    const { serverModule } = await createServerModule({ skipInitialize: true, trustProxy: 'LoOpBack' });
+
+    expect(serverModule.parseTrustProxySetting('LoOpBack')).toBe('loopback');
+  });
+
+  test('parses numeric TRUST_PROXY values as hop counts', async () => {
+    const { serverModule } = await createServerModule({ skipInitialize: true, trustProxy: '1' });
+
+    expect(serverModule.parseTrustProxySetting('1')).toBe(1);
+  });
+
+  test('logs when TRUST_PROXY is unset and backwards-compatible proxy trust is used', async () => {
+    await createServerModule({ skipInitialize: true });
+
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      expect.stringContaining('TRUST_PROXY is unset')
+    );
+  });
+
+  test('does not log about unset TRUST_PROXY when explicitly configured', async () => {
+    await createServerModule({ skipInitialize: true, trustProxy: 'false' });
+
+    expect(loggerMock.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('TRUST_PROXY is unset')
+    );
+  });
+
   test('initializes database and exposes health route', async () => {
     const { app, dbMock, channelModuleMock } = await createServerModule();
 
@@ -422,8 +444,14 @@ describe('server initialization', () => {
     expect(loginOptions.windowMs).toBe(15 * 60 * 1000);
     expect(loginOptions.skipSuccessfulRequests).toBe(true);
 
-    const key = loginOptions.keyGenerator({ ip: '1.2.3.4', body: { username: 'alice' } });
-    expect(key).toBe('1.2.3.4:alice');
+    // With TRUST_PROXY unset, the key generator must ignore req.ip (which can
+    // be spoofed via X-Forwarded-For) and fall back to the direct peer address.
+    const key = loginOptions.keyGenerator({
+      ip: '1.2.3.4',
+      socket: { remoteAddress: '5.6.7.8' },
+      body: { username: 'alice' }
+    });
+    expect(key).toBe('5.6.7.8:alice');
 
     const res = {};
     res.status = jest.fn(() => res);
@@ -433,6 +461,20 @@ describe('server initialization', () => {
     expect(res.json).toHaveBeenCalledWith({
       error: 'Too many failed login attempts. Please wait 15 minutes before trying again.'
     });
+  });
+
+  test('login rate limiter trusts req.ip when TRUST_PROXY is explicitly configured', async () => {
+    const { rateLimitMiddleware } = await createServerModule({ trustProxy: 'true' });
+
+    const loginCall = rateLimitMiddleware.mock.calls.find(([options]) => options.max === 5);
+    const loginOptions = loginCall[0];
+
+    const key = loginOptions.keyGenerator({
+      ip: '1.2.3.4',
+      socket: { remoteAddress: '5.6.7.8' },
+      body: { username: 'alice' }
+    });
+    expect(key).toBe('1.2.3.4:alice');
   });
 
   test('handles paginated /getVideos endpoint with query parameters', async () => {

--- a/server/__tests__/server.routes.test.js
+++ b/server/__tests__/server.routes.test.js
@@ -382,6 +382,21 @@ const createServerModule = ({
         jest.doMock('child_process', () => childProcessMock);
         jest.doMock('pino-http', () => pinoHttpMock);
 
+        const setupTokenModuleMock = {
+          setTokenPath: jest.fn(),
+          reset: jest.fn(),
+          getToken: jest.fn(() => 'mock-token-value'),
+          ensureToken: jest.fn(),
+          verify: jest.fn((provided) => provided === 'mock-token-value'),
+          consume: jest.fn(),
+          claimForSetup: jest.fn((provided) => provided === 'mock-token-value'),
+          releaseSetupClaim: jest.fn(),
+          clearStaleFile: jest.fn(),
+          logBanner: jest.fn()
+        };
+
+        jest.doMock('../modules/setupTokenModule', () => setupTokenModuleMock);
+
         const serverModule = require('../server');
 
         state.app = serverModule.app;
@@ -397,6 +412,7 @@ const createServerModule = ({
         state.videoDeletionModuleMock = videoDeletionModuleMock;
         state.videoValidationModuleMock = videoValidationModuleMock;
         state.channelSettingsModuleMock = channelSettingsModuleMock;
+        state.setupTokenModuleMock = setupTokenModuleMock;
         state.bcryptMock = bcryptMock;
         state.uuidMock = uuidMock;
         state.httpsMock = httpsMock;

--- a/server/modules/__tests__/setupTokenModule.test.js
+++ b/server/modules/__tests__/setupTokenModule.test.js
@@ -1,0 +1,232 @@
+/* eslint-env jest */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+const buildModule = (tokenPath) => {
+  jest.resetModules();
+  jest.doMock('../../logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+  }));
+  // eslint-disable-next-line global-require
+  const fresh = require('../setupTokenModule');
+  fresh.setTokenPath(tokenPath);
+  fresh.reset();
+  return fresh;
+};
+
+describe('setupTokenModule', () => {
+  let tmpDir;
+  let tokenPath;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'youtarr-setup-token-'));
+    tokenPath = path.join(tmpDir, 'setup-token');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('ensureToken', () => {
+    test('generates a 64-char hex token when no file exists', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      const token = mod.getToken();
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+      expect(fs.readFileSync(tokenPath, 'utf8')).toBe(token);
+    });
+
+    test('writes the file with mode 0600', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      const stat = fs.statSync(tokenPath);
+      expect(stat.mode & 0o777).toBe(0o600);
+    });
+
+    test('loads an existing token from disk and does not regenerate', () => {
+      const existing = crypto.randomBytes(32).toString('hex');
+      fs.writeFileSync(tokenPath, existing, { mode: 0o600 });
+
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+
+      expect(mod.getToken()).toBe(existing);
+      expect(fs.readFileSync(tokenPath, 'utf8')).toBe(existing);
+    });
+
+    test('tightens permissions on an existing valid token file', () => {
+      const existing = crypto.randomBytes(32).toString('hex');
+      fs.writeFileSync(tokenPath, existing, { mode: 0o644 });
+
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+
+      expect(mod.getToken()).toBe(existing);
+      expect(fs.statSync(tokenPath).mode & 0o777).toBe(0o600);
+    });
+
+    test('regenerates when existing file is malformed', () => {
+      fs.writeFileSync(tokenPath, 'not-a-hex-token', { mode: 0o600 });
+
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+
+      expect(mod.getToken()).toMatch(/^[0-9a-f]{64}$/);
+      expect(fs.readFileSync(tokenPath, 'utf8')).toBe(mod.getToken());
+    });
+
+    test('replaces a malformed permissive file with mode 0600', () => {
+      fs.writeFileSync(tokenPath, 'not-a-hex-token', { mode: 0o644 });
+
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+
+      expect(fs.readFileSync(tokenPath, 'utf8')).toBe(mod.getToken());
+      expect(fs.statSync(tokenPath).mode & 0o777).toBe(0o600);
+    });
+
+    test('is idempotent across multiple calls', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      const first = mod.getToken();
+      mod.ensureToken();
+      mod.ensureToken();
+      expect(mod.getToken()).toBe(first);
+    });
+  });
+
+  describe('verify', () => {
+    test('returns true for the correct token', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      expect(mod.verify(mod.getToken())).toBe(true);
+    });
+
+    test('returns false for an incorrect token of the same length', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      const wrong = 'a'.repeat(64);
+      expect(mod.verify(wrong)).toBe(false);
+    });
+
+    test('returns false for a token of different length', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      expect(mod.verify('short')).toBe(false);
+    });
+
+    test('returns false for non-string input', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      expect(mod.verify(undefined)).toBe(false);
+      expect(mod.verify(null)).toBe(false);
+      expect(mod.verify(12345)).toBe(false);
+    });
+
+    test('returns false when no active token', () => {
+      const mod = buildModule(tokenPath);
+      expect(mod.verify('anything')).toBe(false);
+    });
+  });
+
+  describe('consume', () => {
+    test('deletes the file and clears memory', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      expect(fs.existsSync(tokenPath)).toBe(true);
+
+      mod.consume();
+
+      expect(fs.existsSync(tokenPath)).toBe(false);
+      expect(mod.getToken()).toBeNull();
+      expect(mod.verify('anything')).toBe(false);
+    });
+
+    test('is safe to call when no token is active', () => {
+      const mod = buildModule(tokenPath);
+      expect(() => mod.consume()).not.toThrow();
+    });
+  });
+
+  describe('claimForSetup', () => {
+    test('returns true and blocks another claim when the provided token matches', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      const token = mod.getToken();
+
+      expect(mod.claimForSetup(token)).toBe(true);
+      expect(mod.claimForSetup(token)).toBe(false);
+      expect(fs.existsSync(tokenPath)).toBe(true);
+      expect(mod.getToken()).toBe(token);
+    });
+
+    test('returns false and leaves the token claimable when the provided token does not match', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      const token = mod.getToken();
+
+      expect(mod.claimForSetup('wrong-token')).toBe(false);
+      expect(fs.existsSync(tokenPath)).toBe(true);
+      expect(mod.getToken()).toBe(token);
+      expect(mod.claimForSetup(token)).toBe(true);
+    });
+
+    test('allows another claim after releaseSetupClaim', () => {
+      const mod = buildModule(tokenPath);
+      mod.ensureToken();
+      const token = mod.getToken();
+
+      expect(mod.claimForSetup(token)).toBe(true);
+      mod.releaseSetupClaim();
+      expect(mod.claimForSetup(token)).toBe(true);
+    });
+  });
+
+  describe('clearStaleFile', () => {
+    test('deletes a leftover file and clears memory', () => {
+      fs.writeFileSync(tokenPath, 'a'.repeat(64), { mode: 0o600 });
+
+      const mod = buildModule(tokenPath);
+      mod.clearStaleFile();
+
+      expect(fs.existsSync(tokenPath)).toBe(false);
+      expect(mod.getToken()).toBeNull();
+    });
+
+    test('is a no-op when the file does not exist', () => {
+      const mod = buildModule(tokenPath);
+      expect(() => mod.clearStaleFile()).not.toThrow();
+    });
+  });
+
+  describe('logBanner', () => {
+    test('logs setup guidance and the token-bearing info entry', () => {
+      const mod = buildModule(tokenPath);
+      const logger = require('../../logger');
+      mod.ensureToken();
+
+      mod.logBanner();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        {
+          tokenPath,
+          instruction: 'Read config/setup-token to complete first-time setup. The token-bearing setup log entry is emitted at info level.'
+        },
+        'Youtarr initial setup required'
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        {
+          setupToken: mod.getToken(),
+          tokenPath,
+          instruction: 'Open Youtarr in a browser and paste this token to complete setup.'
+        },
+        'Youtarr initial setup required'
+      );
+    });
+  });
+});

--- a/server/modules/authState.js
+++ b/server/modules/authState.js
@@ -1,0 +1,7 @@
+function isAuthConfigured(config) {
+  return Boolean(config?.username && config?.passwordHash);
+}
+
+module.exports = {
+  isAuthConfigured
+};

--- a/server/modules/setupTokenModule.js
+++ b/server/modules/setupTokenModule.js
@@ -1,0 +1,139 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const logger = require('../logger');
+
+const DEFAULT_TOKEN_PATH = path.join(__dirname, '../../config/setup-token');
+const TOKEN_BYTES = 32;
+const TOKEN_HEX_LENGTH = TOKEN_BYTES * 2;
+const TOKEN_HEX_PATTERN = new RegExp(`^[0-9a-f]{${TOKEN_HEX_LENGTH}}$`);
+
+class SetupTokenModule {
+  constructor() {
+    this.tokenPath = DEFAULT_TOKEN_PATH;
+    this.token = null;
+    this.setupInProgress = false;
+  }
+
+  setTokenPath(tokenPath) {
+    this.tokenPath = tokenPath;
+  }
+
+  reset() {
+    this.token = null;
+    this.setupInProgress = false;
+  }
+
+  getToken() {
+    return this.token;
+  }
+
+  enforceTokenFileMode() {
+    try {
+      fs.chmodSync(this.tokenPath, 0o600);
+    } catch (err) {
+      logger.warn({ err, tokenPath: this.tokenPath }, 'Could not enforce setup-token file mode');
+    }
+  }
+
+  writeTokenFile(token) {
+    const tokenDir = path.dirname(this.tokenPath);
+    const tempPath = path.join(tokenDir, `.setup-token.${process.pid}.${crypto.randomBytes(6).toString('hex')}.tmp`);
+
+    try {
+      fs.writeFileSync(tempPath, token, { mode: 0o600 });
+      fs.chmodSync(tempPath, 0o600);
+      fs.renameSync(tempPath, this.tokenPath);
+      this.enforceTokenFileMode();
+    } catch (err) {
+      if (fs.existsSync(tempPath)) {
+        try {
+          fs.unlinkSync(tempPath);
+        } catch (cleanupErr) {
+          logger.warn({ err: cleanupErr, tokenPath: tempPath }, 'Could not remove temporary setup-token file');
+        }
+      }
+      throw err;
+    }
+  }
+
+  ensureToken() {
+    if (this.token) return this.token;
+
+    if (fs.existsSync(this.tokenPath)) {
+      const existing = fs.readFileSync(this.tokenPath, 'utf8').trim();
+      if (TOKEN_HEX_PATTERN.test(existing)) {
+        this.enforceTokenFileMode();
+        this.token = existing;
+        return this.token;
+      }
+      logger.warn({ tokenPath: this.tokenPath }, 'Existing setup-token file is malformed; regenerating');
+    }
+
+    const generated = crypto.randomBytes(TOKEN_BYTES).toString('hex');
+    this.writeTokenFile(generated);
+    this.token = generated;
+    return this.token;
+  }
+
+  verify(provided) {
+    if (!this.token || typeof provided !== 'string') return false;
+    const expected = Buffer.from(this.token, 'utf8');
+    const padded = Buffer.alloc(expected.length);
+    Buffer.from(provided, 'utf8').copy(padded, 0, 0, expected.length);
+    const equal = crypto.timingSafeEqual(expected, padded);
+    return equal && Buffer.byteLength(provided, 'utf8') === expected.length;
+  }
+
+  claimForSetup(provided) {
+    if (this.setupInProgress || !this.verify(provided)) return false;
+    this.setupInProgress = true;
+    return true;
+  }
+
+  releaseSetupClaim() {
+    this.setupInProgress = false;
+  }
+
+  consume() {
+    this.token = null;
+    this.setupInProgress = false;
+    if (fs.existsSync(this.tokenPath)) {
+      try {
+        fs.unlinkSync(this.tokenPath);
+      } catch (err) {
+        logger.error({ err, tokenPath: this.tokenPath }, 'Failed to delete setup-token file after setup');
+      }
+    }
+  }
+
+  clearStaleFile() {
+    this.token = null;
+    this.setupInProgress = false;
+    if (fs.existsSync(this.tokenPath)) {
+      try {
+        fs.unlinkSync(this.tokenPath);
+        logger.info({ tokenPath: this.tokenPath }, 'Removed stale setup-token file');
+      } catch (err) {
+        logger.warn({ err, tokenPath: this.tokenPath }, 'Could not remove stale setup-token file');
+      }
+    }
+  }
+
+  logBanner() {
+    if (!this.token) return;
+    logger.warn({
+      tokenPath: this.tokenPath,
+      instruction: 'Read config/setup-token to complete first-time setup. The token-bearing setup log entry is emitted at info level.'
+    }, 'Youtarr initial setup required');
+    logger.info({
+      // Intentionally visible: first-time setup depends on operators seeing this
+      // value in logs or reading config/setup-token. Treat forwarded logs as sensitive.
+      setupToken: this.token,
+      tokenPath: this.tokenPath,
+      instruction: 'Open Youtarr in a browser and paste this token to complete setup.'
+    }, 'Youtarr initial setup required');
+  }
+}
+
+module.exports = new SetupTokenModule();

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const bcrypt = require('bcrypt');
 const { v4: uuidv4 } = require('uuid');
 const db = require('../db');
+const { isAuthConfigured } = require('../modules/authState');
 
 const userNameMaxLength = 32;
 const passwordMaxLength = 64;
@@ -13,9 +14,14 @@ const passwordMaxLength = 64;
  * @param {Function} deps.verifyToken - Token verification middleware
  * @param {Function} deps.loginLimiter - Login rate limiter middleware
  * @param {Object} deps.configModule - Config module
+ * @param {Function} deps.getClientAddress - Function to resolve the client address
  * @returns {express.Router}
  */
-module.exports = function createAuthRoutes({ verifyToken, loginLimiter, configModule }) {
+module.exports = function createAuthRoutes({ verifyToken, loginLimiter, configModule, getClientAddress }) {
+  if (typeof getClientAddress !== 'function') {
+    throw new Error('getClientAddress dependency is required');
+  }
+
   /**
    * @swagger
    * /validateToken:
@@ -111,7 +117,7 @@ module.exports = function createAuthRoutes({ verifyToken, loginLimiter, configMo
 
     const config = configModule.getConfig();
 
-    if (!config.username || !config.passwordHash) {
+    if (!isAuthConfigured(config)) {
       return res.status(503).json({
         error: 'Authentication not configured',
         requiresSetup: true
@@ -129,7 +135,7 @@ module.exports = function createAuthRoutes({ verifyToken, loginLimiter, configMo
 
     const sessionToken = uuidv4();
     const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
-    const clientIP = req.ip || req.connection.remoteAddress;
+    const clientIP = getClientAddress(req);
 
     await db.Session.create({
       session_token: sessionToken,
@@ -358,4 +364,3 @@ module.exports = function createAuthRoutes({ verifyToken, loginLimiter, configMo
 
   return router;
 };
-

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -25,6 +25,7 @@ function registerRoutes(app, deps) {
   const {
     verifyToken,
     loginLimiter,
+    setupCreateAuthLimiter,
     youtubeApiKeyTestLimiter,
     ytdlpValidationRateLimiter,
     configModule,
@@ -40,7 +41,8 @@ function registerRoutes(app, deps) {
     getCachedYtDlpVersion,
     refreshYtDlpVersionCache,
     validateEnvAuthCredentials,
-    isLocalhostIP,
+    setupTokenModule,
+    getClientAddress,
     isWslEnvironment,
   } = deps;
 
@@ -48,10 +50,10 @@ function registerRoutes(app, deps) {
   app.use(createHealthRoutes({ getCachedYtDlpVersion, refreshYtDlpVersionCache, verifyToken, configModule }));
 
   // Auth routes
-  app.use(createAuthRoutes({ verifyToken, loginLimiter, configModule }));
+  app.use(createAuthRoutes({ verifyToken, loginLimiter, configModule, getClientAddress }));
 
   // Setup routes
-  app.use(createSetupRoutes({ configModule, isLocalhostIP }));
+  app.use(createSetupRoutes({ configModule, setupTokenModule, setupCreateAuthLimiter, getClientAddress }));
 
   // Config routes
   app.use(createConfigRoutes({ verifyToken, configModule, validateEnvAuthCredentials, isWslEnvironment }));

--- a/server/routes/plex.js
+++ b/server/routes/plex.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const logger = require('../logger');
+const { isAuthConfigured } = require('../modules/authState');
 
 /**
  * Creates Plex routes
@@ -150,7 +151,7 @@ module.exports = function createPlexRoutes({ verifyToken, plexModule, configModu
   router.get('/plex/auth-url', async (req, res) => {
     const config = configModule.getConfig();
 
-    if (process.env.AUTH_ENABLED !== 'false' && !config.passwordHash) {
+    if (process.env.AUTH_ENABLED !== 'false' && !isAuthConfigured(config)) {
       return res.status(503).json({
         error: 'Authentication not configured',
         requiresSetup: true,
@@ -202,7 +203,7 @@ module.exports = function createPlexRoutes({ verifyToken, plexModule, configModu
   router.get('/plex/check-pin/:pinId', async (req, res) => {
     const config = configModule.getConfig();
 
-    if (process.env.AUTH_ENABLED !== 'false' && !config.passwordHash) {
+    if (process.env.AUTH_ENABLED !== 'false' && !isAuthConfigured(config)) {
       return res.status(503).json({
         error: 'Authentication not configured',
         requiresSetup: true,
@@ -221,4 +222,3 @@ module.exports = function createPlexRoutes({ verifyToken, plexModule, configModu
 
   return router;
 };
-

--- a/server/routes/setup.js
+++ b/server/routes/setup.js
@@ -4,15 +4,49 @@ const bcrypt = require('bcrypt');
 const { v4: uuidv4 } = require('uuid');
 const db = require('../db');
 const logger = require('../logger');
+const { isAuthConfigured } = require('../modules/authState');
 
 /**
- * Creates setup routes
+ * Creates setup routes.
+ *
  * @param {Object} deps - Dependencies
  * @param {Object} deps.configModule - Config module
- * @param {Function} deps.isLocalhostIP - Function to check if IP is localhost
+ * @param {Object} deps.setupTokenModule - Setup token module
+ * @param {Function} deps.setupCreateAuthLimiter - Rate limiter for setup attempts
+ * @param {Function} deps.getClientAddress - Function to resolve the client address
  * @returns {express.Router}
  */
-module.exports = function createSetupRoutes({ configModule, isLocalhostIP }) {
+module.exports = function createSetupRoutes({ configModule, setupTokenModule, setupCreateAuthLimiter, getClientAddress }) {
+  const requiredSetupTokenMethods = ['verify', 'claimForSetup', 'consume', 'releaseSetupClaim'];
+  const hasRequiredSetupTokenMethods = setupTokenModule &&
+    requiredSetupTokenMethods.every((method) => typeof setupTokenModule[method] === 'function');
+
+  if (!hasRequiredSetupTokenMethods) {
+    throw new Error('setupTokenModule dependency is required');
+  }
+  if (typeof setupCreateAuthLimiter !== 'function') {
+    throw new Error('setupCreateAuthLimiter dependency is required');
+  }
+  if (typeof getClientAddress !== 'function') {
+    throw new Error('getClientAddress dependency is required');
+  }
+
+  const restoreAuthFields = (config, previousAuth) => {
+    if (!config || !previousAuth) return;
+
+    if (previousAuth.hadUsername) {
+      config.username = previousAuth.username;
+    } else {
+      delete config.username;
+    }
+
+    if (previousAuth.hadPasswordHash) {
+      config.passwordHash = previousAuth.passwordHash;
+    } else {
+      delete config.passwordHash;
+    }
+  };
+
   /**
    * @swagger
    * /setup/status:
@@ -31,42 +65,28 @@ module.exports = function createSetupRoutes({ configModule, isLocalhostIP }) {
    *               properties:
    *                 requiresSetup:
    *                   type: boolean
-   *                 isLocalhost:
-   *                   type: boolean
    *                 platformManaged:
    *                   type: boolean
    *                 message:
    *                   type: string
+   *                   nullable: true
    */
   router.get('/setup/status', (req, res) => {
     if (process.env.AUTH_ENABLED === 'false') {
       return res.json({
         requiresSetup: false,
-        isLocalhost: true,
         platformManaged: true,
         message: 'Authentication is managed by the platform'
       });
     }
 
     const config = configModule.getConfig();
-    const clientIP = req.ip ||
-                    req.connection.remoteAddress ||
-                    req.socket.remoteAddress ||
-                    req.connection.socket?.remoteAddress ||
-                    req.headers['x-forwarded-for']?.split(',')[0];
-
-    const hostIsLocal = req.headers.host && (
-      req.headers.host.startsWith('localhost') ||
-      req.headers.host.startsWith('127.0.0.1') ||
-      req.headers.host.startsWith('[::1]')
-    );
-
-    const isLocalhost = isLocalhostIP(clientIP) || hostIsLocal;
+    const requiresSetup = !isAuthConfigured(config);
 
     res.json({
-      requiresSetup: !config.username || !config.passwordHash,
-      isLocalhost: isLocalhost,
-      message: isLocalhost ? null : 'Setup must be performed from localhost'
+      requiresSetup,
+      platformManaged: false,
+      message: null
     });
   });
 
@@ -75,7 +95,7 @@ module.exports = function createSetupRoutes({ configModule, isLocalhostIP }) {
    * /setup/create-auth:
    *   post:
    *     summary: Create initial authentication
-   *     description: Set up the initial admin username and password. Only accessible from localhost.
+   *     description: Set up the initial admin username and password. Requires the one-time setup token printed to the container logs and stored in the data volume at config/setup-token.
    *     tags: [Setup]
    *     security: []
    *     requestBody:
@@ -84,10 +104,11 @@ module.exports = function createSetupRoutes({ configModule, isLocalhostIP }) {
    *         application/json:
    *           schema:
    *             type: object
-   *             required:
-   *               - username
-   *               - password
+   *             required: [token, username, password]
    *             properties:
+   *               token:
+   *                 type: string
+   *                 description: One-time setup token
    *               username:
    *                 type: string
    *                 maxLength: 32
@@ -98,101 +119,133 @@ module.exports = function createSetupRoutes({ configModule, isLocalhostIP }) {
    *     responses:
    *       200:
    *         description: Setup complete
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 token:
-   *                   type: string
-   *                 message:
-   *                   type: string
-   *                 username:
-   *                   type: string
    *       400:
    *         description: Invalid input or already configured
-   *       403:
-   *         description: Setup only allowed from localhost
+   *       401:
+   *         description: Invalid setup token
    */
-  router.post('/setup/create-auth', async (req, res) => {
-    const config = configModule.getConfig();
+  router.post('/setup/create-auth', setupCreateAuthLimiter, async (req, res) => {
+    let setupClaimed = false;
+    let tokenConsumed = false;
+    let credentialsPersisted = false;
+    let authFieldsMutated = false;
+    let mutatedConfig = null;
+    let previousAuth = null;
 
-    const clientIP = req.ip ||
-                    req.connection.remoteAddress ||
-                    req.socket.remoteAddress ||
-                    req.connection.socket?.remoteAddress ||
-                    req.headers['x-forwarded-for']?.split(',')[0];
+    try {
+      const config = configModule.getConfig();
+      const { token, username, password } = req.body;
+      const clientIP = getClientAddress(req);
 
-    const hostIsLocal = req.headers.host && (
-      req.headers.host.startsWith('localhost') ||
-      req.headers.host.startsWith('127.0.0.1') ||
-      req.headers.host.startsWith('[::1]')
-    );
+      // Keep token verification first. After setup completes the token is consumed, so
+      // replays should receive the same 401 as token-less probes instead of learning
+      // whether credentials are already configured.
+      if (!setupTokenModule.verify(token)) {
+        logger.warn(
+          { event: 'setup_token_invalid', ip: clientIP, userAgent: req.headers['user-agent'] },
+          'Setup attempt with missing or invalid token'
+        );
+        return res.status(401).json({ error: 'Invalid setup token' });
+      }
 
-    const isLocalhost = isLocalhostIP(clientIP) || hostIsLocal;
+      if (isAuthConfigured(config)) {
+        return res.status(400).json({ error: 'Authentication already configured' });
+      }
 
-    if (!isLocalhost) {
-      logger.warn({ clientIP }, 'Setup attempt blocked from non-localhost IP');
-      return res.status(403).json({
-        error: 'Initial setup can only be performed from localhost for security reasons.',
-        instruction: 'Please access Youtarr directly from the server at http://localhost:3087',
-        yourIP: clientIP
+      if (!username || typeof username !== 'string' || username.trim().length === 0) {
+        return res.status(400).json({ error: 'Username is required' });
+      }
+
+      const trimmedUsername = username.trim();
+
+      if (trimmedUsername.length > 32) {
+        return res.status(400).json({ error: 'Username is too long (max 32 characters)' });
+      }
+
+      if (!password || typeof password !== 'string') {
+        return res.status(400).json({ error: 'Password is required' });
+      }
+
+      if (password.length < 8) {
+        return res.status(400).json({ error: 'Password must be at least 8 characters' });
+      }
+
+      if (password.length > 64) {
+        return res.status(400).json({ error: 'Password is too long' });
+      }
+
+      // claimForSetup repeats token verification to reject concurrent valid submissions.
+      if (!setupTokenModule.claimForSetup(token)) {
+        logger.warn(
+          { event: 'setup_token_invalid_or_consumed', ip: clientIP, userAgent: req.headers['user-agent'] },
+          'Setup attempt with invalid or already consumed token'
+        );
+        return res.status(401).json({ error: 'Invalid setup token' });
+      }
+      setupClaimed = true;
+
+      const passwordHash = await bcrypt.hash(password, 10);
+
+      mutatedConfig = config;
+      previousAuth = {
+        hadUsername: Object.prototype.hasOwnProperty.call(config, 'username'),
+        username: config.username,
+        hadPasswordHash: Object.prototype.hasOwnProperty.call(config, 'passwordHash'),
+        passwordHash: config.passwordHash
+      };
+      config.username = trimmedUsername;
+      config.passwordHash = passwordHash;
+      authFieldsMutated = true;
+      configModule.updateConfig(config);
+      credentialsPersisted = true;
+
+      const sessionToken = uuidv4();
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+      await db.Session.create({
+        session_token: sessionToken,
+        username: trimmedUsername,
+        user_agent: req.headers['user-agent'],
+        ip_address: clientIP,
+        expires_at: expiresAt
       });
+
+      setupTokenModule.consume();
+      tokenConsumed = true;
+
+      logger.info({ username: trimmedUsername }, 'Initial setup completed for user');
+
+      res.json({
+        token: sessionToken,
+        message: 'Setup complete! You can now access Youtarr normally.',
+        username: trimmedUsername
+      });
+    } catch (err) {
+      if (authFieldsMutated && !credentialsPersisted) {
+        restoreAuthFields(mutatedConfig || configModule.getConfig(), previousAuth);
+      }
+
+      const setupCompletedWithoutSession = credentialsPersisted && isAuthConfigured(configModule.getConfig());
+
+      if (setupCompletedWithoutSession && !tokenConsumed) {
+        setupTokenModule.consume();
+        tokenConsumed = true;
+      }
+
+      if (setupClaimed && !tokenConsumed) {
+        setupTokenModule.releaseSetupClaim();
+      }
+      logger.error({ err }, 'Initial setup failed');
+      if (!res.headersSent) {
+        if (setupCompletedWithoutSession) {
+          return res.status(500).json({
+            error: 'Setup saved your credentials but the session could not be created. Please log in with the credentials you just entered.'
+          });
+        }
+        res.status(500).json({ error: 'Setup failed' });
+      }
     }
-
-    if (config.username && config.passwordHash) {
-      return res.status(400).json({ error: 'Authentication already configured' });
-    }
-
-    const { username, password } = req.body;
-
-    if (!username || typeof username !== 'string' || username.trim().length === 0) {
-      return res.status(400).json({ error: 'Username is required' });
-    }
-
-    if (username.length > 32) {
-      return res.status(400).json({ error: 'Username is too long (max 32 characters)' });
-    }
-
-    if (!password || typeof password !== 'string') {
-      return res.status(400).json({ error: 'Password is required' });
-    }
-
-    if (password.length < 8) {
-      return res.status(400).json({ error: 'Password must be at least 8 characters' });
-    }
-
-    if (password.length > 64) {
-      return res.status(400).json({ error: 'Password is too long' });
-    }
-
-    const saltRounds = 10;
-    const passwordHash = await bcrypt.hash(password, saltRounds);
-
-    config.username = username.trim();
-    config.passwordHash = passwordHash;
-    configModule.updateConfig(config);
-
-    const sessionToken = uuidv4();
-    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
-
-    await db.Session.create({
-      session_token: sessionToken,
-      username: username.trim(),
-      user_agent: req.headers['user-agent'],
-      ip_address: clientIP,
-      expires_at: expiresAt
-    });
-
-    logger.info({ username: username.trim() }, 'Initial setup completed for user');
-
-    res.json({
-      token: sessionToken,
-      message: 'Setup complete! You can now access Youtarr from anywhere.',
-      username: username
-    });
   });
 
   return router;
 };
-

--- a/server/server.js
+++ b/server/server.js
@@ -11,8 +11,12 @@ const { ipKeyGenerator } = require('express-rate-limit');
 const logger = require('./logger');
 const pinoHttp = require('pino-http');
 const { setupSwagger } = require('./swagger');
+const { isAuthConfigured } = require('./modules/authState');
 const app = express();
-app.set('trust proxy', true); // Trust proxy headers for correct IP detection
+app.set('trust proxy', parseTrustProxySetting(process.env.TRUST_PROXY));
+if (process.env.TRUST_PROXY === undefined || process.env.TRUST_PROXY === '') {
+  logger.info('TRUST_PROXY is unset; defaulting Express proxy trust to true for backwards compatibility. Rate limits use the direct peer IP until TRUST_PROXY is explicitly configured.');
+}
 
 // Strip auth tokens from URLs before logging. The video streaming endpoint
 // passes the auth token as ?token=... because <video src> cannot set headers,
@@ -97,31 +101,51 @@ const userNameMinLength = 1;
 const passwordMaxLength = 64;
 const passwordMinLength = 8;
 
-// Helper function to check if IP is localhost
-function isLocalhostIP(ip) {
-  if (!ip) return false;
+function parseTrustProxySetting(value) {
+  if (value === undefined || value === null || value === '') {
+    return true;
+  }
 
-  // Clean up IP address - handle various formats
-  const cleanIP = ip.replace(/^::ffff:/, '').replace(/^::1$/, '::1');
+  const normalized = String(value).trim().toLowerCase();
+  if (['false', '0', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  if (/^\d+$/.test(normalized)) {
+    return Number(normalized);
+  }
+  if (['true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
 
-  // List of localhost IPs (IPv4 and IPv6)
-  const localhostIPs = [
-    '127.0.0.1',
-    '::1',
-    'localhost',
-    '::ffff:127.0.0.1',
-    '0:0:0:0:0:0:0:1'
-  ];
+  return normalized;
+}
 
-  // Check if IP is localhost
-  const isLocal = localhostIPs.includes(cleanIP) ||
-         localhostIPs.includes(ip) ||
-         cleanIP.startsWith('127.') ||
-         ip.includes('localhost') ||
-         ip === '::' ||
-         ip === '0.0.0.0';
+function hasExplicitTrustedProxyConfig() {
+  const value = process.env.TRUST_PROXY;
+  if (value === undefined || value === null || value === '') {
+    return false;
+  }
 
-  return isLocal;
+  const normalized = String(value).trim().toLowerCase();
+  return !['false', '0', 'no', 'off'].includes(normalized);
+}
+
+function getDirectClientAddress(req) {
+  return req.socket?.remoteAddress ||
+    req.connection?.remoteAddress ||
+    'unknown';
+}
+
+function getClientAddress(req) {
+  return hasExplicitTrustedProxyConfig() ? req.ip : getDirectClientAddress(req);
+}
+
+function getRateLimitAddress(req) {
+  const address = getClientAddress(req);
+  if (!address || address === 'unknown') {
+    return 'unknown';
+  }
+  return ipKeyGenerator(address);
 }
 
 // Helper function to validate ENV auth credentials
@@ -242,6 +266,18 @@ const initialize = async () => {
       logger.warn('Ignoring ENV AUTH credentials: both AUTH_PRESET_USERNAME and AUTH_PRESET_PASSWORD must be set and meet requirements (username: 1-32 chars, password: 8-64 chars)');
     }
 
+    const setupTokenModule = require('./modules/setupTokenModule');
+
+    if (process.env.AUTH_ENABLED !== 'false') {
+      const setupConfig = configModule.getConfig();
+      if (isAuthConfigured(setupConfig)) {
+        setupTokenModule.clearStaleFile();
+      } else {
+        setupTokenModule.ensureToken();
+        setupTokenModule.logBanner();
+      }
+    }
+
     channelModule.subscribe();
 
     subscriptionImportModule.init({
@@ -330,28 +366,14 @@ const initialize = async () => {
 
       const config = configModule.getConfig();
 
-      // If no password hash exists, authentication is not configured
-      // Only allow setup endpoints in this state
-      if (!config.passwordHash) {
-        if (req.path.startsWith('/setup')) {
-          const clientIP = req.ip || req.connection.remoteAddress;
-          const isLocalhost = isLocalhostIP(clientIP);
-
-          if (!isLocalhost) {
-            return res.status(403).json({
-              error: 'Initial setup can only be performed from localhost',
-              instruction: 'Please access from http://localhost:3087'
-            });
-          }
-          return next();
-        } else {
-          // Reject ALL other endpoints if auth not configured
-          return res.status(503).json({
-            error: 'Authentication not configured',
-            requiresSetup: true,
-            message: 'Please complete initial setup first'
-          });
-        }
+      // If authentication is not configured, only allow setup endpoints in
+      // this state; the setup route validates the one-time setup token itself.
+      if (!isAuthConfigured(config)) {
+        return res.status(503).json({
+          error: 'Authentication not configured',
+          requiresSetup: true,
+          message: 'Please complete initial setup first'
+        });
       }
 
       // Check for API key first (x-api-key header)
@@ -453,15 +475,32 @@ const initialize = async () => {
         ip: false, // Disable IP validation - we're using a custom key
       },
       keyGenerator: (req) => {
-        // Use IP + username combination for more granular rate limiting
-        // ipKeyGenerator normalizes IPv6 addresses to prevent bypass
-        const normalizedIp = ipKeyGenerator(req.ip);
+        // Trust forwarded client IPs only when TRUST_PROXY is explicitly
+        // configured; otherwise use the direct peer to avoid spoofable limits.
+        const normalizedIp = getRateLimitAddress(req);
         const username = req.body.username || 'unknown';
         return `${normalizedIp}:${username}`;
       },
       handler: (req, res) => {
         res.status(429).json({
           error: 'Too many failed login attempts. Please wait 15 minutes before trying again.'
+        });
+      }
+    });
+
+    const setupCreateAuthLimiter = rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 10,
+      standardHeaders: true,
+      legacyHeaders: false,
+      validate: {
+        trustProxy: false,
+        ip: false,
+      },
+      keyGenerator: (req) => getRateLimitAddress(req),
+      handler: (_req, res) => {
+        res.status(429).json({
+          error: 'Too many setup attempts. Please wait 15 minutes before trying again.'
         });
       }
     });
@@ -473,7 +512,11 @@ const initialize = async () => {
       message: 'Too many requests from this IP, please try again later',
       standardHeaders: true,
       legacyHeaders: false,
-      validate: { trustProxy: false }, // Suppress trust proxy warning - we run in Docker with proxy
+      validate: {
+        trustProxy: false,
+        ip: false,
+      },
+      keyGenerator: (req) => getRateLimitAddress(req),
     });
 
     // Rate limiter for YouTube API key validation. Each test round-trips to
@@ -484,7 +527,11 @@ const initialize = async () => {
       message: { error: 'Too many key tests. Please wait a minute before trying again.' },
       standardHeaders: true,
       legacyHeaders: false,
-      validate: { trustProxy: false },
+      validate: {
+        trustProxy: false,
+        ip: false,
+      },
+      keyGenerator: (req) => getRateLimitAddress(req),
       handler: (_req, res) => {
         res.status(429).json({
           error: 'Too many key tests. Please wait a minute before trying again.',
@@ -500,7 +547,11 @@ const initialize = async () => {
       message: { error: 'Too many validation requests. Please wait a minute before trying again.' },
       standardHeaders: true,
       legacyHeaders: false,
-      validate: { trustProxy: false },
+      validate: {
+        trustProxy: false,
+        ip: false,
+      },
+      keyGenerator: (req) => getRateLimitAddress(req),
       handler: (_req, res) => {
         res.status(429).json({
           error: 'Too many validation requests. Please wait a minute before trying again.',
@@ -560,6 +611,7 @@ const initialize = async () => {
     registerRoutes(app, {
       verifyToken,
       loginLimiter,
+      setupCreateAuthLimiter,
       youtubeApiKeyTestLimiter,
       ytdlpValidationRateLimiter,
       configModule,
@@ -575,7 +627,8 @@ const initialize = async () => {
       getCachedYtDlpVersion,
       refreshYtDlpVersionCache,
       validateEnvAuthCredentials,
-      isLocalhostIP,
+      setupTokenModule,
+      getClientAddress,
       isWslEnvironment,
     });
 
@@ -664,5 +717,6 @@ if (process.env.NODE_ENV !== 'test') {
 module.exports = {
   app,
   initialize,
-  isLocalhostIP
+  parseTrustProxySetting,
+  getClientAddress
 };


### PR DESCRIPTION
The previous initial-setup flow gated /setup/create-auth on a client-IP allowlist that depends on proxy-header trust and container networking. Replace it with a one-time setup token and tighten rate-limit keying.

- Generate a 32-byte setup token on first boot, write it to config/setup-token (mode 0600), log it at info until setup completes, and require it on /setup/create-auth with constant-time compare, single-use claim, and consume on success.
- Add a per-IP rate limiter to /setup/create-auth.
- Make Express proxy trust explicit via TRUST_PROXY. Until it is set, login, session, setup, and general-API rate limits key on the direct peer IP; the request-level trust-proxy default stays true for compatibility with existing reverse-proxy installs.
- Add YOUTARR_HOST_PORT so the host port can be changed without editing compose files; start scripts poll /setup/status and surface the matching setup URL with token guidance.
- Update the frontend wizard to require the token input and drop the localhost-only error view.
- Update authentication, installation, Docker, env vars, troubleshooting, and platform docs to describe the new flow.

Refs: #431