### PR TITLE
fix: playlist channel backfill and logging

### DIFF
--- a/server/modules/__tests__/playlistModule.test.js
+++ b/server/modules/__tests__/playlistModule.test.js
@@ -5,6 +5,7 @@ jest.mock('../../logger', () => ({
 jest.mock('../../models', () => ({
   Playlist: { findOne: jest.fn(), create: jest.fn(), update: jest.fn(), findAll: jest.fn() },
   PlaylistVideo: { findAll: jest.fn(), bulkCreate: jest.fn(), update: jest.fn(), destroy: jest.fn() },
+  Channel: { findAll: jest.fn() },
 }));
 jest.mock('../channelModule', () => ({
   upsertChannel: jest.fn(),
@@ -24,6 +25,7 @@ describe('playlistModule', () => {
   let playlistModule;
   let Playlist;
   let PlaylistVideo;
+  let Channel;
   let channelModule;
   let downloadModule;
   let childProcess;
@@ -39,7 +41,7 @@ describe('playlistModule', () => {
     childProcess.spawn = jest.fn();
     // Now require the module — its top-level destructure picks up the mock.
     playlistModule = require('../playlistModule');
-    ({ Playlist, PlaylistVideo } = require('../../models'));
+    ({ Playlist, PlaylistVideo, Channel } = require('../../models'));
     channelModule = require('../channelModule');
     downloadModule = require('../downloadModule');
     youtubeApi = require('../youtubeApi');
@@ -636,6 +638,142 @@ describe('playlistModule', () => {
         null,
         expect.objectContaining({ sub_folder: 'Learning' })
       );
+    });
+  });
+
+  describe('backfillDownloadedVideoChannels', () => {
+    test('backfills channel_id on playlist rows from the downloaded video metadata', async () => {
+      PlaylistVideo.findAll.mockResolvedValue([
+        { playlist_id: 'PL1', youtube_id: 'v1', channel_id: null },
+      ]);
+      Channel.findAll.mockResolvedValue([{ channel_id: 'UCreal' }]);
+      Playlist.findAll.mockResolvedValue([]);
+
+      await playlistModule.backfillDownloadedVideoChannels([
+        { youtubeId: 'v1', channel_id: 'UCreal', youTubeChannelName: 'Real Ch' },
+      ]);
+
+      expect(PlaylistVideo.update).toHaveBeenCalledWith(
+        { channel_id: 'UCreal' },
+        { where: { youtube_id: 'v1', channel_id: null } }
+      );
+    });
+
+    test('auto-creates a hidden channel seeded from playlist settings when the channel is untracked', async () => {
+      PlaylistVideo.findAll.mockResolvedValue([
+        { playlist_id: 'PL1', youtube_id: 'v1', channel_id: null },
+      ]);
+      Channel.findAll.mockResolvedValue([]);
+      Playlist.findAll.mockResolvedValue([
+        { playlist_id: 'PL1', default_sub_folder: 'Library1', video_quality: '1080' },
+      ]);
+      channelModule.upsertChannel.mockResolvedValue({ id: 5, channel_id: 'UCnew' });
+
+      await playlistModule.backfillDownloadedVideoChannels([
+        { youtubeId: 'v1', channel_id: 'UCnew', youTubeChannelName: 'Marvelous Videos' },
+      ]);
+
+      expect(channelModule.upsertChannel).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'UCnew', uploader: 'Marvelous Videos' }),
+        false,
+        null,
+        expect.objectContaining({ sub_folder: 'Library1', video_quality: '1080' })
+      );
+      expect(PlaylistVideo.update).toHaveBeenCalledWith(
+        { channel_id: 'UCnew' },
+        { where: { youtube_id: 'v1', channel_id: null } }
+      );
+    });
+
+    test('does not create a channel that is already tracked', async () => {
+      PlaylistVideo.findAll.mockResolvedValue([
+        { playlist_id: 'PL1', youtube_id: 'v1', channel_id: null },
+      ]);
+      Channel.findAll.mockResolvedValue([{ channel_id: 'UCtracked' }]);
+
+      await playlistModule.backfillDownloadedVideoChannels([
+        { youtubeId: 'v1', channel_id: 'UCtracked', youTubeChannelName: 'Tracked Ch' },
+      ]);
+
+      expect(channelModule.upsertChannel).not.toHaveBeenCalled();
+    });
+
+    test('creates an untracked channel only once when it owns several downloaded videos', async () => {
+      PlaylistVideo.findAll.mockResolvedValue([
+        { playlist_id: 'PL1', youtube_id: 'v1', channel_id: null },
+        { playlist_id: 'PL1', youtube_id: 'v2', channel_id: null },
+      ]);
+      Channel.findAll.mockResolvedValue([]);
+      Playlist.findAll.mockResolvedValue([
+        { playlist_id: 'PL1', default_sub_folder: 'Library1', video_quality: '1080' },
+      ]);
+      channelModule.upsertChannel.mockResolvedValue({ id: 5, channel_id: 'UCnew' });
+
+      await playlistModule.backfillDownloadedVideoChannels([
+        { youtubeId: 'v1', channel_id: 'UCnew', youTubeChannelName: 'Marvelous Videos' },
+        { youtubeId: 'v2', channel_id: 'UCnew', youTubeChannelName: 'Marvelous Videos' },
+      ]);
+
+      expect(channelModule.upsertChannel).toHaveBeenCalledTimes(1);
+    });
+
+    test('skips downloaded videos that are not part of any playlist', async () => {
+      PlaylistVideo.findAll.mockResolvedValue([]);
+
+      await playlistModule.backfillDownloadedVideoChannels([
+        { youtubeId: 'v1', channel_id: 'UCnew', youTubeChannelName: 'X' },
+      ]);
+
+      expect(PlaylistVideo.update).not.toHaveBeenCalled();
+      expect(channelModule.upsertChannel).not.toHaveBeenCalled();
+    });
+
+    test('ignores downloaded videos that have no channel_id', async () => {
+      await playlistModule.backfillDownloadedVideoChannels([
+        { youtubeId: 'v1', channel_id: null, youTubeChannelName: 'X' },
+      ]);
+
+      expect(PlaylistVideo.findAll).not.toHaveBeenCalled();
+      expect(channelModule.upsertChannel).not.toHaveBeenCalled();
+    });
+
+    test('does nothing for empty input', async () => {
+      await playlistModule.backfillDownloadedVideoChannels([]);
+
+      expect(PlaylistVideo.findAll).not.toHaveBeenCalled();
+    });
+
+    test('does not rewrite channel_id that is already correct', async () => {
+      PlaylistVideo.findAll.mockResolvedValue([
+        { playlist_id: 'PL1', youtube_id: 'v1', channel_id: 'UCreal' },
+      ]);
+      Channel.findAll.mockResolvedValue([{ channel_id: 'UCreal' }]);
+
+      await playlistModule.backfillDownloadedVideoChannels([
+        { youtubeId: 'v1', channel_id: 'UCreal', youTubeChannelName: 'Real Ch' },
+      ]);
+
+      expect(PlaylistVideo.update).not.toHaveBeenCalled();
+    });
+
+    test('does not overwrite or create a channel when channel_id is already set, even if the downloaded id differs', async () => {
+      // Playlist sync captured the owner channel; the .info.json reports the
+      // auto-generated upload channel (VEVO/Topic). The stored owner id wins, so
+      // no overwrite and no new channel.
+      PlaylistVideo.findAll.mockResolvedValue([
+        { playlist_id: 'PL1', youtube_id: 'v1', channel_id: 'UCowner' },
+      ]);
+      Channel.findAll.mockResolvedValue([]);
+      Playlist.findAll.mockResolvedValue([
+        { playlist_id: 'PL1', default_sub_folder: 'Library1', video_quality: '1080' },
+      ]);
+
+      await playlistModule.backfillDownloadedVideoChannels([
+        { youtubeId: 'v1', channel_id: 'UCupload', youTubeChannelName: 'Artist - Topic' },
+      ]);
+
+      expect(PlaylistVideo.update).not.toHaveBeenCalled();
+      expect(channelModule.upsertChannel).not.toHaveBeenCalled();
     });
   });
 

--- a/server/modules/download/__tests__/downloadCompletionEffects.test.js
+++ b/server/modules/download/__tests__/downloadCompletionEffects.test.js
@@ -50,10 +50,15 @@ jest.mock('../../downloadModule', () => ({
   afterDownloadHook: jest.fn().mockResolvedValue(),
 }));
 
+jest.mock('../../playlistModule', () => ({
+  backfillDownloadedVideoChannels: jest.fn().mockResolvedValue(),
+}));
+
 const plexModule = require('../../plexModule');
 const jobModule = require('../../jobModule');
 const channelModule = require('../../channelModule');
 const downloadModule = require('../../downloadModule');
+const playlistModule = require('../../playlistModule');
 const { JobVideoDownload } = require('../../../models');
 const Channel = require('../../../models/channel');
 const logger = require('../../../logger');
@@ -204,6 +209,44 @@ describe('downloadCompletionEffects', () => {
     await flushPromises();
 
     expect(downloadModule.afterDownloadHook).toHaveBeenCalledWith(['vid1', 'vid2']);
+  });
+
+  it('backfills playlist video channels from the downloaded video metadata', async () => {
+    const videoData = [
+      { youtubeId: 'vid1', channel_id: 'UC1' },
+      { youtubeId: 'vid2', channel_id: 'UC2' },
+    ];
+
+    await runCompletionSideEffects({
+      jobId: 'job-1',
+      videoData,
+      skipJobTransition: true,
+      tempChannelsFile: null,
+      onTempChannelsFileCleaned: jest.fn(),
+    });
+    await flushPromises();
+
+    expect(playlistModule.backfillDownloadedVideoChannels).toHaveBeenCalledWith(videoData);
+  });
+
+  it('does not fail the job when playlist channel backfill throws', async () => {
+    playlistModule.backfillDownloadedVideoChannels.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(
+      runCompletionSideEffects({
+        jobId: 'job-1',
+        videoData: [{ youtubeId: 'vid1', channel_id: 'UC1' }],
+        skipJobTransition: true,
+        tempChannelsFile: null,
+        onTempChannelsFileCleaned: jest.fn(),
+      })
+    ).resolves.toBeUndefined();
+    await flushPromises();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      'Failed to backfill playlist video channels'
+    );
   });
 
   describe('job transition', () => {

--- a/server/modules/download/downloadCompletionEffects.js
+++ b/server/modules/download/downloadCompletionEffects.js
@@ -69,6 +69,16 @@ async function runCompletionSideEffects({
     }
   }
 
+  // Fill in playlist_video.channel_id and auto-create source channels from the
+  // channel_ids learned during this download (see backfillDownloadedVideoChannels).
+  if (videoData && videoData.length > 0) {
+    try {
+      await require('../playlistModule').backfillDownloadedVideoChannels(videoData);
+    } catch (err) {
+      logger.error({ err }, 'Failed to backfill playlist video channels');
+    }
+  }
+
   // Trigger playlist M3U regeneration and media-server sync for any playlists
   // that contain videos from this download batch.
   if (videoData && videoData.length > 0) {

--- a/server/modules/mediaServers/__tests__/mediaServerSync.test.js
+++ b/server/modules/mediaServers/__tests__/mediaServerSync.test.js
@@ -300,6 +300,42 @@ describe('mediaServerSync', () => {
     expect(jellyfinAdapter.createPlaylist).toHaveBeenCalled();
   });
 
+  test('aborts with one friendly warning and a concise last_error when the server is unreachable', async () => {
+    const { MediaServerUnavailableError } = require('../adapters/baseAdapter');
+    const logger = require('../../../logger');
+    Playlist.findByPk.mockResolvedValue({
+      id: 1, playlist_id: 'PL1', title: 'My PL',
+      sync_to_plex: false, sync_to_jellyfin: true, sync_to_emby: false,
+      public_on_servers: false,
+    });
+    PlaylistVideo.findAll.mockResolvedValue([{ youtube_id: 'v1', position: 1, ignored: false }]);
+    Video.findAll.mockResolvedValue([{ youtubeId: 'v1', filePath: '/youtube/A/v1.mp4' }]);
+    PlaylistSyncState.findOne.mockResolvedValue(null);
+    PlaylistSyncState.create.mockResolvedValue({});
+
+    const resolveBatch = jest.fn().mockRejectedValue(
+      new MediaServerUnavailableError({ status: 503, message: 'Request failed with status code 503' })
+    );
+    const jellyfinAdapter = makeAdapter('JellyfinAdapter', {
+      resolveItemIdsByFilepaths: resolveBatch,
+      createPlaylist: jest.fn(),
+    });
+    serverRegistry.getEnabledAdapters.mockReturnValue([jellyfinAdapter]);
+
+    await expect(mediaServerSync.syncPlaylist(1)).resolves.toBeUndefined();
+
+    // Aborted on the first resolve attempt: no backoff retry rounds.
+    expect(resolveBatch).toHaveBeenCalledTimes(1);
+    expect(jellyfinAdapter.createPlaylist).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ serverType: 'jellyfin' }),
+      expect.stringContaining('Unable to sync playlist "My PL" to Jellyfin: server not reachable or not responding')
+    );
+    expect(PlaylistSyncState.create).toHaveBeenCalledWith(
+      expect.objectContaining({ last_error: 'Jellyfin not reachable or not responding' })
+    );
+  });
+
   test('recovers from prior-failure state row (last_error set, no server_playlist_id) by updating in place', async () => {
     Playlist.findByPk.mockResolvedValue({
       id: 1, playlist_id: 'PL1', title: 'PL',

--- a/server/modules/mediaServers/adapters/__tests__/baseAdapter.test.js
+++ b/server/modules/mediaServers/adapters/__tests__/baseAdapter.test.js
@@ -1,5 +1,12 @@
 const BaseAdapter = require('../baseAdapter');
-const { extractBasename, pathSegments, trailingSegmentMatch } = require('../baseAdapter');
+const {
+  extractBasename,
+  pathSegments,
+  trailingSegmentMatch,
+  isServerUnavailableError,
+  describeHttpError,
+  MediaServerUnavailableError,
+} = require('../baseAdapter');
 
 describe('BaseAdapter.resolveItemIdsByFilepaths (default batch)', () => {
   class PerFileAdapter extends BaseAdapter {
@@ -77,6 +84,55 @@ describe('baseAdapter helpers', () => {
     test('handles empty inputs', () => {
       expect(trailingSegmentMatch([], ['a'])).toBe(0);
       expect(trailingSegmentMatch(['a'], [])).toBe(0);
+    });
+  });
+
+  describe('isServerUnavailableError', () => {
+    test('true for an axios error with no response (connection refused / timeout)', () => {
+      expect(isServerUnavailableError({ isAxiosError: true, code: 'ECONNREFUSED' })).toBe(true);
+    });
+
+    test('true for an axios 5xx (e.g. Jellyfin "loading" 503)', () => {
+      expect(isServerUnavailableError({ isAxiosError: true, response: { status: 503 } })).toBe(true);
+    });
+
+    test('false for an axios 4xx', () => {
+      expect(isServerUnavailableError({ isAxiosError: true, response: { status: 404 } })).toBe(false);
+    });
+
+    test('false for a non-axios error', () => {
+      expect(isServerUnavailableError(new Error('boom'))).toBe(false);
+      expect(isServerUnavailableError(null)).toBe(false);
+    });
+  });
+
+  describe('describeHttpError', () => {
+    test('keeps status/code/message and drops config/request/response (no token leak)', () => {
+      const err = {
+        isAxiosError: true,
+        code: 'ERR_BAD_RESPONSE',
+        message: 'Request failed with status code 503',
+        response: { status: 503, data: 'loading' },
+        config: { headers: { 'X-Emby-Token': 'SECRET' } },
+        request: { _header: 'GET /Items ... X-Emby-Token: SECRET' },
+      };
+      const out = describeHttpError(err);
+      expect(out).toEqual({ status: 503, code: 'ERR_BAD_RESPONSE', message: 'Request failed with status code 503' });
+      expect(JSON.stringify(out)).not.toContain('SECRET');
+    });
+
+    test('handles a falsy error', () => {
+      expect(describeHttpError(null)).toEqual({ message: 'unknown error' });
+    });
+  });
+
+  describe('MediaServerUnavailableError', () => {
+    test('carries status and code and is an Error', () => {
+      const e = new MediaServerUnavailableError({ status: 503, code: 'X', message: 'm' });
+      expect(e).toBeInstanceOf(Error);
+      expect(e.status).toBe(503);
+      expect(e.code).toBe('X');
+      expect(e.message).toBe('m');
     });
   });
 });

--- a/server/modules/mediaServers/adapters/__tests__/embyAdapter.test.js
+++ b/server/modules/mediaServers/adapters/__tests__/embyAdapter.test.js
@@ -145,4 +145,36 @@ describe('EmbyAdapter', () => {
       expect.objectContaining({ timeout: REQUEST_TIMEOUT_MS })
     );
   });
+
+  test('resolveItemIdByFilepath throws MediaServerUnavailableError when the server is unreachable', async () => {
+    const { MediaServerUnavailableError } = require('../baseAdapter');
+    axios.get.mockRejectedValueOnce({ isAxiosError: true, code: 'ETIMEDOUT', message: 'timeout of 30000ms exceeded' });
+    const adapter = new EmbyAdapter(cfg);
+    await expect(adapter.resolveItemIdByFilepath('/x/v.mp4')).rejects.toBeInstanceOf(MediaServerUnavailableError);
+  });
+
+  test('resolveItemIdByFilepath throws MediaServerUnavailableError when the server returns 5xx', async () => {
+    const { MediaServerUnavailableError } = require('../baseAdapter');
+    axios.get.mockRejectedValueOnce({ isAxiosError: true, response: { status: 500 }, message: 'Request failed with status code 500' });
+    const adapter = new EmbyAdapter(cfg);
+    await expect(adapter.resolveItemIdByFilepath('/x/v.mp4')).rejects.toBeInstanceOf(MediaServerUnavailableError);
+  });
+
+  test('resolveItemIdByFilepath returns null and logs without the API token on a non-unavailable error', async () => {
+    const logger = require('../../../../logger');
+    const adapter = new EmbyAdapter({ ...cfg, embyApiKey: 'SUPER_SECRET_TOKEN' });
+    axios.get.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { status: 404 },
+      message: 'Request failed with status code 404',
+      config: { headers: { 'X-Emby-Token': 'SUPER_SECRET_TOKEN' } },
+    });
+    const id = await adapter.resolveItemIdByFilepath('/x/v.mp4');
+    expect(id).toBeNull();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [data] = logger.warn.mock.calls[0];
+    expect(data).toMatchObject({ status: 404, filepath: '/x/v.mp4' });
+    expect(data).not.toHaveProperty('config');
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain('SUPER_SECRET_TOKEN');
+  });
 });

--- a/server/modules/mediaServers/adapters/__tests__/jellyfinAdapter.test.js
+++ b/server/modules/mediaServers/adapters/__tests__/jellyfinAdapter.test.js
@@ -115,4 +115,36 @@ describe('JellyfinAdapter', () => {
     expect(axios.post).toHaveBeenCalled();
     expect(result).toEqual({ id: 'new-pl-id' });
   });
+
+  test('resolveItemIdByFilepath throws MediaServerUnavailableError when the server is unreachable', async () => {
+    const { MediaServerUnavailableError } = require('../baseAdapter');
+    axios.get.mockRejectedValueOnce({ isAxiosError: true, code: 'ECONNREFUSED', message: 'connect ECONNREFUSED 192.168.1.174:8096' });
+    const adapter = new JellyfinAdapter(cfg);
+    await expect(adapter.resolveItemIdByFilepath('/x/v.mp4')).rejects.toBeInstanceOf(MediaServerUnavailableError);
+  });
+
+  test('resolveItemIdByFilepath throws MediaServerUnavailableError when the server returns 5xx (loading)', async () => {
+    const { MediaServerUnavailableError } = require('../baseAdapter');
+    axios.get.mockRejectedValueOnce({ isAxiosError: true, response: { status: 503 }, message: 'Request failed with status code 503' });
+    const adapter = new JellyfinAdapter(cfg);
+    await expect(adapter.resolveItemIdByFilepath('/x/v.mp4')).rejects.toBeInstanceOf(MediaServerUnavailableError);
+  });
+
+  test('resolveItemIdByFilepath returns null and logs without the API token on a non-unavailable error', async () => {
+    const logger = require('../../../../logger');
+    const adapter = new JellyfinAdapter({ ...cfg, jellyfinApiKey: 'SUPER_SECRET_TOKEN' });
+    axios.get.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { status: 404 },
+      message: 'Request failed with status code 404',
+      config: { headers: { 'X-Emby-Token': 'SUPER_SECRET_TOKEN' } },
+    });
+    const id = await adapter.resolveItemIdByFilepath('/x/v.mp4');
+    expect(id).toBeNull();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [data] = logger.warn.mock.calls[0];
+    expect(data).toMatchObject({ status: 404, filepath: '/x/v.mp4' });
+    expect(data).not.toHaveProperty('config');
+    expect(JSON.stringify(logger.warn.mock.calls)).not.toContain('SUPER_SECRET_TOKEN');
+  });
 });

--- a/server/modules/mediaServers/adapters/__tests__/plexAdapter.test.js
+++ b/server/modules/mediaServers/adapters/__tests__/plexAdapter.test.js
@@ -266,6 +266,22 @@ describe('PlexAdapter', () => {
       expect(resolved.size).toBe(0);
       expect(axios.get).not.toHaveBeenCalled();
     });
+
+    test('throws MediaServerUnavailableError when a section query reports the server unreachable', async () => {
+      const { MediaServerUnavailableError } = require('../baseAdapter');
+      mockSections(ONE_SECTION);
+      axios.get.mockRejectedValueOnce({ isAxiosError: true, code: 'ECONNREFUSED', message: 'connect ECONNREFUSED' });
+      const adapter = new PlexAdapter(cfg);
+      await expect(adapter.resolveItemIdsByFilepaths(['/data/x.mp4'])).rejects.toBeInstanceOf(MediaServerUnavailableError);
+    });
+
+    test('throws MediaServerUnavailableError on a 5xx section response', async () => {
+      const { MediaServerUnavailableError } = require('../baseAdapter');
+      mockSections(ONE_SECTION);
+      axios.get.mockRejectedValueOnce({ isAxiosError: true, response: { status: 503 }, message: 'Request failed with status code 503' });
+      const adapter = new PlexAdapter(cfg);
+      await expect(adapter.resolveItemIdsByFilepaths(['/data/x.mp4'])).rejects.toBeInstanceOf(MediaServerUnavailableError);
+    });
   });
 
   describe('plexPlaylistToken override', () => {

--- a/server/modules/mediaServers/adapters/baseAdapter.js
+++ b/server/modules/mediaServers/adapters/baseAdapter.js
@@ -74,8 +74,45 @@ function trailingSegmentMatch(aSegments, bSegments) {
 // on large libraries are the slowest legitimate call, hence 30s.
 const REQUEST_TIMEOUT_MS = 30000;
 
+// Raised by an adapter when a media server can't be reached or isn't
+// responding (connection refused, timeout, DNS failure, or a 5xx such as
+// Jellyfin's "loading" 503). Lets the sync abort its resolve/backoff loop
+// instead of retrying an unreachable server through every round.
+class MediaServerUnavailableError extends Error {
+  constructor(info = {}) {
+    super(info.message || 'media server unavailable');
+    this.name = 'MediaServerUnavailableError';
+    this.status = info.status || null;
+    this.code = info.code || null;
+  }
+}
+
+// True when an axios error means the server itself is unreachable or not
+// responding, rather than a normal "queried fine, no such item" result. No
+// response at all (ECONNREFUSED / ETIMEDOUT / ENOTFOUND / timeout) or any 5xx
+// counts; a plain Error (e.g. a programming bug) does not.
+function isServerUnavailableError(err) {
+  if (!err || !err.isAxiosError) return false;
+  return !err.response || err.response.status >= 500;
+}
+
+// Compact, log-safe view of an axios error. Deliberately omits config / request
+// / response, which carry the request headers (and therefore the API token)
+// that the default error serializer would otherwise dump into the logs.
+function describeHttpError(err) {
+  if (!err) return { message: 'unknown error' };
+  return {
+    status: err.response?.status || null,
+    code: err.code || null,
+    message: err.message || String(err),
+  };
+}
+
 module.exports = BaseAdapter;
 module.exports.extractBasename = extractBasename;
 module.exports.pathSegments = pathSegments;
 module.exports.trailingSegmentMatch = trailingSegmentMatch;
 module.exports.REQUEST_TIMEOUT_MS = REQUEST_TIMEOUT_MS;
+module.exports.MediaServerUnavailableError = MediaServerUnavailableError;
+module.exports.isServerUnavailableError = isServerUnavailableError;
+module.exports.describeHttpError = describeHttpError;

--- a/server/modules/mediaServers/adapters/embyAdapter.js
+++ b/server/modules/mediaServers/adapters/embyAdapter.js
@@ -1,6 +1,12 @@
 const axios = require('axios');
 const BaseAdapter = require('./baseAdapter');
-const { extractBasename, REQUEST_TIMEOUT_MS } = require('./baseAdapter');
+const {
+  extractBasename,
+  REQUEST_TIMEOUT_MS,
+  isServerUnavailableError,
+  describeHttpError,
+  MediaServerUnavailableError,
+} = require('./baseAdapter');
 const logger = require('../../../logger');
 
 class EmbyAdapter extends BaseAdapter {
@@ -36,7 +42,7 @@ class EmbyAdapter extends BaseAdapter {
     try {
       await axios.post(`${this.url}/Library/Refresh`, null, { headers: this._headers(), timeout: REQUEST_TIMEOUT_MS });
     } catch (err) {
-      logger.error({ err }, 'emby triggerLibraryScan failed');
+      logger.warn({ ...describeHttpError(err) }, 'emby: library refresh request failed');
     }
   }
 
@@ -55,7 +61,8 @@ class EmbyAdapter extends BaseAdapter {
       const match = items.find((i) => i.Path && extractBasename(i.Path) === target);
       return match ? match.Id : null;
     } catch (err) {
-      logger.error({ err, filepath }, 'emby resolveItemIdByFilepath failed');
+      if (isServerUnavailableError(err)) throw new MediaServerUnavailableError(describeHttpError(err));
+      logger.warn({ ...describeHttpError(err), filepath }, 'emby: could not look up library item by file path');
       return null;
     }
   }
@@ -68,7 +75,7 @@ class EmbyAdapter extends BaseAdapter {
       const found = items.find((i) => i.Name === name);
       return found ? { id: found.Id, itemIds: [] } : null;
     } catch (err) {
-      logger.error({ err }, 'emby getPlaylistByName failed');
+      logger.warn({ ...describeHttpError(err) }, 'emby: could not list playlists');
       return null;
     }
   }

--- a/server/modules/mediaServers/adapters/jellyfinAdapter.js
+++ b/server/modules/mediaServers/adapters/jellyfinAdapter.js
@@ -1,6 +1,12 @@
 const axios = require('axios');
 const BaseAdapter = require('./baseAdapter');
-const { extractBasename, REQUEST_TIMEOUT_MS } = require('./baseAdapter');
+const {
+  extractBasename,
+  REQUEST_TIMEOUT_MS,
+  isServerUnavailableError,
+  describeHttpError,
+  MediaServerUnavailableError,
+} = require('./baseAdapter');
 const logger = require('../../../logger');
 
 class JellyfinAdapter extends BaseAdapter {
@@ -36,7 +42,7 @@ class JellyfinAdapter extends BaseAdapter {
     try {
       await axios.post(`${this.url}/Library/Refresh`, null, { headers: this._headers(), timeout: REQUEST_TIMEOUT_MS });
     } catch (err) {
-      logger.error({ err }, 'jellyfin triggerLibraryScan failed');
+      logger.warn({ ...describeHttpError(err) }, 'jellyfin: library refresh request failed');
     }
   }
 
@@ -56,7 +62,8 @@ class JellyfinAdapter extends BaseAdapter {
       const match = items.find((i) => i.Path && extractBasename(i.Path) === target);
       return match ? match.Id : null;
     } catch (err) {
-      logger.error({ err, filepath }, 'jellyfin resolveItemIdByFilepath failed');
+      if (isServerUnavailableError(err)) throw new MediaServerUnavailableError(describeHttpError(err));
+      logger.warn({ ...describeHttpError(err), filepath }, 'jellyfin: could not look up library item by file path');
       return null;
     }
   }
@@ -69,7 +76,7 @@ class JellyfinAdapter extends BaseAdapter {
       const found = items.find((i) => i.Name === name);
       return found ? { id: found.Id, itemIds: [] } : null;
     } catch (err) {
-      logger.error({ err }, 'jellyfin getPlaylistByName failed');
+      logger.warn({ ...describeHttpError(err) }, 'jellyfin: could not list playlists');
       return null;
     }
   }

--- a/server/modules/mediaServers/adapters/plexAdapter.js
+++ b/server/modules/mediaServers/adapters/plexAdapter.js
@@ -1,6 +1,14 @@
 const axios = require('axios');
 const BaseAdapter = require('./baseAdapter');
-const { extractBasename, pathSegments, trailingSegmentMatch, REQUEST_TIMEOUT_MS } = require('./baseAdapter');
+const {
+  extractBasename,
+  pathSegments,
+  trailingSegmentMatch,
+  REQUEST_TIMEOUT_MS,
+  isServerUnavailableError,
+  describeHttpError,
+  MediaServerUnavailableError,
+} = require('./baseAdapter');
 const logger = require('../../../logger');
 const plexModule = require('../../plexModule');
 
@@ -62,7 +70,7 @@ class PlexAdapter extends BaseAdapter {
         if (dir.type === 'movie' || dir.type === 'show') add(dir.key);
       }
     } catch (err) {
-      logger.warn({ err }, 'plex: could not enumerate library sections; searching configured library only');
+      logger.warn({ ...describeHttpError(err) }, 'plex: could not enumerate library sections; searching configured library only');
     }
     this._videoSectionIds = ids;
     return ids;
@@ -138,8 +146,9 @@ class PlexAdapter extends BaseAdapter {
           }
         }
       } catch (err) {
+        if (isServerUnavailableError(err)) throw new MediaServerUnavailableError(describeHttpError(err));
         // A single section failing shouldn't abort the search of the others.
-        logger.error({ err, libraryId }, 'plex section listing failed during filepath resolution');
+        logger.warn({ ...describeHttpError(err), libraryId }, 'plex: could not list library section during item lookup');
       }
     }
 
@@ -171,7 +180,7 @@ class PlexAdapter extends BaseAdapter {
       const found = (await this._listVideoPlaylists()).find((p) => p.title === name);
       return found ? { id: found.ratingKey, itemIds: [] } : null;
     } catch (err) {
-      logger.error({ err }, 'plex getPlaylistByName failed');
+      logger.warn({ ...describeHttpError(err) }, 'plex: could not list playlists');
       return null;
     }
   }

--- a/server/modules/mediaServers/mediaServerSync.js
+++ b/server/modules/mediaServers/mediaServerSync.js
@@ -1,6 +1,7 @@
 const logger = require('../../logger');
 const configModule = require('../configModule');
 const serverRegistry = require('./serverRegistry');
+const { MediaServerUnavailableError, describeHttpError } = require('./adapters/baseAdapter');
 const { Playlist, PlaylistVideo, PlaylistSyncState, Video } = require('../../models');
 
 // Backoff retry for resolving items after library scan. Tuned for typical Plex/Jellyfin
@@ -11,6 +12,12 @@ const ADAPTER_TYPE_TAG = {
   PlexAdapter: 'plex',
   JellyfinAdapter: 'jellyfin',
   EmbyAdapter: 'emby',
+};
+
+const SERVER_DISPLAY_NAME = {
+  plex: 'Plex',
+  jellyfin: 'Jellyfin',
+  emby: 'Emby',
 };
 
 class MediaServerSync {
@@ -72,8 +79,7 @@ class MediaServerSync {
       try {
         await this._syncToOne(playlist, videos, adapter, serverType);
       } catch (err) {
-        logger.error({ err, playlist_id: playlist.playlist_id, serverType }, 'sync failed');
-        await this._recordError(playlist.id, serverType, err.message);
+        await this._handleSyncError(err, playlist, serverType);
       }
     }
   }
@@ -107,7 +113,10 @@ class MediaServerSync {
     for (const entry of filepaths) {
       const id = resolvedByPath.get(entry.filePath);
       if (id) itemIds.push(id);
-      else logger.warn({ youtube_id: entry.youtube_id, serverType }, 'unresolved on media server, skipping');
+      else logger.warn(
+        { youtube_id: entry.youtube_id, serverType },
+        `Unable to sync item ${entry.youtube_id} for playlist "${playlist.title}" to ${SERVER_DISPLAY_NAME[serverType] || serverType}: not found on server, skipping`
+      );
     }
 
     const name = `YT: ${playlist.title}`;
@@ -121,7 +130,7 @@ class MediaServerSync {
     if (!state?.server_playlist_id && itemIds.length === 0) {
       logger.info(
         { playlist_id: playlist.playlist_id, serverType },
-        'sync: no resolvable items yet, deferring playlist creation until videos are downloaded'
+        `Deferring ${SERVER_DISPLAY_NAME[serverType] || serverType} sync of playlist "${playlist.title}": no downloaded items resolved yet`
       );
       return;
     }
@@ -186,6 +195,27 @@ class MediaServerSync {
       collect(await adapter.resolveItemIdsByFilepaths(pending));
     }
     return resolved;
+  }
+
+  // Turn a thrown sync error into one user-readable log line plus a concise
+  // recorded last_error. An unreachable/unresponsive server gets a friendly
+  // "not reachable" message; anything else logs a compact reason. Never the raw
+  // axios error, which would dump the API token into the logs.
+  async _handleSyncError(err, playlist, serverType) {
+    const serverName = SERVER_DISPLAY_NAME[serverType] || serverType;
+    if (err instanceof MediaServerUnavailableError) {
+      logger.warn(
+        { playlist_id: playlist.playlist_id, serverType },
+        `Unable to sync playlist "${playlist.title}" to ${serverName}: server not reachable or not responding. Please ensure that your media server is up and reachable.`
+      );
+      await this._recordError(playlist.id, serverType, `${serverName} not reachable or not responding`);
+      return;
+    }
+    const logData = { playlist_id: playlist.playlist_id, serverType };
+    if (err && err.isAxiosError) logData.reason = describeHttpError(err);
+    else logData.err = err;
+    logger.error(logData, `Unable to sync playlist "${playlist.title}" to ${serverName}`);
+    await this._recordError(playlist.id, serverType, err && err.message ? err.message : String(err));
   }
 
   // Never throws: this runs inside _doSync's per-adapter catch, and a

--- a/server/modules/playlistModule.js
+++ b/server/modules/playlistModule.js
@@ -1,7 +1,7 @@
 const { spawn } = require('child_process');
 const { Op } = require('sequelize');
 const logger = require('../logger');
-const { Playlist, PlaylistVideo } = require('../models');
+const { Playlist, PlaylistVideo, Channel } = require('../models');
 const youtubeApi = require('./youtubeApi');
 
 // yt-dlp's flat-playlist listing still returns private/deleted/members-only
@@ -302,6 +302,85 @@ class PlaylistModule {
       null,
       seed
     );
+  }
+
+  // A finished download's .info.json carries a per-video channel_id that the
+  // flat-playlist listing often omits, leaving playlist_video.channel_id null.
+  // Fill it onto the still-null rows and auto-create a hidden (enabled=0) source
+  // channel, seeded from the owning playlist, for any new channel not yet
+  // tracked. A non-null channel_id came from playlist sync and wins: the
+  // .info.json id is the auto-generated upload channel for VEVO/Topic videos, so
+  // it must not overwrite a stored owner or spawn a channel from that upload id.
+  // Runs once per job here, not in the per-video --exec post-processor, which
+  // lacks playlist context and races across concurrent videos.
+  async backfillDownloadedVideoChannels(videoData) {
+    if (!Array.isArray(videoData) || videoData.length === 0) return;
+
+    const channelByVideo = new Map();
+    const nameByChannel = new Map();
+    for (const v of videoData) {
+      if (!v || !v.youtubeId || !v.channel_id) continue;
+      channelByVideo.set(v.youtubeId, v.channel_id);
+      if (v.youTubeChannelName && !nameByChannel.has(v.channel_id)) {
+        nameByChannel.set(v.channel_id, v.youTubeChannelName);
+      }
+    }
+    if (channelByVideo.size === 0) return;
+
+    const rows = await PlaylistVideo.findAll({
+      where: { youtube_id: [...channelByVideo.keys()] },
+      attributes: ['playlist_id', 'youtube_id', 'channel_id'],
+    });
+    if (!rows.length) return;
+
+    const filledRows = rows.filter((row) => !row.channel_id && channelByVideo.get(row.youtube_id));
+    if (filledRows.length === 0) return;
+
+    // Keyed on youtube_id so one update fills every playlist still missing it.
+    const needsUpdate = new Set(filledRows.map((row) => row.youtube_id));
+    for (const youtubeId of needsUpdate) {
+      await PlaylistVideo.update(
+        { channel_id: channelByVideo.get(youtubeId) },
+        { where: { youtube_id: youtubeId, channel_id: null } }
+      );
+    }
+
+    // Auto-create source channels only for the just-filled rows. Channels behind
+    // already-attributed rows were handled at download-trigger time.
+    const realChannelIds = [...new Set(filledRows.map((row) => channelByVideo.get(row.youtube_id)).filter(Boolean))];
+    const tracked = await Channel.findAll({
+      where: { channel_id: realChannelIds },
+      attributes: ['channel_id'],
+    });
+    const trackedIds = new Set((tracked || []).map((c) => c.channel_id));
+    const untracked = new Set(realChannelIds.filter((id) => !trackedIds.has(id)));
+    if (untracked.size === 0) return;
+
+    // Pick one owning playlist per channel (first row wins) to seed its settings.
+    const playlistByChannel = new Map();
+    for (const row of filledRows) {
+      const realId = channelByVideo.get(row.youtube_id);
+      if (realId && untracked.has(realId) && !playlistByChannel.has(realId)) {
+        playlistByChannel.set(realId, row.playlist_id);
+      }
+    }
+    const playlists = await Playlist.findAll({
+      where: { playlist_id: [...new Set(playlistByChannel.values())] },
+    });
+    const playlistById = new Map((playlists || []).map((p) => [p.playlist_id, p]));
+
+    for (const channelId of untracked) {
+      const playlist = playlistById.get(playlistByChannel.get(channelId));
+      if (!playlist) continue;
+      try {
+        await this.ensureSourceChannel(
+          { channel_id: channelId, uploader: nameByChannel.get(channelId) || null },
+          playlist
+        );
+      } catch (err) {
+        logger.error({ err, channelId }, 'Failed to auto-create source channel for downloaded playlist video');
+      }
+    }
   }
 
   async playlistAutoDownload(overrideSettings = {}, runId) {


### PR DESCRIPTION

## Fix 1: backfill playlist video channels on download
After downloading playlist videos, some playlist_video rows kept a null channel_id and got no source channel, leaving those videos without channel attribution. Flat-playlist listings often omit the per-video channel_id, but the downloaded video's .info.json carries it.

Add backfillDownloadedVideoChannels, run once per job on download completion. It fills channel_id only where it is still null, so an owner channel captured at playlist sync is preserved (the .info.json id is the auto-generated upload channel for VEVO/Topic videos). For each newly-learned channel not already tracked, it auto-creates a hidden source channel seeded from the owning playlist.

## Fix 2: stop retrying media-server sync when down

An unreachable media server was retried through every backoff round,
logging a full axios error per file; those errors leaked the API token
via the request headers. Now a connection failure or 5xx aborts that
server's sync on the first round with one concise warning, and adapter
errors log {status, code, message} instead of the raw error.

Refs: #144