### PR TITLE
feat: detect and disable terminated channels

### DIFF
--- a/client/src/components/ChannelManager/components/ChannelCard.tsx
+++ b/client/src/components/ChannelManager/components/ChannelCard.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Avatar, Card, CardActionArea, CardContent, Chip, Tooltip, Typography } from '../../ui';
 import { Delete as DeleteIcon, Image as ImageIcon, Folder as FolderIcon } from '../../../lib/icons';
 import { Channel } from '../../../types/Channel';
-import { QualityChip, AutoDownloadChips, DurationFilterChip, TitleFilterChip, DownloadFormatConfigIndicator } from './chips';
+import { QualityChip, AutoDownloadChips, DurationFilterChip, TitleFilterChip, DownloadFormatConfigIndicator, TerminatedChip } from './chips';
 
 interface ChannelCardProps {
     channel: Channel;
@@ -141,10 +141,11 @@ const ChannelCard: React.FC<ChannelCardProps> = ({
                 <CardContent style={{ display: 'flex', flexDirection: 'column', gap: 16, width: '100%', flexGrow: 1 }}>
                     <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 8 }}>
                         <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', width: '100%', minWidth: 0 }}>
-                            <div style={{ minWidth: 0, flexGrow: 1 }}>
+                            <div style={{ minWidth: 0, flexGrow: 1, display: 'flex', flexDirection: 'column', gap: 4 }}>
                                 <Typography variant="subtitle1" fontWeight={600} noWrap>
                                     {channel.uploader || 'Unknown Channel'}
                                 </Typography>
+                                <TerminatedChip terminatedAt={channel.terminated_at} />
                             </div>
                             <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
                                 <FolderIcon size={16} style={{ color: 'var(--muted-foreground)' }} data-testid="FolderIcon" />

--- a/client/src/components/ChannelManager/components/ChannelListRow.tsx
+++ b/client/src/components/ChannelManager/components/ChannelListRow.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../ui';
 import { Delete as DeleteIcon } from '../../../lib/icons';
 import { Channel } from '../../../types/Channel';
-import { SubFolderChip, QualityChip, AutoDownloadChips, DurationFilterChip, TitleFilterChip, DownloadFormatConfigIndicator } from './chips';
+import { SubFolderChip, QualityChip, AutoDownloadChips, DurationFilterChip, TitleFilterChip, DownloadFormatConfigIndicator, TerminatedChip } from './chips';
 import RatingBadge from '../../shared/RatingBadge';
 
 interface ChannelListRowProps {
@@ -65,9 +65,12 @@ const ChannelListRow: React.FC<ChannelListRowProps> = ({
       )}
       <div style={{ minWidth: 0, flex: 1 }}>
         <div style={{ display: 'flex', flexDirection: 'column', minWidth: 0, gap: 0 }}>
-          <Typography variant={isMobile ? 'h6' : 'h5'} noWrap style={{ minWidth: 0 }}>
-            {channel.uploader || 'Unknown Channel'}
-          </Typography>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0, flexWrap: 'wrap' }}>
+            <Typography variant={isMobile ? 'h6' : 'h5'} noWrap style={{ minWidth: 0 }}>
+              {channel.uploader || 'Unknown Channel'}
+            </Typography>
+            <TerminatedChip terminatedAt={channel.terminated_at} />
+          </div>
           {/* On mobile we show folder and quality chips right under the channel name */}
           {isMobile && (
             <div style={{ marginTop: 2, display: 'flex', gap: 4, flexWrap: 'wrap', alignItems: 'center' }}>

--- a/client/src/components/ChannelManager/components/__tests__/ChannelCard.test.tsx
+++ b/client/src/components/ChannelManager/components/__tests__/ChannelCard.test.tsx
@@ -54,6 +54,14 @@ jest.mock('../chips', () => ({
       'data-audio-format': audioFormat,
     }, 'Format');
   },
+  TerminatedChip: function MockTerminatedChip({ terminatedAt }: any) {
+    const React = require('react');
+    if (!terminatedAt) return null;
+    return React.createElement('div', {
+      'data-testid': 'terminated-chip',
+      'data-terminated-at': terminatedAt,
+    }, 'Terminated');
+  },
 }));
 
 describe('ChannelCard Component', () => {

--- a/client/src/components/ChannelManager/components/__tests__/ChannelListRow.test.tsx
+++ b/client/src/components/ChannelManager/components/__tests__/ChannelListRow.test.tsx
@@ -78,6 +78,18 @@ jest.mock('../chips', () => ({
       'Format'
     );
   },
+  TerminatedChip: function MockTerminatedChip({ terminatedAt }: any) {
+    const React = require('react');
+    if (!terminatedAt) return null;
+    return React.createElement(
+      'div',
+      {
+        'data-testid': 'terminated-chip',
+        'data-terminated-at': terminatedAt,
+      },
+      'Terminated'
+    );
+  },
 }));
 
 describe('ChannelListRow', () => {

--- a/client/src/components/ChannelManager/components/chips/TerminatedChip.tsx
+++ b/client/src/components/ChannelManager/components/chips/TerminatedChip.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Chip, Tooltip } from '../../../../components/ui';
+import { Warning as WarningIcon } from '../../../../lib/icons';
+
+interface TerminatedChipProps {
+  terminatedAt: string | null | undefined;
+}
+
+const formatDetectionDate = (terminatedAt: string): string => {
+  const parsed = new Date(terminatedAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'unknown date';
+  }
+  return parsed.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+const TerminatedChip: React.FC<TerminatedChipProps> = ({ terminatedAt }) => {
+  if (!terminatedAt) {
+    return null;
+  }
+
+  const tooltipText = `YouTube terminated this channel; detected on ${formatDetectionDate(terminatedAt)}. Scheduled downloads are disabled. If the channel has been reinstated, load the channel page to update its status automatically.`;
+
+  return (
+    <Tooltip title={tooltipText}>
+      <Chip
+        icon={<WarningIcon size={14} data-testid="WarningIcon" />}
+        label="Terminated"
+        size="small"
+        color="error"
+        aria-label={tooltipText}
+        data-testid="terminated-chip"
+      />
+    </Tooltip>
+  );
+};
+
+export default TerminatedChip;

--- a/client/src/components/ChannelManager/components/chips/__tests__/TerminatedChip.test.tsx
+++ b/client/src/components/ChannelManager/components/chips/__tests__/TerminatedChip.test.tsx
@@ -1,0 +1,37 @@
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TerminatedChip from '../TerminatedChip';
+import { renderWithProviders } from '../../../../../test-utils';
+
+describe('TerminatedChip', () => {
+  test('renders nothing when terminatedAt is null', () => {
+    renderWithProviders(<TerminatedChip terminatedAt={null} />);
+    expect(screen.queryByTestId('terminated-chip')).not.toBeInTheDocument();
+  });
+
+  test('renders nothing when terminatedAt is undefined', () => {
+    renderWithProviders(<TerminatedChip terminatedAt={undefined} />);
+    expect(screen.queryByTestId('terminated-chip')).not.toBeInTheDocument();
+  });
+
+  test('renders chip with Terminated label when terminatedAt is set', () => {
+    renderWithProviders(<TerminatedChip terminatedAt="2026-03-15T12:00:00Z" />);
+    const chip = screen.getByTestId('terminated-chip');
+    expect(chip).toHaveTextContent('Terminated');
+  });
+
+  test('uses an aria-label naming the formatted detection date', () => {
+    renderWithProviders(<TerminatedChip terminatedAt="2026-03-15T12:00:00Z" />);
+    const chip = screen.getByTestId('terminated-chip');
+    expect(chip).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('YouTube terminated this channel; detected on')
+    );
+  });
+
+  test('handles invalid date strings without crashing', () => {
+    renderWithProviders(<TerminatedChip terminatedAt="not-a-real-date" />);
+    const chip = screen.getByTestId('terminated-chip');
+    expect(chip).toHaveAttribute('aria-label', expect.stringContaining('unknown date'));
+  });
+});

--- a/client/src/components/ChannelManager/components/chips/index.ts
+++ b/client/src/components/ChannelManager/components/chips/index.ts
@@ -4,3 +4,4 @@ export { default as AutoDownloadChips } from './AutoDownloadChips';
 export { default as DurationFilterChip } from './DurationFilterChip';
 export { default as TitleFilterChip } from './TitleFilterChip';
 export { default as DownloadFormatConfigIndicator } from './DownloadFormatConfigIndicator';
+export { default as TerminatedChip } from './TerminatedChip';

--- a/client/src/components/ChannelPage.tsx
+++ b/client/src/components/ChannelPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { Card, CardContent, Grid, Typography, Box, Tooltip, Chip, Popover, Dialog, DialogTitle, DialogContent, Button } from './ui';
 import { Settings as SettingsIcon, Clock as AccessTimeIcon, Filter as FilterAltIcon } from 'lucide-react';
@@ -7,6 +7,7 @@ import { Channel } from '../types/Channel';
 import RatingBadge from './shared/RatingBadge';
 import ChannelVideos from './ChannelPage/ChannelVideos';
 import ChannelSettingsDialog from './ChannelPage/ChannelSettingsDialog';
+import TerminatedNotice from './ChannelPage/components/TerminatedNotice';
 import { useConfig } from '../hooks/useConfig';
 import SubFolderChip from './ChannelManager/components/chips/SubFolderChip';
 import QualityChip from './ChannelManager/components/chips/QualityChip';
@@ -69,7 +70,15 @@ function ChannelPage({ token }: ChannelPageProps) {
     });
   };
 
-  useEffect(() => {
+  // Monotonic request id keeps a slow in-flight /getChannelInfo from
+  // clobbering a fresher response that already committed. Without this,
+  // the initial fetch (with stale terminated_at) can resolve after the
+  // post-videos-loaded refetch and overwrite the reinstated state.
+  const latestRequestIdRef = useRef(0);
+  const appliedRequestIdRef = useRef(0);
+
+  const fetchAndCommitChannelInfo = useCallback(() => {
+    const requestId = ++latestRequestIdRef.current;
     fetch(`/getChannelInfo/${channel_id}`, {
       headers: {
         'x-access-token': token || '',
@@ -81,9 +90,33 @@ function ChannelPage({ token }: ChannelPageProps) {
         }
         return response.json();
       })
-      .then((data) => setChannel(data))
+      .then((data) => {
+        if (requestId > appliedRequestIdRef.current) {
+          appliedRequestIdRef.current = requestId;
+          setChannel(data);
+        }
+      })
       .catch((error) => console.error(error));
   }, [token, channel_id]);
+
+  useEffect(() => {
+    fetchAndCommitChannelInfo();
+  }, [fetchAndCommitChannelInfo]);
+
+  // Stale-closure shield: handleVideosLoaded fires from a child hook ref,
+  // so we read the latest channel via a ref rather than closing over state.
+  const channelRef = useRef(channel);
+  channelRef.current = channel;
+
+  // The backend clears terminated_at inside the videos fetch when yt-dlp
+  // succeeds, so a successful first videos load is our signal to refetch
+  // /getChannelInfo. Refetch when the channel is currently terminated OR
+  // when the initial info hasn't landed yet - the request-id gate above
+  // protects us from a late stale initial response overwriting this one.
+  const handleVideosLoaded = useCallback(() => {
+    if (channelRef.current && !channelRef.current.terminated_at) return;
+    fetchAndCommitChannelInfo();
+  }, [fetchAndCommitChannelInfo]);
 
   useEffect(() => {
     setDescriptionExpanded(false);
@@ -377,6 +410,9 @@ function ChannelPage({ token }: ChannelPageProps) {
                 >
                   {channel ? channel.uploader : 'Loading...'}
                 </Typography>
+                {channel?.terminated_at && (
+                  <TerminatedNotice terminatedAt={channel.terminated_at} isMobile={isMobile} />
+                )}
                 {channel && (
                   <Box className="flex flex-wrap gap-1 items-center">
                     {renderFilterIndicators({ includeRating: false })}
@@ -594,6 +630,7 @@ function ChannelPage({ token }: ChannelPageProps) {
         channelVideoQuality={channel?.video_quality || null}
         channelAudioFormat={channel?.audio_format || null}
         channelAvailableTabs={channel?.available_tabs ?? null}
+        onVideosLoaded={handleVideosLoaded}
       />
 
       {channel && channel_id && (

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -61,6 +61,7 @@ interface ChannelVideosProps {
   channelVideoQuality?: string | null;
   channelAudioFormat?: string | null;
   channelAvailableTabs?: string | null;
+  onVideosLoaded?: (channelId: string) => void;
 }
 
 type SortBy = 'date' | 'title' | 'duration' | 'size';
@@ -106,6 +107,7 @@ function ChannelVideos({
   channelVideoQuality,
   channelAudioFormat,
   channelAvailableTabs,
+  onVideosLoaded,
 }: ChannelVideosProps) {
   const isMobile = useMediaQuery('(max-width: 767px)');
   const initialViewMode: VideoListViewMode = isMobile ? 'list' : 'table';
@@ -328,6 +330,7 @@ function ChannelVideos({
     protectedFilter,
     missingFilter,
     ignoredFilter,
+    onFirstLoad: onVideosLoaded,
   });
 
   useEffect(() => {

--- a/client/src/components/ChannelPage/components/TerminatedNotice.tsx
+++ b/client/src/components/ChannelPage/components/TerminatedNotice.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Box, Typography } from '../../ui';
+import { Warning as WarningIcon } from '../../../lib/icons';
+
+interface TerminatedNoticeProps {
+  terminatedAt: string | null | undefined;
+  isMobile?: boolean;
+}
+
+const formatDetectionDate = (terminatedAt: string): string => {
+  const parsed = new Date(terminatedAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'unknown date';
+  }
+  return parsed.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+const TerminatedNotice: React.FC<TerminatedNoticeProps> = ({ terminatedAt, isMobile = false }) => {
+  if (!terminatedAt) {
+    return null;
+  }
+
+  const message = `YouTube terminated this channel; detected on ${formatDetectionDate(terminatedAt)}. Scheduled downloads are disabled.`;
+
+  return (
+    <Box
+      role="status"
+      data-testid="terminated-notice"
+      className="flex items-center gap-2"
+      style={{ color: 'var(--destructive)' }}
+    >
+      <WarningIcon size={isMobile ? 14 : 16} data-testid="WarningIcon" />
+      <Typography
+        variant={isMobile ? 'body2' : 'body1'}
+        style={{ color: 'var(--destructive)' }}
+      >
+        {message}
+      </Typography>
+    </Box>
+  );
+};
+
+export default TerminatedNotice;

--- a/client/src/components/ChannelPage/components/__tests__/TerminatedNotice.test.tsx
+++ b/client/src/components/ChannelPage/components/__tests__/TerminatedNotice.test.tsx
@@ -1,0 +1,33 @@
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TerminatedNotice from '../TerminatedNotice';
+import { renderWithProviders } from '../../../../test-utils';
+
+describe('TerminatedNotice', () => {
+  test('renders nothing when terminatedAt is null', () => {
+    renderWithProviders(<TerminatedNotice terminatedAt={null} />);
+    expect(screen.queryByTestId('terminated-notice')).not.toBeInTheDocument();
+  });
+
+  test('renders nothing when terminatedAt is undefined', () => {
+    renderWithProviders(<TerminatedNotice terminatedAt={undefined} />);
+    expect(screen.queryByTestId('terminated-notice')).not.toBeInTheDocument();
+  });
+
+  test('renders the full message with formatted date when terminatedAt is set', () => {
+    renderWithProviders(<TerminatedNotice terminatedAt="2026-03-15T12:00:00Z" />);
+    const notice = screen.getByTestId('terminated-notice');
+    expect(notice).toHaveTextContent(/YouTube terminated this channel; detected on/);
+    expect(notice).toHaveTextContent(/Scheduled downloads are disabled\./);
+  });
+
+  test('falls back to "unknown date" when terminatedAt is not a valid date', () => {
+    renderWithProviders(<TerminatedNotice terminatedAt="not-a-real-date" />);
+    expect(screen.getByTestId('terminated-notice')).toHaveTextContent(/detected on unknown date/);
+  });
+
+  test('exposes a status role for accessibility', () => {
+    renderWithProviders(<TerminatedNotice terminatedAt="2026-03-15T12:00:00Z" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/ChannelPage/hooks/__tests__/useChannelVideos.test.ts
+++ b/client/src/components/ChannelPage/hooks/__tests__/useChannelVideos.test.ts
@@ -941,4 +941,134 @@ describe('useChannelVideos', () => {
     });
   });
 
+  describe('onFirstLoad callback', () => {
+    const freshResponse = { ...mockResponse, freshFetchPerformed: true };
+
+    test('fires once with channelId after the first fresh-fetch response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(freshResponse),
+      });
+
+      const onFirstLoad = jest.fn();
+      const { result } = renderHook(() =>
+        useChannelVideos({ ...defaultParams, onFirstLoad })
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(onFirstLoad).toHaveBeenCalledTimes(1);
+      expect(onFirstLoad).toHaveBeenCalledWith(mockChannelId);
+    });
+
+    test('does not fire again on subsequent fresh-fetch responses for the same channel', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(freshResponse),
+      });
+
+      const onFirstLoad = jest.fn();
+      const { result } = renderHook(() =>
+        useChannelVideos({ ...defaultParams, onFirstLoad })
+      );
+
+      await waitFor(() => {
+        expect(onFirstLoad).toHaveBeenCalledTimes(1);
+      });
+
+      await result.current.refetch();
+      await result.current.refetch();
+
+      expect(onFirstLoad).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not fire on a cache-only response (freshFetchPerformed absent or false)', async () => {
+      // mockResponse has no freshFetchPerformed key, simulating the cache path.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      const onFirstLoad = jest.fn();
+      const { result } = renderHook(() =>
+        useChannelVideos({ ...defaultParams, onFirstLoad })
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(onFirstLoad).not.toHaveBeenCalled();
+    });
+
+    test('fires on a later fresh-fetch response even when earlier responses were cache-only', async () => {
+      // First response: cache-only (no freshFetchPerformed). Latch must stay open.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      });
+
+      const onFirstLoad = jest.fn();
+      const { result } = renderHook(() =>
+        useChannelVideos({ ...defaultParams, onFirstLoad })
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+      expect(onFirstLoad).not.toHaveBeenCalled();
+
+      // Second response: backend ran yt-dlp this time. Latch fires now.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(freshResponse),
+      });
+
+      await result.current.refetch();
+
+      await waitFor(() => {
+        expect(onFirstLoad).toHaveBeenCalledTimes(1);
+      });
+      expect(onFirstLoad).toHaveBeenCalledWith(mockChannelId);
+    });
+
+    test('does not fire when the server reports fetchError', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          ...freshResponse,
+          fetchError: true,
+        }),
+      });
+
+      const onFirstLoad = jest.fn();
+      const { result } = renderHook(() =>
+        useChannelVideos({ ...defaultParams, onFirstLoad })
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(onFirstLoad).not.toHaveBeenCalled();
+    });
+
+    test('does not fire when the network request rejects', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network error'));
+
+      const onFirstLoad = jest.fn();
+      const { result } = renderHook(() =>
+        useChannelVideos({ ...defaultParams, onFirstLoad })
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(onFirstLoad).not.toHaveBeenCalled();
+    });
+  });
+
 });

--- a/client/src/components/ChannelPage/hooks/useChannelVideos.ts
+++ b/client/src/components/ChannelPage/hooks/useChannelVideos.ts
@@ -22,6 +22,7 @@ interface UseChannelVideosParams {
   protectedFilter?: ChipFilterMode;
   missingFilter?: ChipFilterMode;
   ignoredFilter?: ChipFilterMode;
+  onFirstLoad?: (channelId: string) => void;
 }
 
 interface UseChannelVideosResult {
@@ -55,6 +56,7 @@ export function useChannelVideos({
   protectedFilter,
   missingFilter,
   ignoredFilter,
+  onFirstLoad,
 }: UseChannelVideosParams): UseChannelVideosResult {
   const [videos, setVideos] = useState<ChannelVideo[]>([]);
   const [totalCount, setTotalCount] = useState<number>(0);
@@ -64,6 +66,11 @@ export function useChannelVideos({
   const [autoDownloadsEnabled, setAutoDownloadsEnabled] = useState<boolean>(false);
   const [availableTabs, setAvailableTabs] = useState<string[]>([]);
   const resetKeyRef = useRef<string | undefined>(resetKey);
+  // Fire onFirstLoad once per channelId. Subsequent fetches (sort, page,
+  // tab change) should not retrigger it.
+  const firstLoadFiredFor = useRef<string | null>(null);
+  const onFirstLoadRef = useRef(onFirstLoad);
+  onFirstLoadRef.current = onFirstLoad;
 
   const fetchVideos = useCallback(async () => {
     if (!channelId || !token || !tabType) return;
@@ -161,6 +168,12 @@ export function useChannelVideos({
       // distinguishes "fetch failed" from "filter matched nothing".
       if (data.fetchError) {
         setError(new Error('Failed to fetch channel videos'));
+      } else if (data.freshFetchPerformed && firstLoadFiredFor.current !== channelId) {
+        // Only latch on responses that actually ran yt-dlp - cache-only or
+        // cached-fallback responses leave the door open for a later refetch
+        // (tab change, expiry) to fire it.
+        firstLoadFiredFor.current = channelId;
+        onFirstLoadRef.current?.(channelId);
       }
     } catch (err) {
       console.error('Error fetching channel videos:', err);

--- a/client/src/components/DownloadManager/DownloadProgress.tsx
+++ b/client/src/components/DownloadManager/DownloadProgress.tsx
@@ -73,12 +73,23 @@ interface FailedVideo {
   url?: string;
 }
 
+interface TerminatedChannelSummary {
+  channelId: string;
+  uploader?: string | null;
+  url?: string | null;
+  terminatedAt?: string | null;
+}
+
 interface FinalSummary {
   totalDownloaded: number;
   totalSkipped: number;
   totalFailed?: number;
   totalMembersOnly?: number;
+  totalTerminatedChannels?: number;
+  totalTerminationFailures?: number;
   failedVideos?: FailedVideo[];
+  terminatedChannels?: TerminatedChannelSummary[];
+  terminationFailures?: string[];
   jobType: string;
   completedAt?: string;
 }
@@ -511,11 +522,18 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
 
         {/* Show final summary if available */}
         {finalSummary && !currentProgress && !errorDetails && (() => {
-          // Treat members-only skips as "warning"-shaped too: not a hard failure
-          // but the user couldn't actually download what they queued.
+          // Members-only skips and terminations are warning-shaped, not hard failures.
+          const terminatedCount = finalSummary.totalTerminatedChannels
+            ?? finalSummary.terminatedChannels?.length
+            ?? 0;
+          const terminationFailureCount = finalSummary.totalTerminationFailures
+            ?? finalSummary.terminationFailures?.length
+            ?? 0;
           const hasIssue =
             (finalSummary.totalFailed != null && finalSummary.totalFailed > 0)
-            || (finalSummary.totalMembersOnly != null && finalSummary.totalMembersOnly > 0);
+            || (finalSummary.totalMembersOnly != null && finalSummary.totalMembersOnly > 0)
+            || terminatedCount > 0
+            || terminationFailureCount > 0;
           // text-{success,warning}-foreground is meant for solid bg pairing;
           // on /10 tinted bg we want the saturated colour token itself.
           const bgClass = hasIssue ? 'bg-warning/10' : 'bg-success/10';
@@ -537,6 +555,12 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
                   }
                   if (finalSummary.totalMembersOnly && finalSummary.totalMembersOnly > 0) {
                     parts.push(`${finalSummary.totalMembersOnly} members-only video${finalSummary.totalMembersOnly !== 1 ? 's' : ''} skipped`);
+                  }
+                  if (terminatedCount > 0) {
+                    parts.push(`${terminatedCount} channel${terminatedCount !== 1 ? 's' : ''} marked terminated`);
+                  }
+                  if (terminationFailureCount > 0) {
+                    parts.push(`${terminationFailureCount} termination${terminationFailureCount !== 1 ? 's' : ''} could not be auto-disabled`);
                   }
                   if (finalSummary.totalSkipped > 0) {
                     parts.push(`${finalSummary.totalSkipped} skipped (already downloaded or filtered)`);
@@ -562,6 +586,54 @@ const DownloadProgress: React.FC<DownloadProgressProps> = ({
                 })()}
               </Typography>
             </Box>
+
+            {/* Show details of terminated channels if any */}
+            {finalSummary.terminatedChannels && finalSummary.terminatedChannels.length > 0 && (
+              <Box className="mt-4">
+                <Alert severity="warning">
+                  <AlertTitle>Channels Marked Terminated by YouTube</AlertTitle>
+                  <Typography variant="body2" component="div" className="mb-1">
+                    Scheduled downloads have been disabled for the following channel{finalSummary.terminatedChannels.length !== 1 ? 's' : ''}:
+                  </Typography>
+                  <Box className="mt-1 pl-4">
+                    {finalSummary.terminatedChannels.map((channel) => (
+                      <Typography
+                        key={channel.channelId}
+                        variant="caption"
+                        component="div"
+                        color="text.secondary"
+                      >
+                        • {channel.uploader || channel.channelId}
+                      </Typography>
+                    ))}
+                  </Box>
+                </Alert>
+              </Box>
+            )}
+
+            {/* Termination-persistence failures: detected but not auto-disabled */}
+            {finalSummary.terminationFailures && finalSummary.terminationFailures.length > 0 && (
+              <Box className="mt-4">
+                <Alert severity="warning">
+                  <AlertTitle>Terminations Could Not Be Auto-Disabled</AlertTitle>
+                  <Typography variant="body2" component="div" className="mb-1">
+                    YouTube reported the following channel{finalSummary.terminationFailures.length !== 1 ? 's' : ''} as terminated, but Youtarr could not disable scheduled downloads. Check the channel manually:
+                  </Typography>
+                  <Box className="mt-1 pl-4">
+                    {finalSummary.terminationFailures.map((channelId) => (
+                      <Typography
+                        key={channelId}
+                        variant="caption"
+                        component="div"
+                        color="text.secondary"
+                      >
+                        • {channelId}
+                      </Typography>
+                    ))}
+                  </Box>
+                </Alert>
+              </Box>
+            )}
 
             {/* Show details of failed videos if any */}
             {finalSummary.failedVideos && finalSummary.failedVideos.length > 0 && (

--- a/client/src/components/DownloadManager/__tests__/DownloadProgress.test.tsx
+++ b/client/src/components/DownloadManager/__tests__/DownloadProgress.test.tsx
@@ -287,6 +287,102 @@ describe('DownloadProgress', () => {
     expect(screen.getByText(/Channel update.*Completed/)).toBeInTheDocument();
   });
 
+  test('renders termination summary as warning-shaped even with zero downloads', async () => {
+    renderWithContext(
+      <DownloadProgress
+        downloadProgressRef={mockDownloadProgressRef}
+        downloadInitiatedRef={mockDownloadInitiatedRef}
+        pendingJobs={[]}
+        token="test-token"
+      />
+    );
+
+    const [, processCallback] = mockSubscribe.mock.calls[0];
+
+    await act(async () => {
+      processCallback({
+        finalSummary: {
+          totalDownloaded: 0,
+          totalSkipped: 0,
+          totalTerminatedChannels: 1,
+          terminatedChannels: [
+            { channelId: 'UC1234567890123456789012', uploader: 'Banned Channel' },
+          ],
+          jobType: 'Channel Downloads',
+          completedAt: '2026-05-19T12:00:00Z',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Summary of last job')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/1 channel marked terminated/)).toBeInTheDocument();
+    expect(screen.getByText('Channels Marked Terminated by YouTube')).toBeInTheDocument();
+    expect(screen.getByText(/• Banned Channel/)).toBeInTheDocument();
+  });
+
+  test('renders termination-failure alert when terminationFailures present', async () => {
+    renderWithContext(
+      <DownloadProgress
+        downloadProgressRef={mockDownloadProgressRef}
+        downloadInitiatedRef={mockDownloadInitiatedRef}
+        pendingJobs={[]}
+        token="test-token"
+      />
+    );
+
+    const [, processCallback] = mockSubscribe.mock.calls[0];
+
+    await act(async () => {
+      processCallback({
+        finalSummary: {
+          totalDownloaded: 0,
+          totalSkipped: 0,
+          totalTerminationFailures: 1,
+          terminationFailures: ['UC1234567890123456789012'],
+          jobType: 'Channel Downloads',
+          completedAt: '2026-05-19T12:00:00Z',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Summary of last job')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/1 termination could not be auto-disabled/)).toBeInTheDocument();
+    expect(screen.getByText('Terminations Could Not Be Auto-Disabled')).toBeInTheDocument();
+    expect(screen.getByText(/• UC1234567890123456789012/)).toBeInTheDocument();
+  });
+
+  test('omits the terminated alert when terminatedChannels is empty', async () => {
+    renderWithContext(
+      <DownloadProgress
+        downloadProgressRef={mockDownloadProgressRef}
+        downloadInitiatedRef={mockDownloadInitiatedRef}
+        pendingJobs={[]}
+        token="test-token"
+      />
+    );
+
+    const [, processCallback] = mockSubscribe.mock.calls[0];
+
+    await act(async () => {
+      processCallback({
+        finalSummary: {
+          totalDownloaded: 3,
+          totalSkipped: 0,
+          jobType: 'Channel Downloads',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Summary of last job')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Channels Marked Terminated by YouTube')).not.toBeInTheDocument();
+  });
+
   test('displays final summary with single video grammar', async () => {
     renderWithContext(
       <DownloadProgress

--- a/client/src/components/__tests__/ChannelPage.test.tsx
+++ b/client/src/components/__tests__/ChannelPage.test.tsx
@@ -6,12 +6,14 @@ import { useMediaQuery } from '../../hooks/useMediaQuery';
 import { useConfig } from '../../hooks/useConfig';
 
 const dialogPropsStore: { current: any } = { current: null };
+const channelVideosPropsStore: { current: any } = { current: null };
 
 // Mock child components
 jest.mock('../ChannelPage/ChannelVideos', () => ({
   __esModule: true,
   default: function MockChannelVideos(props: any) {
     const React = require('react');
+    channelVideosPropsStore.current = props;
     return React.createElement('div', {
       'data-testid': 'channel-videos',
       'data-token': props.token,
@@ -84,6 +86,7 @@ describe('ChannelPage Component', () => {
       setInitialConfig: jest.fn(),
     });
     dialogPropsStore.current = null;
+    channelVideosPropsStore.current = null;
   });
 
   describe('Component Rendering', () => {
@@ -1240,6 +1243,202 @@ describe('ChannelPage Component', () => {
 
       // Check for the ChannelVideos component
       expect(screen.getByTestId('channel-videos')).toBeInTheDocument();
+    });
+  });
+
+  describe('Terminated channel refresh on videos load', () => {
+    test('refetches channel info when videos load and current channel is marked terminated', async () => {
+      const terminatedChannel = {
+        ...mockChannel,
+        terminated_at: '2026-03-01T00:00:00Z',
+      };
+      const reinstatedChannel = {
+        ...mockChannel,
+        terminated_at: null,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(terminatedChannel),
+      });
+
+      render(
+        <BrowserRouter>
+          <ChannelPage token={mockToken} />
+        </BrowserRouter>
+      );
+
+      await waitFor(() => {
+        expect(channelVideosPropsStore.current).not.toBeNull();
+      });
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(reinstatedChannel),
+      });
+
+      await act(async () => {
+        channelVideosPropsStore.current.onVideosLoaded('UC123456');
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+      expect(mockFetch.mock.calls[1][0]).toContain('/getChannelInfo/UC123456');
+    });
+
+    test('does NOT refetch channel info when channel was never terminated', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockChannel),
+      });
+
+      render(
+        <BrowserRouter>
+          <ChannelPage token={mockToken} />
+        </BrowserRouter>
+      );
+
+      await waitFor(() => {
+        expect(channelVideosPropsStore.current).not.toBeNull();
+      });
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        channelVideosPropsStore.current.onVideosLoaded('UC123456');
+      });
+
+      // No second fetch: callback short-circuits when terminated_at is unset.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('refetches channel info when videos load before initial /getChannelInfo response lands', async () => {
+      // Race scenario: useChannelVideos resolves and the backend cleared
+      // terminated_at, but the parent's initial /getChannelInfo is still
+      // in flight. channelRef.current is null at callback time. Without
+      // refetching here, the in-flight stale response would overwrite and
+      // the hook latch (already fired) can never retry.
+      const reinstatedChannel = {
+        ...mockChannel,
+        terminated_at: null,
+      };
+
+      let resolveInitial: ((value: any) => void) | undefined;
+      const initialPromise = new Promise((resolve) => {
+        resolveInitial = resolve;
+      });
+      mockFetch.mockReturnValueOnce(initialPromise);
+
+      render(
+        <BrowserRouter>
+          <ChannelPage token={mockToken} />
+        </BrowserRouter>
+      );
+
+      await waitFor(() => {
+        expect(channelVideosPropsStore.current).not.toBeNull();
+      });
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      // Queue the refetch response BEFORE firing the callback so the
+      // mockFetch chain stays deterministic.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(reinstatedChannel),
+      });
+
+      await act(async () => {
+        channelVideosPropsStore.current.onVideosLoaded('UC123456');
+      });
+
+      // The refetch fires even though channelRef.current is still null.
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+      expect(mockFetch.mock.calls[1][0]).toContain('/getChannelInfo/UC123456');
+
+      // Resolve the initial in-flight request so React can clean up cleanly.
+      await act(async () => {
+        resolveInitial!({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            ...mockChannel,
+            terminated_at: '2026-03-01T00:00:00Z',
+          }),
+        });
+      });
+    });
+
+    test('late stale /getChannelInfo response does not overwrite the fresh refetch', async () => {
+      // End-to-end ordering check: the initial request resolves AFTER the
+      // post-videos-loaded refetch. The monotonic request-id gate must
+      // reject the late stale response so the terminated notice stays gone.
+      const terminatedPayload = {
+        ...mockChannel,
+        terminated_at: '2026-03-01T00:00:00Z',
+      };
+      const reinstatedPayload = {
+        ...mockChannel,
+        terminated_at: null,
+      };
+
+      let resolveInitial: ((value: any) => void) | undefined;
+      const initialPromise = new Promise((resolve) => {
+        resolveInitial = resolve;
+      });
+      mockFetch.mockReturnValueOnce(initialPromise);
+
+      render(
+        <BrowserRouter>
+          <ChannelPage token={mockToken} />
+        </BrowserRouter>
+      );
+
+      await waitFor(() => {
+        expect(channelVideosPropsStore.current).not.toBeNull();
+      });
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      // Refetch returns reinstated state.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(reinstatedPayload),
+      });
+
+      await act(async () => {
+        channelVideosPropsStore.current.onVideosLoaded('UC123456');
+      });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+
+      // Reinstated state has committed - terminated notice must not render.
+      await waitFor(() => {
+        expect(screen.getByText('Tech Channel')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('terminated-notice')).not.toBeInTheDocument();
+
+      // Now the slow initial /getChannelInfo arrives with the stale
+      // terminated payload. The request-id gate must reject it.
+      await act(async () => {
+        resolveInitial!({
+          ok: true,
+          json: jest.fn().mockResolvedValue(terminatedPayload),
+        });
+      });
+
+      // Notice still gone - stale response did not overwrite.
+      expect(screen.queryByTestId('terminated-notice')).not.toBeInTheDocument();
     });
   });
 });

--- a/client/src/types/Channel.ts
+++ b/client/src/types/Channel.ts
@@ -16,4 +16,5 @@ export interface Channel {
   title_filter_regex?: string | null;
   audio_format?: string | null;
   default_rating?: string | null;
+  terminated_at?: string | null;
 }

--- a/migrations/20260519220615-add-terminated-at-to-channels.js
+++ b/migrations/20260519220615-add-terminated-at-to-channels.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const { addColumnIfMissing, removeColumnIfExists } = require('./helpers');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await addColumnIfMissing(queryInterface, 'channels', 'terminated_at', {
+      type: Sequelize.DATE,
+      allowNull: true,
+      defaultValue: null
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await removeColumnIfExists(queryInterface, 'channels', 'terminated_at');
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1664,9 +1664,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1829,9 +1829,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2078,9 +2078,9 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2939,9 +2939,10 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
         "content-type": "~1.0.5",
@@ -2951,7 +2952,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -2965,6 +2966,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -2972,7 +2974,8 @@
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -3058,6 +3061,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3515,6 +3519,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4458,13 +4463,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -4483,7 +4489,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -5255,6 +5261,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -6599,11 +6606,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {
@@ -7630,9 +7638,9 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8373,9 +8381,9 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -8424,6 +8432,7 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
       "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -10471,9 +10480,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/server/models/channel.js
+++ b/server/models/channel.js
@@ -103,6 +103,11 @@ Channel.init(
       defaultValue: null,
       comment: 'When true, videos are stored directly in the channel folder without per-video subfolders',
     },
+    terminated_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   {
     sequelize,

--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -459,6 +459,7 @@ describe('ChannelModule', () => {
           min_duration: null,
           max_duration: null,
           title_filter_regex: null,
+          terminated_at: null,
         });
       });
 
@@ -2009,6 +2010,7 @@ describe('ChannelModule', () => {
             max_duration: null,
             title_filter_regex: null,
             audio_format: null,
+            terminated_at: null,
           },
           {
             url: 'https://youtube.com/@channel2',
@@ -2022,6 +2024,7 @@ describe('ChannelModule', () => {
             max_duration: null,
             title_filter_regex: null,
             audio_format: null,
+            terminated_at: null,
           }
         ]);
       });
@@ -2108,6 +2111,7 @@ describe('ChannelModule', () => {
               max_duration: null,
               title_filter_regex: null,
               audio_format: null,
+              terminated_at: null,
             }
           ],
           total: 25,
@@ -2494,6 +2498,17 @@ describe('ChannelModule', () => {
         // Short tab has never been fetched, should refresh
         expect(ChannelModule.shouldRefreshChannelVideos(channel, 10, 'short')).toBe(true);
       });
+
+      test('forces a refresh on terminated channels even with a fresh cache', () => {
+        // Without the terminated_at short-circuit, a recent fetch would skip
+        // yt-dlp on page load and the termination notice would persist.
+        const channel = {
+          ...mockChannelData,
+          lastFetchedByTab: JSON.stringify({ video: new Date().toISOString() }),
+          terminated_at: new Date('2026-03-01T00:00:00Z')
+        };
+        expect(ChannelModule.shouldRefreshChannelVideos(channel, 10, 'video')).toBe(true);
+      });
     });
 
     describe('buildChannelVideosResponse', () => {
@@ -2673,6 +2688,82 @@ describe('ChannelModule', () => {
         expect(result.videos).toEqual([]);
         expect(result.fetchError).toBe(true);
       });
+
+      // freshFetchPerformed is the contract the frontend onFirstLoad latch
+      // depends on. It must flip true only when fetchAndSaveVideosViaYtDlp
+      // resolves; the cache and cached-fallback paths must NOT set it true.
+      // freshFetchPerformed videos are flagged as recently-checked so the
+      // post-fetch removal-validation loop short-circuits and we don't hit
+      // the unmocked ChannelVideo.update path.
+      const freshlyChecked = () => ({
+        youtube_id: 'video1',
+        youtube_removed: false,
+        youtube_removed_checked_at: new Date(),
+        toJSON() { return this; }
+      });
+
+      test('returns freshFetchPerformed=true when yt-dlp auto-refresh resolves', async () => {
+        const Video = require('../../models/video');
+        const mockChannel = {
+          ...mockChannelData,
+          // Stale lastFetched forces shouldRefreshChannelVideos to return true.
+          lastFetchedByTab: JSON.stringify({ video: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString() }),
+          auto_download_enabled_tabs: 'video'
+        };
+
+        Channel.findOne.mockResolvedValue(mockChannel);
+        ChannelVideo.findAll.mockResolvedValue([freshlyChecked()]);
+        ChannelVideo.count.mockResolvedValue(1);
+        Video.findAll = jest.fn().mockResolvedValue([]);
+
+        jest.spyOn(ChannelModule, 'fetchAndSaveVideosViaYtDlp').mockResolvedValue();
+
+        const result = await ChannelModule.getChannelVideos('UC123');
+
+        expect(ChannelModule.fetchAndSaveVideosViaYtDlp).toHaveBeenCalled();
+        expect(result.freshFetchPerformed).toBe(true);
+      });
+
+      test('returns freshFetchPerformed=false when cache is fresh enough to skip yt-dlp', async () => {
+        const Video = require('../../models/video');
+        const mockChannel = {
+          ...mockChannelData,
+          lastFetchedByTab: JSON.stringify({ video: new Date().toISOString() }),
+          auto_download_enabled_tabs: 'video'
+        };
+
+        Channel.findOne.mockResolvedValue(mockChannel);
+        ChannelVideo.findAll.mockResolvedValue([freshlyChecked()]);
+        ChannelVideo.count.mockResolvedValue(1);
+        Video.findAll = jest.fn().mockResolvedValue([]);
+
+        const ytdlpSpy = jest.spyOn(ChannelModule, 'fetchAndSaveVideosViaYtDlp').mockResolvedValue();
+
+        const result = await ChannelModule.getChannelVideos('UC123');
+
+        expect(ytdlpSpy).not.toHaveBeenCalled();
+        expect(result.freshFetchPerformed).toBe(false);
+      });
+
+      test('does not set freshFetchPerformed=true when yt-dlp throws and cache fallback fires', async () => {
+        const Video = require('../../models/video');
+        const mockChannel = {
+          ...mockChannelData,
+          lastFetchedByTab: JSON.stringify({ video: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString() }),
+          auto_download_enabled_tabs: 'video'
+        };
+
+        Channel.findOne.mockResolvedValue(mockChannel);
+        ChannelVideo.findAll.mockResolvedValue([freshlyChecked()]);
+        ChannelVideo.count.mockResolvedValue(1);
+        Video.findAll = jest.fn().mockResolvedValue([]);
+
+        jest.spyOn(ChannelModule, 'fetchAndSaveVideosViaYtDlp').mockRejectedValue(new Error('yt-dlp failed'));
+
+        const result = await ChannelModule.getChannelVideos('UC123');
+
+        expect(result.freshFetchPerformed).toBeFalsy();
+      });
     });
 
     describe('fetchAllChannelVideos', () => {
@@ -2738,6 +2829,66 @@ describe('ChannelModule', () => {
 
         // Verify activeFetches was cleaned up
         expect(ChannelModule.activeFetches.has('UC123')).toBe(false);
+      });
+
+      test('clears terminated_at when a full fetch succeeds on a previously terminated channel', async () => {
+        const Video = require('../../models/video');
+        const mockChannel = {
+          ...mockChannelData,
+          save: jest.fn(),
+          reload: jest.fn(),
+          update: jest.fn().mockResolvedValue(),
+          url: 'https://youtube.com/@test',
+          terminated_at: new Date('2026-03-01T00:00:00Z')
+        };
+
+        Channel.findOne.mockResolvedValue(mockChannel);
+
+        jest.spyOn(ChannelModule, 'executeYtDlpCommand').mockResolvedValue(JSON.stringify({
+          entries: [{ id: 'v1', title: 'V1', timestamp: 1704067200 }],
+          uploader_url: 'https://youtube.com/@test'
+        }));
+
+        ChannelVideo.findOrCreate.mockResolvedValue([{}, true]);
+        ChannelVideo.findAll.mockResolvedValue([
+          { youtube_id: 'v1', toJSON() { return this; } }
+        ]);
+        ChannelVideo.count.mockResolvedValue(1);
+        Video.findAll = jest.fn().mockResolvedValue([]);
+
+        await ChannelModule.fetchAllChannelVideos('UC123', 1, 50);
+
+        expect(mockChannel.update).toHaveBeenCalledWith({ terminated_at: null });
+      });
+
+      test('does not touch terminated_at on a never-terminated channel', async () => {
+        const Video = require('../../models/video');
+        const mockChannel = {
+          ...mockChannelData,
+          save: jest.fn(),
+          reload: jest.fn(),
+          update: jest.fn().mockResolvedValue(),
+          url: 'https://youtube.com/@test',
+          terminated_at: null
+        };
+
+        Channel.findOne.mockResolvedValue(mockChannel);
+
+        jest.spyOn(ChannelModule, 'executeYtDlpCommand').mockResolvedValue(JSON.stringify({
+          entries: [{ id: 'v1', title: 'V1', timestamp: 1704067200 }],
+          uploader_url: 'https://youtube.com/@test'
+        }));
+
+        ChannelVideo.findOrCreate.mockResolvedValue([{}, true]);
+        ChannelVideo.findAll.mockResolvedValue([
+          { youtube_id: 'v1', toJSON() { return this; } }
+        ]);
+        ChannelVideo.count.mockResolvedValue(1);
+        Video.findAll = jest.fn().mockResolvedValue([]);
+
+        await ChannelModule.fetchAllChannelVideos('UC123', 1, 50);
+
+        expect(mockChannel.update).not.toHaveBeenCalled();
       });
 
       test('uses yt-dlp for full fetch even when YouTube API is available', async () => {
@@ -3119,6 +3270,21 @@ describe('ChannelModule', () => {
         await ChannelModule.updateAutoDownloadForTab('UC123', 'videos', false);
 
         expect(mockChannel.auto_download_enabled_tabs).toBe('');
+        expect(mockChannel.save).toHaveBeenCalled();
+      });
+
+      test('preserves empty-string state when enabling a tab on a previously cleared channel', async () => {
+        // Empty string is the terminated state; '||' coalescing would yield 'video,short'.
+        const mockChannel = {
+          ...mockChannelData,
+          auto_download_enabled_tabs: '',
+          save: jest.fn()
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+
+        await ChannelModule.updateAutoDownloadForTab('UC123', 'shorts', true);
+
+        expect(mockChannel.auto_download_enabled_tabs).toBe('short');
         expect(mockChannel.save).toHaveBeenCalled();
       });
     });
@@ -3930,6 +4096,93 @@ describe('ChannelModule', () => {
         media_type: 'video',
       });
       expect(channelModule.executeYtDlpCommand).toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchAndSaveVideosViaYtDlp - terminated_at clearing', () => {
+    let channelModule;
+    const { sequelize } = require('../../db');
+
+    beforeEach(() => {
+      channelModule = require('../channelModule');
+      sequelize.query.mockResolvedValue([]);
+
+      jest.spyOn(channelModule, 'fetchChannelVideos').mockResolvedValue({
+        videos: [],
+        currentChannelUrl: 'https://www.youtube.com/@chan'
+      });
+      jest.spyOn(channelModule, 'insertVideosIntoDb').mockResolvedValue();
+    });
+
+    test('clears terminated_at when fetch succeeds on a previously terminated channel', async () => {
+      const channel = {
+        channel_id: 'UC123',
+        title: 'Test',
+        url: 'https://www.youtube.com/@chan',
+        terminated_at: new Date('2026-03-01T00:00:00Z'),
+        reload: jest.fn(),
+        update: jest.fn().mockResolvedValue()
+      };
+
+      await channelModule.fetchAndSaveVideosViaYtDlp(channel, 'UC123', 'videos', null);
+
+      expect(channel.update).toHaveBeenCalledWith({ terminated_at: null });
+    });
+
+    test('does not touch terminated_at on a channel that was never terminated', async () => {
+      const channel = {
+        channel_id: 'UC123',
+        title: 'Test',
+        url: 'https://www.youtube.com/@chan',
+        terminated_at: null,
+        reload: jest.fn(),
+        update: jest.fn().mockResolvedValue()
+      };
+
+      await channelModule.fetchAndSaveVideosViaYtDlp(channel, 'UC123', 'videos', null);
+
+      expect(channel.update).not.toHaveBeenCalled();
+    });
+
+    test('does not clear terminated_at when fetch throws (channel still unreachable)', async () => {
+      channelModule.fetchChannelVideos.mockRejectedValueOnce(new Error('yt-dlp failed: account terminated'));
+
+      const channel = {
+        channel_id: 'UC123',
+        title: 'Test',
+        url: 'https://www.youtube.com/@chan',
+        terminated_at: new Date('2026-03-01T00:00:00Z'),
+        reload: jest.fn(),
+        update: jest.fn().mockResolvedValue()
+      };
+
+      await expect(
+        channelModule.fetchAndSaveVideosViaYtDlp(channel, 'UC123', 'videos', null)
+      ).rejects.toThrow('yt-dlp failed');
+
+      expect(channel.update).not.toHaveBeenCalled();
+    });
+
+    test('swallows clear failure so the page load is not broken by a stuck UPDATE', async () => {
+      const channel = {
+        channel_id: 'UC123',
+        title: 'Test',
+        url: 'https://www.youtube.com/@chan',
+        terminated_at: new Date('2026-03-01T00:00:00Z'),
+        reload: jest.fn(),
+        update: jest.fn().mockRejectedValue(new Error('db down'))
+      };
+
+      // Fetch and timestamp update both succeed; only the clear fails.
+      await expect(
+        channelModule.fetchAndSaveVideosViaYtDlp(channel, 'UC123', 'videos', null)
+      ).resolves.toBeUndefined();
+
+      expect(channel.update).toHaveBeenCalledWith({ terminated_at: null });
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: 'UC123' }),
+        'Failed to clear terminated_at after successful video fetch'
+      );
     });
   });
 

--- a/server/modules/__tests__/notificationModule.test.js
+++ b/server/modules/__tests__/notificationModule.test.js
@@ -758,7 +758,7 @@ describe('NotificationModule Integration', () => {
       expect(mockLoggerDebug).toHaveBeenCalledWith('Notifications not configured, skipping notification');
     });
 
-    it('should skip notification when no videos downloaded', async () => {
+    it('should skip notification when no videos downloaded and no terminations recorded', async () => {
       const notificationData = {
         ...baseNotificationData,
         finalSummary: { ...baseNotificationData.finalSummary, totalDownloaded: 0 }
@@ -767,7 +767,30 @@ describe('NotificationModule Integration', () => {
       await notificationModule.sendDownloadNotification(notificationData);
 
       expect(mockSpawn).not.toHaveBeenCalled();
-      expect(mockLoggerDebug).toHaveBeenCalledWith('No new videos downloaded, skipping notification');
+      expect(mockLoggerDebug).toHaveBeenCalledWith('No new videos downloaded and no terminations recorded, skipping notification');
+    });
+
+    it('still sends notification when zero videos downloaded but a channel was marked terminated', async () => {
+      const notificationData = {
+        ...baseNotificationData,
+        finalSummary: {
+          ...baseNotificationData.finalSummary,
+          totalDownloaded: 0,
+          terminatedChannels: [
+            { channelId: 'UC1234567890123456789012', uploader: 'Banned Channel' }
+          ]
+        }
+      };
+
+      const sendPromise = notificationModule.sendDownloadNotification(notificationData);
+      // ntfy:// routes through Apprise; close the child so the sender resolves.
+      setImmediate(() => {
+        mockProcess.emit('close', 0);
+      });
+      await sendPromise;
+
+      expect(mockSpawn).toHaveBeenCalled();
+      expect(mockLoggerDebug).not.toHaveBeenCalledWith('No new videos downloaded and no terminations recorded, skipping notification');
     });
 
     it('should use Discord webhook directly for Discord URLs with rich formatting', async () => {

--- a/server/modules/__tests__/ytDlpRunner.test.js
+++ b/server/modules/__tests__/ytDlpRunner.test.js
@@ -306,4 +306,31 @@ describe('YtDlpRunner', () => {
     await expect(runPromise).rejects.toMatchObject({ name: 'AbortError', code: 'ABORT_ERR' });
     expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
   });
+
+  describe('isTerminatedAccountError', () => {
+    it('matches the canonical TOS-termination ERROR line', () => {
+      const message = 'ERROR: [youtube:tab] UC1lg-nYUcZ1pjo6EC2Nj5Sw: YouTube said: This account has been terminated for violating Google\'s Terms of Service.';
+      expect(ytDlpRunner.isTerminatedAccountError(message)).toBe(true);
+    });
+
+    it('matches the community-guidelines termination variant', () => {
+      const message = 'ERROR: [youtube:tab] UCC3L8QaxqEGUiBC252GHy3w: YouTube said: This channel was removed because it violated our Community Guidelines.';
+      expect(ytDlpRunner.isTerminatedAccountError(message)).toBe(true);
+    });
+
+    it('matches the "multiple or severe violations" variant', () => {
+      const message = 'This account has been terminated due to multiple or severe violations of YouTube\'s policy';
+      expect(ytDlpRunner.isTerminatedAccountError(message)).toBe(true);
+    });
+
+    it('returns false for members-only errors', () => {
+      expect(ytDlpRunner.isTerminatedAccountError('Join this channel to get access to members-only content')).toBe(false);
+    });
+
+    it('returns false for unrelated errors', () => {
+      expect(ytDlpRunner.isTerminatedAccountError('HTTP Error 403: Forbidden')).toBe(false);
+      expect(ytDlpRunner.isTerminatedAccountError('')).toBe(false);
+      expect(ytDlpRunner.isTerminatedAccountError()).toBe(false);
+    });
+  });
 });

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -333,6 +333,7 @@ class ChannelModule {
       min_duration: channel.min_duration || null,
       max_duration: channel.max_duration || null,
       title_filter_regex: channel.title_filter_regex || null,
+      terminated_at: channel.terminated_at || null,
     };
 
     if (channel.default_rating != null) {
@@ -361,6 +362,7 @@ class ChannelModule {
       max_duration: channel.max_duration || null,
       title_filter_regex: channel.title_filter_regex || null,
       audio_format: channel.audio_format || null,
+      terminated_at: channel.terminated_at || null,
     };
 
     if (channel.default_rating != null) {
@@ -1925,6 +1927,12 @@ class ChannelModule {
   shouldRefreshChannelVideos(channel, videoCount, mediaType) {
     if (!channel) return false;
 
+    // Always re-probe terminated channels so a reinstatement is detected on
+    // the very next page load, regardless of cache freshness. Without this,
+    // a terminated channel with recent lastFetched would skip yt-dlp and the
+    // termination notice would stick until cache expiry.
+    if (channel.terminated_at) return true;
+
     const lastFetched = this.getLastFetchedForTab(channel, mediaType);
 
     return !lastFetched ||
@@ -2125,7 +2133,7 @@ class ChannelModule {
         logger.debug({ channelId }, 'Tabs already detected, returning cached');
         return {
           availableTabs: channel.available_tabs.split(','),
-          autoDownloadEnabledTabs: channel.auto_download_enabled_tabs || 'video'
+          autoDownloadEnabledTabs: channel.auto_download_enabled_tabs ?? 'video'
         };
       }
 
@@ -2327,7 +2335,7 @@ class ChannelModule {
     const mediaType = MEDIA_TAB_TYPE_MAP[tabType] || 'video';
 
     // Get current enabled tabs
-    const currentEnabledTabs = (channel.auto_download_enabled_tabs || 'video')
+    const currentEnabledTabs = (channel.auto_download_enabled_tabs ?? 'video')
       .split(',')
       .map(t => t.trim())
       .filter(Boolean);
@@ -2403,6 +2411,11 @@ class ChannelModule {
       }
     }
 
+    // Tracks whether yt-dlp actually ran AND resolved in this request.
+    // Frontends key the "channel state may have changed" signal off this flag,
+    // so it must NOT flip true on cache-only or yt-dlp-failed-with-cache paths.
+    let freshFetchPerformed = false;
+
     try {
       // First check if we need to refresh recent videos from YouTube
       const allVideos = await this.fetchNewestVideosFromDb(channelId, 1, 0, 'off', '', 'date', 'desc', false, mediaType);
@@ -2426,6 +2439,7 @@ class ChannelModule {
           try {
             // Fetch videos for the specified tab type
             await this.fetchAndSaveVideosViaYtDlp(channel, channelId, tabType, mostRecentVideoDate);
+            freshFetchPerformed = true;
           } finally {
             // Clear the active fetch record
             this.activeFetches.delete(fetchKey);
@@ -2507,7 +2521,10 @@ class ChannelModule {
       // Get stats for the response
       const stats = await this.getChannelVideoStats(channelId, downloadedFilter, searchQuery, mediaType, minDuration, maxDuration, dateFrom, dateTo, protectedFilter, missingFilter, ignoredFilter);
 
-      return this.buildChannelVideosResponse(paginatedVideos, channel, 'cache', stats, autoDownloadsEnabled, mediaType);
+      return {
+        ...this.buildChannelVideosResponse(paginatedVideos, channel, 'cache', stats, autoDownloadsEnabled, mediaType),
+        freshFetchPerformed
+      };
 
     } catch (error) {
       logger.error({ err: error, channelId }, 'Error fetching channel videos');
@@ -2522,6 +2539,25 @@ class ChannelModule {
         response.fetchError = true;
       }
       return response;
+    }
+  }
+
+  /**
+   * Clear terminated_at on a channel when we've proven it's reachable.
+   * Swallows failures so the calling page-load path can't be broken by a
+   * stuck UPDATE - the marker would just stay set until the next attempt.
+   * @param {Object} channel - Sequelize channel instance
+   * @param {string} channelId - Channel ID for log context
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _clearTerminationMarkerIfSet(channel, channelId) {
+    if (!channel || !channel.terminated_at) return;
+    try {
+      await channel.update({ terminated_at: null });
+      logger.info({ channelId }, 'Channel previously marked terminated is reachable again; clearing termination marker');
+    } catch (clearErr) {
+      logger.warn({ err: clearErr, channelId }, 'Failed to clear terminated_at after successful video fetch');
     }
   }
 
@@ -2561,6 +2597,10 @@ class ChannelModule {
 
         // Update the last fetched timestamp for this specific tab (atomic SQL update)
         await this.setLastFetchedForTab(channel, mediaType, new Date());
+
+        // Reaching this point means yt-dlp returned a valid response, so the
+        // channel is reachable - inverse of persistTerminatedChannel.
+        await this._clearTerminationMarkerIfSet(channel, channelId);
       }
     } catch (ytdlpError) {
       logger.error({ err: ytdlpError, channelId }, 'Error fetching channel videos');
@@ -2649,6 +2689,9 @@ class ChannelModule {
         }
         // Update the last fetched timestamp for this specific tab (atomic SQL update)
         await this.setLastFetchedForTab(channel, mediaType, new Date());
+
+        // yt-dlp returned a valid response, so the channel is reachable.
+        await this._clearTerminationMarkerIfSet(channel, channelId);
 
         // Get the requested page of videos after the full fetch
         const offset = (requestedPage - 1) * requestedPageSize;

--- a/server/modules/download/__tests__/downloadExecutor.test.js
+++ b/server/modules/download/__tests__/downloadExecutor.test.js
@@ -79,7 +79,8 @@ jest.mock('../../../models', () => ({
 }));
 
 jest.mock('../../../models/channel', () => ({
-  findAll: jest.fn().mockResolvedValue([])
+  findAll: jest.fn().mockResolvedValue([]),
+  findOne: jest.fn().mockResolvedValue(null)
 }));
 
 jest.mock('../../../models/channelvideo', () => ({
@@ -1304,6 +1305,72 @@ describe('DownloadExecutor', () => {
       expect(jobModule.saveJobOnly).not.toHaveBeenCalled();
     });
 
+    it('merges terminatedChannels across intermediate groups and dedupes by channelId', async () => {
+      const job = {
+        data: {
+          videos: [],
+          failedVideos: [],
+          cumulativeSkipped: 0,
+          terminatedChannels: [
+            { channelId: 'UCdupe000000000000000000', uploader: 'First Wins', url: 'first', terminatedAt: '2026-01-01' }
+          ]
+        }
+      };
+      jobModule.getJob.mockReturnValue(job);
+
+      await executor.saveIntermediateGroupResults(
+        mockJobId,
+        'output',
+        [],
+        [],
+        0,
+        {},
+        [
+          { channelId: 'UCdupe000000000000000000', uploader: 'Should Not Replace', url: 'second', terminatedAt: '2026-02-02' },
+          { channelId: 'UCnew0000000000000000000', uploader: 'New Channel', url: 'newurl', terminatedAt: '2026-02-02' }
+        ]
+      );
+
+      const updateCall = jobModule.updateJob.mock.calls.find(call => call[0] === mockJobId);
+      expect(updateCall).toBeDefined();
+      const merged = updateCall[1].data.terminatedChannels;
+      expect(merged).toHaveLength(2);
+      // First write wins on duplicate
+      expect(merged.find(c => c.channelId === 'UCdupe000000000000000000')).toEqual(
+        expect.objectContaining({ uploader: 'First Wins' })
+      );
+      expect(merged.find(c => c.channelId === 'UCnew0000000000000000000')).toEqual(
+        expect.objectContaining({ uploader: 'New Channel' })
+      );
+    });
+
+    it('merges terminationFailures across intermediate groups and dedupes by channel id', async () => {
+      const job = {
+        data: {
+          videos: [],
+          failedVideos: [],
+          cumulativeSkipped: 0,
+          terminationFailures: ['UCdupe000000000000000000']
+        }
+      };
+      jobModule.getJob.mockReturnValue(job);
+
+      await executor.saveIntermediateGroupResults(
+        mockJobId,
+        'output',
+        [],
+        [],
+        0,
+        {},
+        [],
+        ['UCdupe000000000000000000', 'UCnew0000000000000000000']
+      );
+
+      const updateCall = jobModule.updateJob.mock.calls.find(call => call[0] === mockJobId);
+      const merged = updateCall[1].data.terminationFailures;
+      expect(merged).toEqual(['UCdupe000000000000000000', 'UCnew0000000000000000000']);
+    });
+
     it('should not persist to database when no videos were downloaded', async () => {
       VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([]);
       archiveModule.getNewVideoUrlsSince.mockReturnValue([]);
@@ -2174,6 +2241,297 @@ describe('DownloadExecutor', () => {
 
     it('should return null when yt-dlp error text has no video id', () => {
       expect(executor.extractYoutubeIdFromYtdlpError('members-only content')).toBeNull();
+    });
+  });
+
+  describe('extractChannelIdFromYtdlpError', () => {
+    it('extracts the canonical channel_id from a [youtube:tab] error line', () => {
+      const message = 'ERROR: [youtube:tab] UC1lg-nYUcZ1pjo6EC2Nj5Sw: YouTube said: This account has been terminated for violating Google\'s Terms of Service.';
+      expect(executor.extractChannelIdFromYtdlpError(message)).toBe('UC1lg-nYUcZ1pjo6EC2Nj5Sw');
+    });
+
+    it('returns null when the line is a [youtube] (video) error rather than [youtube:tab]', () => {
+      const message = 'ERROR: [youtube] OOUclRI0Ae4: Join this channel to get access to members-only content.';
+      expect(executor.extractChannelIdFromYtdlpError(message)).toBeNull();
+    });
+
+    it('returns null when no UC... id is present', () => {
+      expect(executor.extractChannelIdFromYtdlpError('account has been terminated for violating')).toBeNull();
+      expect(executor.extractChannelIdFromYtdlpError('')).toBeNull();
+    });
+  });
+
+  describe('persistTerminatedChannel', () => {
+    beforeEach(() => {
+      Channel.findOne.mockReset();
+    });
+
+    it('stamps terminated_at and clears auto_download_enabled_tabs on first detection', async () => {
+      const channelRow = {
+        terminated_at: null,
+        uploader: 'Test Channel',
+        url: 'https://www.youtube.com/channel/UC1234567890123456789012',
+        update: jest.fn().mockResolvedValue()
+      };
+      Channel.findOne.mockResolvedValueOnce(channelRow);
+
+      const result = await executor.persistTerminatedChannel('UC1234567890123456789012');
+
+      expect(Channel.findOne).toHaveBeenCalledWith({ where: { channel_id: 'UC1234567890123456789012' } });
+      expect(channelRow.update).toHaveBeenCalledWith({
+        terminated_at: expect.any(Date),
+        auto_download_enabled_tabs: ''
+      });
+      expect(result).toBe(channelRow);
+    });
+
+    it('preserves the original terminated_at on re-detection but still clears tabs', async () => {
+      const originalDate = new Date('2026-01-15T12:00:00Z');
+      const channelRow = {
+        terminated_at: originalDate,
+        uploader: 'Test Channel',
+        url: 'https://www.youtube.com/channel/UC1234567890123456789012',
+        update: jest.fn().mockResolvedValue()
+      };
+      Channel.findOne.mockResolvedValueOnce(channelRow);
+
+      await executor.persistTerminatedChannel('UC1234567890123456789012');
+
+      expect(channelRow.update).toHaveBeenCalledWith({
+        terminated_at: originalDate,
+        auto_download_enabled_tabs: ''
+      });
+    });
+
+    it('returns null and logs a warning when the channel is not in the database', async () => {
+      Channel.findOne.mockResolvedValueOnce(null);
+
+      const result = await executor.persistTerminatedChannel('UC0000000000000000000000');
+
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: 'UC0000000000000000000000' }),
+        'Terminated channel not in DB; skipping persistence'
+      );
+    });
+
+    it('swallows db errors and returns null', async () => {
+      Channel.findOne.mockRejectedValueOnce(new Error('db down'));
+
+      const result = await executor.persistTerminatedChannel('UC1234567890123456789012');
+
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: 'UC1234567890123456789012' }),
+        'Failed to persist terminated channel state'
+      );
+    });
+
+    it('is a no-op when channelId is falsy', async () => {
+      await expect(executor.persistTerminatedChannel(null)).resolves.toBeNull();
+      await expect(executor.persistTerminatedChannel('')).resolves.toBeNull();
+      await expect(executor.persistTerminatedChannel(undefined)).resolves.toBeNull();
+      expect(Channel.findOne).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('terminated channel handling in doDownload', () => {
+    const mockArgs = ['--format', 'best', 'https://www.youtube.com/channel/UC1234567890123456789012'];
+    const mockJobId = 'job-term-1';
+    const mockJobType = 'Channel Downloads';
+
+    beforeEach(() => {
+      Channel.findOne.mockReset();
+    });
+
+    it('marks termination-only runs as Complete with Warnings and includes terminatedChannels in finalSummary', async () => {
+      const channelRow = {
+        terminated_at: null,
+        uploader: 'Banned Channel',
+        url: 'https://www.youtube.com/channel/UC1234567890123456789012',
+        update: jest.fn().mockResolvedValue()
+      };
+      Channel.findOne.mockResolvedValue(channelRow);
+
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([]);
+      archiveModule.getNewVideoUrlsSince.mockReturnValue([]);
+
+      setTimeout(() => {
+        const termLine = 'ERROR: [youtube:tab] UC1234567890123456789012: YouTube said: This account has been terminated for violating Google\'s Terms of Service.\n';
+        mockProcess.stderr.emit('data', Buffer.from(termLine));
+        setTimeout(() => mockProcess.emit('exit', 1, null), 5);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(channelRow.update).toHaveBeenCalledWith({
+        terminated_at: expect.any(Date),
+        auto_download_enabled_tabs: ''
+      });
+
+      const updateJobCalls = jobModule.updateJob.mock.calls.filter(c => c[0] === mockJobId);
+      const terminalCall = updateJobCalls[updateJobCalls.length - 1];
+      expect(terminalCall[1].status).toBe('Complete with Warnings');
+      expect(terminalCall[1].data.terminatedChannels).toEqual([
+        expect.objectContaining({ channelId: 'UC1234567890123456789012', uploader: 'Banned Channel' })
+      ]);
+      expect(terminalCall[1].data.totalTerminatedChannels).toBe(1);
+    });
+
+    it('emits a final WebSocket payload with terminatedChannels under finalSummary', async () => {
+      const channelRow = {
+        terminated_at: null,
+        uploader: 'Banned Channel',
+        url: 'https://www.youtube.com/channel/UC1234567890123456789012',
+        update: jest.fn().mockResolvedValue()
+      };
+      Channel.findOne.mockResolvedValue(channelRow);
+
+      setTimeout(() => {
+        const termLine = 'ERROR: [youtube:tab] UC1234567890123456789012: YouTube said: This account has been terminated for violating Google\'s Terms of Service.\n';
+        mockProcess.stderr.emit('data', Buffer.from(termLine));
+        setTimeout(() => mockProcess.emit('exit', 1, null), 5);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      const finalCall = MessageEmitter.emitMessage.mock.calls.find(call => call[4] && call[4].finalSummary);
+      expect(finalCall).toBeDefined();
+      expect(finalCall[4].finalSummary.terminatedChannels).toEqual([
+        expect.objectContaining({ channelId: 'UC1234567890123456789012', uploader: 'Banned Channel' })
+      ]);
+      expect(finalCall[4].finalSummary.totalTerminatedChannels).toBe(1);
+    });
+
+    it('does not increment unexpectedErrorCount or record a failed video for terminated errors', async () => {
+      const channelRow = {
+        terminated_at: null,
+        uploader: 'Banned Channel',
+        url: 'https://www.youtube.com/channel/UC1234567890123456789012',
+        update: jest.fn().mockResolvedValue()
+      };
+      Channel.findOne.mockResolvedValue(channelRow);
+
+      setTimeout(() => {
+        const termLine = 'ERROR: [youtube:tab] UC1234567890123456789012: YouTube said: This account has been terminated for violating Google\'s Terms of Service.\n';
+        mockProcess.stderr.emit('data', Buffer.from(termLine));
+        setTimeout(() => mockProcess.emit('exit', 1, null), 5);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      const updateJobCalls = jobModule.updateJob.mock.calls.filter(c => c[0] === mockJobId);
+      const terminalCall = updateJobCalls[updateJobCalls.length - 1];
+      expect(terminalCall[1].data.failedVideos).toEqual([]);
+    });
+
+    it('dedupes when the same termination message arrives on both stdout and stderr', async () => {
+      const channelRow = {
+        terminated_at: null,
+        uploader: 'Banned Channel',
+        url: 'https://www.youtube.com/channel/UC1234567890123456789012',
+        update: jest.fn().mockResolvedValue()
+      };
+      Channel.findOne.mockResolvedValue(channelRow);
+
+      setTimeout(() => {
+        const termLine = 'ERROR: [youtube:tab] UC1234567890123456789012: YouTube said: This account has been terminated for violating Google\'s Terms of Service.\n';
+        mockProcess.stdout.emit('data', Buffer.from(termLine));
+        mockProcess.stderr.emit('data', Buffer.from(termLine));
+        setTimeout(() => mockProcess.emit('exit', 1, null), 5);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      // Set dedupe means only one lookup across both stream sources.
+      expect(Channel.findOne).toHaveBeenCalledTimes(1);
+      expect(channelRow.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT mark run as handled when channel cannot be persisted', async () => {
+      // Channel not in DB: persistence returns null, run must surface as a failure.
+      Channel.findOne.mockResolvedValue(null);
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([]);
+
+      setTimeout(() => {
+        const termLine = 'ERROR: [youtube:tab] UC1234567890123456789012: YouTube said: This account has been terminated for violating Google\'s Terms of Service.\n';
+        mockProcess.stderr.emit('data', Buffer.from(termLine));
+        setTimeout(() => mockProcess.emit('exit', 1, null), 5);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      const updateJobCalls = jobModule.updateJob.mock.calls.filter(c => c[0] === mockJobId);
+      const terminalCall = updateJobCalls[updateJobCalls.length - 1];
+      // Not Complete with Warnings: persistence failed, this is a real error.
+      expect(['Error', 'Failed']).toContain(terminalCall[1].status);
+      // No false-positive summary entry.
+      expect(terminalCall[1].data.terminatedChannels).toEqual([]);
+      expect(terminalCall[1].data.totalTerminatedChannels).toBe(0);
+      // The channel id IS recorded as a termination failure for the finalizer.
+      expect(terminalCall[1].data.terminationFailures).toEqual(['UC1234567890123456789012']);
+      expect(terminalCall[1].data.totalTerminationFailures).toBe(1);
+    });
+
+    it('records terminationFailures in the finalSummary broadcast', async () => {
+      Channel.findOne.mockResolvedValue(null);
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([]);
+
+      setTimeout(() => {
+        const termLine = 'ERROR: [youtube:tab] UC1234567890123456789012: YouTube said: This account has been terminated for violating Google\'s Terms of Service.\n';
+        mockProcess.stderr.emit('data', Buffer.from(termLine));
+        setTimeout(() => mockProcess.emit('exit', 1, null), 5);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      const finalCall = MessageEmitter.emitMessage.mock.calls.find(call => call[4] && call[4].finalSummary);
+      expect(finalCall).toBeDefined();
+      expect(finalCall[4].finalSummary.terminationFailures).toEqual(['UC1234567890123456789012']);
+      expect(finalCall[4].finalSummary.totalTerminationFailures).toBe(1);
+    });
+
+    it('does NOT mark run as handled when persistTerminatedChannel throws (db error)', async () => {
+      // Update throws: surface as a real failure, same as the "not in DB" path.
+      const channelRow = {
+        terminated_at: null,
+        uploader: 'Banned Channel',
+        url: 'https://www.youtube.com/channel/UC1234567890123456789012',
+        update: jest.fn().mockRejectedValue(new Error('db down'))
+      };
+      Channel.findOne.mockResolvedValue(channelRow);
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([]);
+
+      setTimeout(() => {
+        const termLine = 'ERROR: [youtube:tab] UC1234567890123456789012: YouTube said: This account has been terminated for violating Google\'s Terms of Service.\n';
+        mockProcess.stderr.emit('data', Buffer.from(termLine));
+        setTimeout(() => mockProcess.emit('exit', 1, null), 5);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      const updateJobCalls = jobModule.updateJob.mock.calls.filter(c => c[0] === mockJobId);
+      const terminalCall = updateJobCalls[updateJobCalls.length - 1];
+      expect(['Error', 'Failed']).toContain(terminalCall[1].status);
+      expect(terminalCall[1].data.terminatedChannels).toEqual([]);
+    });
+
+    it('falls through to unexpected-error branch when termination message has no extractable channel_id', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([]);
+
+      setTimeout(() => {
+        const badLine = 'ERROR: account has been terminated for violating Google\'s Terms of Service.\n';
+        mockProcess.stderr.emit('data', Buffer.from(badLine));
+        setTimeout(() => mockProcess.emit('exit', 1, null), 5);
+      }, 10);
+
+      await executor.doDownload(mockArgs, mockJobId, mockJobType);
+
+      expect(Channel.findOne).not.toHaveBeenCalled();
+      const updateJobCalls = jobModule.updateJob.mock.calls.filter(c => c[0] === mockJobId);
+      const terminalCall = updateJobCalls[updateJobCalls.length - 1];
+      // No channel id: generic Error.
+      expect(['Error', 'Failed']).toContain(terminalCall[1].status);
     });
   });
 

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -249,6 +249,11 @@ class DownloadExecutor {
     return match ? match[1] : null;
   }
 
+  extractChannelIdFromYtdlpError(message = '') {
+    const match = String(message).match(/\[youtube:tab\]\s+(UC[a-zA-Z0-9_-]{22}):/);
+    return match ? match[1] : null;
+  }
+
   // Fire-and-forget persistence so we don't block the stdout/stderr stream
   // handlers. Internal try/catch ensures the returned Promise always resolves,
   // so callers don't trigger unhandledRejection warnings when they don't await.
@@ -261,6 +266,27 @@ class DownloadExecutor {
       );
     } catch (err) {
       logger.warn({ err, youtubeId }, 'Failed to persist subscriber_only availability after download error');
+    }
+  }
+
+  // Stamps terminated_at once and always clears auto_download_enabled_tabs.
+  // Returns null if the channel is missing or the update fails.
+  async persistTerminatedChannel(channelId) {
+    if (!channelId) return null;
+    try {
+      const channel = await Channel.findOne({ where: { channel_id: channelId } });
+      if (!channel) {
+        logger.warn({ channelId }, 'Terminated channel not in DB; skipping persistence');
+        return null;
+      }
+      await channel.update({
+        terminated_at: channel.terminated_at || new Date(),
+        auto_download_enabled_tabs: ''
+      });
+      return channel;
+    } catch (err) {
+      logger.warn({ err, channelId }, 'Failed to persist terminated channel state');
+      return null;
     }
   }
 
@@ -281,7 +307,7 @@ class DownloadExecutor {
     await jobModule.saveJobOnly(jobId, currentJob);
   }
 
-  async saveIntermediateGroupResults(jobId, output, videoData, failedVideosList, skippedCount, extraFields = {}) {
+  async saveIntermediateGroupResults(jobId, output, videoData, failedVideosList, skippedCount, extraFields = {}, terminatedChannelsForGroup = [], terminationFailuresForGroup = []) {
     const currentJob = jobModule.getJob(jobId);
     if (!currentJob) {
       logger.warn({ jobId }, 'Unable to merge intermediate group results; job not found');
@@ -291,6 +317,20 @@ class DownloadExecutor {
     const existingVideos = currentJob.data?.videos || [];
     const existingFailedVideos = currentJob.data?.failedVideos || [];
     const existingSkippedCount = currentJob.data?.cumulativeSkipped || 0;
+    const existingTerminated = currentJob.data?.terminatedChannels || [];
+    const existingFailures = currentJob.data?.terminationFailures || [];
+
+    // First write wins so original uploader/url/date stick across groups.
+    const seenChannelIds = new Set(existingTerminated.map(c => c.channelId));
+    const mergedTerminated = [...existingTerminated];
+    for (const entry of (terminatedChannelsForGroup || [])) {
+      if (!entry || !entry.channelId || seenChannelIds.has(entry.channelId)) continue;
+      seenChannelIds.add(entry.channelId);
+      mergedTerminated.push(entry);
+    }
+
+    // Dedupe failures by channel id across groups.
+    const mergedFailures = Array.from(new Set([...existingFailures, ...(terminationFailuresForGroup || [])]));
 
     await jobModule.updateJob(jobId, {
       output: output,
@@ -298,7 +338,9 @@ class DownloadExecutor {
       data: {
         videos: [...existingVideos, ...(videoData || [])],
         failedVideos: [...existingFailedVideos, ...(failedVideosList || [])],
-        cumulativeSkipped: existingSkippedCount + (skippedCount || 0)
+        cumulativeSkipped: existingSkippedCount + (skippedCount || 0),
+        terminatedChannels: mergedTerminated,
+        terminationFailures: mergedFailures
       },
     });
 
@@ -681,12 +723,116 @@ class DownloadExecutor {
       // is known, so unassociated errors still block the
       // "complete with only expected skips" classification.
       let unexpectedErrorCount = 0;
+      // seenTerminatedChannelIds: sync dedupe across stdout/stderr.
+      // terminatedChannelIds: only successful persists; drives hasOnlyHandledErrors.
+      // terminatedChannels: rich entries for the summary, populated on success only.
+      // terminationFailures: channel ids the executor saw terminated but
+      //   couldn't auto-disable (row missing or update threw). Surfaced
+      //   separately so the multi-group finalizer can warn on them.
+      // terminatedPersistencePromises: awaited by the exit handler before final state.
+      const seenTerminatedChannelIds = new Set();
+      const terminatedChannelIds = new Set();
+      const terminatedChannels = [];
+      const terminationFailures = [];
+      const terminatedPersistencePromises = [];
       let currentVideoId = null; // Track the current video being processed
       let lastErrorMessage = null; // Store the last error message seen
 
       const recordExpectedSkip = (reason, source) => {
         expectedSkipCount += 1;
         logger.info({ youtubeId: currentVideoId, reason, source }, 'Expected video skip from yt-dlp');
+      };
+
+      // Shared by stdout and stderr. Returns true when the line was consumed
+      // by an expected skip or termination, so the caller can suppress it.
+      const handleYtdlpErrorLine = (line, source) => {
+        const errorMatch = line.match(/ERROR:\s*(.+)/);
+        if (!errorMatch) return false;
+
+        lastErrorMessage = errorMatch[1].trim();
+
+        if (this.isExpectedYtdlpSkipMessage(lastErrorMessage)) {
+          recordExpectedSkip(lastErrorMessage, source);
+          if (this.isMembersOnlyMessage(lastErrorMessage)) {
+            const membersOnlyVideoId = this.extractYoutubeIdFromYtdlpError(lastErrorMessage) || currentVideoId;
+            if (membersOnlyVideoId) {
+              membersOnlyVideoIds.add(membersOnlyVideoId);
+              this.persistMembersOnlyAvailability(membersOnlyVideoId);
+            }
+          }
+          return true;
+        }
+
+        if (ytDlpRunner.isTerminatedAccountError(lastErrorMessage)) {
+          const channelId = this.extractChannelIdFromYtdlpError(lastErrorMessage);
+          if (channelId) {
+            if (!seenTerminatedChannelIds.has(channelId)) {
+              seenTerminatedChannelIds.add(channelId);
+              logger.warn({ channelId, source }, 'Detected terminated YouTube channel');
+
+              // Broadcast after the lookup so we can name the uploader, not
+              // the raw ID. Only mark as handled on success; persistence
+              // failure stays in the unexpected-error branch so we don't
+              // tell the user "disabled" when nothing was actually disabled.
+              const lookupPromise = this.persistTerminatedChannel(channelId).then(row => {
+                if (row) {
+                  terminatedChannelIds.add(channelId);
+                  terminatedChannels.push({
+                    channelId,
+                    uploader: row.uploader || null,
+                    url: row.url || null,
+                    terminatedAt: row.terminated_at || null
+                  });
+                  const displayName = row.uploader || channelId;
+                  MessageEmitter.emitMessage(
+                    'broadcast',
+                    null,
+                    'download',
+                    'downloadProgress',
+                    {
+                      text: `Channel "${displayName}" marked terminated by YouTube; scheduled downloads disabled`,
+                      progress: monitor.snapshot('warning'),
+                      warning: true
+                    }
+                  );
+                } else {
+                  unexpectedErrorCount += 1;
+                  terminationFailures.push(channelId);
+                  logger.warn({ channelId, source }, 'Termination detected but could not be auto-disabled; channel will continue to retry');
+                  MessageEmitter.emitMessage(
+                    'broadcast',
+                    null,
+                    'download',
+                    'downloadProgress',
+                    {
+                      text: `Channel ${channelId} reported as terminated by YouTube but could not be auto-disabled`,
+                      progress: monitor.snapshot('warning'),
+                      warning: true
+                    }
+                  );
+                }
+              });
+              terminatedPersistencePromises.push(lookupPromise);
+            }
+            return true;
+          }
+          // No channel id: fall through to the unexpected-error branch.
+        }
+
+        unexpectedErrorCount += 1;
+        const errorLogMessage = source === 'stderr'
+          ? 'Error detected in stderr'
+          : 'Error detected during download';
+        logger.warn({ error: lastErrorMessage, currentVideoId }, errorLogMessage);
+        if (currentVideoId && !failedVideos.has(currentVideoId)) {
+          failedVideos.set(currentVideoId, {
+            youtubeId: currentVideoId,
+            error: lastErrorMessage,
+            url: null
+          });
+          logger.info({ youtubeId: currentVideoId, error: lastErrorMessage }, 'Recorded video failure');
+        }
+        return false;
       };
 
       const emitCookiesSuggestionMessage = () => {
@@ -812,40 +958,14 @@ class DownloadExecutor {
               }
             }
 
-            // Detect and track ERROR messages
-            let suppressExpectedSkipLine = false;
+            // Suppress the line when handleYtdlpErrorLine consumed it
+            // (expected skip or termination).
+            let suppressErrorLine = false;
             if (line.includes('ERROR:')) {
-              const errorMatch = line.match(/ERROR:\s*(.+)/);
-              if (errorMatch) {
-                lastErrorMessage = errorMatch[1].trim();
-                if (this.isExpectedYtdlpSkipMessage(lastErrorMessage)) {
-                  recordExpectedSkip(lastErrorMessage, 'stdout');
-                  if (this.isMembersOnlyMessage(lastErrorMessage)) {
-                    const membersOnlyVideoId = this.extractYoutubeIdFromYtdlpError(lastErrorMessage) || currentVideoId;
-                    if (membersOnlyVideoId) {
-                      membersOnlyVideoIds.add(membersOnlyVideoId);
-                      this.persistMembersOnlyAvailability(membersOnlyVideoId);
-                    }
-                  }
-                  suppressExpectedSkipLine = true;
-                } else {
-                  unexpectedErrorCount += 1;
-                  logger.warn({ error: lastErrorMessage, currentVideoId }, 'Error detected during download');
-
-                  // Associate error with current video if we know which video is being processed
-                  if (currentVideoId && !failedVideos.has(currentVideoId)) {
-                    failedVideos.set(currentVideoId, {
-                      youtubeId: currentVideoId,
-                      error: lastErrorMessage,
-                      url: null // Will be populated later from urlsToProcess
-                    });
-                    logger.info({ youtubeId: currentVideoId, error: lastErrorMessage }, 'Recorded video failure');
-                  }
-                }
-              }
+              suppressErrorLine = handleYtdlpErrorLine(line, 'stdout');
             }
 
-            if (suppressExpectedSkipLine) {
+            if (suppressErrorLine) {
               return;
             }
 
@@ -898,34 +1018,7 @@ class DownloadExecutor {
             .map(line => line.trim())
             .filter(line => line.includes('ERROR:'))
             .forEach(line => {
-              const errorMatch = line.match(/ERROR:\s*(.+)/);
-              if (!errorMatch) {
-                return;
-              }
-              lastErrorMessage = errorMatch[1].trim();
-              if (this.isExpectedYtdlpSkipMessage(lastErrorMessage)) {
-                recordExpectedSkip(lastErrorMessage, 'stderr');
-                if (this.isMembersOnlyMessage(lastErrorMessage)) {
-                  const membersOnlyVideoId = this.extractYoutubeIdFromYtdlpError(lastErrorMessage) || currentVideoId;
-                  if (membersOnlyVideoId) {
-                    membersOnlyVideoIds.add(membersOnlyVideoId);
-                    this.persistMembersOnlyAvailability(membersOnlyVideoId);
-                  }
-                }
-                return;
-              }
-              unexpectedErrorCount += 1;
-              logger.warn({ error: lastErrorMessage, currentVideoId }, 'Error detected in stderr');
-
-              // Associate error with current video if we know which video is being processed
-              if (currentVideoId && !failedVideos.has(currentVideoId)) {
-                failedVideos.set(currentVideoId, {
-                  youtubeId: currentVideoId,
-                  error: lastErrorMessage,
-                  url: null // Will be populated later from urlsToProcess
-                });
-                logger.info({ youtubeId: currentVideoId, error: lastErrorMessage }, 'Recorded video failure from stderr');
-              }
+              handleYtdlpErrorLine(line, 'stderr');
             });
         }
 
@@ -993,6 +1086,12 @@ class DownloadExecutor {
             logger.info('HTTP 403 detected in stderr buffer');
             emitCookiesSuggestionMessage();
           }
+        }
+
+        // Wait for terminated-channel lookups before deriving finalState.
+        // Without this barrier the final broadcast can ship raw channel IDs.
+        if (terminatedPersistencePromises.length > 0) {
+          await Promise.allSettled(terminatedPersistencePromises);
         }
 
         let urlsToProcess;
@@ -1144,6 +1243,19 @@ class DownloadExecutor {
           !botDetected &&
           !httpForbiddenDetected;
 
+        // Like hasOnlyExpectedSkips but also admits recognized terminations.
+        // Mixed failure modes still report as an error.
+        const hasOnlyHandledErrors = code === 1 &&
+          (expectedSkipCount > 0 || terminatedChannelIds.size > 0) &&
+          failedVideosList.length === 0 &&
+          unexpectedErrorCount === 0 &&
+          !botDetected &&
+          !httpForbiddenDetected;
+
+        if (terminatedChannelIds.size > 0) {
+          logger.warn({ terminatedChannels }, 'Channels marked terminated during this job');
+        }
+
         let status = '';
         let output = '';
         let jobErrorCode;
@@ -1160,7 +1272,11 @@ class DownloadExecutor {
             output: output,
             data: {
               videos: videoData || [],
-              failedVideos: failedVideosList || []
+              failedVideos: failedVideosList || [],
+              terminatedChannels: [...terminatedChannels],
+              totalTerminatedChannels: terminatedChannelIds.size,
+              terminationFailures: [...terminationFailures],
+              totalTerminationFailures: terminationFailures.length
             },
             notes: 'YouTube requires authentication. Enable cookies in Configuration to resolve this issue.',
             error: 'COOKIES_REQUIRED'
@@ -1188,7 +1304,11 @@ class DownloadExecutor {
             output: output,
             data: {
               videos: videoData || [],
-              failedVideos: failedVideosList || []
+              failedVideos: failedVideosList || [],
+              terminatedChannels: [...terminatedChannels],
+              totalTerminatedChannels: terminatedChannelIds.size,
+              terminationFailures: [...terminationFailures],
+              totalTerminationFailures: terminationFailures.length
             },
             notes: terminationReason,
           });
@@ -1206,9 +1326,13 @@ class DownloadExecutor {
           let errorCode;
 
           // Provide more helpful error messages based on what we detected
-          if (hasOnlyExpectedSkips) {
+          if (hasOnlyExpectedSkips && terminatedChannelIds.size === 0) {
             status = 'Complete';
             output = `${videoCount} videos.`;
+          } else if (hasOnlyHandledErrors && terminatedChannelIds.size > 0) {
+            // Code 1 but every error was recognized: warning-shaped success.
+            output = `${videoCount} videos, ${terminatedChannelIds.size} channel${terminatedChannelIds.size !== 1 ? 's' : ''} marked terminated.`;
+            notes = `${terminatedChannelIds.size} channel${terminatedChannelIds.size !== 1 ? 's' : ''} marked terminated by YouTube`;
           } else if (httpForbiddenDetected) {
             // Failed with 403 errors - likely authentication issue
             output = `${videoCount} videos. Error: YouTube returned HTTP 403 (Forbidden)`;
@@ -1243,12 +1367,16 @@ class DownloadExecutor {
               {
                 notes: notes,
                 ...(errorCode ? { error: errorCode } : {})
-              }
+              },
+              [...terminatedChannels],
+              [...terminationFailures]
             );
           } else {
             await this.persistCompletedVideosBeforeTerminalUpdate(jobId, videoData, failedVideosList);
             let terminalStatus = status;
-            if (hasOnlyExpectedSkips) {
+            if (hasOnlyHandledErrors && terminatedChannelIds.size > 0) {
+              terminalStatus = 'Complete with Warnings';
+            } else if (hasOnlyExpectedSkips) {
               terminalStatus = 'Complete';
             } else if (hasPartialSuccess) {
               terminalStatus = 'Complete with Warnings';
@@ -1259,7 +1387,11 @@ class DownloadExecutor {
               output: output,
               data: {
                 videos: videoData || [],
-                failedVideos: failedVideosList || []
+                failedVideos: failedVideosList || [],
+                terminatedChannels: [...terminatedChannels],
+                totalTerminatedChannels: terminatedChannelIds.size,
+                terminationFailures: [...terminationFailures],
+                totalTerminationFailures: terminationFailures.length
               },
               notes: notes,
               ...(errorCode ? { error: errorCode } : {})
@@ -1276,7 +1408,10 @@ class DownloadExecutor {
               output,
               videoData,
               failedVideosList,
-              monitor.videoCount.skipped || 0
+              monitor.videoCount.skipped || 0,
+              {},
+              [...terminatedChannels],
+              [...terminationFailures]
             );
           } else {
             // For manual/single downloads, persist to DB BEFORE calling updateJob
@@ -1288,13 +1423,23 @@ class DownloadExecutor {
               output: output,
               data: {
                 videos: videoData,
-                failedVideos: failedVideosList || []
+                failedVideos: failedVideosList || [],
+                terminatedChannels: [...terminatedChannels],
+                totalTerminatedChannels: terminatedChannelIds.size,
+                terminationFailures: [...terminationFailures],
+                totalTerminationFailures: terminationFailures.length
               },
             });
           }
         } else {
-          status = 'Complete';
-          output = `${videoCount} videos.`;
+          // Upgrade to warning shape when terminations were recorded.
+          if (terminatedChannelIds.size > 0) {
+            status = 'Complete with Warnings';
+            output = `${videoCount} videos, ${terminatedChannelIds.size} channel${terminatedChannelIds.size !== 1 ? 's' : ''} marked terminated.`;
+          } else {
+            status = 'Complete';
+            output = `${videoCount} videos.`;
+          }
           // When skipJobTransition is true, we're processing multiple groups
           // Don't mark as complete yet - just save the videos
           if (skipJobTransition) {
@@ -1303,7 +1448,10 @@ class DownloadExecutor {
               output,
               videoData,
               failedVideosList,
-              monitor.videoCount.skipped || 0
+              monitor.videoCount.skipped || 0,
+              {},
+              [...terminatedChannels],
+              [...terminationFailures]
             );
           } else {
             // For manual/single downloads, persist to DB BEFORE calling updateJob
@@ -1315,7 +1463,11 @@ class DownloadExecutor {
               output: output,
               data: {
                 videos: videoData,
-                failedVideos: failedVideosList || []
+                failedVideos: failedVideosList || [],
+                terminatedChannels: [...terminatedChannels],
+                totalTerminatedChannels: terminatedChannelIds.size,
+                terminationFailures: [...terminationFailures],
+                totalTerminationFailures: terminationFailures.length
               },
             });
           }
@@ -1335,8 +1487,19 @@ class DownloadExecutor {
         const hasSuccesses = videoData.length > 0;
         const hasNonFatalPartialSuccess = code === 1 && hasSuccesses;
 
+        const hasOnlySuccessfulTerminationsOnCleanExit = code === 0 &&
+          terminatedChannelIds.size > 0 &&
+          failedVideosList.length === 0 &&
+          unexpectedErrorCount === 0 &&
+          !botDetected &&
+          !httpForbiddenDetected;
+
         let finalState;
-        if (code === 0 || hasOnlyExpectedSkips) {
+        if ((hasOnlyHandledErrors && terminatedChannelIds.size > 0) || hasOnlySuccessfulTerminationsOnCleanExit) {
+          // Warning-shaped when the only detected issue is a handled
+          // terminated channel, including when --ignore-errors exits 0.
+          finalState = 'warning';
+        } else if (code === 0 || hasOnlyExpectedSkips) {
           finalState = hasFailures ? 'warning' : 'complete';
         } else if (isWarningOnly || hasNonFatalPartialSuccess) {
           finalState = 'warning';
@@ -1356,6 +1519,8 @@ class DownloadExecutor {
           expectedSkipCount,
           unexpectedErrorCount,
           hasOnlyExpectedSkips,
+          hasOnlyHandledErrors,
+          terminatedChannelCount: terminatedChannelIds.size,
           successCount: videoData.length,
           failureCount: failedVideosList.length,
           finalState
@@ -1373,13 +1538,17 @@ class DownloadExecutor {
           finalState = 'failed';
           finalErrorCode = 'COOKIES_REQUIRED';
           finalText = 'Download failed: Bot detection encountered. Please set cookies in your Configuration or try different cookies to resolve this issue.';
-        } else if (monitor.hasError && finalState === 'complete') {
+        } else if (monitor.hasError && finalState === 'complete' && !hasOnlyHandledErrors) {
+          // Don't let a recognized termination flip the state back to error
+          // via DownloadProgressMonitor's broad hasError flag.
           finalState = 'error';
           finalText = 'Download failed';
         } else if (finalState === 'complete' || finalState === 'warning') {
           const actualCount = videoData.length;
           const skippedCount = monitor.videoCount.skipped || 0;
           const failedCount = failedVideosList.length;
+          const terminatedCount = terminatedChannelIds.size;
+          const terminationFailureCount = terminationFailures.length;
 
           // Build message parts
           const parts = [];
@@ -1391,6 +1560,12 @@ class DownloadExecutor {
           }
           if (skippedCount > 0) {
             parts.push(`${skippedCount} already existed`);
+          }
+          if (terminatedCount > 0) {
+            parts.push(`${terminatedCount} channel${terminatedCount !== 1 ? 's' : ''} marked terminated`);
+          }
+          if (terminationFailureCount > 0) {
+            parts.push(`${terminationFailureCount} termination${terminationFailureCount !== 1 ? 's' : ''} could not be auto-disabled`);
           }
 
           if (parts.length > 0) {
@@ -1424,7 +1599,11 @@ class DownloadExecutor {
             totalSkipped: monitor.videoCount.skipped || 0,
             totalFailed: failedVideosList.length,
             totalMembersOnly: membersOnlyVideoIds.size,
+            totalTerminatedChannels: terminatedChannelIds.size,
+            totalTerminationFailures: terminationFailures.length,
             failedVideos: failedVideosList,
+            terminatedChannels: [...terminatedChannels],
+            terminationFailures: [...terminationFailures],
             jobType: jobType,
             completedAt: new Date().toISOString()
           };

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -252,9 +252,18 @@ class DownloadModule {
     // All groups completed successfully
     logger.info('All download groups completed, marking job as complete');
 
+    // Check terminations and termination-persistence failures before stamping
+    // the status; both feed into the DB record and the WebSocket payload.
+    const inFlightJob = jobModule.getJob(jobId);
+    const terminatedChannelsForJob = (inFlightJob && inFlightJob.data && inFlightJob.data.terminatedChannels) || [];
+    const terminationFailuresForJob = (inFlightJob && inFlightJob.data && inFlightJob.data.terminationFailures) || [];
+    const hasTerminationActivity = terminatedChannelsForJob.length > 0 || terminationFailuresForJob.length > 0;
+    const completedStatus = hasTerminationActivity ? 'Complete with Warnings' : 'Complete';
+    const progressState = hasTerminationActivity ? 'warning' : 'complete';
+
     // Mark the job as complete - this will trigger video reload from DB
     await jobModule.updateJob(jobId, {
-      status: 'Complete',
+      status: completedStatus,
     });
 
     // Get the updated job with all videos reloaded from database
@@ -266,12 +275,18 @@ class DownloadModule {
       const totalVideos = completedJob.data.videos?.length || 0;
       const failedVideos = completedJob.data.failedVideos || [];
       const totalSkipped = completedJob.data.cumulativeSkipped || 0;
+      const terminatedChannels = completedJob.data.terminatedChannels || [];
+      const terminationFailures = completedJob.data.terminationFailures || [];
 
       const finalSummary = {
         totalDownloaded: totalVideos,
         totalSkipped: totalSkipped,
         totalFailed: failedVideos.length,
+        totalTerminatedChannels: terminatedChannels.length,
+        totalTerminationFailures: terminationFailures.length,
         failedVideos: failedVideos,
+        terminatedChannels: terminatedChannels,
+        terminationFailures: terminationFailures,
         jobType: 'Channel Downloads - All Groups',
         completedAt: new Date().toISOString()
       };
@@ -280,13 +295,19 @@ class DownloadModule {
       const messageParts = [`${totalVideos} downloaded`];
       if (totalSkipped > 0) messageParts.push(`${totalSkipped} skipped`);
       if (failedVideos.length > 0) messageParts.push(`${failedVideos.length} failed`);
+      if (terminatedChannels.length > 0) {
+        messageParts.push(`${terminatedChannels.length} channel${terminatedChannels.length !== 1 ? 's' : ''} marked terminated`);
+      }
+      if (terminationFailures.length > 0) {
+        messageParts.push(`${terminationFailures.length} termination${terminationFailures.length !== 1 ? 's' : ''} could not be auto-disabled`);
+      }
       const completionText = `Download completed: ${messageParts.join(', ')} across ${groups.length} groups`;
 
       const finalPayload = {
         text: completionText,
         progress: {
           jobId: jobId,
-          state: 'complete',
+          state: progressState,
           videoCount: {
             completed: totalVideos,
             total: totalVideos,
@@ -296,6 +317,10 @@ class DownloadModule {
         finalSummary: finalSummary
       };
 
+      if (hasTerminationActivity) {
+        finalPayload.warning = true;
+      }
+
       MessageEmitter.emitMessage(
         'broadcast',
         null,
@@ -304,11 +329,12 @@ class DownloadModule {
         finalPayload
       );
 
-      logger.info({ jobId, totalVideos, totalFailed: failedVideos.length, groupCount: groups.length },
+      logger.info({ jobId, totalVideos, totalFailed: failedVideos.length, totalTerminated: terminatedChannels.length, totalTerminationFailures: terminationFailures.length, groupCount: groups.length },
         'Emitted final summary for multi-group download');
 
-      // Send notification for successful multi-group download
-      if (totalVideos > 0) {
+      // Include termination-only runs (zero downloads, one or more terminated
+      // or one or more termination-persistence failures).
+      if (totalVideos > 0 || terminatedChannels.length > 0 || terminationFailures.length > 0) {
         const notificationModule = require('./notificationModule');
         notificationModule.sendDownloadNotification({
           finalSummary: finalSummary,

--- a/server/modules/notifications/__tests__/utils.test.js
+++ b/server/modules/notifications/__tests__/utils.test.js
@@ -1,0 +1,114 @@
+/* eslint-env jest */
+
+const {
+  buildTitle,
+  getTerminatedCount,
+  buildTerminatedCountLabel,
+  formatTerminatedChannelLine,
+  getTerminationFailureCount,
+  buildTerminationFailureCountLabel,
+  formatTerminationFailureLine,
+} = require('../utils');
+
+describe('notification utils - terminated channel helpers', () => {
+  describe('buildTitle', () => {
+    test('uses video headline when totalDownloaded > 0 regardless of terminations', () => {
+      expect(buildTitle(3, 1)).toBe('🎬 3 New Videos Downloaded');
+      expect(buildTitle(1, 0)).toBe('🎬 New Video Downloaded');
+    });
+
+    test('switches to termination headline when zero videos and one termination', () => {
+      expect(buildTitle(0, 1)).toBe('⚠️ Channel Termination Detected');
+    });
+
+    test('pluralizes the termination headline for multiple events', () => {
+      expect(buildTitle(0, 3)).toBe('⚠️ 3 Channel Terminations Detected');
+    });
+
+    test('combines successes and failures in the title count', () => {
+      expect(buildTitle(0, 1, 1)).toBe('⚠️ 2 Channel Terminations Detected');
+      expect(buildTitle(0, 0, 1)).toBe('⚠️ Channel Termination Detected');
+    });
+
+    test('falls back to video headline when all counts are zero', () => {
+      expect(buildTitle(0, 0)).toBe('🎬 0 New Videos Downloaded');
+    });
+  });
+
+  describe('getTerminatedCount', () => {
+    test('prefers totalTerminatedChannels when present', () => {
+      expect(getTerminatedCount({ totalTerminatedChannels: 2, terminatedChannels: [] })).toBe(2);
+    });
+
+    test('falls back to terminatedChannels length', () => {
+      expect(getTerminatedCount({ terminatedChannels: [{ channelId: 'UC1' }, { channelId: 'UC2' }] })).toBe(2);
+    });
+
+    test('returns 0 for missing/empty summaries', () => {
+      expect(getTerminatedCount({})).toBe(0);
+      expect(getTerminatedCount()).toBe(0);
+    });
+  });
+
+  describe('buildTerminatedCountLabel', () => {
+    test('singular form for count of 1', () => {
+      expect(buildTerminatedCountLabel(1)).toBe('1 channel marked terminated');
+    });
+
+    test('plural form for other counts', () => {
+      expect(buildTerminatedCountLabel(2)).toBe('2 channels marked terminated');
+      expect(buildTerminatedCountLabel(0)).toBe('0 channels marked terminated');
+    });
+  });
+
+  describe('formatTerminatedChannelLine', () => {
+    test('uses uploader when present', () => {
+      expect(formatTerminatedChannelLine({ uploader: 'My Channel', channelId: 'UC123' })).toBe(
+        'My Channel: scheduled downloads disabled'
+      );
+    });
+
+    test('falls back to channelId when uploader missing', () => {
+      expect(formatTerminatedChannelLine({ channelId: 'UC123' })).toBe(
+        'UC123: scheduled downloads disabled'
+      );
+    });
+
+    test('falls back to placeholder when both missing', () => {
+      expect(formatTerminatedChannelLine({})).toBe('Unknown channel: scheduled downloads disabled');
+    });
+  });
+
+  describe('getTerminationFailureCount', () => {
+    test('prefers totalTerminationFailures when present', () => {
+      expect(getTerminationFailureCount({ totalTerminationFailures: 2, terminationFailures: [] })).toBe(2);
+    });
+
+    test('falls back to terminationFailures length', () => {
+      expect(getTerminationFailureCount({ terminationFailures: ['UC1', 'UC2'] })).toBe(2);
+    });
+
+    test('returns 0 for missing/empty summaries', () => {
+      expect(getTerminationFailureCount({})).toBe(0);
+      expect(getTerminationFailureCount()).toBe(0);
+    });
+  });
+
+  describe('buildTerminationFailureCountLabel', () => {
+    test('singular form', () => {
+      expect(buildTerminationFailureCountLabel(1)).toBe('1 termination could not be auto-disabled');
+    });
+
+    test('plural form', () => {
+      expect(buildTerminationFailureCountLabel(3)).toBe('3 terminations could not be auto-disabled');
+    });
+  });
+
+  describe('formatTerminationFailureLine', () => {
+    test('renders a channel id with the auto-disable failure note', () => {
+      expect(formatTerminationFailureLine('UC123')).toBe(
+        'UC123: detected as terminated but could not be auto-disabled (check the channel manually)'
+      );
+    });
+  });
+});

--- a/server/modules/notifications/formatters/discordFormatter.js
+++ b/server/modules/notifications/formatters/discordFormatter.js
@@ -11,7 +11,13 @@ const {
   getSubtitle,
   buildAutoRemovalTitle,
   formatBytes,
-  groupVideosByChannel
+  groupVideosByChannel,
+  getTerminatedCount,
+  buildTerminatedCountLabel,
+  formatTerminatedChannelLine,
+  getTerminationFailureCount,
+  buildTerminationFailureCountLabel,
+  formatTerminationFailureLine
 } = require('../utils');
 
 const DISCORD_FIELD_VALUE_LIMIT = 1024;
@@ -35,12 +41,43 @@ function truncateFieldValueAtLineBoundary(value, limit = DISCORD_FIELD_VALUE_LIM
 function formatDownloadMessage(finalSummary, videoData) {
   const { totalDownloaded, jobType } = finalSummary;
   const failedCount = getFailedCount(finalSummary);
+  const terminatedCount = getTerminatedCount(finalSummary);
+  const terminationFailureCount = getTerminationFailureCount(finalSummary);
 
-  const title = buildTitle(totalDownloaded);
+  const title = buildTitle(totalDownloaded, terminatedCount, terminationFailureCount);
   let description = `**${getSubtitle(jobType)}:**\n`;
 
   // Build fields for each video (up to 10)
   const fields = [];
+
+  if (terminatedCount > 0) {
+    description += `\n⚠️ **${buildTerminatedCountLabel(terminatedCount)}.**`;
+    const terminatedChannelsToShow = (finalSummary.terminatedChannels || []).slice(0, 5);
+    const terminatedValue = terminatedChannelsToShow.length > 0
+      ? truncateFieldValueAtLineBoundary(terminatedChannelsToShow.map(formatTerminatedChannelLine).join('\n'))
+      : 'See Youtarr channels list for details.';
+
+    fields.push({
+      name: '⚠️ Channels marked terminated',
+      value: terminatedValue,
+      inline: false
+    });
+  }
+
+  if (terminationFailureCount > 0) {
+    description += `\n⚠️ **${buildTerminationFailureCountLabel(terminationFailureCount)}.**`;
+    const failuresToShow = (finalSummary.terminationFailures || []).slice(0, 5);
+    const failuresValue = failuresToShow.length > 0
+      ? truncateFieldValueAtLineBoundary(failuresToShow.map(formatTerminationFailureLine).join('\n'))
+      : 'Check Youtarr logs for details.';
+
+    fields.push({
+      name: '⚠️ Terminations not auto-disabled',
+      value: failuresValue,
+      inline: false
+    });
+  }
+
   if (videoData && videoData.length > 0) {
     const videosToShow = videoData.slice(0, 10);
 
@@ -78,11 +115,12 @@ function formatDownloadMessage(finalSummary, videoData) {
     });
   }
 
+  const hasWarning = failedCount > 0 || terminatedCount > 0 || terminationFailureCount > 0;
   return {
     embeds: [{
       title,
       description,
-      color: failedCount > 0 ? 0xffa500 : 0x00ff00, // Orange for partial success, green for success
+      color: hasWarning ? 0xffa500 : 0x00ff00,
       fields,
       timestamp: new Date().toISOString(),
       footer: {

--- a/server/modules/notifications/formatters/emailFormatter.js
+++ b/server/modules/notifications/formatters/emailFormatter.js
@@ -12,7 +12,13 @@ const {
   getSubtitle,
   buildAutoRemovalTitle,
   formatBytes,
-  groupVideosByChannel
+  groupVideosByChannel,
+  getTerminatedCount,
+  buildTerminatedCountLabel,
+  formatTerminatedChannelLine,
+  getTerminationFailureCount,
+  buildTerminationFailureCountLabel,
+  formatTerminationFailureLine
 } = require('../utils');
 
 const DEFAULT_HEADER_GRADIENT = 'linear-gradient(135deg, #1976d2 0%, #1565c0 100%)';
@@ -83,11 +89,47 @@ function buildEmailHtml(title, subtitle, content) {
 function formatDownloadMessage(finalSummary, videoData) {
   const { totalDownloaded, jobType } = finalSummary;
   const failedCount = getFailedCount(finalSummary);
+  const terminatedCount = getTerminatedCount(finalSummary);
+  const terminationFailureCount = getTerminationFailureCount(finalSummary);
 
-  const title = buildTitle(totalDownloaded);
+  const title = buildTitle(totalDownloaded, terminatedCount, terminationFailureCount);
   const subtitle = getSubtitle(jobType);
 
   let content = '';
+
+  if (terminatedCount > 0) {
+    const terminatedChannelsToShow = (finalSummary.terminatedChannels || []).slice(0, 5);
+    const terminatedItems = terminatedChannelsToShow.map(channel =>
+      `<li>${escapeHtml(formatTerminatedChannelLine(channel))}</li>`
+    ).join('');
+    const moreTerminated = terminatedCount > terminatedChannelsToShow.length
+      ? `<p class="more-videos">...and ${terminatedCount - terminatedChannelsToShow.length} more</p>`
+      : '';
+
+    content += `
+      <div class="warning-card">
+        <strong>⚠️ ${escapeHtml(buildTerminatedCountLabel(terminatedCount))}.</strong>
+        ${terminatedItems ? `<ul>${terminatedItems}</ul>` : '<p>See Youtarr channels list for details.</p>'}
+        ${moreTerminated}
+      </div>`;
+  }
+
+  if (terminationFailureCount > 0) {
+    const failuresToShow = (finalSummary.terminationFailures || []).slice(0, 5);
+    const failureItems = failuresToShow.map(channelId =>
+      `<li>${escapeHtml(formatTerminationFailureLine(channelId))}</li>`
+    ).join('');
+    const moreFailures = terminationFailureCount > failuresToShow.length
+      ? `<p class="more-videos">...and ${terminationFailureCount - failuresToShow.length} more</p>`
+      : '';
+
+    content += `
+      <div class="warning-card">
+        <strong>⚠️ ${escapeHtml(buildTerminationFailureCountLabel(terminationFailureCount))}.</strong>
+        ${failureItems ? `<ul>${failureItems}</ul>` : '<p>Check Youtarr logs for details.</p>'}
+        ${moreFailures}
+      </div>`;
+  }
 
   if (failedCount > 0) {
     const failedVideosToShow = (finalSummary.failedVideos || []).slice(0, 5);

--- a/server/modules/notifications/formatters/plainFormatter.js
+++ b/server/modules/notifications/formatters/plainFormatter.js
@@ -11,7 +11,13 @@ const {
   getSubtitle,
   buildAutoRemovalTitle,
   formatBytes,
-  groupVideosByChannel
+  groupVideosByChannel,
+  getTerminatedCount,
+  buildTerminatedCountLabel,
+  formatTerminatedChannelLine,
+  getTerminationFailureCount,
+  buildTerminationFailureCountLabel,
+  formatTerminationFailureLine
 } = require('../utils');
 
 /**
@@ -23,9 +29,35 @@ const {
 function formatDownloadMessage(finalSummary, videoData) {
   const { totalDownloaded, jobType } = finalSummary;
   const failedCount = getFailedCount(finalSummary);
+  const terminatedCount = getTerminatedCount(finalSummary);
+  const terminationFailureCount = getTerminationFailureCount(finalSummary);
 
-  const title = buildTitle(totalDownloaded);
+  const title = buildTitle(totalDownloaded, terminatedCount, terminationFailureCount);
   let body = `${getSubtitle(jobType)}:\n`;
+
+  if (terminatedCount > 0) {
+    body += `\n⚠️ ${buildTerminatedCountLabel(terminatedCount)}.\n`;
+    const terminatedChannelsToShow = (finalSummary.terminatedChannels || []).slice(0, 5);
+    terminatedChannelsToShow.forEach(channel => {
+      body += `• ${formatTerminatedChannelLine(channel)}\n`;
+    });
+    if (terminatedCount > terminatedChannelsToShow.length) {
+      body += `...and ${terminatedCount - terminatedChannelsToShow.length} more\n`;
+    }
+    body += '\n';
+  }
+
+  if (terminationFailureCount > 0) {
+    body += `\n⚠️ ${buildTerminationFailureCountLabel(terminationFailureCount)}.\n`;
+    const failuresToShow = (finalSummary.terminationFailures || []).slice(0, 5);
+    failuresToShow.forEach(channelId => {
+      body += `• ${formatTerminationFailureLine(channelId)}\n`;
+    });
+    if (terminationFailureCount > failuresToShow.length) {
+      body += `...and ${terminationFailureCount - failuresToShow.length} more\n`;
+    }
+    body += '\n';
+  }
 
   if (failedCount > 0) {
     body += `\n⚠️ ${buildFailedCountLabel(failedCount)}.\n`;

--- a/server/modules/notifications/formatters/slackMarkdownFormatter.js
+++ b/server/modules/notifications/formatters/slackMarkdownFormatter.js
@@ -13,7 +13,13 @@ const {
   getSubtitle,
   buildAutoRemovalTitle,
   formatBytes,
-  groupVideosByChannel
+  groupVideosByChannel,
+  getTerminatedCount,
+  buildTerminatedCountLabel,
+  formatTerminatedChannelLine,
+  getTerminationFailureCount,
+  buildTerminationFailureCountLabel,
+  formatTerminationFailureLine
 } = require('../utils');
 
 /**
@@ -25,9 +31,35 @@ const {
 function formatDownloadMessage(finalSummary, videoData) {
   const { totalDownloaded, jobType } = finalSummary;
   const failedCount = getFailedCount(finalSummary);
+  const terminatedCount = getTerminatedCount(finalSummary);
+  const terminationFailureCount = getTerminationFailureCount(finalSummary);
 
-  const title = buildTitle(totalDownloaded);
+  const title = buildTitle(totalDownloaded, terminatedCount, terminationFailureCount);
   let body = `*${getSubtitle(jobType)}*\n\n`;
+
+  if (terminatedCount > 0) {
+    body += `⚠️ *${buildTerminatedCountLabel(terminatedCount)}.*\n`;
+    const terminatedChannelsToShow = (finalSummary.terminatedChannels || []).slice(0, 5);
+    terminatedChannelsToShow.forEach(channel => {
+      body += `• ${formatTerminatedChannelLine(channel)}\n`;
+    });
+    if (terminatedCount > terminatedChannelsToShow.length) {
+      body += `_...and ${terminatedCount - terminatedChannelsToShow.length} more_\n`;
+    }
+    body += '\n';
+  }
+
+  if (terminationFailureCount > 0) {
+    body += `⚠️ *${buildTerminationFailureCountLabel(terminationFailureCount)}.*\n`;
+    const failuresToShow = (finalSummary.terminationFailures || []).slice(0, 5);
+    failuresToShow.forEach(channelId => {
+      body += `• ${formatTerminationFailureLine(channelId)}\n`;
+    });
+    if (terminationFailureCount > failuresToShow.length) {
+      body += `_...and ${terminationFailureCount - failuresToShow.length} more_\n`;
+    }
+    body += '\n';
+  }
 
   if (failedCount > 0) {
     body += `⚠️ *${buildFailedCountLabel(failedCount)}.*\n`;

--- a/server/modules/notifications/formatters/telegramFormatter.js
+++ b/server/modules/notifications/formatters/telegramFormatter.js
@@ -12,7 +12,13 @@ const {
   getSubtitle,
   buildAutoRemovalTitle,
   formatBytes,
-  groupVideosByChannel
+  groupVideosByChannel,
+  getTerminatedCount,
+  buildTerminatedCountLabel,
+  formatTerminatedChannelLine,
+  getTerminationFailureCount,
+  buildTerminationFailureCountLabel,
+  formatTerminationFailureLine
 } = require('../utils');
 
 /**
@@ -24,9 +30,35 @@ const {
 function formatDownloadMessage(finalSummary, videoData) {
   const { totalDownloaded, jobType } = finalSummary;
   const failedCount = getFailedCount(finalSummary);
+  const terminatedCount = getTerminatedCount(finalSummary);
+  const terminationFailureCount = getTerminationFailureCount(finalSummary);
 
-  const title = buildTitle(totalDownloaded);
+  const title = buildTitle(totalDownloaded, terminatedCount, terminationFailureCount);
   let body = `<b>${getSubtitle(jobType)}:</b>\n\n`;
+
+  if (terminatedCount > 0) {
+    body += `⚠️ <b>${escapeHtml(buildTerminatedCountLabel(terminatedCount))}.</b>\n`;
+    const terminatedChannelsToShow = (finalSummary.terminatedChannels || []).slice(0, 5);
+    terminatedChannelsToShow.forEach(channel => {
+      body += `• ${escapeHtml(formatTerminatedChannelLine(channel))}\n`;
+    });
+    if (terminatedCount > terminatedChannelsToShow.length) {
+      body += `<i>...and ${terminatedCount - terminatedChannelsToShow.length} more</i>\n`;
+    }
+    body += '\n';
+  }
+
+  if (terminationFailureCount > 0) {
+    body += `⚠️ <b>${escapeHtml(buildTerminationFailureCountLabel(terminationFailureCount))}.</b>\n`;
+    const failuresToShow = (finalSummary.terminationFailures || []).slice(0, 5);
+    failuresToShow.forEach(channelId => {
+      body += `• ${escapeHtml(formatTerminationFailureLine(channelId))}\n`;
+    });
+    if (terminationFailureCount > failuresToShow.length) {
+      body += `<i>...and ${terminationFailureCount - failuresToShow.length} more</i>\n`;
+    }
+    body += '\n';
+  }
 
   if (failedCount > 0) {
     body += `⚠️ <b>${escapeHtml(buildFailedCountLabel(failedCount))}.</b>\n`;

--- a/server/modules/notifications/index.js
+++ b/server/modules/notifications/index.js
@@ -104,8 +104,15 @@ class NotificationModule {
       const { finalSummary, videoData } = notificationData;
       const config = this.configModule.getConfig();
 
-      if (finalSummary.totalDownloaded === 0) {
-        logger.debug('No new videos downloaded, skipping notification');
+      const terminatedChannelCount = Array.isArray(finalSummary.terminatedChannels)
+        ? finalSummary.terminatedChannels.length
+        : 0;
+      const terminationFailureCount = Array.isArray(finalSummary.terminationFailures)
+        ? finalSummary.terminationFailures.length
+        : 0;
+
+      if (finalSummary.totalDownloaded === 0 && terminatedChannelCount === 0 && terminationFailureCount === 0) {
+        logger.debug('No new videos downloaded and no terminations recorded, skipping notification');
         return;
       }
 

--- a/server/modules/notifications/utils.js
+++ b/server/modules/notifications/utils.js
@@ -36,15 +36,84 @@ function formatDuration(seconds) {
 }
 
 /**
- * Build notification title based on download count
+ * Build notification title based on download count.
+ * When no videos downloaded but channels were marked terminated or failed
+ * to auto-disable, the headline shifts to the termination event.
  * @param {number} totalDownloaded - Number of videos downloaded
+ * @param {number} [terminatedCount=0] - Number of channels marked terminated
+ * @param {number} [terminationFailureCount=0] - Number of terminations not auto-disabled
  * @returns {string} Title string
  */
-function buildTitle(totalDownloaded) {
+function buildTitle(totalDownloaded, terminatedCount = 0, terminationFailureCount = 0) {
+  if (totalDownloaded === 0 && (terminatedCount + terminationFailureCount) > 0) {
+    const total = terminatedCount + terminationFailureCount;
+    return total === 1
+      ? '⚠️ Channel Termination Detected'
+      : `⚠️ ${total} Channel Terminations Detected`;
+  }
   if (totalDownloaded === 1) {
     return '🎬 New Video Downloaded';
   }
   return `🎬 ${totalDownloaded} New Videos Downloaded`;
+}
+
+/**
+ * Get terminated channel count from a final summary.
+ * @param {Object} finalSummary - Summary object from downloadExecutor
+ * @returns {number} Number of channels marked terminated
+ */
+function getTerminatedCount(finalSummary = {}) {
+  return finalSummary.totalTerminatedChannels
+    || finalSummary.terminatedChannels?.length
+    || 0;
+}
+
+/**
+ * Build a concise terminated channel label.
+ * @param {number} count - Number of terminated channels
+ * @returns {string} Human-readable terminated count
+ */
+function buildTerminatedCountLabel(count) {
+  return `${count} ${count === 1 ? 'channel' : 'channels'} marked terminated`;
+}
+
+/**
+ * Format a terminated channel entry for notification bodies.
+ * @param {Object} channel - Terminated channel entry
+ * @returns {string} Human-readable line
+ */
+function formatTerminatedChannelLine(channel = {}) {
+  const label = channel.uploader || channel.channelId || 'Unknown channel';
+  return `${label}: scheduled downloads disabled`;
+}
+
+/**
+ * Get termination-persistence-failure count from a final summary.
+ * @param {Object} finalSummary - Summary object from downloadExecutor
+ * @returns {number} Number of channels detected as terminated but not auto-disabled
+ */
+function getTerminationFailureCount(finalSummary = {}) {
+  return finalSummary.totalTerminationFailures
+    || finalSummary.terminationFailures?.length
+    || 0;
+}
+
+/**
+ * Build a concise label for termination-persistence failures.
+ * @param {number} count - Number of failures
+ * @returns {string} Human-readable label
+ */
+function buildTerminationFailureCountLabel(count) {
+  return `${count} termination${count === 1 ? '' : 's'} could not be auto-disabled`;
+}
+
+/**
+ * Format a termination-persistence-failure entry for notification bodies.
+ * @param {string} channelId - The channel id
+ * @returns {string} Human-readable line
+ */
+function formatTerminationFailureLine(channelId) {
+  return `${channelId}: detected as terminated but could not be auto-disabled (check the channel manually)`;
 }
 
 /**
@@ -165,5 +234,11 @@ module.exports = {
   getSubtitle,
   buildAutoRemovalTitle,
   formatBytes,
-  groupVideosByChannel
+  groupVideosByChannel,
+  getTerminatedCount,
+  buildTerminatedCountLabel,
+  formatTerminatedChannelLine,
+  getTerminationFailureCount,
+  buildTerminationFailureCountLabel,
+  formatTerminationFailureLine
 };

--- a/server/modules/ytDlpRunner.js
+++ b/server/modules/ytDlpRunner.js
@@ -10,9 +10,18 @@ const MEMBERS_ONLY_PATTERNS = [
   /subscriber[_ -]?only/i,
 ];
 
+// YouTube uses two phrasings for terminations:
+//   "account has been terminated ..." (TOS violations)
+//   "channel was removed because it violated ..." (community guidelines)
+const TERMINATED_ACCOUNT_PATTERN = /(account has been terminated|channel was removed because it violated)/i;
+
 function isMembersOnlyError(message = '') {
   const normalized = String(message);
   return MEMBERS_ONLY_PATTERNS.some(pattern => pattern.test(normalized));
+}
+
+function isTerminatedAccountError(message = '') {
+  return TERMINATED_ACCOUNT_PATTERN.test(String(message));
 }
 
 class YtDlpRunner {
@@ -22,6 +31,10 @@ class YtDlpRunner {
 
   isMembersOnlyError(message = '') {
     return isMembersOnlyError(message);
+  }
+
+  isTerminatedAccountError(message = '') {
+    return isTerminatedAccountError(message);
   }
 
   /**


### PR DESCRIPTION
Terminated channels used to fail silently and keep retrying on the cron.

The download executor recognizes yt-dlp's two termination errors, stamps terminated_at, and clears auto_download_enabled_tabs to stop scheduled runs. The job finishes warning-shaped, not as a hard failure. When the channel can't be auto-disabled, the id is recorded as a termination-failure so the user still sees it.

A successful yt-dlp probe clears terminated_at again, and the channel page refetches once its videos load. TerminatedChip and TerminatedNotice show the state in the UI; notification formatters and DownloadProgress get matching sections.

Refs: #621