### PR TITLE
fix: decode entities in youtube search results

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -75,6 +75,10 @@
         "ts-node": "^10.9.2",
         "vite": "^7.3.1",
         "vite-tsconfig-paths": "^6.0.5"
+      },
+      "engines": {
+        "node": ">=20.19.0",
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6867,16 +6871,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -7121,9 +7125,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/client/package.json
+++ b/client/package.json
@@ -112,6 +112,7 @@
   "overrides": {
     "jsdom": {
       "form-data": "^3.0.4"
-    }
+    },
+    "form-data": "^4.0.6"
   }
 }

--- a/client/src/components/FindVideos/hooks/__tests__/useVideoSearch.test.ts
+++ b/client/src/components/FindVideos/hooks/__tests__/useVideoSearch.test.ts
@@ -24,6 +24,21 @@ describe('useVideoSearch', () => {
     expect(result.current.error).toBeNull();
   });
 
+  test('decodes HTML entities in title and channelName from the YouTube API', async () => {
+    axios.post.mockResolvedValueOnce({
+      data: {
+        results: [
+          { youtubeId: 'a', title: 'Rubik&#39;s Cube &amp; You', channelName: 'Tom &amp; Jerry' },
+        ],
+      },
+    });
+    const { result } = renderHook(() => useVideoSearch('token'));
+
+    await act(async () => { await result.current.search('rubiks', 25); });
+    expect(result.current.results[0].title).toBe("Rubik's Cube & You");
+    expect(result.current.results[0].channelName).toBe('Tom & Jerry');
+  });
+
   test('second search while loading aborts the first and runs the new one', async () => {
     const firstSignals: AbortSignal[] = [];
     axios.post.mockImplementationOnce((_url: string, _body: unknown, opts: { signal?: AbortSignal }) => {

--- a/client/src/components/FindVideos/hooks/useVideoSearch.ts
+++ b/client/src/components/FindVideos/hooks/useVideoSearch.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
+import { decodeHtml } from '../../../utils/formatters';
 import { SearchResult, PageSize } from '../types';
 
 interface UseVideoSearchResult {
@@ -43,7 +44,15 @@ export function useVideoSearch(token: string | null): UseVideoSearchResult {
       );
       // Late-arriving response from a superseded search: drop it.
       if (controllerRef.current !== controller) return;
-      setResults(res.data.results || []);
+      // The YouTube Data API HTML-encodes titles/channel names (e.g. "Rubik&#39;s").
+      // Decode here so all result views render plain text; yt-dlp results are already
+      // plain, so decodeHtml is a no-op for them.
+      const decoded = (res.data.results || []).map((r: SearchResult) => ({
+        ...r,
+        title: r.title ? decodeHtml(r.title) : r.title,
+        channelName: r.channelName ? decodeHtml(r.channelName) : r.channelName,
+      }));
+      setResults(decoded);
     } catch (err: unknown) {
       if (axios.isCancel(err)) {
         // user canceled or superseded; do not surface as error

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,10 @@
         "nodemon": "^3.1.9",
         "supertest": "^7.1.4",
         "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=20.19.0",
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -4755,15 +4759,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5193,9 +5198,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "overrides": {
+    "form-data": "^4.0.6"
+  },
   "dependencies": {
     "axios": "^1.12.0",
     "bcrypt": "^6.0.0",


### PR DESCRIPTION
Search result titles and channel names from the YouTube Data API rendered HTML entities literally (e.g. "Rubik&#39;s"). Decode them once in the search hook so all views render plain text; yt-dlp results are already plain, so it's a no-op for that path.

Note: CICD is failing because we need to update `form-data` to `4.0.6`, but we need to wait until tomorrow to respect the `min-release-age=5` 

Refs: #652