### PR TITLE
fix: stop clobbering channelvideo publishedAt on empty refresh

### DIFF
--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -920,7 +920,10 @@ describe('ChannelModule', () => {
         expect(secondCall.defaults.publishedAt).toBe('2024-01-02T00:00:00Z');
       });
 
-      test('should update publishedAt with synthetic date when not provided on existing videos', async () => {
+      test('should preserve existing publishedAt when refresh has no date', async () => {
+        // yt-dlp's youtubetab:approximate_date is non-deterministic for
+        // lockupViewModel entries. An empty refresh must not clobber a
+        // known-good DB date with Date.now().
         const mockVideo = {
           publishedAt: '2024-01-01T00:00:00Z',
           update: jest.fn()
@@ -933,16 +936,10 @@ describe('ChannelModule', () => {
 
         ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
 
-        const beforeTime = Date.now();
         await ChannelModule.insertVideosIntoDb([videoWithoutDate], 'UC123');
-        const afterTime = Date.now();
 
-        // Should always update publishedAt (with synthetic date if not provided)
         const updateCall = mockVideo.update.mock.calls[0][0];
-        expect(updateCall.publishedAt).toBeDefined();
-        const timestamp = new Date(updateCall.publishedAt).getTime();
-        expect(timestamp).toBeGreaterThanOrEqual(beforeTime - 1000);
-        expect(timestamp).toBeLessThanOrEqual(afterTime + 1000);
+        expect(updateCall).not.toHaveProperty('publishedAt');
       });
 
       test('should set synthetic publishedAt on existing videos without dates', async () => {

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -1328,7 +1328,6 @@ class ChannelModule {
           thumbnail: video.thumbnail,
           duration: video.duration,
           media_type: mediaType,
-          publishedAt: video.publishedAt || syntheticPublishedAt,
         };
 
         // Only overwrite availability/live_status when yt-dlp returned a real value.
@@ -1337,6 +1336,18 @@ class ChannelModule {
         // code paths (modal open, download error, URL validation) populated.
         if (video.availability) updates.availability = video.availability;
         if (video.live_status) updates.live_status = video.live_status;
+
+        // Same logic for publishedAt: yt-dlp's youtubetab:approximate_date is
+        // non-deterministic for lockupViewModel entries (sometimes returns
+        // timestamp, sometimes upload_date, sometimes neither), so a refresh
+        // that comes back empty must not clobber a previously-stored real
+        // date with a synthetic Date.now() value. Only stamp synthetic when
+        // the row had no date to begin with.
+        if (video.publishedAt) {
+          updates.publishedAt = video.publishedAt;
+        } else if (!videoRecord.publishedAt) {
+          updates.publishedAt = syntheticPublishedAt;
+        }
 
         if (video.content_rating != null) updates.content_rating = video.content_rating;
         if (video.age_limit != null) updates.age_limit = video.age_limit;


### PR DESCRIPTION
Some channel listing refreshes returned video entries with no timestamp, upload_date, or release_timestamp, and the update path overwrote the existing DB publishedAt with a synthetic Date.now() value. Affected channels showed every video stamped at "now" until a later refresh happened to come back with dates.

Restore the conditional update: write publishedAt when the refresh provided one, fall back to a synthetic value only when the existing row had no date, otherwise leave the column alone. Mirrors the availability and live_status guards already in this branch.

Refs: #608