### PR TITLE
Hotfix Release: stop Settings crash on missing config field

### DIFF
--- a/client/src/components/Configuration/utils/__tests__/configValidation.test.ts
+++ b/client/src/components/Configuration/utils/__tests__/configValidation.test.ts
@@ -104,4 +104,12 @@ describe('validateConfig', () => {
     });
     expect(validateConfig(config)).toBeNull();
   });
+
+  // Regression for #611: missing videoFilenamePrefix crashed the Settings page on render.
+  test('does not crash when videoFilenamePrefix is missing from the config object', () => {
+    const config = createConfig();
+    delete (config as Partial<ConfigState>).videoFilenamePrefix;
+    expect(() => validateConfig(config)).not.toThrow();
+    expect(validateConfig(config)).toMatch(/Cannot save:/);
+  });
 });

--- a/client/src/config/__tests__/configSchemaAlignment.test.ts
+++ b/client/src/config/__tests__/configSchemaAlignment.test.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+import { DEFAULT_CONFIG } from '../configSchema';
+
+// useConfig fills missing server fields from DEFAULT_CONFIG and save POSTs the
+// full object back, so a default mismatch here silently overwrites the server's.
+describe('DEFAULT_CONFIG alignment with config.example.json', () => {
+  const examplePath = path.resolve(__dirname, '../../../../config/config.example.json');
+  const exampleConfig = JSON.parse(fs.readFileSync(examplePath, 'utf8')) as Record<string, unknown>;
+  delete exampleConfig['//comment'];
+
+  // plexUrl is platform-managed and not in the client schema.
+  const SERVER_ONLY_FIELDS = new Set<string>(['plexUrl']);
+
+  // Runtime-derived fields populated by the server at /getconfig time
+  // (not persisted to config.json, intentionally absent from the template).
+  const CLIENT_RUNTIME_FIELDS = new Set<string>([
+    'youtubeOutputDirectory',
+    'envAuthApplied',
+  ]);
+
+  // null vs '': both falsy, treated identically by all consumers.
+  const ACCEPTED_TYPE_DIFFERENCES = new Set<string>([
+    'autoRemovalFreeSpaceThreshold',
+    'autoRemovalVideoAgeThreshold',
+  ]);
+
+  test.each(
+    Object.entries(exampleConfig).filter(
+      ([key]) => !SERVER_ONLY_FIELDS.has(key) && !ACCEPTED_TYPE_DIFFERENCES.has(key)
+    )
+  )('%s in server template has a matching client default', (key, serverValue) => {
+    expect(key in DEFAULT_CONFIG).toBe(true);
+    const clientValue = (DEFAULT_CONFIG as Record<string, unknown>)[key];
+    expect(clientValue).toEqual(serverValue);
+  });
+
+  test.each(
+    Object.entries(DEFAULT_CONFIG).filter(
+      ([key]) => !CLIENT_RUNTIME_FIELDS.has(key) && !ACCEPTED_TYPE_DIFFERENCES.has(key)
+    )
+  )('%s in DEFAULT_CONFIG has a matching server template entry', (key, clientValue) => {
+    expect(key in exampleConfig).toBe(true);
+    const serverValue = exampleConfig[key];
+    expect(clientValue).toEqual(serverValue);
+  });
+});

--- a/client/src/config/configSchema.ts
+++ b/client/src/config/configSchema.ts
@@ -20,9 +20,12 @@ import { SponsorBlockCategories } from '../components/Configuration/types';
  */
 export const CONFIG_FIELDS = {
   // Channel settings
+  // Defaults must match config/config.example.json: useConfig fills missing
+  // server fields from here and save POSTs the full object back.
+  // Enforced by configSchemaAlignment.test.ts.
   channelAutoDownload: { default: false, trackChanges: true },
-  channelDownloadFrequency: { default: '', trackChanges: true },
-  channelFilesToDownload: { default: 3, trackChanges: true },
+  channelDownloadFrequency: { default: '0 * * * *', trackChanges: true },
+  channelFilesToDownload: { default: 5, trackChanges: true },
 
   // Video settings
   preferredResolution: { default: '1080', trackChanges: true },
@@ -104,7 +107,7 @@ export const CONFIG_FIELDS = {
 
   // Appearance
   darkModeEnabled: { default: false, trackChanges: true },
-  channelVideosHotLoad: { default: true, trackChanges: true },
+  channelVideosHotLoad: { default: false, trackChanges: true },
 
   // API Keys
   apiKeyRateLimit: { default: 10, trackChanges: true },

--- a/client/src/hooks/useConfig.ts
+++ b/client/src/hooks/useConfig.ts
@@ -81,8 +81,10 @@ export function useConfig(token: string | null): UseConfigResult {
         });
       }
 
-      // Apply defaults
+      // Spread DEFAULT_CONFIG first so fields missing from the server response
+      // (stale config pre-dating a new field) fall back to defaults instead of undefined.
       const resolvedConfig = {
+        ...DEFAULT_CONFIG,
         ...data,
         writeChannelPosters: data.writeChannelPosters ?? true,
         writeVideoNfoFiles: data.writeVideoNfoFiles ?? true,

--- a/client/src/utils/filenameTemplate/__tests__/validate.test.ts
+++ b/client/src/utils/filenameTemplate/__tests__/validate.test.ts
@@ -18,6 +18,13 @@ describe('validatePrefix', () => {
     expect(r.error).toMatch(/empty/i);
   });
 
+  // Regression for #611: undefined/null reached validatePrefix and crashed `.replace`.
+  it.each([undefined, null])('rejects %p without crashing', (input) => {
+    const r = validatePrefix(input);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/empty/i);
+  });
+
   it('rejects a whitespace-only prefix', () => {
     const r = validatePrefix('   ');
     expect(r.ok).toBe(false);

--- a/client/src/utils/filenameTemplate/validate.ts
+++ b/client/src/utils/filenameTemplate/validate.ts
@@ -26,7 +26,12 @@ export const MAX_VIDEO_FILENAME_PREFIX_LENGTH = 160;
  * grammar in a regex produced false rejections for valid templates like
  * `%(view_count)05d` and `%(uploader)20s`.
  */
-export function validatePrefix(prefix: string): ValidationResult {
+export function validatePrefix(prefix: string | null | undefined): ValidationResult {
+  // Called with values loaded from /getconfig, which can omit fields at runtime
+  // despite the ConfigState type. Guard so `.replace` doesn't crash on undefined.
+  if (typeof prefix !== 'string') {
+    return { ok: false, error: 'Prefix may not be empty.' };
+  }
   const trimmedPrefix = prefix.replace(/\s+$/, '');
   if (trimmedPrefix.trim().length === 0) {
     return { ok: false, error: 'Prefix may not be empty.' };

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -50,6 +50,7 @@
   "subtitlesEnabled": false,
   "subtitleLanguage": "en",
   "darkModeEnabled": false,
+  "channelVideosHotLoad": false,
   "uuid": "",
   "apiKeyRateLimit": 10,
   "autoUpdateYtdlp": false,


### PR DESCRIPTION
Old configs predating videoFilenamePrefix reached Settings with
the field undefined, crashing validatePrefix on .replace.

useConfig now spreads DEFAULT_CONFIG before the server response,
and validatePrefix guards non-string input.

Also aligns DEFAULT_CONFIG with config.example.json and adds an
alignment test so future drift breaks CI instead of silently
overwriting server defaults on save.

Refs: #611