### PR TITLE
fix: correct published dates on channel videos

### DIFF
--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -152,6 +152,7 @@ function ChannelVideos({
   const [localIgnoreStatus, setLocalIgnoreStatus] = useState<Record<string, boolean>>({});
   const [localProtectedStatus, setLocalProtectedStatus] = useState<Record<string, boolean>>({});
   const [localAvailabilityStatus, setLocalAvailabilityStatus] = useState<Record<string, string>>({});
+  const [localPublishedAtStatus, setLocalPublishedAtStatus] = useState<Record<string, string>>({});
 
   const {
     filters,
@@ -413,7 +414,8 @@ function ChannelVideos({
       const hasIgnoreOverride = video.youtube_id in localIgnoreStatus;
       const hasProtectedOverride = video.youtube_id in localProtectedStatus;
       const hasAvailabilityOverride = video.youtube_id in localAvailabilityStatus;
-      if (!hasIgnoreOverride && !hasProtectedOverride && !hasAvailabilityOverride) return video;
+      const hasPublishedAtOverride = video.youtube_id in localPublishedAtStatus;
+      if (!hasIgnoreOverride && !hasProtectedOverride && !hasAvailabilityOverride && !hasPublishedAtOverride) return video;
       return {
         ...video,
         ...(hasIgnoreOverride
@@ -428,9 +430,15 @@ function ChannelVideos({
         ...(hasAvailabilityOverride
           ? { availability: localAvailabilityStatus[video.youtube_id] }
           : {}),
+        ...(hasPublishedAtOverride
+          ? {
+              publishedAt: localPublishedAtStatus[video.youtube_id],
+              published_at_source: 'exact' as const,
+            }
+          : {}),
       };
     });
-  }, [videos, localIgnoreStatus, localProtectedStatus, localAvailabilityStatus]);
+  }, [videos, localIgnoreStatus, localProtectedStatus, localAvailabilityStatus, localPublishedAtStatus]);
 
   const paginatedVideos = videosWithOverrides;
   const totalPages = Math.ceil(totalCount / effectivePageSize) || 1;
@@ -978,12 +986,20 @@ function ChannelVideos({
     );
   };
 
+  const hasPendingDates = videos.some(
+    (v) => v.published_at_source === 'estimated' && v.media_type !== 'short'
+  );
   const dateTooltipBase =
-    'Publish dates come from yt-dlp and may be approximate when YouTube only provides relative times. Videos remain sorted to match YouTube.';
+    'Publish dates come from YouTube, which doesn\'t always provide them, so Youtarr does the best it can with what it has. ' +
+    'A ~ means the date is approximate: YouTube only reported something like "1 month ago", so it can be off by days. ' +
+    'A date becomes exact once the video is downloaded or its details are opened. ' +
+    'Youtarr keeps videos in the same order they appear on YouTube as best it can; if the order looks off, click "Load More" to rebuild it.';
+  const pendingDatesSentence =
+    'Some videos show "Pending" because YouTube returned this list without dates. ';
   const dateTooltipText =
     selectedTab === 'shorts'
       ? 'Shorts do not expose publish dates via yt-dlp, so dates are hidden. ' + dateTooltipBase
-      : dateTooltipBase;
+      : (hasPendingDates ? pendingDatesSentence : '') + dateTooltipBase;
 
   const headerSlot = (
     <div
@@ -1031,7 +1047,8 @@ function ChannelVideos({
                 cursor: 'pointer',
                 display: 'inline-flex',
                 alignItems: 'center',
-                color: 'var(--foreground)',
+                // Warn-tint the icon when any date is pending, to invite a click
+                color: hasPendingDates ? 'var(--warning)' : 'var(--foreground)',
               }}
               aria-label="Date info"
             >
@@ -1049,7 +1066,7 @@ function ChannelVideos({
                   cursor: 'pointer',
                   display: 'inline-flex',
                   alignItems: 'center',
-                  color: 'var(--foreground)',
+                  color: hasPendingDates ? 'var(--warning)' : 'var(--foreground)',
                 }}
                 aria-label="Date info"
               >
@@ -1289,6 +1306,9 @@ function ChannelVideos({
           onRatingChanged={() => refetchVideos()}
           onAvailabilityDetected={(youtubeId, availability) => {
             setLocalAvailabilityStatus((prev) => ({ ...prev, [youtubeId]: availability }));
+          }}
+          onPublishedDateDetected={(youtubeId, isoDate) => {
+            setLocalPublishedAtStatus((prev) => ({ ...prev, [youtubeId]: isoDate }));
           }}
         />
       )}

--- a/client/src/components/ChannelPage/VideoCard.tsx
+++ b/client/src/components/ChannelPage/VideoCard.tsx
@@ -19,6 +19,7 @@ import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
 import ProtectionShieldButton from '../shared/ProtectionShieldButton';
 import ThumbnailClickOverlay from '../shared/ThumbnailClickOverlay';
 import { SHARED_STATUS_CHIP_SMALL_STYLE, SHARED_THEMED_CHIP_SMALL_STYLE } from '../shared/chipStyles';
+import { getPublishedDateDisplay } from './publishedDateDisplay';
 
 interface VideoCardProps {
   video: ChannelVideo;
@@ -336,13 +337,12 @@ function VideoCard({
             <div style={{ marginTop: 'auto', display: 'flex', flexDirection: 'column', gap: 8 }}>
               {/* Date and download format info */}
               <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-                {video.media_type !== 'short' && video.publishedAt && (
+                {video.media_type !== 'short' && (video.publishedAt || video.published_at_source === 'estimated') && (
                 <Typography variant="caption" color="text.secondary" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                     <CalendarTodayIcon size={12} />
-                  {isMobile
-                    ? new Date(video.publishedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-                    : new Date(video.publishedAt).toLocaleDateString()
-                  }
+                  {getPublishedDateDisplay(video, (d) => isMobile
+                    ? d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+                    : d.toLocaleDateString())}
                 </Typography>
               )}
                 {video.added && !video.removed && (

--- a/client/src/components/ChannelPage/VideoListItem.tsx
+++ b/client/src/components/ChannelPage/VideoListItem.tsx
@@ -13,6 +13,7 @@ import { formatDuration } from '../../utils';
 import { ChannelVideo } from '../../types/ChannelVideo';
 import { decodeHtml, formatAddedDate } from '../../utils/formatters';
 import { SHARED_STATUS_CHIP_SMALL_STYLE, SHARED_THEMED_CHIP_SMALL_STYLE } from '../shared/chipStyles';
+import { getPublishedDateDisplay } from './publishedDateDisplay';
 import { getVideoStatus, getStatusColor, getStatusIcon, getStatusLabel, getMediaTypeInfo, getStatusChipVariant, getStatusChipStyle } from '../../utils/videoStatus';
 import StillLiveDot from './StillLiveDot';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
@@ -323,10 +324,10 @@ function VideoListItem({
           </Typography>
 
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 'auto' }}>
-            {video.media_type !== 'short' && video.publishedAt && (
+            {video.media_type !== 'short' && (video.publishedAt || video.published_at_source === 'estimated') && (
             <Typography variant="caption" color="text.secondary" style={{ display: 'flex', alignItems: 'center', gap: 2, fontSize: '0.7rem' }}>
                 <CalendarTodayIcon size={11} />
-              {new Date(video.publishedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: '2-digit' })}
+              {getPublishedDateDisplay(video, (d) => d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: '2-digit' }))}
             </Typography>
           )}
             {video.added && video.timeCreated && (

--- a/client/src/components/ChannelPage/VideoTableView.tsx
+++ b/client/src/components/ChannelPage/VideoTableView.tsx
@@ -15,6 +15,7 @@ import StillLiveDot from './StillLiveDot';
 import RatingBadge from '../shared/RatingBadge';
 import DownloadFormatIndicator from '../shared/DownloadFormatIndicator';
 import { SHARED_STATUS_CHIP_SMALL_STYLE, SHARED_THEMED_CHIP_SMALL_STYLE } from '../shared/chipStyles';
+import { getPublishedDateDisplay } from './publishedDateDisplay';
 
 type SortBy = 'date' | 'title' | 'duration' | 'size';
 type SortOrder = 'asc' | 'desc';
@@ -292,9 +293,7 @@ function VideoTableView({
                   </Typography>
                 </td>
                 <td style={{ whiteSpace: 'nowrap', padding: '8px 4px' }}>
-                  {video.media_type === 'short' || !video.publishedAt
-                    ? 'N/A'
-                    : new Date(video.publishedAt).toLocaleDateString()}
+                  {getPublishedDateDisplay(video, (d) => d.toLocaleDateString()) ?? 'N/A'}
                 </td>
                 <td style={{ whiteSpace: 'nowrap', padding: '8px 4px' }}>
                   {(() => {

--- a/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelVideos.test.tsx
@@ -198,7 +198,8 @@ jest.mock('../ChannelVideosDialogs', () => ({
       'data-default-resolution-source': props.defaultResolutionSource,
       'data-selected-tab': props.selectedTab,
       'data-tab-label': props.tabLabel,
-      'data-missing-video-count': props.missingVideoCount
+      'data-missing-video-count': props.missingVideoCount,
+      'data-mobile-tooltip': props.mobileTooltip
     });
   }
 }));
@@ -1008,6 +1009,74 @@ describe('ChannelVideos Component', () => {
       // Both should be present
       expect(screen.getAllByRole('button', { name: '16' }).length).toBeGreaterThan(0);
       expect(screen.getAllByRole('navigation').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Pending dates indicator', () => {
+    const estimatedVideo: ChannelVideo = {
+      title: 'Pending Date Video',
+      youtube_id: 'pending1',
+      publishedAt: null,
+      published_at_source: 'estimated',
+      thumbnail: 'https://i.ytimg.com/vi/pending1/mqdefault.jpg',
+      added: false,
+      duration: 120,
+      media_type: 'video',
+      live_status: null,
+    };
+
+    const mockVideosReturn = (videos: ChannelVideo[]) => {
+      useChannelVideos.mockReturnValue({
+        videos,
+        totalCount: videos.length,
+        oldestVideoDate: null,
+        error: null,
+        autoDownloadsEnabled: false,
+        loading: false,
+        refetch: mockRefetchVideos,
+      });
+    };
+
+    test('mobile date info explains pending dates when estimated rows are present', () => {
+      (useMediaQuery as jest.Mock).mockReturnValue(true);
+      mockVideosReturn([estimatedVideo]);
+
+      renderChannelVideos();
+      fireEvent.click(screen.getByLabelText('Date info'));
+
+      expect(screen.getByTestId('channel-videos-dialogs')).toHaveAttribute(
+        'data-mobile-tooltip',
+        expect.stringContaining('Some videos show "Pending"')
+      );
+    });
+
+    test('mobile date info omits the pending explanation when all rows have dates', () => {
+      (useMediaQuery as jest.Mock).mockReturnValue(true);
+      mockVideosReturn(mockVideos);
+
+      renderChannelVideos();
+      fireEvent.click(screen.getByLabelText('Date info'));
+
+      expect(screen.getByTestId('channel-videos-dialogs')).not.toHaveAttribute(
+        'data-mobile-tooltip',
+        expect.stringContaining('Some videos show "Pending"')
+      );
+    });
+
+    test('highlights the date info icon when estimated rows are present', () => {
+      mockVideosReturn([estimatedVideo]);
+
+      renderChannelVideos();
+
+      expect(screen.getByLabelText('Date info')).toHaveStyle({ color: 'var(--warning)' });
+    });
+
+    test('does not highlight the date info icon when all rows have dates', () => {
+      mockVideosReturn(mockVideos);
+
+      renderChannelVideos();
+
+      expect(screen.getByLabelText('Date info')).toHaveStyle({ color: 'var(--foreground)' });
     });
   });
 

--- a/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
@@ -91,6 +91,18 @@ describe('VideoCard Component', () => {
       expect(screen.getByText(/Jan 15/)).toBeInTheDocument();
     });
 
+    test('renders Pending for estimated published dates', () => {
+      const estimatedVideo = { ...mockVideo, publishedAt: null, published_at_source: 'estimated' as const };
+      renderWithProviders(<VideoCard {...defaultProps} video={estimatedVideo} />);
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+    });
+
+    test('renders tilde prefix for approximate published dates', () => {
+      const approximateVideo = { ...mockVideo, published_at_source: 'approximate' as const };
+      renderWithProviders(<VideoCard {...defaultProps} video={approximateVideo} />);
+      expect(screen.getByText(/~1\/15\/2023/)).toBeInTheDocument();
+    });
+
     test('does not render published date for shorts', () => {
       const shortVideo = { ...mockVideo, media_type: 'short' };
       renderWithProviders(<VideoCard {...defaultProps} video={shortVideo} />);

--- a/client/src/components/ChannelPage/__tests__/VideoListItem.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoListItem.test.tsx
@@ -79,6 +79,18 @@ describe('VideoListItem Component', () => {
       renderWithProviders(<VideoListItem {...defaultProps} />);
       expect(screen.getByText(/Jan 15, 23/)).toBeInTheDocument();
     });
+
+    test('renders Pending for estimated published dates', () => {
+      const estimatedVideo = { ...mockVideo, publishedAt: null, published_at_source: 'estimated' as const };
+      renderWithProviders(<VideoListItem {...defaultProps} video={estimatedVideo} />);
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+    });
+
+    test('renders tilde prefix for approximate published dates', () => {
+      const approximateVideo = { ...mockVideo, published_at_source: 'approximate' as const };
+      renderWithProviders(<VideoListItem {...defaultProps} video={approximateVideo} />);
+      expect(screen.getByText(/~Jan 15, 23/)).toBeInTheDocument();
+    });
   });
 
   describe('Video Status', () => {

--- a/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
@@ -161,6 +161,24 @@ describe('VideoTableView Component', () => {
       expect(screen.getByText('N/A')).toBeInTheDocument();
     });
 
+    test('renders Pending for estimated published dates', () => {
+      const estimatedVideo = { ...mockVideo, publishedAt: null, published_at_source: 'estimated' as const };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[estimatedVideo]} />);
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+    });
+
+    test('renders tilde prefix for approximate published dates', () => {
+      const approximateVideo = { ...mockVideo, published_at_source: 'approximate' as const };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[approximateVideo]} />);
+      expect(screen.getByText(/^~1\/15\/2023/)).toBeInTheDocument();
+    });
+
+    test('renders exact published dates without a tilde', () => {
+      const exactVideo = { ...mockVideo, published_at_source: 'exact' as const };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[exactVideo]} />);
+      expect(screen.getByText(/^1\/15\/2023/)).toBeInTheDocument();
+    });
+
     test('renders duration for regular videos', () => {
       renderWithProviders(<VideoTableView {...defaultProps} />);
       // Duration is 600 seconds = 10 minutes
@@ -931,10 +949,13 @@ describe('VideoTableView Component', () => {
       renderWithProviders(
         <VideoTableView {...defaultProps} videos={[downloadedVideo]} />
       );
-      // Downloaded cell stacks date above time. Time format is unique to this cell
-      // (Published has no time); date regex also matches Published so use getAllByText.
+      // Downloaded cell stacks date above time. Time format is unique to this
+      // cell (Published has no time). The Published column renders with a ~
+      // prefix (approximate source), so the bare date regex matches only the
+      // Downloaded cell.
       expect(screen.getByText(/^\d{2}:\d{2} (AM|PM)$/)).toBeInTheDocument();
-      expect(screen.getAllByText(/^\d{1,2}\/\d{1,2}\/\d{4}$/).length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByText(/^\d{1,2}\/\d{1,2}\/\d{4}$/)).toBeInTheDocument();
+      expect(screen.getByText(/^~\d{1,2}\/\d{1,2}\/\d{4}$/)).toBeInTheDocument();
     });
 
     test('renders "-" for never downloaded videos', () => {

--- a/client/src/components/ChannelPage/__tests__/publishedDateDisplay.test.ts
+++ b/client/src/components/ChannelPage/__tests__/publishedDateDisplay.test.ts
@@ -1,0 +1,53 @@
+import { getPublishedDateDisplay } from '../publishedDateDisplay';
+
+const formatDate = (d: Date) => d.toISOString().slice(0, 10);
+
+describe('getPublishedDateDisplay', () => {
+  it('returns the plain date for exact sources', () => {
+    const result = getPublishedDateDisplay(
+      { publishedAt: '2024-03-15T00:00:00.000Z', published_at_source: 'exact', media_type: 'video' },
+      formatDate
+    );
+    expect(result).toBe('2024-03-15');
+  });
+
+  it('prefixes approximate dates with a tilde', () => {
+    const result = getPublishedDateDisplay(
+      { publishedAt: '2024-03-15T00:00:00.000Z', published_at_source: 'approximate', media_type: 'video' },
+      formatDate
+    );
+    expect(result).toBe('~2024-03-15');
+  });
+
+  it('treats legacy rows without a source as approximate', () => {
+    const result = getPublishedDateDisplay(
+      { publishedAt: '2024-03-15T00:00:00.000Z', published_at_source: null, media_type: 'video' },
+      formatDate
+    );
+    expect(result).toBe('~2024-03-15');
+  });
+
+  it('returns Pending for estimated rows', () => {
+    const result = getPublishedDateDisplay(
+      { publishedAt: null, published_at_source: 'estimated', media_type: 'video' },
+      formatDate
+    );
+    expect(result).toBe('Pending');
+  });
+
+  it('returns null for shorts regardless of date', () => {
+    const result = getPublishedDateDisplay(
+      { publishedAt: '2024-03-15T00:00:00.000Z', published_at_source: 'exact', media_type: 'short' },
+      formatDate
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when there is no date and no estimate', () => {
+    const result = getPublishedDateDisplay(
+      { publishedAt: null, published_at_source: null, media_type: 'video' },
+      formatDate
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/client/src/components/ChannelPage/publishedDateDisplay.ts
+++ b/client/src/components/ChannelPage/publishedDateDisplay.ts
@@ -1,0 +1,28 @@
+import { ChannelVideo } from '../../types/ChannelVideo';
+
+/**
+ * Format a video's published date for display, encoding provenance:
+ * - exact (.info.json):                 plain date
+ * - approximate / legacy (flat fetch):  "~" prefix; YouTube only reports
+ *   relative times like "1 month ago", so the real date may differ by
+ *   days or more
+ * - estimated (date-less YouTube batch): "Pending" until a refresh or
+ *   download fills the real date in
+ * - shorts or no date at all:           null (caller hides or shows N/A)
+ */
+export function getPublishedDateDisplay(
+  video: Pick<ChannelVideo, 'publishedAt' | 'published_at_source' | 'media_type'>,
+  formatDate: (date: Date) => string
+): string | null {
+  if (video.media_type === 'short') {
+    return null;
+  }
+  if (video.published_at_source === 'estimated') {
+    return 'Pending';
+  }
+  if (!video.publishedAt) {
+    return null;
+  }
+  const formatted = formatDate(new Date(video.publishedAt));
+  return video.published_at_source === 'exact' ? formatted : `~${formatted}`;
+}

--- a/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
+++ b/client/src/components/shared/VideoModal/__tests__/VideoModal.test.tsx
@@ -311,6 +311,48 @@ describe('VideoModal', () => {
     expect(onAvailabilityDetected).not.toHaveBeenCalled();
   });
 
+  test('fires onPublishedDateDetected once with a UTC-midnight ISO date when metadata yields an upload date', async () => {
+    videoMetadataReturn.metadata = {
+      uploadDate: '20260606',
+    } as unknown as typeof videoMetadataReturn.metadata;
+    const onPublishedDateDetected = jest.fn();
+
+    const { rerender } = renderModal({ onPublishedDateDetected });
+
+    await waitFor(() => {
+      expect(onPublishedDateDetected).toHaveBeenCalledWith(
+        baseVideo.youtubeId,
+        '2026-06-06T00:00:00.000Z',
+      );
+    });
+    expect(onPublishedDateDetected).toHaveBeenCalledTimes(1);
+
+    // A re-render with the same video must not refire.
+    rerender(
+      <MemoryRouter>
+        <VideoModal
+          open
+          onClose={jest.fn()}
+          video={baseVideo}
+          token="test-token"
+          onPublishedDateDetected={onPublishedDateDetected}
+        />
+      </MemoryRouter>
+    );
+    expect(onPublishedDateDetected).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not fire onPublishedDateDetected when metadata has no upload date', () => {
+    videoMetadataReturn.metadata = {
+      uploadDate: null,
+    } as unknown as typeof videoMetadataReturn.metadata;
+    const onPublishedDateDetected = jest.fn();
+
+    renderModal({ onPublishedDateDetected });
+
+    expect(onPublishedDateDetected).not.toHaveBeenCalled();
+  });
+
   test('renders a clickable rating chip when rating exists', () => {
     renderModal({
       video: { ...baseVideo, normalizedRating: 'PG-13', ratingSource: 'manual' },

--- a/client/src/components/shared/VideoModal/index.tsx
+++ b/client/src/components/shared/VideoModal/index.tsx
@@ -23,6 +23,7 @@ import DeleteVideosDialog from '../DeleteVideosDialog';
 import ChangeRatingDialog from '../ChangeRatingDialog';
 import DownloadSettingsDialog from '../../DownloadManager/ManualDownload/DownloadSettingsDialog';
 import { useConfig } from '../../../hooks/useConfig';
+import { uploadDateToIso } from '../../../utils/formatters';
 
 const SNACKBAR_AUTO_HIDE_MS = 4000;
 
@@ -37,6 +38,7 @@ function VideoModal({
   onDownloadQueued,
   onRatingChanged,
   onAvailabilityDetected,
+  onPublishedDateDetected,
   allowIgnore,
 }: VideoModalProps) {
   const isMobile = useMediaQuery('(max-width: 599px)');
@@ -142,6 +144,24 @@ function VideoModal({
       onAvailabilityDetected?.(video.youtubeId, 'subscriber_only');
     }
   }, [metadata?.availability, localVideo.status, video.youtubeId, onAvailabilityDetected]);
+
+  // Notify the parent the first time the metadata fetch yields an authoritative
+  // upload date (from the .info.json), so list pages can replace an estimated or
+  // approximate date with the exact one without a manual refresh. The backend
+  // stamps the channelvideos row in the same request; this just keeps the
+  // already-rendered list in sync. Keyed on youtubeId so it fires once per video
+  // and re-arms when the modal switches videos.
+  const datePropagatedForRef = useRef<string | null>(null);
+  useEffect(() => {
+    const uploadDate = metadata?.uploadDate;
+    if (uploadDate && datePropagatedForRef.current !== video.youtubeId) {
+      const isoDate = uploadDateToIso(uploadDate);
+      if (isoDate) {
+        datePropagatedForRef.current = video.youtubeId;
+        onPublishedDateDetected?.(video.youtubeId, isoDate);
+      }
+    }
+  }, [metadata?.uploadDate, video.youtubeId, onPublishedDateDetected]);
 
   const hasChannelQualityOverride = Boolean(channelSettings.video_quality);
   const defaultResolution = channelSettings.video_quality || config.preferredResolution || '1080';

--- a/client/src/components/shared/VideoModal/types.ts
+++ b/client/src/components/shared/VideoModal/types.ts
@@ -34,6 +34,7 @@ export interface VideoModalProps {
   onDownloadQueued?: (youtubeId: string) => void;
   onRatingChanged?: (youtubeId: string, rating: string | null) => void;
   onAvailabilityDetected?: (youtubeId: string, availability: string) => void;
+  onPublishedDateDetected?: (youtubeId: string, isoDate: string) => void;
   allowIgnore?: boolean;
 }
 

--- a/client/src/types/ChannelVideo.ts
+++ b/client/src/types/ChannelVideo.ts
@@ -11,6 +11,10 @@ export interface ChannelVideo {
   title: string;
   youtube_id: string;
   publishedAt: string | null | undefined;
+  // Provenance of publishedAt. The server blanks publishedAt for 'estimated'
+  // rows (ordering-only placeholders), so UI date displays never see them.
+  // Backend source of truth: server/modules/constants/publishedAtSource.js
+  published_at_source?: 'exact' | 'approximate' | 'estimated' | null;
   thumbnail: string;
   added: boolean;
   removed?: boolean;

--- a/client/src/utils/__tests__/formatters.test.ts
+++ b/client/src/utils/__tests__/formatters.test.ts
@@ -5,6 +5,7 @@ import {
   formatAddedDate,
   formatAddedDateTime,
   formatAddedDateParts,
+  uploadDateToIso,
 } from '../formatters';
 
 describe('formatters date helpers', () => {
@@ -39,6 +40,26 @@ describe('formatters date helpers', () => {
       expect(date!.getUTCFullYear()).toBe(2026);
       expect(date!.getUTCMonth()).toBe(3);
       expect(date!.getUTCDate()).toBe(20);
+    });
+  });
+
+  describe('uploadDateToIso', () => {
+    test('returns null for null/undefined/empty', () => {
+      expect(uploadDateToIso(null)).toBeNull();
+      expect(uploadDateToIso(undefined)).toBeNull();
+      expect(uploadDateToIso('')).toBeNull();
+    });
+
+    test('converts YYYYMMDD to UTC-midnight ISO', () => {
+      expect(uploadDateToIso('20260606')).toBe('2026-06-06T00:00:00.000Z');
+    });
+
+    test('passes an already-ISO string through as ISO', () => {
+      expect(uploadDateToIso('2026-06-06T00:00:00.000Z')).toBe('2026-06-06T00:00:00.000Z');
+    });
+
+    test('returns null for an unparseable string', () => {
+      expect(uploadDateToIso('not a date')).toBeNull();
     });
   });
 

--- a/client/src/utils/formatters.ts
+++ b/client/src/utils/formatters.ts
@@ -36,6 +36,22 @@ export function formatDate(dateStr: string | null | undefined): string | null {
   return date ? date.toLocaleDateString() : null;
 }
 
+// Convert yt-dlp's YYYYMMDD upload_date into a UTC-midnight ISO string, matching
+// how the backend stores channelvideos.publishedAt (so an override set on the
+// client renders identically to a value fetched from the server). Strings that
+// are already ISO pass through. Returns null if unparseable.
+export function uploadDateToIso(dateStr: string | null | undefined): string | null {
+  if (!dateStr) {
+    return null;
+  }
+  if (/^\d{8}$/.test(dateStr)) {
+    const iso = `${dateStr.substring(0, 4)}-${dateStr.substring(4, 6)}-${dateStr.substring(6, 8)}T00:00:00.000Z`;
+    return isNaN(new Date(iso).getTime()) ? null : iso;
+  }
+  const parsed = new Date(dateStr);
+  return isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
 const DATE_TIME_OPTIONS: Intl.DateTimeFormatOptions = {
   hour: '2-digit',
   minute: '2-digit',

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -24,7 +24,7 @@ Youtarr uses MariaDB/MySQL for storing:
 | :----------------- | :-------------    | :-------------------------------- |
 | `channels`         | `Channel`         | YouTube channel information       |
 | `Videos`           | `Video`           | Downloaded video metadata         |
-| `channelvideos`    | `ChannelVideo`    | Channel <-> video associations    |
+| `channelvideos`    | `ChannelVideo`    | Channel <-> video associations. `published_at_source` tracks publishedAt provenance: `exact` (.info.json), `approximate` (yt-dlp flat-playlist date), `estimated` (ordering-only placeholder assigned when YouTube returns a listing with no dates; never displayed), NULL (legacy, treated as approximate) |
 | `Jobs`             | `Job`             | Download job queue                |
 | `JobVideos`        | `JobVideo`        | Job <-> video associations        |
 | `JobVideoDownloads`| `JobVideoDownload`| Download progress tracking        |

--- a/migrations/20260613010556-add-published-at-source-to-channelvideos.js
+++ b/migrations/20260613010556-add-published-at-source-to-channelvideos.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { addColumnIfMissing, removeColumnIfExists, columnExists } = require('./helpers');
+
+/**
+ * Adds channelvideos.published_at_source to track the provenance of
+ * publishedAt values:
+ *   - 'exact':       from a downloaded video's .info.json (authoritative)
+ *   - 'approximate': from yt-dlp's youtubetab:approximate_date flat-playlist
+ *                    extraction (rounded to day/hour granularity)
+ *   - 'estimated':   an ordering-only placeholder assigned when YouTube
+ *                    served a degraded response with no dates at all; never
+ *                    shown to users
+ *   - NULL:          legacy rows written before this column existed; treated
+ *                    like 'approximate'
+ *
+ * Also repairs legacy data in place:
+ *   1. Rows for downloaded videos get the accurate date from
+ *      Videos.originalDate and become 'exact'.
+ *   2. Remaining rows whose publishedAt has sub-hour precision are marked
+ *      'estimated'. Real dates in this table are always rounded (midnight
+ *      for day granularity, on-the-hour for recent uploads), while the old
+ *      synthetic fallback stamped `Date.now() - index` values with arbitrary
+ *      seconds/milliseconds, so non-round values are synthetic garbage from
+ *      date-less YouTube responses. Rare false positives (e.g. a fresh
+ *      upload dated at minute granularity) only hide the date until the next
+ *      channel refresh restores it.
+ *
+ * The data repair is intentionally not reversed in down(): the overwritten
+ * synthetic values were meaningless, and restoring them would reintroduce
+ * the bug this migration fixes.
+ */
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await addColumnIfMissing(queryInterface, 'channelvideos', 'published_at_source', {
+      type: Sequelize.STRING(20),
+      allowNull: true,
+      defaultValue: null
+    });
+
+    const videosTableHasOriginalDate = await columnExists(queryInterface, 'Videos', 'originalDate');
+    if (videosTableHasOriginalDate) {
+      await queryInterface.sequelize.query(`
+        UPDATE channelvideos cv
+        JOIN Videos v ON v.youtubeId = cv.youtube_id
+        SET cv.publishedAt = CONCAT(
+              SUBSTRING(v.originalDate, 1, 4), '-',
+              SUBSTRING(v.originalDate, 5, 2), '-',
+              SUBSTRING(v.originalDate, 7, 2), 'T00:00:00.000Z'
+            ),
+            cv.published_at_source = 'exact'
+        WHERE v.originalDate IS NOT NULL
+          AND CHAR_LENGTH(v.originalDate) = 8
+      `);
+    }
+
+    await queryInterface.sequelize.query(`
+      UPDATE channelvideos
+      SET published_at_source = 'estimated'
+      WHERE published_at_source IS NULL
+        AND publishedAt IS NOT NULL
+        AND publishedAt NOT LIKE '%:00:00.000Z'
+    `);
+  },
+
+  async down(queryInterface) {
+    await removeColumnIfExists(queryInterface, 'channelvideos', 'published_at_source');
+  }
+};

--- a/server/models/channelvideo.js
+++ b/server/models/channelvideo.js
@@ -35,6 +35,14 @@ ChannelVideo.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    // Provenance of publishedAt: 'exact' (.info.json), 'approximate'
+    // (yt-dlp flat-playlist date), 'estimated' (ordering-only placeholder,
+    // never displayed). NULL = legacy row, treated like 'approximate'.
+    published_at_source: {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    },
     availability: {
       type: DataTypes.STRING,
       allowNull: true,

--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -28,6 +28,7 @@ jest.mock('../../models/channelvideo', () => {
   MockChannelVideo.findOrCreate = jest.fn();
   MockChannelVideo.count = jest.fn();
   MockChannelVideo.findOne = jest.fn();
+  MockChannelVideo.update = jest.fn();
   MockChannelVideo.init = jest.fn(() => MockChannelVideo);
   return MockChannelVideo;
 });
@@ -957,15 +958,41 @@ describe('ChannelModule', () => {
     });
 
     describe('insertVideosIntoDb', () => {
+      // insertVideosIntoDb runs in two phases: phase 1 upserts fields and sets
+      // the initial date on CREATE (via findOrCreate defaults); phase 2 runs the
+      // shared anchoring algorithm over the whole batch and persists the final
+      // dates for non-created/changed rows via ChannelVideo.update(..., {where:{id}}).
+
+      // Make findOrCreate echo the defaults back as a created record (with an id
+      // and update stub) so phase-2 sees a realistic created row.
+      const echoCreates = (existingByYoutubeId = {}) => {
+        let nextId = 100;
+        ChannelVideo.findOrCreate.mockImplementation(async ({ where, defaults }) => {
+          const existing = existingByYoutubeId[where.youtube_id];
+          if (existing) return [existing, false];
+          return [
+            {
+              id: nextId++,
+              publishedAt: defaults.publishedAt,
+              published_at_source: defaults.published_at_source,
+              update: jest.fn(),
+            },
+            true,
+          ];
+        });
+      };
+
+      // Collect phase-2 date writes as { id, publishedAt, published_at_source }.
+      const dateWrites = () =>
+        ChannelVideo.update.mock.calls.map(([fields, opts]) => ({ id: opts.where.id, ...fields }));
+
       test('should insert new videos into database', async () => {
         const videos = [
           { ...mockVideoData, youtube_id: 'video1' },
           { ...mockVideoData, youtube_id: 'video2' }
         ];
 
-        ChannelVideo.findOrCreate
-          .mockResolvedValueOnce([{}, true])
-          .mockResolvedValueOnce([{}, true]);
+        echoCreates();
 
         await ChannelModule.insertVideosIntoDb(videos, 'UC123');
 
@@ -982,26 +1009,58 @@ describe('ChannelModule', () => {
         });
       });
 
-      test('should update existing videos', async () => {
+      test('phase 1 upserts non-date fields without the date; phase 2 writes the date', async () => {
         const mockVideo = {
+          id: 7,
+          publishedAt: '2023-01-01T00:00:00.000Z',
+          published_at_source: 'approximate',
           update: jest.fn()
         };
         ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
 
         await ChannelModule.insertVideosIntoDb([mockVideoData], 'UC123');
 
+        // Phase 1: fields only, never the date.
         expect(mockVideo.update).toHaveBeenCalledWith({
           title: mockVideoData.title,
           thumbnail: mockVideoData.thumbnail,
           duration: mockVideoData.duration,
           media_type: 'video',
-          publishedAt: mockVideoData.publishedAt,
           availability: mockVideoData.availability,
         });
+        const phase1 = mockVideo.update.mock.calls[0][0];
+        expect(phase1).not.toHaveProperty('publishedAt');
+        expect(phase1).not.toHaveProperty('published_at_source');
+
+        // Phase 2: the fetched date is persisted (normalized to ISO) for this
+        // row. The source field is omitted because it is unchanged (approximate).
+        expect(ChannelVideo.update).toHaveBeenCalledWith(
+          { publishedAt: '2024-01-01T00:00:00.000Z' },
+          { where: { id: 7 } },
+        );
+      });
+
+      test('should never rewrite an exact date from a download', async () => {
+        const mockVideo = {
+          id: 9,
+          publishedAt: '2024-01-10T00:00:00.000Z',
+          published_at_source: 'exact',
+          update: jest.fn()
+        };
+        ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
+
+        await ChannelModule.insertVideosIntoDb([mockVideoData], 'UC123');
+
+        // Phase 1 never carries the date...
+        const phase1 = mockVideo.update.mock.calls[0][0];
+        expect(phase1).not.toHaveProperty('publishedAt');
+        // ...and phase 2 skips exact rows entirely.
+        const wroteDate = ChannelVideo.update.mock.calls.some(([, opts]) => opts.where.id === 9);
+        expect(wroteDate).toBe(false);
       });
 
       test('should preserve existing availability when refresh has no availability', async () => {
-        const mockVideo = { update: jest.fn() };
+        const mockVideo = { id: 1, publishedAt: '2023-01-01T00:00:00.000Z', published_at_source: 'approximate', update: jest.fn() };
         ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
 
         const videoWithoutAvailability = { ...mockVideoData };
@@ -1014,7 +1073,7 @@ describe('ChannelModule', () => {
       });
 
       test('should preserve existing live_status when refresh has no live_status', async () => {
-        const mockVideo = { update: jest.fn() };
+        const mockVideo = { id: 1, publishedAt: '2023-01-01T00:00:00.000Z', published_at_source: 'approximate', update: jest.fn() };
         ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
 
         await ChannelModule.insertVideosIntoDb([mockVideoData], 'UC123');
@@ -1024,7 +1083,7 @@ describe('ChannelModule', () => {
       });
 
       test('should overwrite availability when refresh has a real value (real demotion still works)', async () => {
-        const mockVideo = { update: jest.fn() };
+        const mockVideo = { id: 1, publishedAt: '2023-01-01T00:00:00.000Z', published_at_source: 'approximate', update: jest.fn() };
         ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
 
         const videoWithPublic = { ...mockVideoData, availability: 'public' };
@@ -1036,7 +1095,7 @@ describe('ChannelModule', () => {
       });
 
       test('should overwrite live_status when refresh has a real value', async () => {
-        const mockVideo = { update: jest.fn() };
+        const mockVideo = { id: 1, publishedAt: '2023-01-01T00:00:00.000Z', published_at_source: 'approximate', update: jest.fn() };
         ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
 
         const videoWithLive = { ...mockVideoData, live_status: 'is_live' };
@@ -1053,7 +1112,7 @@ describe('ChannelModule', () => {
           live_status: 'was_live'
         };
 
-        ChannelVideo.findOrCreate.mockResolvedValue([{}, true]);
+        echoCreates();
 
         await ChannelModule.insertVideosIntoDb([videoWithLiveStatus], 'UC123');
 
@@ -1068,128 +1127,171 @@ describe('ChannelModule', () => {
         });
       });
 
-      test('should generate synthetic publishedAt for videos without dates', async () => {
+      test('should write strictly descending estimated dates for a date-less batch', async () => {
         const videosWithoutDates = [
           { youtube_id: 'video1', title: 'Video 1', publishedAt: null },
           { youtube_id: 'video2', title: 'Video 2', publishedAt: null },
           { youtube_id: 'video3', title: 'Video 3', publishedAt: null }
         ];
 
-        ChannelVideo.findOrCreate
-          .mockResolvedValueOnce([{}, true])
-          .mockResolvedValueOnce([{}, true])
-          .mockResolvedValueOnce([{}, true]);
+        echoCreates();
 
-        const beforeTime = Date.now();
         await ChannelModule.insertVideosIntoDb(videosWithoutDates, 'UC123');
-        const afterTime = Date.now();
 
-        // Verify all videos got synthetic timestamps
-        expect(ChannelVideo.findOrCreate).toHaveBeenCalledTimes(3);
+        // Created with the estimated source.
+        for (const call of ChannelVideo.findOrCreate.mock.calls) {
+          expect(call[0].defaults.published_at_source).toBe('estimated');
+        }
 
-        // First video should have the most recent synthetic timestamp
-        const firstCall = ChannelVideo.findOrCreate.mock.calls[0][0];
-        const firstTimestamp = new Date(firstCall.defaults.publishedAt).getTime();
-        expect(firstTimestamp).toBeGreaterThanOrEqual(beforeTime - 1000);
-        expect(firstTimestamp).toBeLessThanOrEqual(afterTime + 1000);
-
-        // Second video should be 1 second earlier
-        const secondCall = ChannelVideo.findOrCreate.mock.calls[1][0];
-        const secondTimestamp = new Date(secondCall.defaults.publishedAt).getTime();
-        expect(secondTimestamp).toBe(firstTimestamp - 1000);
-
-        // Third video should be 2 seconds earlier
-        const thirdCall = ChannelVideo.findOrCreate.mock.calls[2][0];
-        const thirdTimestamp = new Date(thirdCall.defaults.publishedAt).getTime();
-        expect(thirdTimestamp).toBe(firstTimestamp - 2000);
+        // Phase 2 persists strictly-descending dates, 1s apart, source unchanged.
+        const writes = dateWrites();
+        expect(writes).toHaveLength(3);
+        const times = writes.map((w) => new Date(w.publishedAt).getTime());
+        expect(times[1]).toBe(times[0] - 1000);
+        expect(times[2]).toBe(times[0] - 2000);
+        for (const w of writes) {
+          expect(w).not.toHaveProperty('published_at_source'); // estimated stays estimated
+        }
       });
 
-      test('should preserve publishedAt when provided', async () => {
-        const videosWithDates = [
-          { youtube_id: 'video1', title: 'Video 1', publishedAt: '2024-01-01T00:00:00Z' },
-          { youtube_id: 'video2', title: 'Video 2', publishedAt: '2024-01-02T00:00:00Z' }
+      test('should anchor estimated dates just below the nearest dated entry above', async () => {
+        // Mixed batch: dates for only the first entry. The undated entries must
+        // sort below it, not jump to "now".
+        const videos = [
+          { youtube_id: 'video1', title: 'Video 1', publishedAt: '2024-01-10T00:00:00.000Z' },
+          { youtube_id: 'video2', title: 'Video 2', publishedAt: null },
+          { youtube_id: 'video3', title: 'Video 3', publishedAt: null }
         ];
 
-        ChannelVideo.findOrCreate
-          .mockResolvedValueOnce([{}, true])
-          .mockResolvedValueOnce([{}, true]);
+        echoCreates();
+
+        await ChannelModule.insertVideosIntoDb(videos, 'UC123');
+
+        const anchor = new Date('2024-01-10T00:00:00.000Z').getTime();
+        const writes = dateWrites();
+        // video1 was created with the right date in defaults, so it isn't rewritten;
+        // the two estimated rows are written just below the anchor.
+        const estimatedTimes = writes.map((w) => new Date(w.publishedAt).getTime()).sort((a, b) => b - a);
+        expect(estimatedTimes).toEqual([anchor - 1000, anchor - 2000]);
+      });
+
+      test('should anchor estimated dates below an existing record real date when the response has none', async () => {
+        const existingRecord = {
+          id: 50,
+          publishedAt: '2024-02-01T00:00:00.000Z',
+          published_at_source: 'approximate',
+          update: jest.fn()
+        };
+
+        const videos = [
+          { youtube_id: 'video1', title: 'Video 1', publishedAt: null },
+          { youtube_id: 'video2', title: 'Video 2', publishedAt: null }
+        ];
+
+        echoCreates({ video1: existingRecord });
+
+        await ChannelModule.insertVideosIntoDb(videos, 'UC123');
+
+        // The existing real date is kept (no phase-2 write for that id)...
+        const wroteExisting = ChannelVideo.update.mock.calls.some(([, opts]) => opts.where.id === 50);
+        expect(wroteExisting).toBe(false);
+
+        // ...and the new undated row slots in just below it.
+        const anchor = new Date('2024-02-01T00:00:00.000Z').getTime();
+        const writes = dateWrites();
+        expect(writes).toHaveLength(1);
+        expect(new Date(writes[0].publishedAt).getTime()).toBe(anchor - 1000);
+      });
+
+      test('should re-anchor existing estimated rows on a date-less refresh', async () => {
+        const estimatedRecord = {
+          id: 60,
+          publishedAt: '2026-06-12T17:21:21.205Z',
+          published_at_source: 'estimated',
+          update: jest.fn()
+        };
+
+        const videos = [
+          { youtube_id: 'video1', title: 'Video 1', publishedAt: '2024-03-01T00:00:00.000Z' },
+          { youtube_id: 'video2', title: 'Video 2', publishedAt: null }
+        ];
+
+        echoCreates({ video2: estimatedRecord });
+
+        await ChannelModule.insertVideosIntoDb(videos, 'UC123');
+
+        const anchor = new Date('2024-03-01T00:00:00.000Z').getTime();
+        const write = dateWrites().find((w) => w.id === 60);
+        expect(write).toBeDefined();
+        expect(new Date(write.publishedAt).getTime()).toBe(anchor - 1000);
+        expect(write).not.toHaveProperty('published_at_source'); // estimated stays estimated
+      });
+
+      test('clamps a fetched approximate date that would sort above a nearby exact date', async () => {
+        // The bug this refactor fixes: an approximate date newer than an exact
+        // date below it in the listing must be clamped into position.
+        const exactRow = {
+          id: 71,
+          publishedAt: '2026-05-07T00:00:00.000Z',
+          published_at_source: 'exact',
+          update: jest.fn()
+        };
+        const videos = [
+          { youtube_id: 'before', title: 'Before', publishedAt: '2026-05-20T00:00:00.000Z' },
+          { youtube_id: 'exactvid', title: 'Exact', publishedAt: '2026-05-10T00:00:00.000Z' }, // fetch date ignored; row is exact
+          { youtube_id: 'after', title: 'After', publishedAt: '2026-05-12T00:00:00.000Z' } // newer than the exact -> must be clamped below it
+        ];
+
+        echoCreates({ exactvid: exactRow });
+
+        await ChannelModule.insertVideosIntoDb(videos, 'UC123');
+
+        // The exact row keeps its date (not rewritten).
+        const wroteExact = ChannelVideo.update.mock.calls.some(([, opts]) => opts.where.id === 71);
+        expect(wroteExact).toBe(false);
+
+        // The "after" row, despite a 5/12 fetched date, is written below 5/7.
+        const exactMs = new Date('2026-05-07T00:00:00.000Z').getTime();
+        const writes = dateWrites();
+        const afterWrite = writes.find((w) => new Date(w.publishedAt).getTime() < exactMs);
+        expect(afterWrite).toBeDefined();
+        // It keeps its approximate source (created with it; not downgraded to estimated).
+        expect(afterWrite.published_at_source).not.toBe('estimated');
+      });
+
+      test('should keep fetched dates as approximate when consistent', async () => {
+        const videosWithDates = [
+          { youtube_id: 'video1', title: 'Video 1', publishedAt: '2024-01-02T00:00:00.000Z' },
+          { youtube_id: 'video2', title: 'Video 2', publishedAt: '2024-01-01T00:00:00.000Z' }
+        ];
+
+        echoCreates();
 
         await ChannelModule.insertVideosIntoDb(videosWithDates, 'UC123');
 
         const firstCall = ChannelVideo.findOrCreate.mock.calls[0][0];
-        expect(firstCall.defaults.publishedAt).toBe('2024-01-01T00:00:00Z');
+        expect(firstCall.defaults.publishedAt).toBe('2024-01-02T00:00:00.000Z');
+        expect(firstCall.defaults.published_at_source).toBe('approximate');
 
-        const secondCall = ChannelVideo.findOrCreate.mock.calls[1][0];
-        expect(secondCall.defaults.publishedAt).toBe('2024-01-02T00:00:00Z');
+        // Consistent fetched dates need no phase-2 rewrite.
+        expect(ChannelVideo.update).not.toHaveBeenCalled();
       });
+    });
 
-      test('should preserve existing publishedAt when refresh has no date', async () => {
-        // yt-dlp's youtubetab:approximate_date is non-deterministic for
-        // lockupViewModel entries. An empty refresh must not clobber a
-        // known-good DB date with Date.now().
-        const mockVideo = {
-          publishedAt: '2024-01-01T00:00:00Z',
-          update: jest.fn()
-        };
+    describe('extractVideosFromYtDlpResponse', () => {
+      test('parses a real degraded flat-playlist response (timestamp: null) preserving order', () => {
+        // Captured from a live YouTube degraded response: every entry has
+        // timestamp: null but the order is still newest-first.
+        const fixture = require('./fixtures/flat-playlist-dateless.json');
 
-        const videoWithoutDate = {
-          ...mockVideoData,
-          publishedAt: null
-        };
+        const videos = ChannelModule.extractVideosFromYtDlpResponse(fixture);
 
-        ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
-
-        await ChannelModule.insertVideosIntoDb([videoWithoutDate], 'UC123');
-
-        const updateCall = mockVideo.update.mock.calls[0][0];
-        expect(updateCall).not.toHaveProperty('publishedAt');
-      });
-
-      test('should set synthetic publishedAt on existing videos without dates', async () => {
-        const mockVideo = {
-          publishedAt: null,
-          update: jest.fn()
-        };
-
-        const videoWithoutDate = {
-          ...mockVideoData,
-          publishedAt: null
-        };
-
-        ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
-
-        const beforeTime = Date.now();
-        await ChannelModule.insertVideosIntoDb([videoWithoutDate], 'UC123');
-        const afterTime = Date.now();
-
-        // Should set synthetic publishedAt when existing video has no date
-        const updateCall = mockVideo.update.mock.calls[0][0];
-        expect(updateCall.publishedAt).toBeDefined();
-        const timestamp = new Date(updateCall.publishedAt).getTime();
-        expect(timestamp).toBeGreaterThanOrEqual(beforeTime - 1000);
-        expect(timestamp).toBeLessThanOrEqual(afterTime + 1000);
-      });
-
-      test('should update publishedAt when new date is provided for existing video', async () => {
-        const mockVideo = {
-          publishedAt: '2024-01-01T00:00:00Z',
-          update: jest.fn()
-        };
-
-        const videoWithNewDate = {
-          ...mockVideoData,
-          publishedAt: '2024-01-15T00:00:00Z'
-        };
-
-        ChannelVideo.findOrCreate.mockResolvedValue([mockVideo, false]);
-
-        await ChannelModule.insertVideosIntoDb([videoWithNewDate], 'UC123');
-
-        expect(mockVideo.update).toHaveBeenCalledWith(
-          expect.objectContaining({
-            publishedAt: '2024-01-15T00:00:00Z'
-          })
-        );
+        expect(videos).toHaveLength(fixture.entries.length);
+        expect(videos.map(v => v.youtube_id)).toEqual(fixture.entries.map(e => e.id));
+        for (const video of videos) {
+          expect(video.publishedAt).toBeNull();
+          expect(video.title).toBeTruthy();
+        }
       });
     });
   });
@@ -1528,6 +1630,26 @@ describe('ChannelModule', () => {
 
         expect(result).toHaveLength(10);
         expect(result[0].youtube_id).toBe('video20');
+      });
+
+      test('should blank publishedAt for estimated rows but keep their sort position', async () => {
+        const Video = require('../../models/video');
+        const mockVideos = [
+          { youtube_id: 'newest', publishedAt: '2024-05-01T00:00:00.000Z', published_at_source: 'approximate', toJSON() { return { youtube_id: this.youtube_id, publishedAt: this.publishedAt, published_at_source: this.published_at_source }; } },
+          { youtube_id: 'undated', publishedAt: '2024-04-30T23:59:59.000Z', published_at_source: 'estimated', toJSON() { return { youtube_id: this.youtube_id, publishedAt: this.publishedAt, published_at_source: this.published_at_source }; } },
+          { youtube_id: 'oldest', publishedAt: '2024-04-01T00:00:00.000Z', published_at_source: 'exact', toJSON() { return { youtube_id: this.youtube_id, publishedAt: this.publishedAt, published_at_source: this.published_at_source }; } }
+        ];
+        ChannelVideo.findAll.mockResolvedValue(mockVideos);
+        Video.findAll = jest.fn().mockResolvedValue([]);
+
+        const result = await ChannelModule.fetchNewestVideosFromDb('UC123');
+
+        // Estimated row keeps its position between the dated rows...
+        expect(result.map(v => v.youtube_id)).toEqual(['newest', 'undated', 'oldest']);
+        // ...but its placeholder date is not exposed to consumers
+        expect(result[0].publishedAt).toBe('2024-05-01T00:00:00.000Z');
+        expect(result[1].publishedAt).toBeNull();
+        expect(result[2].publishedAt).toBe('2024-04-01T00:00:00.000Z');
       });
 
       test('should filter out downloaded videos when downloadedFilter="exclude"', async () => {
@@ -2020,7 +2142,7 @@ describe('ChannelModule', () => {
         expect(ChannelVideo.findOne).toHaveBeenCalledWith({
           where: { channel_id: 'UC123', media_type: 'video' },
           order: [['publishedAt', 'ASC']],
-          attributes: ['publishedAt']
+          attributes: ['publishedAt', 'published_at_source']
         });
         expect(result).toEqual({
           totalCount: 100,
@@ -2040,8 +2162,20 @@ describe('ChannelModule', () => {
         expect(ChannelVideo.findOne).toHaveBeenCalledWith({
           where: { channel_id: 'UC123', media_type: 'short' },
           order: [['publishedAt', 'ASC']],
-          attributes: ['publishedAt']
+          attributes: ['publishedAt', 'published_at_source']
         });
+      });
+
+      test('should return null oldestVideoDate when the oldest row is estimated', async () => {
+        ChannelVideo.count.mockResolvedValue(10);
+        ChannelVideo.findOne.mockResolvedValue({
+          publishedAt: '2026-06-12T17:21:21.205Z',
+          published_at_source: 'estimated'
+        });
+
+        const result = await ChannelModule.getChannelVideoStats('UC123');
+
+        expect(result.oldestVideoDate).toBeNull();
       });
 
       test('should filter by downloadedFilter="exclude" when specified', async () => {

--- a/server/modules/__tests__/channelVideoReanchor.test.js
+++ b/server/modules/__tests__/channelVideoReanchor.test.js
@@ -1,0 +1,239 @@
+const { Op } = require('sequelize');
+
+jest.mock('../../logger');
+
+jest.mock('../../models/channelvideo', () => ({
+  findOne: jest.fn(),
+  findAll: jest.fn(),
+  count: jest.fn(),
+  update: jest.fn(),
+}));
+
+jest.mock('../../db', () => ({
+  sequelize: {
+    transaction: jest.fn(async (cb) => cb('TXN')),
+  },
+  Sequelize: require('sequelize').Sequelize,
+}));
+
+const ChannelVideo = require('../../models/channelvideo');
+const reanchor = require('../channelVideoReanchor');
+
+const DAY = 86400000;
+// Arbitrary epoch base so the numbers stay readable; absolute value is irrelevant.
+const BASE = 1700000000000;
+const at = (days) => BASE + days * DAY;
+const NOW = at(1000);
+
+describe('channelVideoReanchor.computeReanchoredDates (pure ordering)', () => {
+  test('returns empty for empty input', () => {
+    expect(reanchor.computeReanchoredDates([], NOW)).toEqual([]);
+  });
+
+  test('leaves a consistent descending list of approximate dates unchanged', () => {
+    const rows = [
+      { ms: at(100), source: 'approximate' },
+      { ms: at(90), source: 'approximate' },
+      { ms: at(80), source: 'approximate' },
+    ];
+    expect(reanchor.computeReanchoredDates(rows, NOW)).toEqual([at(100), at(90), at(80)]);
+  });
+
+  test('keeps exact dates exactly and never moves them', () => {
+    const rows = [
+      { ms: at(100), source: 'exact' },
+      { ms: at(50), source: 'estimated' },
+      { ms: at(60), source: 'exact' },
+    ];
+    const result = reanchor.computeReanchoredDates(rows, NOW);
+    expect(result[0]).toBe(at(100));
+    expect(result[2]).toBe(at(60));
+  });
+
+  test('an exact date inside an identical approximate cluster preserves order', () => {
+    // The user's scenario: 5 videos at ~day100, open the middle one -> exact day95.
+    const rows = [
+      { ms: at(100), source: 'approximate' },
+      { ms: at(100), source: 'approximate' },
+      { ms: at(95), source: 'exact' },
+      { ms: at(100), source: 'approximate' },
+      { ms: at(100), source: 'approximate' },
+    ];
+    const result = reanchor.computeReanchoredDates(rows, NOW);
+    // strictly descending => original positions preserved after a publishedAt sort
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]).toBeLessThan(result[i - 1]);
+    }
+    expect(result[0]).toBe(at(100)); // first sibling kept as anchor
+    expect(result[2]).toBe(at(95)); // exact preserved
+    // the tied sibling above the exact is pulled between day100 and day95
+    expect(result[1]).toBeLessThan(at(100));
+    expect(result[1]).toBeGreaterThan(at(95));
+    // the siblings after the exact are pushed below it
+    expect(result[3]).toBeLessThan(at(95));
+    expect(result[4]).toBeLessThan(result[3]);
+  });
+
+  test('interpolates an estimated run evenly between two exact anchors', () => {
+    const rows = [
+      { ms: at(100), source: 'exact' },
+      { ms: at(50), source: 'estimated' },
+      { ms: at(50), source: 'estimated' },
+      { ms: at(50), source: 'estimated' },
+      { ms: at(60), source: 'exact' },
+    ];
+    const result = reanchor.computeReanchoredDates(rows, NOW);
+    expect(result).toEqual([at(100), at(90), at(80), at(70), at(60)]);
+  });
+
+  test('steps estimated rows down by a fixed gap when there is no lower bound', () => {
+    const rows = [
+      { ms: at(100), source: 'exact' },
+      { ms: at(50), source: 'estimated' },
+      { ms: at(50), source: 'estimated' },
+    ];
+    const result = reanchor.computeReanchoredDates(rows, NOW);
+    expect(result[0]).toBe(at(100));
+    expect(result[1]).toBe(at(100) - 1000);
+    expect(result[2]).toBe(at(100) - 2000);
+  });
+
+  test('uses now as the upper bound for an estimated run at the newest end', () => {
+    const rows = [
+      { ms: at(50), source: 'estimated' },
+      { ms: at(50), source: 'estimated' },
+      { ms: at(100), source: 'exact' },
+    ];
+    const result = reanchor.computeReanchoredDates(rows, NOW);
+    expect(result[0]).toBeLessThan(NOW);
+    expect(result[1]).toBeLessThan(result[0]);
+    expect(result[2]).toBe(at(100));
+    expect(result[1]).toBeGreaterThan(at(100));
+  });
+
+  test('reassigns an out-of-order approximate date to preserve position', () => {
+    const rows = [
+      { ms: at(80), source: 'approximate' },
+      { ms: at(100), source: 'approximate' }, // violates: newer date but older position
+    ];
+    const result = reanchor.computeReanchoredDates(rows, NOW);
+    expect(result[0]).toBe(at(80));
+    expect(result[1]).toBeLessThan(at(80));
+  });
+
+  test('treats null-source legacy rows as approximate anchors when consistent', () => {
+    const rows = [
+      { ms: at(100), source: null },
+      { ms: at(90), source: null },
+    ];
+    expect(reanchor.computeReanchoredDates(rows, NOW)).toEqual([at(100), at(90)]);
+  });
+});
+
+describe('channelVideoReanchor.applyExactDateForGroup (DB wrapper)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const args = {
+    channelId: 'UC1',
+    mediaType: 'video',
+    youtubeId: 'vid-mid',
+    exactIso: '2026-05-07T00:00:00.000Z',
+  };
+
+  test('no-ops when the row already holds this exact date', async () => {
+    ChannelVideo.findOne.mockResolvedValue({
+      publishedAt: '2026-05-07T00:00:00.000Z',
+      published_at_source: 'exact',
+      update: jest.fn(),
+    });
+
+    await reanchor.applyExactDateForGroup(args);
+
+    expect(ChannelVideo.count).not.toHaveBeenCalled();
+    expect(ChannelVideo.findAll).not.toHaveBeenCalled();
+  });
+
+  test('fast path: writes only the target when ordering is not broken', async () => {
+    const update = jest.fn();
+    ChannelVideo.findOne.mockResolvedValue({
+      publishedAt: '2026-05-08T00:00:00.000Z',
+      published_at_source: 'approximate',
+      update,
+    });
+    ChannelVideo.count.mockResolvedValue(0); // no tie sibling, nothing between
+
+    await reanchor.applyExactDateForGroup(args);
+
+    expect(update).toHaveBeenCalledWith({
+      publishedAt: args.exactIso,
+      published_at_source: 'exact',
+    });
+    expect(ChannelVideo.findAll).not.toHaveBeenCalled();
+  });
+
+  test('full repair: re-anchors and writes changed rows when a tie sibling exists', async () => {
+    ChannelVideo.findOne.mockResolvedValue({
+      publishedAt: '2026-05-12T00:00:00.000Z',
+      published_at_source: 'approximate',
+      update: jest.fn(),
+    });
+    // tie-sibling check returns > 0 -> full repair
+    ChannelVideo.count.mockResolvedValue(2);
+
+    // Two siblings at the same date as the target, one before and one after it.
+    ChannelVideo.findAll.mockResolvedValue([
+      { id: 1, youtube_id: 'before', publishedAt: '2026-05-12T00:00:00.000Z', published_at_source: 'approximate' },
+      { id: 2, youtube_id: 'vid-mid', publishedAt: '2026-05-12T00:00:00.000Z', published_at_source: 'approximate' },
+      { id: 3, youtube_id: 'after', publishedAt: '2026-05-12T00:00:00.000Z', published_at_source: 'approximate' },
+    ]);
+
+    await reanchor.applyExactDateForGroup(args);
+
+    // The target gets the exact date + source.
+    expect(ChannelVideo.update).toHaveBeenCalledWith(
+      { publishedAt: args.exactIso, published_at_source: 'exact' },
+      { where: { id: 2 }, transaction: 'TXN' },
+    );
+    // The trailing sibling (after the exact date) is pushed below it, source untouched.
+    const afterCall = ChannelVideo.update.mock.calls.find((c) => c[1].where.id === 3);
+    expect(afterCall).toBeDefined();
+    expect(afterCall[0].published_at_source).toBeUndefined();
+    expect(new Date(afterCall[0].publishedAt).getTime()).toBeLessThan(new Date(args.exactIso).getTime());
+  });
+
+  test('returns without writing when the target row does not exist', async () => {
+    ChannelVideo.findOne.mockResolvedValue(null);
+    await reanchor.applyExactDateForGroup(args);
+    expect(ChannelVideo.count).not.toHaveBeenCalled();
+    expect(ChannelVideo.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('channelVideoReanchor._orderWouldBreak', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('returns false when the date is unchanged', async () => {
+    const result = await reanchor._orderWouldBreak('UC1', 'video', 'v', '2026-05-07T00:00:00.000Z', '2026-05-07T00:00:00.000Z');
+    expect(result).toBe(false);
+    expect(ChannelVideo.count).not.toHaveBeenCalled();
+  });
+
+  test('returns true when a tie sibling shares the old date', async () => {
+    ChannelVideo.count.mockResolvedValueOnce(1);
+    const result = await reanchor._orderWouldBreak('UC1', 'video', 'v', '2026-05-12T00:00:00.000Z', '2026-05-07T00:00:00.000Z');
+    expect(result).toBe(true);
+  });
+
+  test('checks the older-positioned window when the new date is older', async () => {
+    ChannelVideo.count
+      .mockResolvedValueOnce(0) // no tie
+      .mockResolvedValueOnce(0); // nothing strictly between
+    const result = await reanchor._orderWouldBreak('UC1', 'video', 'v', '2026-05-12T00:00:00.000Z', '2026-05-07T00:00:00.000Z');
+    expect(result).toBe(false);
+    const betweenWhere = ChannelVideo.count.mock.calls[1][0].where;
+    expect(betweenWhere.publishedAt[Op.lt]).toBe('2026-05-12T00:00:00.000Z');
+    expect(betweenWhere.publishedAt[Op.gt]).toBe('2026-05-07T00:00:00.000Z');
+  });
+});

--- a/server/modules/__tests__/fixtures/flat-playlist-dateless.json
+++ b/server/modules/__tests__/fixtures/flat-playlist-dateless.json
@@ -1,0 +1,97 @@
+{
+  "id": "UCfQgsKhHjSyRLOp9mnffqVg",
+  "channel": "Renaissance Periodization",
+  "channel_id": "UCfQgsKhHjSyRLOp9mnffqVg",
+  "title": "Renaissance Periodization - Videos",
+  "uploader": "Renaissance Periodization",
+  "uploader_id": "@RenaissancePeriodization",
+  "uploader_url": "https://www.youtube.com/@RenaissancePeriodization",
+  "channel_url": "https://www.youtube.com/channel/UCfQgsKhHjSyRLOp9mnffqVg",
+  "_type": "playlist",
+  "extractor_key": "YoutubeTab",
+  "extractor": "youtube:tab",
+  "webpage_url": "https://www.youtube.com/channel/UCfQgsKhHjSyRLOp9mnffqVg/videos",
+  "original_url": "https://www.youtube.com/channel/UCfQgsKhHjSyRLOp9mnffqVg/videos",
+  "entries": [
+    {
+      "title": "Exercise Scientist Critiques Dr. Berg’s Dangerous Health Advice",
+      "thumbnails": [
+        {
+          "url": "https://i.ytimg.com/vi/57xw33VP67c/hqdefault.jpg?sqp=-oaymwEbCKgBEF5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLCjHnso3zXiwI7FBaWcoK0y44-F8g",
+          "height": 94,
+          "width": 168
+        }
+      ],
+      "duration": 1301,
+      "timestamp": null,
+      "ie_key": "Youtube",
+      "id": "57xw33VP67c",
+      "_type": "url",
+      "url": "https://www.youtube.com/watch?v=57xw33VP67c"
+    },
+    {
+      "title": "Exercise Scientist Critiques Dr. Berg’s Dangerous Health Advice UNCENSORED",
+      "thumbnails": [
+        {
+          "url": "https://i.ytimg.com/vi/ZXcdRt8pGvo/hqdefault.jpg?sqp=-oaymwEbCKgBEF5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLCkyvdjPu8JLQv467vwS__AUFtxlw",
+          "height": 94,
+          "width": 168
+        }
+      ],
+      "duration": 2192,
+      "timestamp": null,
+      "ie_key": "Youtube",
+      "id": "ZXcdRt8pGvo",
+      "_type": "url",
+      "url": "https://www.youtube.com/watch?v=ZXcdRt8pGvo"
+    },
+    {
+      "title": "The Smartest Way to Do Cardio for Fat Loss and Health",
+      "thumbnails": [
+        {
+          "url": "https://i.ytimg.com/vi/0r_AlKrc70c/hqdefault.jpg?sqp=-oaymwEbCKgBEF5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLDXzlgjBDBRiu8FGIb93Y67gj5AAQ",
+          "height": 94,
+          "width": 168
+        }
+      ],
+      "duration": 1288,
+      "timestamp": null,
+      "ie_key": "Youtube",
+      "id": "0r_AlKrc70c",
+      "_type": "url",
+      "url": "https://www.youtube.com/watch?v=0r_AlKrc70c"
+    },
+    {
+      "title": "Who Knows More About Fitness: Gym Girls or Gym Boys?",
+      "thumbnails": [
+        {
+          "url": "https://i.ytimg.com/vi/mWe60vjvNSQ/hqdefault.jpg?sqp=-oaymwEbCKgBEF5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLC4TXKDUE9h3j3S9jQggiE2q3sugA",
+          "height": 94,
+          "width": 168
+        }
+      ],
+      "duration": 1122,
+      "timestamp": null,
+      "ie_key": "Youtube",
+      "id": "mWe60vjvNSQ",
+      "_type": "url",
+      "url": "https://www.youtube.com/watch?v=mWe60vjvNSQ"
+    },
+    {
+      "title": "Can the Gym Fix Depression?",
+      "thumbnails": [
+        {
+          "url": "https://i.ytimg.com/vi/S6bPaV38WYY/hqdefault.jpg?sqp=-oaymwEbCKgBEF5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLCSrxtqK7Yq0Gg0GvE58tRPOdH4WA",
+          "height": 94,
+          "width": 168
+        }
+      ],
+      "duration": 1320,
+      "timestamp": null,
+      "ie_key": "Youtube",
+      "id": "S6bPaV38WYY",
+      "_type": "url",
+      "url": "https://www.youtube.com/watch?v=S6bPaV38WYY"
+    }
+  ]
+}

--- a/server/modules/__tests__/jobModule.test.js
+++ b/server/modules/__tests__/jobModule.test.js
@@ -12,6 +12,10 @@ jest.mock('../../models/video');
 jest.mock('../../models/jobvideo');
 jest.mock('../../models/jobvideodownload');
 jest.mock('../../models/channelvideo');
+jest.mock('../channelVideoReanchor', () => ({
+  applyExactDateForGroup: jest.fn().mockResolvedValue(undefined),
+  applyExactDateForVideo: jest.fn().mockResolvedValue(undefined),
+}));
 jest.mock('../download/downloadExecutor', () => {
   return jest.fn().mockImplementation(() => ({
     cleanupInProgressVideos: jest.fn().mockResolvedValue()
@@ -1963,7 +1967,7 @@ describe('JobModule', () => {
 
       await JobModule.upsertChannelVideoFromInfo(info);
 
-      // Verify that update is called with correct fields, including clearing ignored flags
+      // The non-date fields are updated directly (and ignored flags cleared)...
       expect(mockRecord.update).toHaveBeenCalledWith({
         title: 'Updated Video',
         thumbnail: 'https://i.ytimg.com/vi/video-1/mqdefault.jpg',
@@ -1973,10 +1977,34 @@ describe('JobModule', () => {
         ignored: false,
         ignored_at: null
       });
-
-      // Explicitly verify that publishedAt is NOT included in the update
+      // ...but the authoritative date is applied via the re-anchor module so the
+      // row's old position is read first and neighbours stay ordered.
+      const channelVideoReanchor = require('../channelVideoReanchor');
+      expect(channelVideoReanchor.applyExactDateForGroup).toHaveBeenCalledWith({
+        channelId: 'channel-1',
+        mediaType: 'video',
+        youtubeId: 'video-1',
+        exactIso: '2024-01-15T00:00:00.000Z',
+      });
+      // The direct update must not carry the date fields.
       const updateCall = mockRecord.update.mock.calls[0][0];
       expect(updateCall).not.toHaveProperty('publishedAt');
+      expect(updateCall).not.toHaveProperty('published_at_source');
+    });
+
+    test('should not touch publishedAt on update when info has no upload_date', async () => {
+      const mockRecord = { update: jest.fn() };
+      ChannelVideo.findOrCreate.mockResolvedValue([mockRecord, false]);
+
+      await JobModule.upsertChannelVideoFromInfo({
+        id: 'video-1',
+        channel_id: 'channel-1',
+        title: 'No Date Video'
+      });
+
+      const updateCall = mockRecord.update.mock.calls[0][0];
+      expect(updateCall).not.toHaveProperty('publishedAt');
+      expect(updateCall).not.toHaveProperty('published_at_source');
     });
 
     test('should skip update when skipUpdateIfExists is true', async () => {

--- a/server/modules/__tests__/videoMetadataModule.test.js
+++ b/server/modules/__tests__/videoMetadataModule.test.js
@@ -9,6 +9,7 @@ describe('VideoMetadataModule', () => {
   let mockConfigModule;
   let mockYtDlpRunner;
   let mockYoutubeApi;
+  let mockChannelVideoReanchor;
 
   beforeEach(() => {
     jest.resetModules();
@@ -71,6 +72,11 @@ describe('VideoMetadataModule', () => {
       YoutubeApiErrorCode: { QUOTA_EXCEEDED: 'QUOTA_EXCEEDED' },
     };
 
+    mockChannelVideoReanchor = {
+      applyExactDateForVideo: jest.fn().mockResolvedValue(undefined),
+      applyExactDateForGroup: jest.fn().mockResolvedValue(undefined),
+    };
+
     jest.doMock('fs', () => ({ promises: mockFs }));
     jest.doMock('../../models', () => ({ Video: mockVideo }));
     jest.doMock('../../models/channelvideo', () => mockChannelVideo);
@@ -78,6 +84,7 @@ describe('VideoMetadataModule', () => {
     jest.doMock('../../logger', () => mockLogger);
     jest.doMock('../ytDlpRunner', () => mockYtDlpRunner);
     jest.doMock('../youtubeApi', () => mockYoutubeApi);
+    jest.doMock('../channelVideoReanchor', () => mockChannelVideoReanchor);
 
     videoMetadataModule = require('../videoMetadataModule');
   });
@@ -325,6 +332,39 @@ describe('VideoMetadataModule', () => {
         expect.objectContaining({ youtubeId: 'errvid1' }),
         'Failed to backfill ChannelVideo.availability',
       );
+    });
+
+    test('re-anchors ChannelVideo order with the exact date when info.json has upload_date', async () => {
+      const rawInfoJson = {
+        upload_date: '20240315',
+        description: 'dated video',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+      mockVideo.findOne.mockResolvedValue(null);
+
+      await videoMetadataModule.getVideoMetadata('datedvid1');
+
+      expect(mockChannelVideoReanchor.applyExactDateForVideo).toHaveBeenCalledWith(
+        'datedvid1',
+        '2024-03-15T00:00:00.000Z',
+      );
+    });
+
+    test('does not re-anchor ChannelVideo when upload_date is malformed', async () => {
+      const rawInfoJson = {
+        upload_date: 'garbage',
+        description: 'video with bad date',
+      };
+
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue(JSON.stringify(rawInfoJson));
+      mockVideo.findOne.mockResolvedValue(null);
+
+      await videoMetadataModule.getVideoMetadata('badvid1');
+
+      expect(mockChannelVideoReanchor.applyExactDateForVideo).not.toHaveBeenCalled();
     });
 
     test('handles missing optional fields gracefully', async () => {

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -15,6 +15,8 @@ const { sanitizeNameLikeYtDlp, GLOBAL_DEFAULT_SENTINEL } = require('./filesystem
 const youtubeApi = require('./youtubeApi');
 const ratingMapper = require('./ratingMapper');
 const tempPathManager = require('./download/tempPathManager');
+const channelVideoReanchor = require('./channelVideoReanchor');
+const { PUBLISHED_AT_SOURCE } = require('./constants/publishedAtSource');
 
 const { v4: uuidv4 } = require('uuid');
 const { spawn, execSync } = require('child_process');
@@ -1332,18 +1334,35 @@ class ChannelModule {
   }
 
   /**
-   * Insert or update videos in the database.
-   * Creates new records or updates existing ones with latest metadata.
-   * @param {Array<Object>} videos - Array of video objects to save
+   * Insert or update videos in the database, keeping the channel in YouTube
+   * order even when some rows carry authoritative exact dates.
+   *
+   * YouTube intermittently serves channel-tab listings where every entry has
+   * timestamp: null, but the entry order is still newest-first (verified
+   * against captured degraded responses; only the timestamp field differs).
+   * So rather than trust per-row dates, this runs in two phases (see the inline
+   * Phase 1 / Phase 2 comments): the date value is deferred to a batch-wide
+   * anchoring pass that assigns strictly-descending dates in fetch order.
+   *
+   * publishedAt precedence: 'estimated' < 'approximate'/NULL < 'exact'.
+   * 'exact' comes from a download's .info.json and is never overwritten here.
+   * @param {Array<Object>} videos - Video objects in yt-dlp response order
+   *   (newest first)
    * @param {string} channelId - Channel ID these videos belong to
    * @returns {Promise<void>}
    */
   async insertVideosIntoDb(videos, channelId, mediaType = 'video') {
-    const syntheticBaseTime = Date.now();
+    const nowMs = Date.now();
+    const provisionalIso = new Date(nowMs).toISOString();
 
-    for (const [index, video] of videos.entries()) {
-      const syntheticPublishedAt = video.publishedAt || new Date(syntheticBaseTime - index * 1000).toISOString();
-
+    // Phase 1: ensure every row exists and upsert its non-date fields, and
+    // classify each row's ordering source + candidate date. The date VALUE is
+    // deliberately deferred to phase 2, where the shared anchoring algorithm
+    // assigns strictly-descending dates across the whole batch. This keeps
+    // ordering correct around scattered exact dates, since a fetched/existing
+    // approximate date newer than a nearby exact date must be clamped below it.
+    const entries = [];
+    for (const video of videos) {
       const [videoRecord, created] = await ChannelVideo.findOrCreate({
         where: {
           youtube_id: video.youtube_id,
@@ -1351,7 +1370,8 @@ class ChannelModule {
         },
         defaults: {
           ...video,
-          publishedAt: syntheticPublishedAt,
+          publishedAt: video.publishedAt || provisionalIso,
+          published_at_source: video.publishedAt ? PUBLISHED_AT_SOURCE.APPROXIMATE : PUBLISHED_AT_SOURCE.ESTIMATED,
           channel_id: channelId,
           media_type: mediaType,
         },
@@ -1371,24 +1391,66 @@ class ChannelModule {
         // code paths (modal open, download error, URL validation) populated.
         if (video.availability) updates.availability = video.availability;
         if (video.live_status) updates.live_status = video.live_status;
-
-        // Same logic for publishedAt: yt-dlp's youtubetab:approximate_date is
-        // non-deterministic for lockupViewModel entries (sometimes returns
-        // timestamp, sometimes upload_date, sometimes neither), so a refresh
-        // that comes back empty must not clobber a previously-stored real
-        // date with a synthetic Date.now() value. Only stamp synthetic when
-        // the row had no date to begin with.
-        if (video.publishedAt) {
-          updates.publishedAt = video.publishedAt;
-        } else if (!videoRecord.publishedAt) {
-          updates.publishedAt = syntheticPublishedAt;
-        }
-
         if (video.content_rating != null) updates.content_rating = video.content_rating;
         if (video.age_limit != null) updates.age_limit = video.age_limit;
         if (video.normalized_rating != null) updates.normalized_rating = video.normalized_rating;
-
+        // publishedAt / published_at_source intentionally deferred to phase 2.
         await videoRecord.update(updates);
+      }
+
+      // Classify for ordering. Exact dates (.info.json) are immovable anchors;
+      // a freshly fetched or existing real date is a soft anchor; everything
+      // else is an estimated placeholder.
+      const isExact = videoRecord.published_at_source === PUBLISHED_AT_SOURCE.EXACT;
+      let orderingSource;
+      let candidateMs;
+      if (isExact) {
+        orderingSource = PUBLISHED_AT_SOURCE.EXACT;
+        candidateMs = videoRecord.publishedAt ? Date.parse(videoRecord.publishedAt) : null;
+      } else if (video.publishedAt) {
+        orderingSource = PUBLISHED_AT_SOURCE.APPROXIMATE;
+        candidateMs = Date.parse(video.publishedAt);
+      } else if (videoRecord.publishedAt && videoRecord.published_at_source !== PUBLISHED_AT_SOURCE.ESTIMATED) {
+        // Existing real (approximate / legacy) date, no fresh date this fetch.
+        orderingSource = PUBLISHED_AT_SOURCE.APPROXIMATE;
+        candidateMs = Date.parse(videoRecord.publishedAt);
+      } else {
+        orderingSource = PUBLISHED_AT_SOURCE.ESTIMATED;
+        candidateMs = null;
+      }
+
+      entries.push({
+        id: videoRecord.id,
+        oldIso: videoRecord.publishedAt,
+        oldSource: videoRecord.published_at_source,
+        orderingSource,
+        candidateMs: Number.isFinite(candidateMs) ? candidateMs : null,
+        hasFetchedDate: Boolean(video.publishedAt),
+      });
+    }
+
+    if (entries.length === 0) return;
+
+    // Phase 2: compute a strictly-descending date for every row in fetch order
+    // (newest first) and persist only the rows whose date or source changed.
+    const orderedDates = channelVideoReanchor.computeReanchoredDates(
+      entries.map((e) => ({ ms: e.candidateMs, source: e.orderingSource })),
+      nowMs
+    );
+
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      if (entry.orderingSource === PUBLISHED_AT_SOURCE.EXACT) continue; // never rewrite exact dates
+
+      const newIso = new Date(orderedDates[i]).toISOString();
+      // A freshly fetched date is 'approximate'; otherwise preserve the existing
+      // label (estimated stays estimated, legacy NULL stays NULL).
+      const newSource = entry.hasFetchedDate ? PUBLISHED_AT_SOURCE.APPROXIMATE : entry.oldSource;
+
+      if (newIso !== entry.oldIso || newSource !== entry.oldSource) {
+        const fields = { publishedAt: newIso };
+        if (newSource !== entry.oldSource) fields.published_at_source = newSource;
+        await ChannelVideo.update(fields, { where: { id: entry.id } });
       }
     }
   }
@@ -1535,16 +1597,22 @@ class ChannelModule {
         video.duration && video.duration <= maxDuration
       );
     }
+    // Estimated dates are ordering-only placeholders; date-range filters
+    // must not match on them.
     if (dateFrom) {
       const fromDate = new Date(dateFrom);
       filtered = filtered.filter(video =>
-        video.publishedAt && new Date(video.publishedAt) >= fromDate
+        video.publishedAt &&
+        video.published_at_source !== PUBLISHED_AT_SOURCE.ESTIMATED &&
+        new Date(video.publishedAt) >= fromDate
       );
     }
     if (dateTo) {
       const toDate = new Date(dateTo);
       filtered = filtered.filter(video =>
-        video.publishedAt && new Date(video.publishedAt) <= toDate
+        video.publishedAt &&
+        video.published_at_source !== PUBLISHED_AT_SOURCE.ESTIMATED &&
+        new Date(video.publishedAt) <= toDate
       );
     }
 
@@ -1699,6 +1767,14 @@ class ChannelModule {
       }
     }
 
+    // Estimated dates exist only for ordering (already applied above); blank
+    // them so consumers render "no date" instead of a fabricated one.
+    for (const video of paginatedVideos) {
+      if (video.published_at_source === PUBLISHED_AT_SOURCE.ESTIMATED) {
+        video.publishedAt = null;
+      }
+    }
+
     return paginatedVideos;
   }
 
@@ -1750,10 +1826,12 @@ class ChannelModule {
 
       filteredVideos = this._applyStatusFilters(filteredVideos, protectedFilter, missingFilter, ignoredFilter);
 
+      // Estimated dates are ordering-only placeholders; never surface them.
+      const oldest = filteredVideos.length > 0 ? filteredVideos[filteredVideos.length - 1] : null;
       return {
         totalCount: filteredVideos.length,
-        oldestVideoDate: filteredVideos.length > 0 ?
-          filteredVideos[filteredVideos.length - 1].publishedAt : null
+        oldestVideoDate: oldest && oldest.published_at_source !== PUBLISHED_AT_SOURCE.ESTIMATED ?
+          oldest.publishedAt : null
       };
     } else {
       // Fast path - just use database counts when no filters
@@ -1770,12 +1848,13 @@ class ChannelModule {
           media_type: mediaType,
         },
         order: [['publishedAt', 'ASC']],
-        attributes: ['publishedAt']
+        attributes: ['publishedAt', 'published_at_source']
       });
 
       return {
         totalCount,
-        oldestVideoDate: oldestVideo ? oldestVideo.publishedAt : null
+        oldestVideoDate: oldestVideo && oldestVideo.published_at_source !== PUBLISHED_AT_SOURCE.ESTIMATED ?
+          oldestVideo.publishedAt : null
       };
     }
   }

--- a/server/modules/channelVideoReanchor.js
+++ b/server/modules/channelVideoReanchor.js
@@ -1,0 +1,233 @@
+const { Op } = require('sequelize');
+const { sequelize } = require('../db');
+const ChannelVideo = require('../models/channelvideo');
+const logger = require('../logger');
+const { PUBLISHED_AT_SOURCE } = require('./constants/publishedAtSource');
+
+// Step between consecutive synthetic dates when there is no lower bound to
+// interpolate against (a run of undated videos at the oldest end of the list).
+const FALLBACK_STEP_MS = 1000;
+
+/**
+ * Keeps channelvideos rows in YouTube/yt-dlp order when an authoritative
+ * (.info.json) "exact" date is written out of band - i.e. by the video modal
+ * opening or a download completing, which bypass the fetch-time anchoring in
+ * channelModule.insertVideosIntoDb.
+ *
+ * An exact date dropped into the middle of a cluster of approximate/estimated
+ * dates would, on the next server-side sort, jump the video out of its real
+ * position (e.g. an exact 5/7 sinks below sibling videos still labelled ~5/12).
+ * This module re-derives the surrounding synthetic dates so a publishedAt sort
+ * preserves the existing order, never touching YouTube - all the ordering
+ * information is already in the current row order.
+ *
+ * Date provenance is preserved: exact stays exact (and immovable), approximate
+ * stays approximate, estimated stays estimated. Only the date VALUES of
+ * non-exact rows are adjusted, and only where ordering requires it.
+ */
+class ChannelVideoReanchorModule {
+  /**
+   * Pure ordering core. Given rows already in YouTube order (newest first),
+   * returns a strictly-descending array of epoch-ms dates that preserves that
+   * order. Exact dates are immovable anchors; approximate/legacy dates are kept
+   * as anchors while they stay consistent and reassigned when they would break
+   * order; estimated (and dateless) rows are always reassigned. Reassigned runs
+   * are interpolated evenly between their bounding anchors so the synthetic
+   * guesses land as close as possible to the real dates.
+   *
+   * @param {Array<{ms: number|null, source: string|null}>} rows - newest first
+   * @param {number} nowMs - upper bound for a flexible run at the newest end
+   * @returns {number[]} new epoch-ms date for each row, same order
+   */
+  computeReanchoredDates(rows, nowMs) {
+    const n = rows.length;
+    if (n === 0) return [];
+
+    // Pass 1: mark anchors (kept dates) vs flexible rows (to be reassigned).
+    const fixed = new Array(n).fill(null);
+    let lastFixed = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < n; i++) {
+      const r = rows[i];
+      if (r.source === PUBLISHED_AT_SOURCE.EXACT && r.ms != null) {
+        // Authoritative: always an anchor, even in the rare case its date
+        // contradicts an anchor above it.
+        fixed[i] = r.ms;
+        lastFixed = Math.min(lastFixed, r.ms);
+      } else if (r.source !== PUBLISHED_AT_SOURCE.ESTIMATED && r.ms != null && r.ms < lastFixed) {
+        // Approximate or legacy (null source) date that is still consistent.
+        fixed[i] = r.ms;
+        lastFixed = r.ms;
+      } else {
+        fixed[i] = null;
+      }
+    }
+
+    // Pass 2: fill flexible runs by interpolating between bounding anchors.
+    const result = new Array(n);
+    let i = 0;
+    while (i < n) {
+      if (fixed[i] != null) {
+        result[i] = fixed[i];
+        i++;
+        continue;
+      }
+      let j = i;
+      while (j + 1 < n && fixed[j + 1] == null) j++;
+      const upper = i > 0 ? result[i - 1] : nowMs;
+      const lower = j + 1 < n ? fixed[j + 1] : null;
+      const count = j - i + 1;
+      if (lower != null && upper > lower) {
+        const step = (upper - lower) / (count + 1);
+        for (let k = 0; k < count; k++) {
+          result[i + k] = Math.round(upper - step * (k + 1));
+        }
+      } else {
+        for (let k = 0; k < count; k++) {
+          result[i + k] = upper - FALLBACK_STEP_MS * (k + 1);
+        }
+      }
+      i = j + 1;
+    }
+
+    // Safety net: guarantee strict descent for flexible rows even if dense
+    // interpolation rounded two neighbours equal. Anchors are left untouched.
+    for (let k = 1; k < n; k++) {
+      if (fixed[k] == null && result[k] >= result[k - 1]) {
+        result[k] = result[k - 1] - 1;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Apply an exact date to one video and re-anchor its channel+tab so order is
+   * preserved. Cheap-checks first and only does the full read+rewrite when the
+   * exact date actually breaks order.
+   * @param {{channelId: string, mediaType: string, youtubeId: string, exactIso: string}} args
+   */
+  async applyExactDateForGroup({ channelId, mediaType, youtubeId, exactIso }) {
+    const newMs = Date.parse(exactIso);
+    if (!Number.isFinite(newMs)) return;
+
+    const target = await ChannelVideo.findOne({
+      where: { youtube_id: youtubeId, channel_id: channelId, media_type: mediaType },
+    });
+    if (!target) return;
+
+    const oldIso = target.publishedAt;
+    const alreadyExact = target.published_at_source === PUBLISHED_AT_SOURCE.EXACT;
+    if (oldIso === exactIso && alreadyExact) return;
+
+    const breaks = await this._orderWouldBreak(channelId, mediaType, youtubeId, oldIso, exactIso);
+    if (!breaks) {
+      await target.update({ publishedAt: exactIso, published_at_source: PUBLISHED_AT_SOURCE.EXACT });
+      return;
+    }
+
+    // Read in current order BEFORE changing anything so the target still sits in
+    // its correct position, then apply the exact date in memory and re-anchor.
+    const rows = await ChannelVideo.findAll({
+      where: { channel_id: channelId, media_type: mediaType },
+      order: [['publishedAt', 'DESC']],
+      attributes: ['id', 'youtube_id', 'publishedAt', 'published_at_source'],
+    });
+
+    const input = rows.map((r) => {
+      const isTarget = r.youtube_id === youtubeId;
+      return {
+        id: r.id,
+        isTarget,
+        oldIso: r.publishedAt,
+        source: isTarget ? PUBLISHED_AT_SOURCE.EXACT : r.published_at_source,
+        ms: isTarget ? newMs : (r.publishedAt ? Date.parse(r.publishedAt) : null),
+      };
+    });
+
+    const newDates = this.computeReanchoredDates(input, Date.now());
+
+    const changes = [];
+    for (let i = 0; i < input.length; i++) {
+      const row = input[i];
+      if (row.isTarget) {
+        changes.push({ id: row.id, fields: { publishedAt: exactIso, published_at_source: PUBLISHED_AT_SOURCE.EXACT } });
+        continue;
+      }
+      const computedIso = new Date(newDates[i]).toISOString();
+      if (computedIso !== row.oldIso) {
+        // Source is preserved; only the date value shifts to hold ordering.
+        changes.push({ id: row.id, fields: { publishedAt: computedIso } });
+      }
+    }
+
+    if (changes.length === 0) return;
+
+    await sequelize.transaction(async (t) => {
+      for (const change of changes) {
+        await ChannelVideo.update(change.fields, { where: { id: change.id }, transaction: t });
+      }
+    });
+
+    logger.debug(
+      { channelId, mediaType, youtubeId, rowsUpdated: changes.length },
+      'Re-anchored channelvideos order after exact date'
+    );
+  }
+
+  /**
+   * Resolve every (channel, media_type) a video appears under and re-anchor each.
+   * Convenience for callers that only know the youtube_id (e.g. modal metadata).
+   * @param {string} youtubeId
+   * @param {string} exactIso
+   */
+  async applyExactDateForVideo(youtubeId, exactIso) {
+    const rows = await ChannelVideo.findAll({
+      where: { youtube_id: youtubeId },
+      attributes: ['channel_id', 'media_type'],
+    });
+    const groups = new Map();
+    for (const r of rows) {
+      groups.set(`${r.channel_id}::${r.media_type}`, {
+        channelId: r.channel_id,
+        mediaType: r.media_type,
+      });
+    }
+    for (const g of groups.values()) {
+      await this.applyExactDateForGroup({
+        channelId: g.channelId,
+        mediaType: g.mediaType,
+        youtubeId,
+        exactIso,
+      });
+    }
+  }
+
+  /**
+   * Cheap pre-check: would moving this row to newIso violate descending order?
+   * publishedAt is stored as same-format UTC ISO, so string comparison is
+   * chronological. Conservatively returns true when the row is in a tie cluster,
+   * since tie sub-order is otherwise ambiguous.
+   * @private
+   */
+  async _orderWouldBreak(channelId, mediaType, youtubeId, oldIso, newIso) {
+    if (!oldIso) return true;
+    if (oldIso === newIso) return false;
+
+    const base = {
+      channel_id: channelId,
+      media_type: mediaType,
+      youtube_id: { [Op.ne]: youtubeId },
+    };
+
+    const tie = await ChannelVideo.count({ where: { ...base, publishedAt: oldIso } });
+    if (tie > 0) return true;
+
+    const between = newIso > oldIso
+      ? { [Op.gt]: oldIso, [Op.lt]: newIso }
+      : { [Op.lt]: oldIso, [Op.gt]: newIso };
+    const count = await ChannelVideo.count({ where: { ...base, publishedAt: between } });
+    return count > 0;
+  }
+}
+
+module.exports = new ChannelVideoReanchorModule();

--- a/server/modules/constants/publishedAtSource.js
+++ b/server/modules/constants/publishedAtSource.js
@@ -1,0 +1,11 @@
+// Provenance of a channelvideo's publishedAt. Persisted to the
+// channelvideos.published_at_source column; mirrored by the frontend union in
+// client/src/types/ChannelVideo.ts. NULL is a valid legacy value (treated like
+// 'approximate') and is intentionally not a member here.
+const PUBLISHED_AT_SOURCE = Object.freeze({
+  EXACT: 'exact', // from a download's .info.json (authoritative)
+  APPROXIMATE: 'approximate', // yt-dlp flat-playlist date
+  ESTIMATED: 'estimated', // ordering-only placeholder, never displayed
+});
+
+module.exports = { PUBLISHED_AT_SOURCE };

--- a/server/modules/jobModule.js
+++ b/server/modules/jobModule.js
@@ -7,6 +7,8 @@ const Video = require('../models/video');
 const JobVideo = require('../models/jobvideo');
 const JobVideoDownload = require('../models/jobvideodownload');
 const ChannelVideo = require('../models/channelvideo');
+const channelVideoReanchor = require('./channelVideoReanchor');
+const { PUBLISHED_AT_SOURCE } = require('./constants/publishedAtSource');
 const cron = require('node-cron');
 const MessageEmitter = require('./messageEmitter.js'); // import the helper function
 const configModule = require('./configModule');
@@ -729,6 +731,7 @@ class JobModule {
       thumbnail,
       duration,
       publishedAt,
+      published_at_source: publishedAt ? PUBLISHED_AT_SOURCE.EXACT : null,
       availability,
       media_type,
       ignored: false,
@@ -757,6 +760,25 @@ class JobModule {
       if (age_limit != null) updates.age_limit = age_limit;
       if (normalized_rating != null) updates.normalized_rating = normalized_rating;
       await record.update(updates);
+
+      // The .info.json upload_date is authoritative; it replaces estimated and
+      // approximate dates from flat-playlist fetches. Delegated to the re-anchor
+      // module (which owns the publishedAt write) so the row's existing position
+      // is read first and neighbouring synthetic dates are shifted to keep the
+      // channel in YouTube order. On create the date is set via defaults above;
+      // a brand-new row has no prior position to preserve, so no re-anchor.
+      if (publishedAt) {
+        try {
+          await channelVideoReanchor.applyExactDateForGroup({
+            channelId: channel_id,
+            mediaType: media_type,
+            youtubeId: youtube_id,
+            exactIso: publishedAt,
+          });
+        } catch (reanchorErr) {
+          logger.error({ err: reanchorErr, youtube_id }, 'Error re-anchoring channel video order after download');
+        }
+      }
     }
   }
 

--- a/server/modules/videoMetadataModule.js
+++ b/server/modules/videoMetadataModule.js
@@ -6,6 +6,7 @@ const ytDlpRunner = require('./ytDlpRunner');
 const logger = require('../logger');
 const youtubeApi = require('./youtubeApi');
 const ChannelVideo = require('../models/channelvideo');
+const channelVideoReanchor = require('./channelVideoReanchor');
 
 const NULL_METADATA = {
   description: null,
@@ -33,6 +34,19 @@ const NULL_METADATA = {
 };
 
 const YTDLP_FETCH_TIMEOUT_MS = 60000;
+
+// Convert yt-dlp upload_date (YYYYMMDD) to the ISO string format used by
+// channelvideos.publishedAt. Returns null if unparseable.
+function uploadDateToIso(uploadDate) {
+  if (!uploadDate || typeof uploadDate !== 'string' || uploadDate.length < 8) {
+    return null;
+  }
+  const year = uploadDate.substring(0, 4);
+  const month = uploadDate.substring(4, 6);
+  const day = uploadDate.substring(6, 8);
+  const d = new Date(`${year}-${month}-${day}T00:00:00Z`);
+  return isNaN(d.getTime()) ? null : d.toISOString();
+}
 
 const SUPPORTED_HEIGHTS = [360, 480, 720, 1080, 1440, 2160];
 
@@ -180,6 +194,20 @@ class VideoMetadataModule {
           );
         } catch (backfillErr) {
           logger.warn({ err: backfillErr, youtubeId }, 'Failed to backfill ChannelVideo.availability');
+        }
+      }
+
+      // Backfill ChannelVideo.publishedAt from the authoritative .info.json
+      // upload_date, replacing estimated/approximate dates from flat-playlist
+      // channel fetches. Delegated to the re-anchor module so neighbouring
+      // synthetic dates are shifted to keep the channel in YouTube order when
+      // this exact date would otherwise sort the video out of place.
+      const uploadDateIso = uploadDateToIso(rawData.upload_date);
+      if (uploadDateIso) {
+        try {
+          await channelVideoReanchor.applyExactDateForVideo(youtubeId, uploadDateIso);
+        } catch (backfillErr) {
+          logger.warn({ err: backfillErr, youtubeId }, 'Failed to backfill ChannelVideo.publishedAt');
         }
       }
 


### PR DESCRIPTION
Channel video lists could show wrong or out-of-order published dates, because YouTube often returns listings with no real upload date and the old fallback invented dates to fill the gaps.

Videos now track where their date came from. Real dates from a download show as-is, approximate dates from YouTube are marked with a "~", and ordering-only placeholders show "Pending" instead of a made-up date. A migration backfills accurate dates for already-downloaded videos.