### PR TITLE
fix: prevent utf8mb4 migration failure on upgrade

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -258,10 +258,56 @@ for how to create your DB with the correct character set.
 Either:
 1. Recreate your DB with the correct character set (**THIS WILL CAUSE LOSS OF ALL DB DATA**)
 or
-2. Backup your DB and then alter your existing DB to the correct character set using:
+2. Backup your DB and then convert your existing DB to the correct character set.
+
 ```
   ALTER DATABASE youtarr CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
 ```
+
+**Note:** `ALTER DATABASE` only changes the default for *new* tables. Existing tables keep their old
+character set, so you'll need to convert each one too. See
+[UTF8mb4 Migration Fails on Foreign Key Columns](#utf8mb4-migration-fails-on-foreign-key-columns)
+below for how (foreign key checks have to be off first).
+
+### UTF8mb4 Migration Fails on Foreign Key Columns
+
+**Problem**: On startup the `20250907000000-upgrade-to-utf8mb4-if-needed` migration fails with logs like:
+```
+Upgrading database to utf8mb4...
+Converting table JobVideos from utf8mb3_general_ci to utf8mb4_unicode_ci
+UTF8mb4 migration failed: ...
+```
+It fails on an `ALTER TABLE ... CONVERT TO CHARACTER SET` for a table that has a `job_id` foreign key
+(`JobVideos` or `JobVideoDownloads`). This is almost always an external database that was created as
+`utf8`/`utf8mb3` instead of `utf8mb4`.
+
+**Cause**: The `job_id` columns are UUIDs stored as `CHAR(36)`, and they're part of a foreign key into
+the `Jobs` table. MariaDB won't change the character set of a column that's part of a foreign key, so
+the conversion fails right there. It only happens when the database was created as `utf8mb3` in the
+first place. The bundled MariaDB is created as `utf8mb4`, so it skips the conversion entirely and
+never runs into this.
+
+**Solution**: Update Youtarr. The migration now turns foreign key checks off while it converts the
+tables and turns them back on afterward. It also checks each table on its own instead of trusting the
+database default, so it'll finish the job on a database that an earlier failed run left half-converted
+(database default already on `utf8mb4`, some tables still on `utf8mb3`).
+
+To fix it by hand before updating, connect to the database as root and run the conversion with foreign
+key checks off. Replace `youtarr` with your database name, and add an `ALTER TABLE` line for every
+table that's still on `utf8mb3`:
+```sql
+SET FOREIGN_KEY_CHECKS = 0;
+ALTER DATABASE youtarr CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE JobVideos CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE JobVideoDownloads CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+-- ... repeat for any other table still on utf8mb3 ...
+SET FOREIGN_KEY_CHECKS = 1;
+```
+The character-set query in [UTF-8 Character Errors](#utf-8-character-errors) above will tell you which
+tables are still on the wrong character set.
+
+**Prevention**: If you run your own database, create it as `utf8mb4` from the start and this conversion
+never has to run. See the [External Database Guide](platforms/external-db.md).
 
 ### Database Connection Failed
 

--- a/migrations/20250907000000-upgrade-to-utf8mb4-if-needed.js
+++ b/migrations/20250907000000-upgrade-to-utf8mb4-if-needed.js
@@ -4,98 +4,123 @@
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     const transaction = await queryInterface.sequelize.transaction();
+    let foreignKeyChecksDisabled = false;
 
     try {
-      // Check current database charset
       const [dbInfo] = await queryInterface.sequelize.query(
-        `SELECT DEFAULT_CHARACTER_SET_NAME as charset, DEFAULT_COLLATION_NAME as collation 
-         FROM information_schema.SCHEMATA 
+        `SELECT SCHEMA_NAME as name, DEFAULT_CHARACTER_SET_NAME as charset, DEFAULT_COLLATION_NAME as collation
+         FROM information_schema.SCHEMATA
          WHERE SCHEMA_NAME = DATABASE()`,
         { transaction, type: Sequelize.QueryTypes.SELECT }
       );
 
       console.log(`Current database charset: ${dbInfo.charset}, collation: ${dbInfo.collation}`);
 
-      // Only migrate if not already utf8mb4
-      if (dbInfo.charset !== 'utf8mb4') {
-        console.log('Upgrading database to utf8mb4...');
+      // Check the tables directly, not just the database default. A failed earlier run
+      // can flip the database default to utf8mb4 (ALTER DATABASE auto-commits) while
+      // leaving tables on utf8mb3, so the default alone isn't reliable.
+      const tables = await queryInterface.sequelize.query(
+        `SELECT TABLE_NAME, TABLE_COLLATION
+         FROM information_schema.tables
+         WHERE TABLE_SCHEMA = DATABASE()
+         AND TABLE_TYPE = 'BASE TABLE'
+         AND TABLE_NAME NOT LIKE '_charset_migration_log'`,
+        { transaction, type: Sequelize.QueryTypes.SELECT }
+      );
 
-        // Log current state for reference
-        await queryInterface.sequelize.query(
-          `CREATE TABLE IF NOT EXISTS _charset_migration_log (
-            id INT AUTO_INCREMENT PRIMARY KEY,
-            migration_date DATETIME DEFAULT CURRENT_TIMESTAMP,
-            original_db_charset VARCHAR(50),
-            original_db_collation VARCHAR(50),
-            table_name VARCHAR(64),
-            original_table_collation VARCHAR(50),
-            new_table_collation VARCHAR(50)
-          )`,
-          { transaction }
-        );
+      const tablesToConvert = tables.filter(
+        (table) => !table.TABLE_COLLATION || !table.TABLE_COLLATION.includes('utf8mb4')
+      );
+      const databaseNeedsUpgrade = dbInfo.charset !== 'utf8mb4';
 
-        // Log database upgrade
-        await queryInterface.sequelize.query(
-          `INSERT INTO _charset_migration_log (original_db_charset, original_db_collation, table_name) 
-           VALUES ('${dbInfo.charset}', '${dbInfo.collation}', 'DATABASE')`,
-          { transaction }
-        );
-
-        // Get all table information before migration
-        const tables = await queryInterface.sequelize.query(
-          `SELECT TABLE_NAME, TABLE_COLLATION 
-           FROM information_schema.tables 
-           WHERE TABLE_SCHEMA = DATABASE() 
-           AND TABLE_TYPE = 'BASE TABLE'
-           AND TABLE_NAME NOT LIKE '_charset_migration_log'`,
-          { transaction, type: Sequelize.QueryTypes.SELECT }
-        );
-
-        // Log each table's current state
-        for (const table of tables) {
-          await queryInterface.sequelize.query(
-            `INSERT INTO _charset_migration_log (table_name, original_table_collation) 
-             VALUES ('${table.TABLE_NAME}', '${table.TABLE_COLLATION}')`,
-            { transaction }
-          );
-        }
-
-        // Upgrade database
-        await queryInterface.sequelize.query(
-          'ALTER DATABASE youtarr CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci',
-          { transaction }
-        );
-
-        // Upgrade tables that need it
-        for (const table of tables) {
-          if (!table.TABLE_COLLATION.includes('utf8mb4')) {
-            console.log(`Converting table ${table.TABLE_NAME} from ${table.TABLE_COLLATION} to utf8mb4_unicode_ci`);
-
-            await queryInterface.sequelize.query(
-              `ALTER TABLE \`${table.TABLE_NAME}\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`,
-              { transaction }
-            );
-
-            // Update log with new collation
-            await queryInterface.sequelize.query(
-              `UPDATE _charset_migration_log 
-               SET new_table_collation = 'utf8mb4_unicode_ci' 
-               WHERE table_name = '${table.TABLE_NAME}' 
-               AND migration_date = (SELECT MAX(migration_date) FROM _charset_migration_log AS l2 WHERE l2.table_name = '${table.TABLE_NAME}')`,
-              { transaction }
-            );
-          } else {
-            console.log(`Table ${table.TABLE_NAME} already uses utf8mb4, skipping`);
-          }
-        }
-
-        console.log('UTF8mb4 migration completed successfully');
-      } else {
+      if (!databaseNeedsUpgrade && tablesToConvert.length === 0) {
         console.log('Database already uses utf8mb4, skipping migration');
+        await transaction.commit();
+        return;
       }
+
+      console.log('Upgrading database to utf8mb4...');
+
+      // Log current state for reference
+      await queryInterface.sequelize.query(
+        `CREATE TABLE IF NOT EXISTS _charset_migration_log (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          migration_date DATETIME DEFAULT CURRENT_TIMESTAMP,
+          original_db_charset VARCHAR(50),
+          original_db_collation VARCHAR(50),
+          table_name VARCHAR(64),
+          original_table_collation VARCHAR(50),
+          new_table_collation VARCHAR(50)
+        )`,
+        { transaction }
+      );
+
+      // Log database upgrade
+      await queryInterface.sequelize.query(
+        `INSERT INTO _charset_migration_log (original_db_charset, original_db_collation, table_name)
+         VALUES (?, ?, 'DATABASE')`,
+        { transaction, replacements: [dbInfo.charset, dbInfo.collation] }
+      );
+
+      // Log each table's current state
+      for (const table of tablesToConvert) {
+        await queryInterface.sequelize.query(
+          `INSERT INTO _charset_migration_log (table_name, original_table_collation)
+           VALUES (?, ?)`,
+          { transaction, replacements: [table.TABLE_NAME, table.TABLE_COLLATION] }
+        );
+      }
+
+      // Turn off foreign key checks while converting. JobVideos.job_id and
+      // JobVideoDownloads.job_id are CHAR-based UUIDs in a foreign key into Jobs, and
+      // MariaDB won't change the charset of a column that's in a foreign key. Every table
+      // is converted in the same run, so the constraints stay consistent.
+      await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS = 0', { transaction });
+      foreignKeyChecksDisabled = true;
+
+      // Use the real database name; it's not always "youtarr"
+      if (databaseNeedsUpgrade) {
+        await queryInterface.sequelize.query(
+          `ALTER DATABASE \`${dbInfo.name}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`,
+          { transaction }
+        );
+      }
+
+      // Upgrade tables that need it
+      for (const table of tablesToConvert) {
+        console.log(`Converting table ${table.TABLE_NAME} from ${table.TABLE_COLLATION} to utf8mb4_unicode_ci`);
+
+        await queryInterface.sequelize.query(
+          `ALTER TABLE \`${table.TABLE_NAME}\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`,
+          { transaction }
+        );
+
+        // Update log with new collation
+        await queryInterface.sequelize.query(
+          `UPDATE _charset_migration_log
+           SET new_table_collation = 'utf8mb4_unicode_ci'
+           WHERE table_name = ?
+           AND migration_date = (SELECT MAX(migration_date) FROM _charset_migration_log AS l2 WHERE l2.table_name = ?)`,
+          { transaction, replacements: [table.TABLE_NAME, table.TABLE_NAME] }
+        );
+      }
+
+      await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });
+      foreignKeyChecksDisabled = false;
+
+      console.log('UTF8mb4 migration completed successfully');
 
       await transaction.commit();
     } catch (error) {
+      // Re-enable foreign key checks before the connection goes back to the pool, so a
+      // failure doesn't leave a pooled connection with checks off.
+      if (foreignKeyChecksDisabled) {
+        try {
+          await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });
+        } catch (resetError) {
+          console.error('Failed to re-enable foreign key checks after migration error:', resetError);
+        }
+      }
       await transaction.rollback();
       console.error('UTF8mb4 migration failed:', error);
       throw error;


### PR DESCRIPTION
The migration could fail converting tables with a foreign-key column (JobVideos, JobVideoDownloads) on databases not already utf8mb4. Disable foreign key checks around the conversions, scan tables individually instead of the database default, and use the actual database name. Adds a troubleshooting entry.

Refs: #658