### PR TITLE
chore(security): gate npm installs on a cooldown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           node-version: '20.x'
           cache: 'npm'
 
+      - name: Pin npm
+        run: npm install -g npm@11.15.0 --ignore-scripts
+
       - name: Install root dependencies
         run: npm ci --ignore-scripts
 
@@ -82,6 +85,9 @@ jobs:
           node-version: '20.x'
           cache: 'npm'
 
+      - name: Pin npm
+        run: npm install -g npm@11.15.0 --ignore-scripts
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
@@ -137,6 +143,9 @@ jobs:
         with:
           node-version: '20.x'
           cache: 'npm'
+
+      - name: Pin npm
+        run: npm install -g npm@11.15.0 --ignore-scripts
 
       - name: Install root dependencies
         run: npm ci --ignore-scripts
@@ -199,6 +208,9 @@ jobs:
           node-version: '20.x'
           cache: 'npm'
 
+      - name: Pin npm
+        run: npm install -g npm@11.15.0 --ignore-scripts
+
       - name: Install root dependencies
         run: npm ci --ignore-scripts
 
@@ -238,6 +250,9 @@ jobs:
         with:
           node-version: '20.x'
           cache: 'npm'
+
+      - name: Pin npm
+        run: npm install -g npm@11.15.0 --ignore-scripts
 
       - name: Install root dependencies
         run: npm ci --ignore-scripts

--- a/.github/workflows/coverage-badges.yml
+++ b/.github/workflows/coverage-badges.yml
@@ -36,6 +36,9 @@ jobs:
           node-version: '20.x'
           cache: 'npm'
 
+      - name: Pin npm
+        run: npm install -g npm@11.15.0 --ignore-scripts
+
       - name: Install dependencies
         run: |
           npm ci --ignore-scripts

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Pin npm
+        run: npm install -g npm@11.15.0 --ignore-scripts
+
       - name: Install server dependencies
         run: npm ci --ignore-scripts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Pin npm
+        run: npm install -g npm@11.15.0 --ignore-scripts
+
       - name: Install server dependencies
         run: npm ci --ignore-scripts
 

--- a/.npmrc
+++ b/.npmrc
@@ -6,3 +6,17 @@ strict-ssl=true
 
 # Ensure lock file integrity
 package-lock=true
+
+# Don't run dependency lifecycle scripts on install, so a malicious package
+# can't execute code just by being installed. Explicitly invoked scripts (e.g.
+# npm run prepare) still run. Native builds: npm rebuild <pkg> --ignore-scripts=false.
+ignore-scripts=true
+
+# Fail installs when the local Node/npm versions don't satisfy "engines" in
+# package.json (min-release-age needs npm >= 11.10)
+engine-strict=true
+
+# Supply-chain cooldown: refuse to install package versions published less than
+# 5 days ago, so malicious zero-day releases are flagged/removed before adoption.
+# Applies at resolution time (npm install/update); npm ci is unaffected.
+min-release-age=5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # ---- Base Node ----
 FROM node:20-slim AS base
 WORKDIR /app
+# Pin npm >= 11.10 so it honors min-release-age/engine-strict from .npmrc.
+# Pick a release older than the 5-day cooldown (this global install isn't
+# lockfile-pinned). --ignore-scripts since the project .npmrc isn't in the image yet.
+RUN npm install -g npm@11.15.0 --ignore-scripts
 
 # ---- Dependencies ----
 FROM base AS dependencies

--- a/client/.npmrc
+++ b/client/.npmrc
@@ -1,0 +1,10 @@
+# Don't run dependency lifecycle scripts by default (see repo-root .npmrc for rationale).
+ignore-scripts=true
+
+# Fail installs when the local Node/npm versions don't satisfy "engines" in
+# package.json (min-release-age needs npm >= 11.10)
+engine-strict=true
+
+# Supply-chain cooldown (see repo-root .npmrc). Repeated here because npm reads
+# the .npmrc of the project it operates on and doesn't inherit the parent's.
+min-release-age=5

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "proxy": "http://localhost:3011",
+  "engines": {
+    "node": ">=20.19.0",
+    "npm": ">=11.10.0"
+  },
   "dependencies": {
     "@fontsource/archivo": "^5.2.8",
     "@fontsource/ibm-plex-sans": "^5.2.8",

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -44,12 +44,32 @@ If you set `YOUTARR_IMAGE` in `.env`, remove or comment that line first, otherwi
 
 For development, you'll need:
 
-1. **Node.js 20.19+ and npm** (needed for the build script that compiles the client and installs dependencies before Docker runs)
+1. **Node.js 20.19+ and npm 11.10+** (needed for the build script that compiles the client and installs dependencies before Docker runs)
 2. **Docker** and Docker Compose (v2 or v1)
 3. **Git** for version control
 4. A code editor (VS Code recommended)
 
 **Note:** Runtime dependencies (MariaDB, yt-dlp, ffmpeg, Node) run inside the dev containers, but the `build-dev` script uses your host Node.js to install packages and build the frontend before the Docker image is created.
+
+### npm version requirement and install cooldown
+
+Installs are gated on a **5-day cooldown**: npm refuses to install any package version published less than 5 days ago (`min-release-age=5` in `.npmrc`). This is a supply-chain defense; most malicious package releases are caught and removed within a day or two, so waiting before adopting a new version avoids the bulk of the risk. The cooldown applies at resolution time (`npm install` / `npm update`), not to `npm ci`, so your day-to-day builds against the committed lockfile are unaffected.
+
+The cooldown requires **npm 11.10 or newer**, which is enforced via `engines` in `package.json` plus `engine-strict=true` in `.npmrc`. If your local npm is older, `npm ci` / `npm install` will fail with an engine error instead of silently skipping the cooldown. Upgrade with:
+
+```bash
+# Pin to an npm 11.10+ release that is itself older than the 5-day cooldown
+# window (this global install is not lockfile-pinned, so it is not cooldown-protected),
+# matching the pin used by CI and the Docker build.
+npm install -g npm@11.15.0 --ignore-scripts
+npm --version   # confirm >= 11.10.0
+```
+
+CI and the Docker build pin npm to a known 11.x via a "Pin npm" step / `npm install -g`, so they honor the same gate.
+
+If you ever need an urgent dependency update that the cooldown blocks (for example a same-day security patch), override it for that one install with `npm install <pkg> --before=<date>` or a temporary `--min-release-age=0`, rather than removing the repo-wide setting.
+
+**Lifecycle scripts are disabled by default.** `.npmrc` sets `ignore-scripts=true`, so a dependency's `preinstall` / `install` / `postinstall` scripts do not run just because you install it. This blocks the most common malicious-package execution path. The CI and Docker installs already passed `--ignore-scripts`; this extends the same protection to a bare local `npm install`. Explicitly invoked scripts still run, so Husky setup via `npm run prepare` (used by `build-dev.sh`) is unaffected. If you add a dependency that needs a native build step, run `npm rebuild <pkg> --ignore-scripts=false` after confirming you trust the package; a plain `npm rebuild` inherits `ignore-scripts=true` and would still skip the build.
 
 ## Project Structure
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.69.2",
   "description": "",
   "main": "server/index.js",
+  "engines": {
+    "node": ">=20.19.0",
+    "npm": ">=11.10.0"
+  },
   "scripts": {
     "start": "node server/server.js",
     "lint": "eslint ./client/src/. --ext .ts,.tsx && eslint ./server/. --ext .js",


### PR DESCRIPTION
Add a supply-chain cooldown so npm refuses package versions published less than 5 days ago (min-release-age=5), which gives malicious releases time to be caught and pulled before adoption. The cooldown needs npm 11.10+, enforced via engines in package.json plus engine-strict in .npmrc, so an older npm fails loudly instead of silently skipping the gate.

Also default ignore-scripts to true so a dependency's lifecycle scripts don't run just from being installed; explicitly invoked scripts still run. Pin npm to 11.15.0 in CI and the Docker build so they honor the same gate, and document the requirement and the override path in docs/DEVELOPMENT.md.

Refs: #631