### PR TITLE
fix: restore members-only video detection

### DIFF
--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -149,6 +149,7 @@ function ChannelVideos({
   const [modalVideo, setModalVideo] = useState<ChannelVideo | null>(null);
   const [localIgnoreStatus, setLocalIgnoreStatus] = useState<Record<string, boolean>>({});
   const [localProtectedStatus, setLocalProtectedStatus] = useState<Record<string, boolean>>({});
+  const [localAvailabilityStatus, setLocalAvailabilityStatus] = useState<Record<string, string>>({});
 
   const {
     filters,
@@ -408,7 +409,8 @@ function ChannelVideos({
     return videos.map((video) => {
       const hasIgnoreOverride = video.youtube_id in localIgnoreStatus;
       const hasProtectedOverride = video.youtube_id in localProtectedStatus;
-      if (!hasIgnoreOverride && !hasProtectedOverride) return video;
+      const hasAvailabilityOverride = video.youtube_id in localAvailabilityStatus;
+      if (!hasIgnoreOverride && !hasProtectedOverride && !hasAvailabilityOverride) return video;
       return {
         ...video,
         ...(hasIgnoreOverride
@@ -420,9 +422,12 @@ function ChannelVideos({
         ...(hasProtectedOverride
           ? { protected: localProtectedStatus[video.youtube_id] }
           : {}),
+        ...(hasAvailabilityOverride
+          ? { availability: localAvailabilityStatus[video.youtube_id] }
+          : {}),
       };
     });
-  }, [videos, localIgnoreStatus, localProtectedStatus]);
+  }, [videos, localIgnoreStatus, localProtectedStatus, localAvailabilityStatus]);
 
   const paginatedVideos = videosWithOverrides;
   const totalPages = Math.ceil(totalCount / effectivePageSize) || 1;
@@ -1270,6 +1275,9 @@ function ChannelVideos({
           }}
           onDownloadQueued={() => setModalVideo(null)}
           onRatingChanged={() => refetchVideos()}
+          onAvailabilityDetected={(youtubeId, availability) => {
+            setLocalAvailabilityStatus((prev) => ({ ...prev, [youtubeId]: availability }));
+          }}
         />
       )}
     </>

--- a/client/src/components/DownloadManager/DownloadProgress.tsx
+++ b/client/src/components/DownloadManager/DownloadProgress.tsx
@@ -77,6 +77,7 @@ interface FinalSummary {
   totalDownloaded: number;
   totalSkipped: number;
   totalFailed?: number;
+  totalMembersOnly?: number;
   failedVideos?: FailedVideo[];
   jobType: string;
   completedAt?: string;
@@ -509,13 +510,23 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
         )}
 
         {/* Show final summary if available */}
-        {finalSummary && !currentProgress && !errorDetails && (
+        {finalSummary && !currentProgress && !errorDetails && (() => {
+          // Treat members-only skips as "warning"-shaped too: not a hard failure
+          // but the user couldn't actually download what they queued.
+          const hasIssue =
+            (finalSummary.totalFailed != null && finalSummary.totalFailed > 0)
+            || (finalSummary.totalMembersOnly != null && finalSummary.totalMembersOnly > 0);
+          // text-{success,warning}-foreground is meant for solid bg pairing;
+          // on /10 tinted bg we want the saturated colour token itself.
+          const bgClass = hasIssue ? 'bg-warning/10' : 'bg-success/10';
+          const textClass = hasIssue ? 'text-warning' : 'text-success';
+          return (
           <Box className="px-4 pb-4">
-            <Box className={`p-2 rounded-[var(--radius-ui)] text-center ${(finalSummary.totalFailed && finalSummary.totalFailed > 0) ? 'bg-warning/10' : 'bg-success/10'}`}>
-              <Typography variant="h6" className={(finalSummary.totalFailed && finalSummary.totalFailed > 0) ? 'text-warning-foreground' : 'text-success-foreground'}>
+            <Box className={`p-2 rounded-[var(--radius-ui)] text-center ${bgClass}`}>
+              <Typography variant="h6" className={textClass}>
                 Summary of last job
               </Typography>
-              <Typography variant="body1" className={(finalSummary.totalFailed && finalSummary.totalFailed > 0) ? 'text-warning-foreground' : 'text-success-foreground'}>
+              <Typography variant="body1" className={textClass}>
                 {(() => {
                   const parts: string[] = [];
                   if (finalSummary.totalDownloaded > 0) {
@@ -523,6 +534,9 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
                   }
                   if (finalSummary.totalFailed && finalSummary.totalFailed > 0) {
                     parts.push(`✗ ${finalSummary.totalFailed} failed`);
+                  }
+                  if (finalSummary.totalMembersOnly && finalSummary.totalMembersOnly > 0) {
+                    parts.push(`${finalSummary.totalMembersOnly} members-only video${finalSummary.totalMembersOnly !== 1 ? 's' : ''} skipped`);
                   }
                   if (finalSummary.totalSkipped > 0) {
                     parts.push(`${finalSummary.totalSkipped} skipped (already downloaded or filtered)`);
@@ -533,7 +547,7 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
                   return parts.join(', ');
                 })()}
               </Typography>
-              <Typography variant="caption" className={`mt-1 block ${(finalSummary.totalFailed && finalSummary.totalFailed > 0) ? 'text-warning-foreground' : 'text-success-foreground'}`}>
+              <Typography variant="caption" className={`mt-1 block ${textClass}`}>
                 {(() => {
                   let jobTypeLabel: string;
                   if (finalSummary.jobType.includes('Channel Downloads')) {
@@ -592,7 +606,8 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
               </Box>
             )}
           </Box>
-        )}
+          );
+        })()}
 
         {/* Show progress when active */}
         {currentProgress && showProgress && (

--- a/client/src/components/DownloadManager/__tests__/DownloadProgress.test.tsx
+++ b/client/src/components/DownloadManager/__tests__/DownloadProgress.test.tsx
@@ -315,6 +315,62 @@ describe('DownloadProgress', () => {
     expect(screen.getByText(/Manual download/)).toBeInTheDocument();
   });
 
+  test('displays members-only count in final summary when totalMembersOnly > 0', async () => {
+    renderWithContext(
+      <DownloadProgress
+        downloadProgressRef={mockDownloadProgressRef}
+        downloadInitiatedRef={mockDownloadInitiatedRef}
+        pendingJobs={[]}
+        token="test-token"
+      />
+    );
+
+    const [, processCallback] = mockSubscribe.mock.calls[0];
+
+    await act(async () => {
+      processCallback({
+        finalSummary: {
+          totalDownloaded: 0,
+          totalSkipped: 0,
+          totalMembersOnly: 2,
+          jobType: 'Manually Added Urls',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 members-only videos skipped/)).toBeInTheDocument();
+    });
+  });
+
+  test('singular grammar for one members-only video', async () => {
+    renderWithContext(
+      <DownloadProgress
+        downloadProgressRef={mockDownloadProgressRef}
+        downloadInitiatedRef={mockDownloadInitiatedRef}
+        pendingJobs={[]}
+        token="test-token"
+      />
+    );
+
+    const [, processCallback] = mockSubscribe.mock.calls[0];
+
+    await act(async () => {
+      processCallback({
+        finalSummary: {
+          totalDownloaded: 0,
+          totalSkipped: 0,
+          totalMembersOnly: 1,
+          jobType: 'Manually Added Urls',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 members-only video skipped/)).toBeInTheDocument();
+    });
+  });
+
   test('displays error with cookies required', async () => {
     const user = userEvent.setup();
     renderWithContext(

--- a/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
+++ b/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
@@ -205,6 +205,10 @@ describe('VideoModal', () => {
     jest.clearAllMocks();
     protectionReturn.error = null;
     mockTriggerDownloads.mockResolvedValue(true);
+    // Reset shared metadata mock so tests don't bleed
+    videoMetadataReturn.metadata = null;
+    videoMetadataReturn.loading = false;
+    videoMetadataReturn.error = null;
   });
 
   test('renders video title when open', () => {
@@ -215,6 +219,95 @@ describe('VideoModal', () => {
   test('renders status chip', () => {
     renderModal();
     expect(screen.getByText('Available')).toBeInTheDocument();
+  });
+
+  test('promotes status to Members Only when metadata reports subscriber_only', () => {
+    // Simulate the first-open case: video prop has stale availability (the
+    // channelvideos row hadn't been stamped yet), but the metadata fetch
+    // detected members-only and the backend overrode the response.
+    videoMetadataReturn.metadata = {
+      availability: 'subscriber_only',
+    } as unknown as typeof videoMetadataReturn.metadata;
+
+    renderModal({ video: neverDownloadedVideo });
+
+    // The members_only status chip label is "Members Only"
+    expect(screen.getByText('Members Only')).toBeInTheDocument();
+    // And the original 'Not Downloaded' label should NOT be shown
+    expect(screen.queryByText('Not Downloaded')).not.toBeInTheDocument();
+  });
+
+  test('does not promote when metadata reports public availability', () => {
+    videoMetadataReturn.metadata = {
+      availability: 'public',
+    } as unknown as typeof videoMetadataReturn.metadata;
+
+    renderModal({ video: neverDownloadedVideo });
+
+    expect(screen.queryByText('Members Only')).not.toBeInTheDocument();
+    expect(screen.getByText('Not Downloaded')).toBeInTheDocument();
+  });
+
+  test('fires onAvailabilityDetected once when promoting to members_only', async () => {
+    videoMetadataReturn.metadata = {
+      availability: 'subscriber_only',
+    } as unknown as typeof videoMetadataReturn.metadata;
+    const onAvailabilityDetected = jest.fn();
+
+    const { rerender } = renderModal({
+      video: neverDownloadedVideo,
+      onAvailabilityDetected,
+    });
+
+    await waitFor(() => {
+      expect(onAvailabilityDetected).toHaveBeenCalledWith(
+        neverDownloadedVideo.youtubeId,
+        'subscriber_only',
+      );
+    });
+    expect(onAvailabilityDetected).toHaveBeenCalledTimes(1);
+
+    // A re-render with the same video must not refire.
+    rerender(
+      <MemoryRouter>
+        <VideoModal
+          open
+          onClose={jest.fn()}
+          video={neverDownloadedVideo}
+          token="test-token"
+          onAvailabilityDetected={onAvailabilityDetected}
+        />
+      </MemoryRouter>
+    );
+    expect(onAvailabilityDetected).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not fire onAvailabilityDetected when video is already members_only', () => {
+    videoMetadataReturn.metadata = {
+      availability: 'subscriber_only',
+    } as unknown as typeof videoMetadataReturn.metadata;
+    const onAvailabilityDetected = jest.fn();
+
+    renderModal({
+      video: { ...neverDownloadedVideo, status: 'members_only' },
+      onAvailabilityDetected,
+    });
+
+    expect(onAvailabilityDetected).not.toHaveBeenCalled();
+  });
+
+  test('does not fire onAvailabilityDetected for non-members-only availability', () => {
+    videoMetadataReturn.metadata = {
+      availability: 'public',
+    } as unknown as typeof videoMetadataReturn.metadata;
+    const onAvailabilityDetected = jest.fn();
+
+    renderModal({
+      video: neverDownloadedVideo,
+      onAvailabilityDetected,
+    });
+
+    expect(onAvailabilityDetected).not.toHaveBeenCalled();
   });
 
   test('renders a clickable rating chip when rating exists', () => {

--- a/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
@@ -204,12 +204,41 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
               </IconButton>
             </>
           ) : video.status === 'members_only' ? (
+            // Dark text + white glow stays legible on both light and dark
+            // thumbnails. Hardcoded color: this label sits on top of an
+            // arbitrary photo, not on themed UI background.
             <>
-              <LockIcon size={48} color="white" />
-              <Typography variant="body1" sx={{ color: 'common.white', fontWeight: 500 }}>
+              <LockIcon
+                size={48}
+                color="#0f172a"
+                style={{
+                  filter:
+                    'drop-shadow(0 0 4px rgba(255,255,255,0.95)) drop-shadow(0 0 10px rgba(255,255,255,0.75))',
+                }}
+              />
+              <Typography
+                variant="body1"
+                sx={{
+                  color: '#0f172a',
+                  fontWeight: 600,
+                  textShadow:
+                    '0 0 4px rgba(255,255,255,0.95), 0 0 10px rgba(255,255,255,0.8), 0 0 16px rgba(255,255,255,0.55)',
+                }}
+              >
                 Members Only
               </Typography>
-              <Typography variant="body2" sx={{ color: 'common.white', opacity: 0.85, textAlign: 'center', paddingLeft: 16, paddingRight: 16 }}>
+              <Typography
+                variant="body2"
+                sx={{
+                  color: '#0f172a',
+                  fontWeight: 500,
+                  textAlign: 'center',
+                  paddingLeft: 16,
+                  paddingRight: 16,
+                  textShadow:
+                    '0 0 4px rgba(255,255,255,0.95), 0 0 10px rgba(255,255,255,0.8), 0 0 16px rgba(255,255,255,0.55)',
+                }}
+              >
                 Youtarr cannot download this video or fetch its metadata
               </Typography>
             </>

--- a/client/src/components/shared/VideoModal/hooks/__tests__/useVideoMetadata.test.ts
+++ b/client/src/components/shared/VideoModal/hooks/__tests__/useVideoMetadata.test.ts
@@ -73,6 +73,26 @@ describe('useVideoMetadata', () => {
     expect(axios.get).not.toHaveBeenCalled();
   });
 
+  test('clears stale metadata when youtubeId changes', async () => {
+    axios.get.mockResolvedValueOnce({ data: mockMetadata });
+
+    const { result, rerender } = renderHook(
+      ({ youtubeId }) => useVideoMetadata(youtubeId, 'test-token'),
+      { initialProps: { youtubeId: 'testId123' } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.metadata).toEqual(mockMetadata);
+    });
+
+    axios.get.mockReturnValueOnce(new Promise(() => {}));
+    rerender({ youtubeId: 'nextId456' });
+
+    await waitFor(() => {
+      expect(result.current.metadata).toBeNull();
+    });
+  });
+
   test('does not fetch when token is null', () => {
     const { result } = renderHook(() =>
       useVideoMetadata('testId123', null)

--- a/client/src/components/shared/VideoModal/hooks/useVideoMetadata.ts
+++ b/client/src/components/shared/VideoModal/hooks/useVideoMetadata.ts
@@ -13,11 +13,16 @@ export const useVideoMetadata = (
   token: string | null
 ): UseVideoMetadataReturn => {
   const [metadata, setMetadata] = useState<VideoExtendedMetadata | null>(null);
+  const [metadataYoutubeId, setMetadataYoutubeId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!youtubeId || !token) {
+      setMetadata(null);
+      setMetadataYoutubeId(null);
+      setLoading(false);
+      setError(null);
       return;
     }
 
@@ -25,6 +30,8 @@ export const useVideoMetadata = (
 
     const fetchMetadata = async () => {
       setLoading(true);
+      setMetadata(null);
+      setMetadataYoutubeId(youtubeId);
       setError(null);
 
       try {
@@ -35,6 +42,7 @@ export const useVideoMetadata = (
 
         if (!cancelled) {
           setMetadata(response.data);
+          setMetadataYoutubeId(youtubeId);
         }
       } catch (err: unknown) {
         if (!cancelled) {
@@ -57,5 +65,9 @@ export const useVideoMetadata = (
     };
   }, [youtubeId, token]);
 
-  return { metadata, loading, error };
+  return {
+    metadata: Boolean(token) && metadataYoutubeId === youtubeId ? metadata : null,
+    loading,
+    error,
+  };
 };

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import axios from 'axios';
 import {
   Dialog,
@@ -36,6 +36,7 @@ function VideoModal({
   onIgnoreChanged,
   onDownloadQueued,
   onRatingChanged,
+  onAvailabilityDetected,
   allowIgnore,
 }: VideoModalProps) {
   const isMobile = useMediaQuery('(max-width: 599px)');
@@ -114,6 +115,34 @@ function VideoModal({
     return () => { controller.abort(); };
   }, [open, video.channelId, token]);
 
+  // Promote localVideo to members_only display when the metadata fetch detects
+  // a members-only video. The backend stamps the channelvideos row in the same
+  // request, so a second open would catch it via getVideoStatus, but on the
+  // first open the prop's status is stale (still 'never_downloaded' or similar).
+  // Deriving here keeps VideoPlayer/VideoActions in sync without round-tripping.
+  const displayVideo = useMemo(() => {
+    if (metadata?.availability === 'subscriber_only' && localVideo.status !== 'members_only') {
+      return { ...localVideo, status: 'members_only' as const };
+    }
+    return localVideo;
+  }, [localVideo, metadata?.availability]);
+
+  // Notify the parent the first time we promote a video to members_only, so
+  // list pages that read availability (e.g. ChannelVideos via getVideoStatus)
+  // can update without a manual refresh. Keyed on youtubeId so we fire once
+  // per video and re-arm when the modal switches to a different one.
+  const promotedForRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (
+      metadata?.availability === 'subscriber_only' &&
+      localVideo.status !== 'members_only' &&
+      promotedForRef.current !== video.youtubeId
+    ) {
+      promotedForRef.current = video.youtubeId;
+      onAvailabilityDetected?.(video.youtubeId, 'subscriber_only');
+    }
+  }, [metadata?.availability, localVideo.status, video.youtubeId, onAvailabilityDetected]);
+
   const hasChannelQualityOverride = Boolean(channelSettings.video_quality);
   const defaultResolution = channelSettings.video_quality || config.preferredResolution || '1080';
   const defaultResolutionSource: 'channel' | 'global' = hasChannelQualityOverride ? 'channel' : 'global';
@@ -166,7 +195,7 @@ function VideoModal({
                 wordBreak: 'break-word',
               }}
             >
-              {localVideo.title}
+              {displayVideo.title}
             </Typography>
           </span>
         </DialogTitle>
@@ -187,13 +216,13 @@ function VideoModal({
             }}
           >
             <VideoPlayer
-              video={localVideo}
+              video={displayVideo}
               token={token}
               onDownloadClick={() => setDownloadDialogOpen(true)}
               isMobile={isMobile}
             />
             <VideoActions
-              video={localVideo}
+              video={displayVideo}
               onDelete={() => setDeleteDialogOpen(true)}
               onProtectionToggle={handleProtectionToggle}
               onIgnoreToggle={handleIgnoreToggle}
@@ -204,12 +233,12 @@ function VideoModal({
               allowIgnore={allowIgnore}
             />
             <VideoMetadata
-              video={localVideo}
+              video={displayVideo}
               metadata={metadata}
               loading={metadataLoading}
             />
             <VideoTechnical
-              video={localVideo}
+              video={displayVideo}
               metadata={metadata}
               loading={metadataLoading}
             />

--- a/client/src/components/shared/VideoModal/types.ts
+++ b/client/src/components/shared/VideoModal/types.ts
@@ -33,6 +33,7 @@ export interface VideoModalProps {
   onIgnoreChanged?: (youtubeId: string, isIgnored: boolean) => void;
   onDownloadQueued?: (youtubeId: string) => void;
   onRatingChanged?: (youtubeId: string, rating: string | null) => void;
+  onAvailabilityDetected?: (youtubeId: string, availability: string) => void;
   allowIgnore?: boolean;
 }
 

--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -794,8 +794,54 @@ describe('ChannelModule', () => {
           media_type: 'video',
           publishedAt: mockVideoData.publishedAt,
           availability: mockVideoData.availability,
-          live_status: null
         });
+      });
+
+      test('should preserve existing availability when refresh has no availability', async () => {
+        const mockVideo = { update: jest.fn() };
+        ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
+
+        const videoWithoutAvailability = { ...mockVideoData };
+        delete videoWithoutAvailability.availability;
+
+        await ChannelModule.insertVideosIntoDb([videoWithoutAvailability], 'UC123');
+
+        const updateArgs = mockVideo.update.mock.calls[0][0];
+        expect(updateArgs).not.toHaveProperty('availability');
+      });
+
+      test('should preserve existing live_status when refresh has no live_status', async () => {
+        const mockVideo = { update: jest.fn() };
+        ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
+
+        await ChannelModule.insertVideosIntoDb([mockVideoData], 'UC123');
+
+        const updateArgs = mockVideo.update.mock.calls[0][0];
+        expect(updateArgs).not.toHaveProperty('live_status');
+      });
+
+      test('should overwrite availability when refresh has a real value (real demotion still works)', async () => {
+        const mockVideo = { update: jest.fn() };
+        ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
+
+        const videoWithPublic = { ...mockVideoData, availability: 'public' };
+        await ChannelModule.insertVideosIntoDb([videoWithPublic], 'UC123');
+
+        expect(mockVideo.update).toHaveBeenCalledWith(
+          expect.objectContaining({ availability: 'public' })
+        );
+      });
+
+      test('should overwrite live_status when refresh has a real value', async () => {
+        const mockVideo = { update: jest.fn() };
+        ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
+
+        const videoWithLive = { ...mockVideoData, live_status: 'is_live' };
+        await ChannelModule.insertVideosIntoDb([videoWithLive], 'UC123');
+
+        expect(mockVideo.update).toHaveBeenCalledWith(
+          expect.objectContaining({ live_status: 'is_live' })
+        );
       });
 
       test('should insert videos with live_status field', async () => {

--- a/server/modules/__tests__/videoMetadataModule.test.js
+++ b/server/modules/__tests__/videoMetadataModule.test.js
@@ -4,6 +4,7 @@ describe('VideoMetadataModule', () => {
   let videoMetadataModule;
   let mockFs;
   let mockVideo;
+  let mockChannelVideo;
   let mockLogger;
   let mockConfigModule;
   let mockYtDlpRunner;
@@ -30,6 +31,10 @@ describe('VideoMetadataModule', () => {
       update: jest.fn(),
     };
 
+    mockChannelVideo = {
+      update: jest.fn().mockResolvedValue([1]),
+    };
+
     mockLogger = {
       info: jest.fn(),
       warn: jest.fn(),
@@ -46,6 +51,15 @@ describe('VideoMetadataModule', () => {
 
     mockYtDlpRunner = {
       fetchMetadata: jest.fn(),
+      isMembersOnlyError: jest.fn((message = '') => {
+        const normalized = String(message);
+        return [
+          /join this channel to get access to members-only content/i,
+          /available to this channel'?s members/i,
+          /members[- ]only/i,
+          /subscriber[_ -]?only/i,
+        ].some(pattern => pattern.test(normalized));
+      }),
     };
 
     mockYoutubeApi = {
@@ -59,6 +73,7 @@ describe('VideoMetadataModule', () => {
 
     jest.doMock('fs', () => ({ promises: mockFs }));
     jest.doMock('../../models', () => ({ Video: mockVideo }));
+    jest.doMock('../../models/channelvideo', () => mockChannelVideo);
     jest.doMock('../configModule', () => mockConfigModule);
     jest.doMock('../../logger', () => mockLogger);
     jest.doMock('../ytDlpRunner', () => mockYtDlpRunner);
@@ -239,6 +254,77 @@ describe('VideoMetadataModule', () => {
       await videoMetadataModule.getVideoMetadata('nobackfill');
 
       expect(mockVideoRecord.update).not.toHaveBeenCalled();
+    });
+
+    test('backfills ChannelVideo.availability when yt-dlp returns subscriber_only', async () => {
+      const rawInfoJson = {
+        availability: 'subscriber_only',
+        description: 'members-only video',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+      mockVideo.findOne.mockResolvedValue(null);
+
+      await videoMetadataModule.getVideoMetadata('memvid1');
+
+      expect(mockChannelVideo.update).toHaveBeenCalledWith(
+        { availability: 'subscriber_only' },
+        { where: { youtube_id: 'memvid1' } },
+      );
+    });
+
+    test('backfills ChannelVideo.availability when yt-dlp returns public', async () => {
+      const rawInfoJson = {
+        availability: 'public',
+        description: 'public video',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+      mockVideo.findOne.mockResolvedValue(null);
+
+      await videoMetadataModule.getVideoMetadata('pubvid1');
+
+      expect(mockChannelVideo.update).toHaveBeenCalledWith(
+        { availability: 'public' },
+        { where: { youtube_id: 'pubvid1' } },
+      );
+    });
+
+    test('does not call ChannelVideo.update when rawData has no availability', async () => {
+      const rawInfoJson = {
+        description: 'video without availability field',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+      mockVideo.findOne.mockResolvedValue(null);
+
+      await videoMetadataModule.getVideoMetadata('noavail1');
+
+      expect(mockChannelVideo.update).not.toHaveBeenCalled();
+    });
+
+    test('logs and swallows ChannelVideo.update errors', async () => {
+      const rawInfoJson = {
+        availability: 'subscriber_only',
+        description: 'members-only video',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+      mockVideo.findOne.mockResolvedValue(null);
+      mockChannelVideo.update.mockRejectedValueOnce(new Error('db down'));
+
+      const result = await videoMetadataModule.getVideoMetadata('errvid1');
+
+      // Backfill failure must not break the metadata return
+      expect(result.availability).toBe('subscriber_only');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ youtubeId: 'errvid1' }),
+        'Failed to backfill ChannelVideo.availability',
+      );
     });
 
     test('handles missing optional fields gracefully', async () => {
@@ -669,6 +755,113 @@ describe('VideoMetadataModule', () => {
       await videoMetadataModule.getVideoMetadata('abc12345678');
 
       expect(updateMock).toHaveBeenCalledWith({ originalDate: '20240101' });
+    });
+
+    test('does not backfill ChannelVideo.availability from API fallback path', async () => {
+      // The YouTube Data API never returns 'subscriber_only' (only public/unlisted/private),
+      // so backfilling from this path would silently downgrade real values to 'public'.
+      mockYoutubeApi.isAvailable.mockReturnValue(true);
+      mockYoutubeApi.getApiKey.mockReturnValue('test-key');
+      mockYoutubeApi.client.getVideoMetadata.mockResolvedValueOnce([{
+        id: 'apivid1',
+        availability: 'public',
+      }]);
+
+      await videoMetadataModule.getVideoMetadata('apivid1');
+
+      expect(mockChannelVideo.update).not.toHaveBeenCalled();
+    });
+
+    test('stamps subscriber_only when yt-dlp errors with members-only message', async () => {
+      // Real-world error text from yt-dlp for a members-only video
+      const membersOnlyError = new Error(
+        'Failed to fetch video metadata: ERROR: [youtube] memvid2: ' +
+        'This video is available to this channel\'s members on level: LTT Members Plus (or any higher level). ' +
+        'Join this channel to get access to members-only content and other exclusive perks.'
+      );
+      mockYtDlpRunner.fetchMetadata.mockRejectedValue(membersOnlyError);
+
+      await videoMetadataModule.getVideoMetadata('memvid2');
+
+      expect(mockChannelVideo.update).toHaveBeenCalledWith(
+        { availability: 'subscriber_only' },
+        { where: { youtube_id: 'memvid2' } },
+      );
+    });
+
+    test('returned metadata reports availability=subscriber_only after members-only detection', async () => {
+      // The API fallback would normally set availability from the API response
+      // (which never reports subscriber_only). We must override so the modal
+      // can render the Members Only state on first open.
+      mockYtDlpRunner.fetchMetadata.mockRejectedValue(
+        new Error('ERROR: [youtube] memvid4: Join this channel to get access to members-only content.')
+      );
+      // No API key configured -> API fallback returns NULL_METADATA, which has
+      // availability: null. Verify our override flips it to subscriber_only.
+      const result = await videoMetadataModule.getVideoMetadata('memvid4');
+
+      expect(result.availability).toBe('subscriber_only');
+    });
+
+    test('members-only override does not mutate null fallback metadata for later calls', async () => {
+      mockYtDlpRunner.fetchMetadata
+        .mockRejectedValueOnce(
+          new Error('ERROR: [youtube] memvid4: Join this channel to get access to members-only content.')
+        )
+        .mockRejectedValueOnce(
+          new Error('Failed to fetch video metadata: ERROR: [youtube] xyz: HTTP Error 403: Forbidden')
+        );
+
+      const membersOnlyResult = await videoMetadataModule.getVideoMetadata('memvid4');
+      const unrelatedResult = await videoMetadataModule.getVideoMetadata('xyz');
+
+      expect(membersOnlyResult.availability).toBe('subscriber_only');
+      expect(unrelatedResult.availability).toBeNull();
+    });
+
+    test('returned metadata reports availability=subscriber_only even when API fallback returns public', async () => {
+      mockYtDlpRunner.fetchMetadata.mockRejectedValue(
+        new Error('ERROR: [youtube] memvid5: members-only content.')
+      );
+      mockYoutubeApi.isAvailable.mockReturnValue(true);
+      mockYoutubeApi.getApiKey.mockReturnValue('test-key');
+      mockYoutubeApi.client.getVideoMetadata.mockResolvedValueOnce([{
+        id: 'memvid5',
+        availability: 'public', // API can't see members-only gating
+        description: 'cached desc from api',
+      }]);
+
+      const result = await videoMetadataModule.getVideoMetadata('memvid5');
+
+      expect(result.availability).toBe('subscriber_only');
+      // Other API-derived fields should still come through
+      expect(result.description).toBe('cached desc from api');
+    });
+
+    test('does not stamp subscriber_only on unrelated yt-dlp errors', async () => {
+      mockYtDlpRunner.fetchMetadata.mockRejectedValue(
+        new Error('Failed to fetch video metadata: ERROR: [youtube] xyz: HTTP Error 403: Forbidden')
+      );
+
+      await videoMetadataModule.getVideoMetadata('xyz');
+
+      expect(mockChannelVideo.update).not.toHaveBeenCalled();
+    });
+
+    test('logs and swallows backfill error when stamping after members-only fetch failure', async () => {
+      mockYtDlpRunner.fetchMetadata.mockRejectedValue(
+        new Error('ERROR: [youtube] memvid3: Join this channel to get access to members-only content.')
+      );
+      mockChannelVideo.update.mockRejectedValueOnce(new Error('db down'));
+
+      // Should still resolve (returning fallback) despite the backfill failure
+      const result = await videoMetadataModule.getVideoMetadata('memvid3');
+
+      expect(result).toBeDefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ youtubeId: 'memvid3' }),
+        'Failed to backfill ChannelVideo.availability after members-only fetch error',
+      );
     });
 
     test('returns NULL_METADATA when both yt-dlp and API fail', async () => {

--- a/server/modules/__tests__/videoValidationModule.test.js
+++ b/server/modules/__tests__/videoValidationModule.test.js
@@ -6,15 +6,30 @@ jest.mock('../download/tempPathManager', () => ({
   getTempBasePath: jest.fn(() => '/tmp/youtarr-downloads'),
 }));
 
+jest.mock('../../models/channelvideo', () => ({
+  update: jest.fn().mockResolvedValue([1]),
+}));
+
 const videoValidationModule = require('../videoValidationModule');
 const ytDlpRunner = require('../ytDlpRunner');
 const archiveModule = require('../archiveModule');
+const ChannelVideo = require('../../models/channelvideo');
 const logger = require('../../logger');
 
 // Mock dependencies
 jest.mock('../ytDlpRunner');
 jest.mock('../archiveModule');
 jest.mock('../../logger');
+
+const isMembersOnlyMessage = (message = '') => {
+  const normalized = String(message);
+  return [
+    /join this channel to get access to members-only content/i,
+    /available to this channel'?s members/i,
+    /members[- ]only/i,
+    /subscriber[_ -]?only/i,
+  ].some(pattern => pattern.test(normalized));
+};
 
 describe('VideoValidationModule', () => {
   beforeEach(() => {
@@ -27,6 +42,10 @@ describe('VideoValidationModule', () => {
     logger.info.mockClear();
     logger.warn.mockClear();
     logger.error.mockClear();
+    // Reset ChannelVideo mock
+    ChannelVideo.update.mockClear();
+    ChannelVideo.update.mockResolvedValue([1]);
+    ytDlpRunner.isMembersOnlyError.mockImplementation(isMembersOnlyMessage);
   });
 
   describe('normalizeUrlToVideoId', () => {
@@ -332,6 +351,136 @@ describe('VideoValidationModule', () => {
 
       expect(result.isValidUrl).toBe(true);
       expect(result.isMembersOnly).toBe(true);
+    });
+
+    it('should backfill ChannelVideo.availability on fresh fetch path', async () => {
+      const mockMetadata = {
+        title: 'Members Only',
+        channel: 'TestChannel',
+        duration: 300,
+        availability: 'subscriber_only'
+      };
+
+      ytDlpRunner.fetchMetadata.mockResolvedValue(mockMetadata);
+      archiveModule.isVideoInArchive.mockResolvedValue(false);
+
+      await videoValidationModule.validateVideo('https://www.youtube.com/watch?v=OOUclRI0Ae4');
+
+      expect(ChannelVideo.update).toHaveBeenCalledWith(
+        { availability: 'subscriber_only' },
+        { where: { youtube_id: 'OOUclRI0Ae4' } },
+      );
+    });
+
+    it('should not backfill defaulted public availability when yt-dlp omits availability', async () => {
+      const mockMetadata = {
+        title: 'No Availability',
+        channel: 'TestChannel',
+        duration: 300,
+      };
+
+      ytDlpRunner.fetchMetadata.mockResolvedValue(mockMetadata);
+      archiveModule.isVideoInArchive.mockResolvedValue(false);
+
+      const result = await videoValidationModule.validateVideo('https://www.youtube.com/watch?v=OOUclRI0Ae4');
+
+      expect(result.metadata.availability).toBe('public');
+      expect(ChannelVideo.update).not.toHaveBeenCalled();
+    });
+
+    it('should not repeat ChannelVideo.availability backfill on cache hit path', async () => {
+      const mockMetadata = {
+        title: 'Test Video',
+        channel: 'TestChannel',
+        duration: 300,
+        availability: 'public'
+      };
+
+      ytDlpRunner.fetchMetadata.mockResolvedValue(mockMetadata);
+      archiveModule.isVideoInArchive.mockResolvedValue(false);
+
+      // First call populates cache and triggers one update
+      await videoValidationModule.validateVideo('https://www.youtube.com/watch?v=OOUclRI0Ae4');
+      expect(ChannelVideo.update).toHaveBeenCalledTimes(1);
+
+      // Second call hits cache; the original miss already stamped availability.
+      await videoValidationModule.validateVideo('https://www.youtube.com/watch?v=OOUclRI0Ae4');
+      expect(ChannelVideo.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('should backfill ChannelVideo.availability on members-only error catch path', async () => {
+      ytDlpRunner.fetchMetadata.mockRejectedValue(
+        new Error('ERROR: [youtube] OOUclRI0Ae4: Join this channel to get access to members-only content')
+      );
+
+      const result = await videoValidationModule.validateVideo('https://www.youtube.com/watch?v=OOUclRI0Ae4');
+
+      expect(result.isMembersOnly).toBe(true);
+      expect(ChannelVideo.update).toHaveBeenCalledWith(
+        { availability: 'subscriber_only' },
+        { where: { youtube_id: 'OOUclRI0Ae4' } },
+      );
+    });
+  });
+
+  describe('_persistAvailabilityFromResponse', () => {
+    it('should call ChannelVideo.update when response has youtubeId and availability', () => {
+      videoValidationModule._persistAvailabilityFromResponse({
+        metadata: { youtubeId: 'abc12345678', availability: 'subscriber_only', availabilityProvided: true },
+      });
+
+      expect(ChannelVideo.update).toHaveBeenCalledWith(
+        { availability: 'subscriber_only' },
+        { where: { youtube_id: 'abc12345678' } },
+      );
+    });
+
+    it('should be a no-op when response has no metadata', () => {
+      videoValidationModule._persistAvailabilityFromResponse({});
+      videoValidationModule._persistAvailabilityFromResponse(null);
+      videoValidationModule._persistAvailabilityFromResponse(undefined);
+
+      expect(ChannelVideo.update).not.toHaveBeenCalled();
+    });
+
+    it('should be a no-op when youtubeId is missing', () => {
+      videoValidationModule._persistAvailabilityFromResponse({
+        metadata: { availability: 'public' },
+      });
+
+      expect(ChannelVideo.update).not.toHaveBeenCalled();
+    });
+
+    it('should be a no-op when availability was defaulted', () => {
+      videoValidationModule._persistAvailabilityFromResponse({
+        metadata: { youtubeId: 'abc12345678', availability: 'public' },
+      });
+
+      expect(ChannelVideo.update).not.toHaveBeenCalled();
+    });
+
+    it('should be a no-op when availability is missing', () => {
+      videoValidationModule._persistAvailabilityFromResponse({
+        metadata: { youtubeId: 'abc12345678' },
+      });
+
+      expect(ChannelVideo.update).not.toHaveBeenCalled();
+    });
+
+    it('should swallow update errors and log a warning', async () => {
+      ChannelVideo.update.mockRejectedValueOnce(new Error('db down'));
+
+      // The helper itself doesn't await; we have to wait a tick for the
+      // rejection handler to run.
+      videoValidationModule._persistAvailabilityFromResponse({
+        metadata: { youtubeId: 'errvid1', availability: 'subscriber_only', availabilityProvided: true },
+      });
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ videoId: 'errvid1' }),
+        'Failed to backfill ChannelVideo.availability from validation',
+      );
     });
   });
 

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -1327,11 +1327,16 @@ class ChannelModule {
           title: video.title,
           thumbnail: video.thumbnail,
           duration: video.duration,
-          availability: video.availability || null,
           media_type: mediaType,
-          live_status: video.live_status || null,
           publishedAt: video.publishedAt || syntheticPublishedAt,
         };
+
+        // Only overwrite availability/live_status when yt-dlp returned a real value.
+        // yt-dlp's flat-playlist mode currently omits these for lockupViewModel
+        // entries, so an empty refresh must not wipe known-good values that other
+        // code paths (modal open, download error, URL validation) populated.
+        if (video.availability) updates.availability = video.availability;
+        if (video.live_status) updates.live_status = video.live_status;
 
         if (video.content_rating != null) updates.content_rating = video.content_rating;
         if (video.age_limit != null) updates.age_limit = video.age_limit;

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -82,6 +82,10 @@ jest.mock('../../../models/channel', () => ({
   findAll: jest.fn().mockResolvedValue([])
 }));
 
+jest.mock('../../../models/channelvideo', () => ({
+  update: jest.fn().mockResolvedValue([1]),
+}));
+
 // Mock filesystem module
 jest.mock('../../filesystem', () => {
   const actualPathBuilder = jest.requireActual('../../filesystem/pathBuilder');
@@ -118,6 +122,7 @@ const VideoMetadataProcessor = require('../videoMetadataProcessor');
 const tempPathManager = require('../tempPathManager');
 const { JobVideoDownload } = require('../../../models');
 const Channel = require('../../../models/channel');
+const ChannelVideo = require('../../../models/channelvideo');
 const logger = require('../../../logger');
 
 describe('DownloadExecutor', () => {
@@ -2135,6 +2140,77 @@ describe('DownloadExecutor', () => {
       'ERROR: [youtube] abc123: The following content is not available on this app.'
     ])('should not classify real failures as expected skips: %s', (message) => {
       expect(executor.isExpectedYtdlpSkipMessage(message)).toBe(false);
+    });
+  });
+
+  describe('isMembersOnlyMessage', () => {
+    it.each([
+      'ERROR: [youtube] abc123: Join this channel to get access to members-only content like this video, and other exclusive perks.',
+      'ERROR: [youtube] abc123: This video is available to this channel\'s members on level: Assistant (or any higher level).',
+      'ERROR: [youtube] abc123: members-only content',
+      'ERROR: [youtube] abc123: subscriber_only',
+    ])('should match members-only patterns: %s', (message) => {
+      expect(executor.isMembersOnlyMessage(message)).toBe(true);
+    });
+
+    it.each([
+      'ERROR: [youtube] abc123: This live event will begin in 21 hours.',
+      'WARNING: [youtube] This live event will begin in a few moments.',
+      'ERROR: [youtube] abc123: Premiere will begin shortly.',
+      'ERROR: [youtube] abc123: This pre-release video is not yet available.',
+      'ERROR: [youtube] abc123: Release time of video is not known.',
+      'ERROR: [youtube] abc123: Sign in to confirm you are not a bot.',
+    ])('should NOT match premiere, pre-release, or unrelated patterns: %s', (message) => {
+      expect(executor.isMembersOnlyMessage(message)).toBe(false);
+    });
+  });
+
+  describe('extractYoutubeIdFromYtdlpError', () => {
+    it('should extract the authoritative youtube id from yt-dlp error text', () => {
+      const message = 'ERROR: [youtube] OOUclRI0Ae4: Join this channel to get access to members-only content.';
+
+      expect(executor.extractYoutubeIdFromYtdlpError(message)).toBe('OOUclRI0Ae4');
+    });
+
+    it('should return null when yt-dlp error text has no video id', () => {
+      expect(executor.extractYoutubeIdFromYtdlpError('members-only content')).toBeNull();
+    });
+  });
+
+  describe('persistMembersOnlyAvailability', () => {
+    beforeEach(() => {
+      ChannelVideo.update.mockClear();
+      ChannelVideo.update.mockResolvedValue([1]);
+    });
+
+    it('should update channelvideos with subscriber_only when youtubeId provided', async () => {
+      await executor.persistMembersOnlyAvailability('abc12345678');
+
+      expect(ChannelVideo.update).toHaveBeenCalledWith(
+        { availability: 'subscriber_only' },
+        { where: { youtube_id: 'abc12345678' } },
+      );
+    });
+
+    it('should be a no-op when youtubeId is null', async () => {
+      await executor.persistMembersOnlyAvailability(null);
+      await executor.persistMembersOnlyAvailability(undefined);
+      await executor.persistMembersOnlyAvailability('');
+
+      expect(ChannelVideo.update).not.toHaveBeenCalled();
+    });
+
+    it('should swallow update errors and log a warning', async () => {
+      const dbErr = new Error('db down');
+      ChannelVideo.update.mockRejectedValueOnce(dbErr);
+
+      // Must not throw
+      await expect(executor.persistMembersOnlyAvailability('errvid1')).resolves.toBeUndefined();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ youtubeId: 'errvid1' }),
+        'Failed to persist subscriber_only availability after download error',
+      );
     });
   });
 

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -7,8 +7,10 @@ const MessageEmitter = require('../messageEmitter');
 const DownloadProgressMonitor = require('./DownloadProgressMonitor');
 const VideoMetadataProcessor = require('./videoMetadataProcessor');
 const tempPathManager = require('./tempPathManager');
+const ytDlpRunner = require('../ytDlpRunner');
 const { JobVideoDownload } = require('../../models');
 const Channel = require('../../models/channel');
+const ChannelVideo = require('../../models/channelvideo');
 const logger = require('../../logger');
 const filesystem = require('../filesystem');
 
@@ -218,11 +220,10 @@ class DownloadExecutor {
 
   isExpectedYtdlpSkipMessage(message = '') {
     const normalized = String(message);
+    if (ytDlpRunner.isMembersOnlyError(normalized)) {
+      return true;
+    }
     const expectedPatterns = [
-      /join this channel to get access to members-only content/i,
-      /available to this channel'?s members/i,
-      /members[- ]only/i,
-      /subscriber[_ -]?only/i,
       /this live event will begin/i,
       /will begin in (?:a few moments|\d+)/i,
       /premiere (?:will begin|starts|is upcoming)/i,
@@ -233,6 +234,34 @@ class DownloadExecutor {
     ];
 
     return expectedPatterns.some(pattern => pattern.test(normalized));
+  }
+
+  // Narrower predicate than isExpectedYtdlpSkipMessage: only matches members-only
+  // patterns, not upcoming-premiere or pre-release ones. Used to decide whether
+  // to stamp channelvideos.availability with 'subscriber_only', which would be
+  // wrong for premiere/pre-release skips (those are temporary states).
+  isMembersOnlyMessage(message = '') {
+    return ytDlpRunner.isMembersOnlyError(message);
+  }
+
+  extractYoutubeIdFromYtdlpError(message = '') {
+    const match = String(message).match(/\[youtube\]\s+([a-zA-Z0-9_-]{11}):/);
+    return match ? match[1] : null;
+  }
+
+  // Fire-and-forget persistence so we don't block the stdout/stderr stream
+  // handlers. Internal try/catch ensures the returned Promise always resolves,
+  // so callers don't trigger unhandledRejection warnings when they don't await.
+  async persistMembersOnlyAvailability(youtubeId) {
+    if (!youtubeId) return;
+    try {
+      await ChannelVideo.update(
+        { availability: 'subscriber_only' },
+        { where: { youtube_id: youtubeId } },
+      );
+    } catch (err) {
+      logger.warn({ err, youtubeId }, 'Failed to persist subscriber_only availability after download error');
+    }
   }
 
   async persistCompletedVideosBeforeTerminalUpdate(jobId, videoData, failedVideosList) {
@@ -641,6 +670,12 @@ class DownloadExecutor {
       // upcoming live, premiere, etc.). Only the count drives downstream
       // behavior; per-skip context goes to the structured log.
       let expectedSkipCount = 0;
+      // Set of youtube_id values that yt-dlp specifically rejected as
+      // members-only. Tracked separately from expectedSkipCount so the final
+      // summary can call out membership-gated skips (the user can't fix
+      // those by waiting like with premieres). Set semantics dedupe across
+      // stdout+stderr emitting the same error for one video.
+      const membersOnlyVideoIds = new Set();
       // Count of yt-dlp errors that are NOT expected skips. Incremented in
       // both stdout and stderr handlers regardless of whether currentVideoId
       // is known, so unassociated errors still block the
@@ -785,6 +820,13 @@ class DownloadExecutor {
                 lastErrorMessage = errorMatch[1].trim();
                 if (this.isExpectedYtdlpSkipMessage(lastErrorMessage)) {
                   recordExpectedSkip(lastErrorMessage, 'stdout');
+                  if (this.isMembersOnlyMessage(lastErrorMessage)) {
+                    const membersOnlyVideoId = this.extractYoutubeIdFromYtdlpError(lastErrorMessage) || currentVideoId;
+                    if (membersOnlyVideoId) {
+                      membersOnlyVideoIds.add(membersOnlyVideoId);
+                      this.persistMembersOnlyAvailability(membersOnlyVideoId);
+                    }
+                  }
                   suppressExpectedSkipLine = true;
                 } else {
                   unexpectedErrorCount += 1;
@@ -863,6 +905,13 @@ class DownloadExecutor {
               lastErrorMessage = errorMatch[1].trim();
               if (this.isExpectedYtdlpSkipMessage(lastErrorMessage)) {
                 recordExpectedSkip(lastErrorMessage, 'stderr');
+                if (this.isMembersOnlyMessage(lastErrorMessage)) {
+                  const membersOnlyVideoId = this.extractYoutubeIdFromYtdlpError(lastErrorMessage) || currentVideoId;
+                  if (membersOnlyVideoId) {
+                    membersOnlyVideoIds.add(membersOnlyVideoId);
+                    this.persistMembersOnlyAvailability(membersOnlyVideoId);
+                  }
+                }
                 return;
               }
               unexpectedErrorCount += 1;
@@ -1374,6 +1423,7 @@ class DownloadExecutor {
             totalDownloaded: videoData.length,
             totalSkipped: monitor.videoCount.skipped || 0,
             totalFailed: failedVideosList.length,
+            totalMembersOnly: membersOnlyVideoIds.size,
             failedVideos: failedVideosList,
             jobType: jobType,
             completedAt: new Date().toISOString()

--- a/server/modules/videoMetadataModule.js
+++ b/server/modules/videoMetadataModule.js
@@ -5,6 +5,7 @@ const configModule = require('./configModule');
 const ytDlpRunner = require('./ytDlpRunner');
 const logger = require('../logger');
 const youtubeApi = require('./youtubeApi');
+const ChannelVideo = require('../models/channelvideo');
 
 const NULL_METADATA = {
   description: null,
@@ -109,10 +110,37 @@ class VideoMetadataModule {
           }
         } catch (fetchErr) {
           logger.warn({ err: fetchErr, youtubeId }, 'Failed to fetch metadata via yt-dlp');
+
+          // yt-dlp throws "Join this channel..." / "available to this channel's
+          // members..." style errors for members-only videos. The fetch failure
+          // is itself the signal: stamp subscriber_only so the next modal open
+          // short-circuits the failing fetch (VideoModal skips getVideoMetadata
+          // when video.status === 'members_only').
+          const detectedMembersOnly = ytDlpRunner.isMembersOnlyError(fetchErr?.message);
+          if (detectedMembersOnly) {
+            try {
+              await ChannelVideo.update(
+                { availability: 'subscriber_only' },
+                { where: { youtube_id: youtubeId } },
+              );
+            } catch (backfillErr) {
+              logger.warn({ err: backfillErr, youtubeId }, 'Failed to backfill ChannelVideo.availability after members-only fetch error');
+            }
+          }
+
           // Try API fallback so the UI isn't left completely empty. File
           // detail fields will be null (API can't provide them), but text
           // fields are still useful.
-          return this._getApiFallbackMetadata(youtubeId);
+          const fallbackMetadata = { ...(await this._getApiFallbackMetadata(youtubeId)) };
+          // The Data API never reports 'subscriber_only' (it sees the video as
+          // 'public' since the gating is membership-side). When we already
+          // detected members-only from the yt-dlp error, override the response
+          // so the modal renders the Members Only state on first open instead
+          // of treating the video as public until the next refetch.
+          if (detectedMembersOnly) {
+            fallbackMetadata.availability = 'subscriber_only';
+          }
+          return fallbackMetadata;
         }
       }
 
@@ -135,6 +163,23 @@ class VideoMetadataModule {
           }
         } catch (backfillErr) {
           logger.warn({ err: backfillErr, youtubeId }, 'Failed to backfill originalDate');
+        }
+      }
+
+      // Backfill ChannelVideo.availability so members-only videos surfaced via
+      // modal open get marked, even when yt-dlp's flat-playlist channel listing
+      // omits availability for lockupViewModel entries. Same shape as the
+      // originalDate backfill above. Only runs on the yt-dlp path; the API
+      // fallback never reports 'subscriber_only' so backfilling from there
+      // would silently downgrade real values to 'public'.
+      if (rawData.availability) {
+        try {
+          await ChannelVideo.update(
+            { availability: rawData.availability },
+            { where: { youtube_id: youtubeId } },
+          );
+        } catch (backfillErr) {
+          logger.warn({ err: backfillErr, youtubeId }, 'Failed to backfill ChannelVideo.availability');
         }
       }
 

--- a/server/modules/videoValidationModule.js
+++ b/server/modules/videoValidationModule.js
@@ -1,6 +1,7 @@
 const ytDlpRunner = require('./ytDlpRunner');
 const archiveModule = require('./archiveModule');
 const logger = require('../logger');
+const ChannelVideo = require('../models/channelvideo');
 
 class VideoValidationModule {
   constructor() {
@@ -106,6 +107,26 @@ class VideoValidationModule {
   }
 
   /**
+   * Backfill ChannelVideo.availability from a validation response.
+   * Fire-and-forget: a write failure should never block the validation reply.
+   * Idempotent: safe to call multiple times for the same video.
+   * Only persists values that came from yt-dlp, not defaulted response values.
+   * @param {Object} response - Validation response with metadata.youtubeId and metadata.availability
+   * @private
+   */
+  _persistAvailabilityFromResponse(response) {
+    const youtubeId = response?.metadata?.youtubeId;
+    const availability = response?.metadata?.availability;
+    if (!youtubeId || !availability || !response?.metadata?.availabilityProvided) return;
+    ChannelVideo.update(
+      { availability },
+      { where: { youtube_id: youtubeId } },
+    ).catch(err => {
+      logger.warn({ err, videoId: youtubeId }, 'Failed to backfill ChannelVideo.availability from validation');
+    });
+  }
+
+  /**
    * Convert metadata to validation response format
    * @param {string} videoId - YouTube video ID
    * @param {Object} metadata - yt-dlp metadata
@@ -114,6 +135,7 @@ class VideoValidationModule {
    */
   toValidationResponse(videoId, metadata, isDuplicate) {
     const isMembersOnly = metadata.availability === 'subscriber_only';
+    const availabilityProvided = Boolean(metadata.availability);
 
     const contentRating = metadata.contentRating || metadata.content_rating || null;
     const ageLimit = metadata.age_limit ?? null;
@@ -139,6 +161,10 @@ class VideoValidationModule {
         media_type: metadata.media_type || 'video',
       }
     };
+    Object.defineProperty(resp.metadata, 'availabilityProvided', {
+      value: availabilityProvided,
+      enumerable: false,
+    });
 
     if (contentRating != null) resp.metadata.content_rating = contentRating;
     if (ageLimit != null) resp.metadata.age_limit = ageLimit;
@@ -257,6 +283,7 @@ class VideoValidationModule {
       }
 
       this.setCachedResponse(videoId, response);
+      this._persistAvailabilityFromResponse(response);
 
       return response;
     } catch (error) {
@@ -270,14 +297,13 @@ class VideoValidationModule {
         };
       }
       // Check for members-only video error
-      else if (error.message.includes('members-only') ||
-          error.message.includes('Join this channel to get access')) {
+      else if (ytDlpRunner.isMembersOnlyError(error.message)) {
         // Extract video ID from error message if possible, or use the one we parsed from URL
         const videoIdMatch = error.message.match(/\[youtube\]\s+([a-zA-Z0-9_-]{11}):/);
         const extractedVideoId = videoIdMatch ? videoIdMatch[1] : videoId;
 
         // Return a valid response indicating it's members-only
-        return {
+        const membersOnlyResponse = {
           isValidUrl: true,
           isAlreadyDownloaded: false,
           isMembersOnly: true,
@@ -292,6 +318,12 @@ class VideoValidationModule {
             media_type: 'video'
           }
         };
+        Object.defineProperty(membersOnlyResponse.metadata, 'availabilityProvided', {
+          value: true,
+          enumerable: false,
+        });
+        this._persistAvailabilityFromResponse(membersOnlyResponse);
+        return membersOnlyResponse;
       } else if (error.message.includes('Invalid YouTube URL')) {
         return {
           isValidUrl: false,

--- a/server/modules/ytDlpRunner.js
+++ b/server/modules/ytDlpRunner.js
@@ -3,9 +3,25 @@ const path = require('path');
 const fs = require('fs');
 const tempPathManager = require('./download/tempPathManager');
 
+const MEMBERS_ONLY_PATTERNS = [
+  /join this channel to get access to members-only content/i,
+  /available to this channel'?s members/i,
+  /members[- ]only/i,
+  /subscriber[_ -]?only/i,
+];
+
+function isMembersOnlyError(message = '') {
+  const normalized = String(message);
+  return MEMBERS_ONLY_PATTERNS.some(pattern => pattern.test(normalized));
+}
+
 class YtDlpRunner {
   constructor() {
     this.defaultTimeout = 10000;
+  }
+
+  isMembersOnlyError(message = '') {
+    return isMembersOnlyError(message);
   }
 
   /**


### PR DESCRIPTION
Availability stopped arriving in the flat-playlist channel fetch, so members-only videos showed up unmarked in the list, queued downloads silently dropped from the summary, and the modal first-open showed an empty failed fetch.

Stamp subscriber_only wherever we can (eg, when fetching individual video data or downloadinig videos), stop empty refreshes from wiping known-good values, and surface the counts in job summaries:

- Modal metadata fetch backfills on success and on the yt-dlp members-only error catch, with API fallback override so the modal renders Members Only on first open.
- URL validation backfills on cache hit, fresh fetch, and the members-only error catch.
- Download executor tracks members-only IDs per job and includes the count in the final summary.
- Channel-video update no longer overwrites availability or live_status with null when a refresh omits them.

Frontend: VideoModal derives a members_only display status from the metadata response and signals the parent so list pages update in place. Summary panel uses the saturated success/warning tokens (the foreground variant didn't contrast on /10 tinted bg). The VideoPlayer overlay was restyled (dark text + white halo) for legibility on any thumbnail.

Refs: yt-dlp/yt-dlp#16665