### PR TITLE
Release: harden supply chain

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,27 @@ database/
 database/*
 database.bind-mount-backup.*
 
-# Ignore local setup secrets
-config/setup-token
+# Ignore all local config except the example (keeps cookies, tokens, json
+# backups, and per-host config.json out of the build context)
+config/*
+!config/config.example.json
+.env
+.env.*
+!.env.example
+!.env.dev.example
+
+# Ignore local dependencies and generated outputs
+node_modules/
+client/node_modules/
+client/build-storybook/
+client/storybook-static/
+coverage/
+client/coverage/
+
+# Ignore local caches and logs
+.cache/
+.npm/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+client/public/mockServiceWorker.js linguist-generated=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  actions: write
+  actions: read
 
 jobs:
   lint:
@@ -15,21 +15,28 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20.x'
           cache: 'npm'
 
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install client dependencies
         run: |
           cd client
-          npm ci
+          npm ci --ignore-scripts
+
+      - name: Verify MSW worker is current
+        run: |
+          cd client
+          npm run msw:init
+          cd ..
+          git diff --exit-code -- client/package.json client/package-lock.json client/public/mockServiceWorker.js
 
       - name: Run ESLint on Backend
         id: lint-backend
@@ -67,16 +74,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20.x'
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run backend tests with coverage
         run: npm run test:backend -- --coverage --coverageReporters=json-summary --coverageReporters=lcov --coverageReporters=text
@@ -110,7 +117,7 @@ jobs:
           fi
 
       - name: Upload backend coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: backend-coverage
           path: |
@@ -123,21 +130,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20.x'
           cache: 'npm'
 
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install client dependencies
         run: |
           cd client
-          npm ci
+          npm ci --ignore-scripts
 
       - name: Run frontend tests with coverage
         run: cd client && npm test -- --coverage --coverageReporters=json-summary --coverageReporters=lcov --coverageReporters=text --watchAll=false
@@ -171,7 +178,7 @@ jobs:
           fi
 
       - name: Upload frontend coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: frontend-coverage
           path: |
@@ -184,25 +191,25 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20.x'
           cache: 'npm'
 
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install client dependencies
         run: |
           cd client
-          npm ci
+          npm ci --ignore-scripts
 
       - name: Cache Storybook build
         id: cache-storybook
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: client/storybook-static
           key: ${{ runner.os }}-storybook-${{ hashFiles('client/src/**', 'client/.storybook/**', 'client/package-lock.json') }}
@@ -224,27 +231,33 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20.x'
           cache: 'npm'
 
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install client dependencies
         run: |
           cd client
-          npm ci
+          npm ci --ignore-scripts
 
-      - name: Audit root dependencies
+      - name: Audit root runtime dependencies
         run: npm audit --audit-level=high --omit=dev
 
-      - name: Audit client dependencies
+      - name: Audit all root dependencies (critical only)
+        run: npm audit --audit-level=critical
+
+      - name: Audit client runtime dependencies
         run: cd client && npm audit --audit-level=high --omit=dev
+
+      - name: Audit all client dependencies (critical only)
+        run: cd client && npm audit --audit-level=critical
 
   # This job is required for branch protection rules
   # It will only succeed if all tests and linting pass

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,10 +24,10 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -128,10 +128,10 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1
         continue-on-error: true
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/coverage-badges.yml
+++ b/.github/workflows/coverage-badges.yml
@@ -26,20 +26,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.ACTION_RUNNER_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20.x'
           cache: 'npm'
 
       - name: Install dependencies
         run: |
-          npm ci
-          cd client && npm ci
+          npm ci --ignore-scripts
+          cd client && npm ci --ignore-scripts
 
       - name: Run backend tests with coverage
         run: npm run test:backend -- --coverage --coverageReporters=json-summary

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Download backend coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: backend-coverage
           path: backend-coverage
@@ -30,7 +30,7 @@ jobs:
         continue-on-error: true
 
       - name: Download frontend coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: frontend-coverage
           path: frontend-coverage
@@ -39,7 +39,7 @@ jobs:
         continue-on-error: true
 
       - name: Generate coverage report comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
           echo "🏷️ RC tag: ${RC_TAG}"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -49,7 +49,7 @@ jobs:
       - name: Install client dependencies
         run: |
           cd client
-          npm ci
+          npm ci --ignore-scripts
 
       - name: Build client
         run: |
@@ -57,20 +57,28 @@ jobs:
           npm run build
           echo "✅ Client build successful"
 
+      - name: Verify MSW worker excluded from production bundle
+        run: |
+          if [ -e client/build/mockServiceWorker.js ]; then
+            echo "❌ client/build/mockServiceWorker.js should not exist in production output"
+            exit 1
+          fi
+          echo "✅ MSW worker correctly excluded from production bundle"
+
       - name: Set up QEMU (multi-arch)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push RC Docker images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           fetch-depth: 0
@@ -41,7 +41,7 @@ jobs:
 
       - name: Calculate next version (dry run)
         id: calculate_version
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.ACTION_RUNNER_TOKEN }}
           tag_prefix: v
@@ -55,7 +55,7 @@ jobs:
           echo "No conventional commit changes since last tag (${{ steps.calculate_version.outputs.previous_tag }}). Skipping release."
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -65,18 +65,18 @@ jobs:
       - name: Install client dependencies
         run: |
           cd client
-          npm ci
+          npm ci --ignore-scripts
           cd ..
 
       - name: Set up QEMU (multi-arch)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Docker Hub
         if: ${{ !inputs.dry_run && steps.calculate_version.outputs.release_type != 'none' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -100,9 +100,18 @@ jobs:
           cd ..
           echo "✅ Client build successful"
 
+      - name: Verify MSW worker excluded from production bundle
+        if: ${{ steps.calculate_version.outputs.release_type != 'none' }}
+        run: |
+          if [ -e client/build/mockServiceWorker.js ]; then
+            echo "❌ client/build/mockServiceWorker.js should not exist in production output"
+            exit 1
+          fi
+          echo "✅ MSW worker correctly excluded from production bundle"
+
       - name: Build Docker image (verification)
         if: ${{ steps.calculate_version.outputs.release_type != 'none' }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: false
@@ -118,7 +127,7 @@ jobs:
       - name: Create and push tag
         if: ${{ !inputs.dry_run && steps.calculate_version.outputs.release_type != 'none' }}
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.ACTION_RUNNER_TOKEN }}
           tag_prefix: v
@@ -130,7 +139,7 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{ !inputs.dry_run && steps.calculate_version.outputs.release_type != 'none' }}
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           tag: ${{ steps.calculate_version.outputs.new_tag }}
           name: Release ${{ steps.calculate_version.outputs.new_tag }}
@@ -197,7 +206,7 @@ jobs:
 
       - name: Build and push Docker images
         if: ${{ !inputs.dry_run && steps.calculate_version.outputs.release_type != 'none' }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: true
@@ -281,7 +290,7 @@ jobs:
 
       - name: Cleanup tag and release on failure
         if: ${{ failure() && !inputs.dry_run && steps.calculate_version.outputs.release_type != 'none' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.ACTION_RUNNER_TOKEN }}
           script: |

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,3 @@ client/build-storybook/
 # Storybook test artifacts
 .out_storybook_
 .storyshots
-
-# MSW service worker - regenerate with: cd client && npx msw init public/ --save
-client/public/mockServiceWorker.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN npm ci --only=production --ignore-scripts
 # ---- Build ----
 FROM base AS build
 COPY package*.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
 # Copy server code and built React app
 COPY server/ ./server/
 COPY client/build/ ./client/build/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,77 @@
+# Security Policy
+
+## Supported Versions
+
+Youtarr provides security support for the latest stable release only:
+
+| Version | Supported |
+| --- | --- |
+| Latest stable release (`latest` Docker tag and newest `vX.Y.Z` tag) | Yes |
+| Older stable releases | No |
+| Development builds (`dev-latest`, `dev-rc.<sha>`, or unreleased branch builds) | No |
+
+Youtarr is supported as a Docker-based application. Direct host-side Node.js
+production deployments are unsupported.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities using GitHub private vulnerability
+reporting for this repository:
+
+https://github.com/DialmasterOrg/Youtarr/security/advisories/new
+
+Do not report vulnerabilities through public GitHub issues, public pull
+requests, Discord, or other public channels. Public reports can expose users
+before a fix is available.
+
+## What to Include
+
+Include as much of the following as you can:
+
+- The Youtarr version, Docker tag, or image digest you tested.
+- Your install method, such as helper scripts, Docker Compose, external
+  database, or platform-managed deployment.
+- Host OS, Docker version, browser, and database type/version when relevant.
+- Clear reproduction steps and the security impact.
+- Redacted logs, screenshots, or proof-of-concept details that help verify the
+  issue.
+
+Do not include secrets in a report. Redact `.env` values, config files,
+cookies, API tokens, Discord webhook URLs, Plex tokens, database passwords,
+YouTube credentials, and any other private data.
+
+## Scope
+
+Examples of in-scope issues include:
+
+- Authentication or authorization bypasses.
+- Stored or reflected cross-site scripting in the web UI.
+- CSRF or unsafe state-changing requests.
+- Path traversal, unintended file writes, or unintended file deletion.
+- Exposure of secrets through logs, API responses, config handling, Docker
+  images, or build context.
+- Supply-chain or release-process issues that could affect published Youtarr
+  artifacts.
+- Database migration or data exposure issues with a security impact.
+
+Examples of out-of-scope issues include:
+
+- Generic scanner output without a Youtarr-specific exploit path.
+- Issues requiring administrator or root access to the Docker host, unless they
+  cross a meaningful trust boundary.
+- Vulnerabilities in upstream services such as YouTube, Plex, Discord, Docker,
+  MariaDB, or yt-dlp unless Youtarr makes them exploitable in a specific way.
+- Social engineering, spam, physical attacks, or denial of service by simply
+  overwhelming a self-hosted instance.
+
+## Response Expectations
+
+We aim to acknowledge valid reports within 3 business days and provide an
+initial triage response within 7 days.
+
+For confirmed high or critical vulnerabilities, we aim to release a fix within
+30 days when feasible. Timelines may vary based on complexity, required
+coordination, and maintainer availability.
+
+After a fix is available, we may publish a GitHub Security Advisory, release
+notes, or both. Reporter credit is offered unless anonymity is requested.

--- a/client/.storybook/fixtures/mswHandlers.js
+++ b/client/.storybook/fixtures/mswHandlers.js
@@ -4,8 +4,8 @@
  * These provide baseline API responses so stories render without real network
  * requests. Individual stories can override handlers via `parameters.msw`.
  *
- * Regenerate mockServiceWorker.js if it goes missing:
- *   cd client && npx msw init public/ --save
+ * Regenerate mockServiceWorker.js after bumping msw:
+ *   cd client && npm run msw:init
  */
 import { http, HttpResponse } from 'msw';
 import { DEFAULT_CONFIG } from '../../src/config/configSchema';

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "client",
       "version": "1.69.1",
-      "hasInstallScript": true,
       "dependencies": {
         "@fontsource/archivo": "^5.2.8",
         "@fontsource/ibm-plex-sans": "^5.2.8",
@@ -67,7 +66,7 @@
         "jest": "^30.1.3",
         "jest-environment-jsdom": "^30.2.0",
         "jest-transform-stub": "^2.0.0",
-        "msw": "^2.12.7",
+        "msw": "2.12.10",
         "msw-storybook-addon": "^2.0.6",
         "postcss": "^8.5.6",
         "react-icons": "^5.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -49,7 +49,7 @@
     "typescript": "5.9.3"
   },
   "scripts": {
-    "postinstall": "npx msw init public/ --save",
+    "msw:init": "msw init public/ --save",
     "dev": "vite",
     "start": "vite",
     "build": "vite build",
@@ -90,7 +90,7 @@
     "jest": "^30.1.3",
     "jest-environment-jsdom": "^30.2.0",
     "jest-transform-stub": "^2.0.0",
-    "msw": "^2.12.7",
+    "msw": "2.12.10",
     "msw-storybook-addon": "^2.0.6",
     "postcss": "^8.5.6",
     "storybook": "^10.2.10",

--- a/client/public/mockServiceWorker.js
+++ b/client/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.12.10'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,14 +1,27 @@
+import { rmSync } from 'node:fs';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-export default defineConfig(({ command }) => {
+const buildOutDir = 'build';
+
+function excludeProductionMswWorker() {
+  return {
+    name: 'exclude-production-msw-worker',
+    apply: 'build' as const,
+    closeBundle() {
+      rmSync(`${buildOutDir}/mockServiceWorker.js`, { force: true });
+    },
+  };
+}
+
+export default defineConfig(() => {
   const backendPort = process.env.VITE_BACKEND_PORT || '3087';
   const backendTarget = `http://127.0.0.1:${backendPort}`;
   const devServerHost = process.env.VITE_HOST || '0.0.0.0';
 
   return {
-    plugins: [react(), tsconfigPaths()],
+    plugins: [react(), tsconfigPaths(), excludeProductionMswWorker()],
     envPrefix: ['VITE_', 'REACT_APP_'],
     server: {
       host: devServerHost,
@@ -60,7 +73,7 @@ export default defineConfig(({ command }) => {
       },
     },
     build: {
-      outDir: 'build',
+      outDir: buildOutDir,
       sourcemap: true,
       rollupOptions: {
         output: {
@@ -101,4 +114,3 @@ export default defineConfig(({ command }) => {
     },
   };
 });
-

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -84,9 +84,6 @@ cd Youtarr
 
 ### 2. Build Development Environment
 ```bash
-# Install root dependencies
-npm i
-
 # First build (installs dependencies and builds the client)
 ./scripts/build-dev.sh --install-deps
 
@@ -95,7 +92,7 @@ npm i
 ```
 
 Optional flags:
-- `--install-deps` - Runs `npm install` in the root and `client/` before building (required on a clean clone or after dependency changes)
+- `--install-deps` - Runs `npm ci --ignore-scripts` in the root and `client/` before building, then runs `npm run prepare` once to wire up Husky git hooks (Husky's own script only; dependency lifecycle scripts stay disabled). Required on a clean clone or after dependency changes.
 - `--no-cache` - Force rebuild to get latest yt-dlp version
 - `SKIP_DEV_IMAGE_PRUNE=1` - Skip automatic cleanup of old untagged `youtarr-dev` images (pruning is enabled by default to keep Docker storage from filling)
 
@@ -158,10 +155,10 @@ Use Storybook to develop and document components in isolation.
 
 **Prerequisites:** Complete Step 2 (Build Development Environment) first, or at minimum install client dependencies:
 ```bash
-cd client && npm install
+cd client && npm ci --ignore-scripts
 ```
 
-This automatically generates the MSW (Mock Service Worker) file needed for API mocking in stories.
+The MSW (Mock Service Worker) file used for Storybook API mocking is committed at `client/public/mockServiceWorker.js`. After bumping `msw`, regenerate it with `cd client && npm run msw:init` and commit the updated worker.
 
 ```bash
 # Start Storybook Server
@@ -202,7 +199,7 @@ Create your admin account on first access.
 The development setup is a "build-and-test-in-Docker" workflow that ensures your code works in a containerized environment:
 
 **Build Phase** (`./scripts/build-dev.sh`):
-1. Runs `npm install` on your host (if `--install-deps` is used)
+1. Runs `npm ci --ignore-scripts` on your host (if `--install-deps` is used)
 2. Builds the React frontend (`npm run build` in client directory) - creates production build
 3. Builds a Docker image with the pre-built static files
 

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 IMAGE_NAME="youtarr-dev:latest"
 IMAGE_LABEL="youtarr.image=youtarr-dev"
 
@@ -7,15 +9,26 @@ echo "Note: If you want to install dependencies, run with --install-deps, may be
 echo "If you want to build without caching, run with --no-cache, this will take much longer, but will download a new yt-dlp binary."
 echo "In Github Actions, there will never be a cache, so it will always get a new yt-dlp binary."
 
-# Check if --install-deps was passed as an argument
-if [ "$1" = "--install-deps" ]
-then
-  # Install dependencies for the base
-  npm install
+INSTALL_DEPS=false
+NO_CACHE=false
+for arg in "$@"; do
+  case "$arg" in
+    --install-deps) INSTALL_DEPS=true ;;
+    --no-cache)     NO_CACHE=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
+
+if $INSTALL_DEPS; then
+  # Install exact locked dependencies while skipping lifecycle scripts to limit supply-chain risk.
+  npm ci --ignore-scripts
+  # Wire up husky git hooks. Safe under our supply-chain policy: this runs only
+  # our own `prepare` script (husky install), not arbitrary dependency hooks.
+  npm run prepare
 
   # Install dependencies and build the client
   cd client
-  npm install
+  npm ci --ignore-scripts
   cd ..
 fi
 
@@ -26,16 +39,16 @@ cd ..
 
 # Build the Docker container -- do we need --no-cache?
 BUILD_ARGS=(--label "$IMAGE_LABEL" -t "$IMAGE_NAME")
-if [ "$1" = "--no-cache" ]; then
+if $NO_CACHE; then
   BUILD_ARGS+=(--no-cache)
 fi
 docker build "${BUILD_ARGS[@]}" .
 
 # Prune dangling dev images so repeats don't pile up
-if [ -z "$SKIP_DEV_IMAGE_PRUNE" ]; then
+if [ -z "${SKIP_DEV_IMAGE_PRUNE:-}" ]; then
   echo ""
   echo "Cleaning up old dangling dev images..."
-  docker image prune --force --filter "label=$IMAGE_LABEL"
+  docker image prune --force --filter "label=$IMAGE_LABEL" || true
 else
   echo ""
   echo "Skipping dev image prune because SKIP_DEV_IMAGE_PRUNE is set."


### PR DESCRIPTION
Pin every third-party GitHub Action to a commit SHA so workflow
execution is reproducible and not subject to mutable tag rewrites.

Pass `--ignore-scripts` to every npm ci invocation in CI, the
Dockerfile, and build-dev.sh to block postinstall hooks in
transitive dependencies.

Pin MSW to an exact version, commit client/public/mockServiceWorker.js
instead of regenerating it via a postinstall hook

Reduce ci.yml from actions: write to actions: read.

Switch .dockerignore from a single-file blocklist to an allow-list
under config/ and .env*, so secrets cannot be copied into the
image even if added later.

Add strict mode (set -euo pipefail) and allow-list argument
parsing to scripts/build-dev.sh.

Add SECURITY.md with a vulnerability disclosure policy.