### PR TITLE
Feat(#666): consistent downloaded video chip UI

### DIFF
--- a/client/src/components/ChannelPage/VideoTableView.tsx
+++ b/client/src/components/ChannelPage/VideoTableView.tsx
@@ -333,6 +333,7 @@ function VideoTableView({
                       audioFilePath={video.audioFilePath}
                       fileSize={video.fileSize}
                       audioFileSize={video.audioFileSize}
+                      orientation="vertical"
                     />
                   ) : '-'}
                 </td>

--- a/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoCard.test.tsx
@@ -175,13 +175,13 @@ describe('VideoCard Component', () => {
       renderWithProviders(<VideoCard {...defaultProps} video={videoWithFile} />);
       // File size shown in format indicator chip
       expect(screen.getByText(/50/)).toBeInTheDocument();
-      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
     });
 
     test('does not render format indicator when no file path exists', () => {
       renderWithProviders(<VideoCard {...defaultProps} />);
-      const movieIcons = screen.queryAllByTestId('StorageIcon');
-      expect(movieIcons.length).toBe(0);
+      const indicators = screen.queryAllByTestId('download-format-indicator');
+      expect(indicators.length).toBe(0);
     });
   });
 
@@ -700,7 +700,7 @@ describe('VideoCard Component', () => {
       renderWithProviders(<VideoCard {...defaultProps} video={largeVideo} />);
       // Check for file size presence in format indicator chip
       expect(screen.getByText(/GB/)).toBeInTheDocument();
-      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
     });
 
     test('handles video in both selectedForDeletion and checkedBoxes', () => {

--- a/client/src/components/ChannelPage/__tests__/VideoListItem.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoListItem.test.tsx
@@ -156,13 +156,13 @@ describe('VideoListItem Component', () => {
       renderWithProviders(<VideoListItem {...defaultProps} video={videoWithFile} />);
       // File size shown in format indicator chip
       expect(screen.getByText(/50/)).toBeInTheDocument();
-      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
     });
 
     test('does not render format indicator when no file path exists', () => {
       renderWithProviders(<VideoListItem {...defaultProps} />);
-      const movieIcons = screen.queryAllByTestId('StorageIcon');
-      expect(movieIcons.length).toBe(0);
+      const indicators = screen.queryAllByTestId('download-format-indicator');
+      expect(indicators.length).toBe(0);
     });
   });
 
@@ -663,7 +663,7 @@ describe('VideoListItem Component', () => {
       renderWithProviders(<VideoListItem {...defaultProps} video={largeVideo} />);
       // File size shown in format indicator chip
       expect(screen.getByText(/GB/)).toBeInTheDocument();
-      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
     });
 
     test('handles video in both selectedForDeletion and checkedBoxes', () => {

--- a/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/VideoTableView.test.tsx
@@ -198,7 +198,7 @@ describe('VideoTableView Component', () => {
       renderWithProviders(<VideoTableView {...defaultProps} videos={[videoWithFile]} />);
       // File size shown in format indicator chip
       expect(screen.getByText(/50/)).toBeInTheDocument();
-      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
     });
 
     test('renders dash when no file path exists', () => {
@@ -206,6 +206,21 @@ describe('VideoTableView Component', () => {
       renderWithProviders(<VideoTableView {...defaultProps} videos={[videoNoFile]} />);
       // Two dashes on a never-downloaded row: Downloaded column and Size column
       expect(screen.getAllByText('-').length).toBeGreaterThan(0);
+    });
+
+    test('stacks the format chips vertically so they fit the narrow size column', () => {
+      const videoWithBothFormats = {
+        ...mockVideo,
+        filePath: '/path/to/video.mp4',
+        fileSize: 1024 * 1024 * 50,
+        audioFilePath: '/path/to/audio.mp3',
+        audioFileSize: 1024 * 1024 * 5,
+      };
+      renderWithProviders(<VideoTableView {...defaultProps} videos={[videoWithBothFormats]} />);
+
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('AudioFormatIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('download-format-indicator')).toHaveClass('flex-col');
     });
   });
 
@@ -868,7 +883,7 @@ describe('VideoTableView Component', () => {
       renderWithProviders(<VideoTableView {...defaultProps} videos={[largeVideo]} />);
       // File size shown in format indicator chip
       expect(screen.getByText(/GB/)).toBeInTheDocument();
-      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
     });
 
     test('handles video in both selectedForDeletion and checkedBoxes', () => {

--- a/client/src/components/PlaylistPage.tsx
+++ b/client/src/components/PlaylistPage.tsx
@@ -27,6 +27,7 @@ import VideoListSelectionPill from './shared/VideoList/VideoListSelectionPill';
 import { SelectionAction } from './shared/VideoList/types';
 import { Download as DownloadIcon } from '../lib/icons';
 import PlaylistSettingsDialog from './PlaylistPage/components/PlaylistSettingsDialog';
+import { toDownloadFileProps } from './PlaylistPage/components/playlistVideoHelpers';
 import DownloadSettingsDialog from './DownloadManager/ManualDownload/DownloadSettingsDialog';
 import { DownloadSettings } from './DownloadManager/ManualDownload/types';
 import SubscriptionsBackButton from './shared/SubscriptionsBackButton';
@@ -60,10 +61,7 @@ function toModalData(v: PlaylistVideo): VideoModalData {
     mediaType: 'video',
     status,
     isDownloaded: v.downloaded,
-    filePath: v.file_path,
-    fileSize: v.file_size,
-    audioFilePath: null,
-    audioFileSize: null,
+    ...toDownloadFileProps(v),
     isProtected: false,
     isIgnored: v.ignored,
     normalizedRating: null,

--- a/client/src/components/PlaylistPage/components/PlaylistVideoCard.tsx
+++ b/client/src/components/PlaylistPage/components/PlaylistVideoCard.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Button, Card, CardContent, Checkbox, Chip, Typography } from '../../ui';
 import { PlaylistVideo } from '../../../types/playlist';
 import { formatDurationClock } from '../../../utils';
-import { isDownloadable, statusLabel, PublishedDate } from './playlistVideoHelpers';
+import { isDownloadable, statusLabel, PublishedDate, toDownloadFileProps } from './playlistVideoHelpers';
+import DownloadFormatIndicator from '../../shared/DownloadFormatIndicator';
 
 const THUMB_WIDTH = 120;
 const THUMB_HEIGHT = 68;
@@ -73,7 +74,11 @@ const PlaylistVideoCard: React.FC<PlaylistVideoCardProps> = ({
         <div className="flex items-center gap-2 flex-wrap mt-1 text-xs text-muted-foreground">
           <PublishedDate value={video.published_at} />
           <span className="whitespace-nowrap">{formatDurationClock(video.duration) || '-'}</span>
-          <Chip label={status.label} color={status.color} size="small" />
+          {video.downloaded ? (
+            <DownloadFormatIndicator {...toDownloadFileProps(video)} orientation="horizontal" />
+          ) : (
+            <Chip label={status.label} color={status.color} size="small" />
+          )}
         </div>
         <div className="mt-2" onClick={(e) => e.stopPropagation()}>
           {video.ignored ? (

--- a/client/src/components/PlaylistPage/components/PlaylistVideoTable.tsx
+++ b/client/src/components/PlaylistPage/components/PlaylistVideoTable.tsx
@@ -12,7 +12,8 @@ import {
 } from '../../ui';
 import { PlaylistVideo } from '../../../types/playlist';
 import { formatDurationClock } from '../../../utils';
-import { isDownloadable, statusLabel, PublishedDate } from './playlistVideoHelpers';
+import { isDownloadable, statusLabel, PublishedDate, toDownloadFileProps } from './playlistVideoHelpers';
+import DownloadFormatIndicator from '../../shared/DownloadFormatIndicator';
 
 const THUMB_WIDTH = 120;
 const THUMB_HEIGHT = 67;
@@ -125,7 +126,11 @@ const PlaylistVideoTable: React.FC<PlaylistVideoTableProps> = ({
                 {formatDurationClock(v.duration) || '-'}
               </TableCell>
               <TableCell>
-                <Chip label={status.label} color={status.color} size="small" />
+                {v.downloaded ? (
+                  <DownloadFormatIndicator {...toDownloadFileProps(v)} orientation="vertical" />
+                ) : (
+                  <Chip label={status.label} color={status.color} size="small" />
+                )}
               </TableCell>
               <TableCell align="right" onClick={(e) => e.stopPropagation()}>
                 {v.ignored ? (

--- a/client/src/components/PlaylistPage/components/__tests__/PlaylistVideoCard.test.tsx
+++ b/client/src/components/PlaylistPage/components/__tests__/PlaylistVideoCard.test.tsx
@@ -8,7 +8,7 @@ function makeVideo(overrides: Partial<PlaylistVideo> = {}): PlaylistVideo {
     channel_id: null, ignored: false, ignored_at: null, title: 'Title',
     channel_name: 'Chan', duration: 60, published_at: null, thumbnail: null,
     downloaded: false, previously_downloaded: false, youtube_removed: false, video_id: null, file_path: null,
-    file_size: null, ...overrides,
+    file_size: null, audio_file_path: null, audio_file_size: null, ...overrides,
   };
 }
 
@@ -49,5 +49,26 @@ describe('PlaylistVideoCard', () => {
     render(<PlaylistVideoCard {...baseProps} onIgnore={onIgnore} video={makeVideo({ youtube_id: 'x' })} />);
     fireEvent.click(screen.getByRole('button', { name: 'Ignore' }));
     expect(onIgnore).toHaveBeenCalledWith('x');
+  });
+
+  describe('downloaded status', () => {
+    test('renders the download format indicator (size + format icon) for a downloaded video', () => {
+      render(
+        <PlaylistVideoCard
+          {...baseProps}
+          video={makeVideo({ downloaded: true, file_path: '/data/v.mp4', file_size: 1024 * 1024 * 50 })}
+        />
+      );
+      expect(screen.getByTestId('download-format-indicator')).toBeInTheDocument();
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
+      expect(screen.getByText(/50/)).toBeInTheDocument();
+      expect(screen.queryByText('Downloaded')).not.toBeInTheDocument();
+    });
+
+    test('shows the status chip (not the indicator) for a tracked video', () => {
+      render(<PlaylistVideoCard {...baseProps} video={makeVideo()} />);
+      expect(screen.getByText('Tracked')).toBeInTheDocument();
+      expect(screen.queryByTestId('download-format-indicator')).not.toBeInTheDocument();
+    });
   });
 });

--- a/client/src/components/PlaylistPage/components/__tests__/PlaylistVideoList.test.tsx
+++ b/client/src/components/PlaylistPage/components/__tests__/PlaylistVideoList.test.tsx
@@ -14,7 +14,7 @@ function makeVideo(overrides: Partial<PlaylistVideo> = {}): PlaylistVideo {
     channel_id: null, ignored: false, ignored_at: null, title: 'Title',
     channel_name: 'Chan', duration: 60, published_at: null, thumbnail: null,
     downloaded: false, previously_downloaded: false, youtube_removed: false, video_id: null, file_path: null,
-    file_size: null, ...overrides,
+    file_size: null, audio_file_path: null, audio_file_size: null, ...overrides,
   };
 }
 

--- a/client/src/components/PlaylistPage/components/__tests__/PlaylistVideoTable.test.tsx
+++ b/client/src/components/PlaylistPage/components/__tests__/PlaylistVideoTable.test.tsx
@@ -8,7 +8,7 @@ function makeVideo(overrides: Partial<PlaylistVideo> = {}): PlaylistVideo {
     channel_id: null, ignored: false, ignored_at: null, title: 'Title',
     channel_name: 'Chan', duration: 60, published_at: null, thumbnail: null,
     downloaded: false, previously_downloaded: false, youtube_removed: false, video_id: null, file_path: null,
-    file_size: null, ...overrides,
+    file_size: null, audio_file_path: null, audio_file_size: null, ...overrides,
   };
 }
 
@@ -83,5 +83,41 @@ describe('PlaylistVideoTable selection', () => {
     const header = screen.getAllByRole('checkbox')[0];
     fireEvent.click(header);
     expect(onClearSelection).toHaveBeenCalled();
+  });
+
+  describe('downloaded status', () => {
+    test('renders the download format indicator (size + format icon) for a downloaded video', () => {
+      render(
+        <PlaylistVideoTable
+          {...baseProps}
+          videos={[makeVideo({ youtube_id: 'done', downloaded: true, file_path: '/data/v.mp4', file_size: 1024 * 1024 * 50 })]}
+        />
+      );
+      expect(screen.getByTestId('download-format-indicator')).toBeInTheDocument();
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
+      expect(screen.getByText(/50/)).toBeInTheDocument();
+      expect(screen.queryByText('Downloaded')).not.toBeInTheDocument();
+    });
+
+    test('shows both format icons when a downloaded video also has an audio file', () => {
+      render(
+        <PlaylistVideoTable
+          {...baseProps}
+          videos={[makeVideo({
+            youtube_id: 'both', downloaded: true,
+            file_path: '/data/v.mp4', file_size: 1024 * 1024 * 50,
+            audio_file_path: '/data/v.m4a', audio_file_size: 1024 * 1024 * 5,
+          })]}
+        />
+      );
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('AudioFormatIcon')).toBeInTheDocument();
+    });
+
+    test('shows the status chip (not the indicator) for a tracked video', () => {
+      render(<PlaylistVideoTable {...baseProps} videos={[makeVideo({ youtube_id: 'trk' })]} />);
+      expect(screen.getByText('Tracked')).toBeInTheDocument();
+      expect(screen.queryByTestId('download-format-indicator')).not.toBeInTheDocument();
+    });
   });
 });

--- a/client/src/components/PlaylistPage/components/__tests__/playlistVideoHelpers.test.tsx
+++ b/client/src/components/PlaylistPage/components/__tests__/playlistVideoHelpers.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { isDownloadable, statusLabel, PublishedDate } from '../playlistVideoHelpers';
+import { isDownloadable, statusLabel, PublishedDate, toDownloadFileProps } from '../playlistVideoHelpers';
 import { PlaylistVideo } from '../../../../types/playlist';
 
 function makeVideo(overrides: Partial<PlaylistVideo> = {}): PlaylistVideo {
@@ -23,6 +23,8 @@ function makeVideo(overrides: Partial<PlaylistVideo> = {}): PlaylistVideo {
     video_id: null,
     file_path: null,
     file_size: null,
+    audio_file_path: null,
+    audio_file_size: null,
     ...overrides,
   };
 }
@@ -66,6 +68,33 @@ describe('statusLabel', () => {
   });
   test('returns Tracked for a plain tracked video', () => {
     expect(statusLabel(makeVideo())).toEqual({ label: 'Tracked', color: 'default' });
+  });
+});
+
+describe('toDownloadFileProps', () => {
+  test('maps snake_case file fields to DownloadFormatIndicator camelCase props', () => {
+    const v = makeVideo({
+      file_path: '/data/video.mp4',
+      file_size: 1000,
+      audio_file_path: '/data/audio.m4a',
+      audio_file_size: 500,
+    });
+    expect(toDownloadFileProps(v)).toEqual({
+      filePath: '/data/video.mp4',
+      audioFilePath: '/data/audio.m4a',
+      fileSize: 1000,
+      audioFileSize: 500,
+    });
+  });
+
+  test('preserves nulls when no audio file exists', () => {
+    const v = makeVideo({ file_path: '/data/video.mp4', file_size: 1000 });
+    expect(toDownloadFileProps(v)).toEqual({
+      filePath: '/data/video.mp4',
+      audioFilePath: null,
+      fileSize: 1000,
+      audioFileSize: null,
+    });
   });
 });
 

--- a/client/src/components/PlaylistPage/components/playlistVideoHelpers.tsx
+++ b/client/src/components/PlaylistPage/components/playlistVideoHelpers.tsx
@@ -10,6 +10,21 @@ export function isDownloadable(v: PlaylistVideo): boolean {
   return !v.downloaded && !v.youtube_removed;
 }
 
+// Maps PlaylistVideo's snake_case file fields to the indicator's camelCase props.
+export function toDownloadFileProps(v: PlaylistVideo): {
+  filePath: string | null;
+  audioFilePath: string | null;
+  fileSize: number | null;
+  audioFileSize: number | null;
+} {
+  return {
+    filePath: v.file_path,
+    audioFilePath: v.audio_file_path,
+    fileSize: v.file_size,
+    audioFileSize: v.audio_file_size,
+  };
+}
+
 export function statusLabel(v: PlaylistVideo): { label: string; color: PlaylistVideoStatusColor } {
   if (v.ignored) return { label: 'Ignored', color: 'warning' };
   if (v.youtube_removed) return { label: 'Removed on YT', color: 'error' };

--- a/client/src/components/__tests__/PlaylistPage.test.tsx
+++ b/client/src/components/__tests__/PlaylistPage.test.tsx
@@ -31,6 +31,8 @@ const mockVideo: PlaylistVideo = {
   video_id: null,
   file_path: null,
   file_size: null,
+  audio_file_path: null,
+  audio_file_size: null,
 };
 
 const mockMissingVideo: PlaylistVideo = {

--- a/client/src/components/__tests__/VideosPage.test.tsx
+++ b/client/src/components/__tests__/VideosPage.test.tsx
@@ -830,7 +830,7 @@ describe('VideosPage Component', () => {
 
       // Check file size display in format indicator chip (1GB formatted)
       expect(screen.getByText('1.0GB')).toBeInTheDocument();
-      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
     });
 
     test('displays missing file status for removed videos', async () => {

--- a/client/src/components/shared/DownloadFormatIndicator.tsx
+++ b/client/src/components/shared/DownloadFormatIndicator.tsx
@@ -71,7 +71,12 @@ const DownloadFormatIndicator: React.FC<DownloadFormatIndicatorProps> = ({
       : 'inline-flex items-center gap-1';
 
   return (
-    <Box className={containerClassName} data-testid="download-format-indicator">
+    <Box
+      className={containerClassName}
+      data-testid="download-format-indicator"
+      // A chip tap should just show its path tooltip, not bubble up to row/card selection.
+      onClick={(e) => e.stopPropagation()}
+    >
       {hasVideo && (
         <Tooltip title={renderPathTooltip(displayVideoPath)} arrow placement="top" enterTouchDelay={0}>
           <Chip

--- a/client/src/components/shared/DownloadFormatIndicator.tsx
+++ b/client/src/components/shared/DownloadFormatIndicator.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Chip, Tooltip } from '../ui';
-import { Storage as StorageIcon } from '../../lib/icons';
+import { MovieOutlined as VideoFormatIcon, AudioIcon as AudioFormatIcon } from '../../lib/icons';
 import { formatFileSize } from '../../utils/formatters';
 import { SHARED_THEMED_CHIP_SMALL_STYLE } from './chipStyles';
 
@@ -9,6 +9,8 @@ interface DownloadFormatIndicatorProps {
   audioFilePath?: string | null;
   fileSize?: number | string | null;
   audioFileSize?: number | string | null;
+  // 'vertical' stacks the chips to fit narrow table columns
+  orientation?: 'horizontal' | 'vertical';
 }
 
 // Strip internal Docker paths from display
@@ -22,22 +24,15 @@ const stripInternalPath = (path: string): string => {
   return path;
 };
 
-const getPathLocation = (path: string): string => {
-  const normalizedPath = stripInternalPath(path).replace(/\\/g, '/').replace(/\/+$/, '');
-  const lastSlashIndex = normalizedPath.lastIndexOf('/');
-
-  if (lastSlashIndex <= 0) {
-    return normalizedPath.startsWith('/') ? '/' : 'Downloads';
-  }
-
-  return normalizedPath.slice(0, lastSlashIndex);
-};
+const getDisplayPath = (path: string): string =>
+  stripInternalPath(path).replace(/\\/g, '/').replace(/\/+$/, '');
 
 const DownloadFormatIndicator: React.FC<DownloadFormatIndicatorProps> = ({
   filePath,
   audioFilePath,
   fileSize,
-  audioFileSize
+  audioFileSize,
+  orientation = 'horizontal'
 }) => {
   const hasVideo = !!filePath;
   const hasAudio = !!audioFilePath;
@@ -51,8 +46,8 @@ const DownloadFormatIndicator: React.FC<DownloadFormatIndicatorProps> = ({
   const videoSizeNum = typeof fileSize === 'string' ? parseInt(fileSize, 10) : fileSize;
   const audioSizeNum = typeof audioFileSize === 'string' ? parseInt(audioFileSize, 10) : audioFileSize;
 
-  const displayVideoLocation = filePath ? getPathLocation(filePath) : '';
-  const displayAudioLocation = audioFilePath ? getPathLocation(audioFilePath) : '';
+  const displayVideoPath = filePath ? getDisplayPath(filePath) : '';
+  const displayAudioPath = audioFilePath ? getDisplayPath(audioFilePath) : '';
 
   // Format size labels
   const videoSizeLabel = videoSizeNum ? formatFileSize(videoSizeNum) : 'Unknown';
@@ -70,13 +65,18 @@ const DownloadFormatIndicator: React.FC<DownloadFormatIndicatorProps> = ({
     </div>
   );
 
+  const containerClassName =
+    orientation === 'vertical'
+      ? 'inline-flex flex-col items-start gap-1'
+      : 'inline-flex items-center gap-1';
+
   return (
-    <Box className="inline-flex items-center gap-1">
+    <Box className={containerClassName} data-testid="download-format-indicator">
       {hasVideo && (
-        <Tooltip title={renderPathTooltip(displayVideoLocation)} arrow placement="top" enterTouchDelay={0}>
+        <Tooltip title={renderPathTooltip(displayVideoPath)} arrow placement="top" enterTouchDelay={0}>
           <Chip
             size="small"
-            icon={<StorageIcon size={14} className="text-primary" data-testid="StorageIcon" />}
+            icon={<VideoFormatIcon size={14} className="text-primary" data-testid="VideoFormatIcon" />}
             label={videoSizeLabel}
             variant="outlined"
             style={SHARED_THEMED_CHIP_SMALL_STYLE}
@@ -84,10 +84,10 @@ const DownloadFormatIndicator: React.FC<DownloadFormatIndicatorProps> = ({
         </Tooltip>
       )}
       {hasAudio && (
-        <Tooltip title={renderPathTooltip(displayAudioLocation)} arrow placement="top" enterTouchDelay={0}>
+        <Tooltip title={renderPathTooltip(displayAudioPath)} arrow placement="top" enterTouchDelay={0}>
           <Chip
             size="small"
-            icon={<StorageIcon size={14} className="text-secondary" data-testid="StorageIcon" />}
+            icon={<AudioFormatIcon size={14} className="text-secondary" data-testid="AudioFormatIcon" />}
             label={audioSizeLabel}
             variant="outlined"
             style={SHARED_THEMED_CHIP_SMALL_STYLE}

--- a/client/src/components/shared/__tests__/DownloadFormatIndicator.test.tsx
+++ b/client/src/components/shared/__tests__/DownloadFormatIndicator.test.tsx
@@ -126,4 +126,35 @@ describe('DownloadFormatIndicator', () => {
       expect(tooltip).toHaveTextContent('/custom/path/video.mp4');
     });
   });
+
+  describe('Click propagation', () => {
+    test('does not bubble a chip click to a parent row/card handler', async () => {
+      const user = userEvent.setup();
+      const handleParentClick = jest.fn();
+      render(
+        <div onClick={handleParentClick}>
+          <DownloadFormatIndicator filePath="/videos/test.mp4" fileSize={104857600} />
+        </div>
+      );
+
+      await user.click(screen.getByText('100MB'));
+
+      expect(handleParentClick).not.toHaveBeenCalled();
+    });
+
+    test('still lets the parent handler fire for clicks outside the indicator', async () => {
+      const user = userEvent.setup();
+      const handleParentClick = jest.fn();
+      render(
+        <div onClick={handleParentClick}>
+          <span>elsewhere</span>
+          <DownloadFormatIndicator filePath="/videos/test.mp4" fileSize={104857600} />
+        </div>
+      );
+
+      await user.click(screen.getByText('elsewhere'));
+
+      expect(handleParentClick).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/client/src/components/shared/__tests__/DownloadFormatIndicator.test.tsx
+++ b/client/src/components/shared/__tests__/DownloadFormatIndicator.test.tsx
@@ -20,21 +20,21 @@ describe('DownloadFormatIndicator', () => {
       expect(container).toBeEmptyDOMElement();
     });
 
-    test('renders video chip when filePath is provided', () => {
+    test('renders video chip with the video icon when filePath is provided', () => {
       render(<DownloadFormatIndicator filePath="/videos/test.mp4" fileSize={104857600} />);
 
       expect(screen.getByText('100MB')).toBeInTheDocument();
-      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
     });
 
-    test('renders audio chip when audioFilePath is provided', () => {
+    test('renders audio chip with the audio icon when audioFilePath is provided', () => {
       render(<DownloadFormatIndicator audioFilePath="/audio/test.mp3" audioFileSize={52428800} />);
 
       expect(screen.getByText('50MB')).toBeInTheDocument();
-      expect(screen.getByTestId('StorageIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('AudioFormatIcon')).toBeInTheDocument();
     });
 
-    test('renders both chips when both paths are provided', () => {
+    test('renders distinct icons for the video and audio chips', () => {
       render(
         <DownloadFormatIndicator
           filePath="/videos/test.mp4"
@@ -46,7 +46,8 @@ describe('DownloadFormatIndicator', () => {
 
       expect(screen.getByText('1.0GB')).toBeInTheDocument();
       expect(screen.getByText('50MB')).toBeInTheDocument();
-      expect(screen.getAllByTestId('StorageIcon')).toHaveLength(2);
+      expect(screen.getByTestId('VideoFormatIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('AudioFormatIcon')).toBeInTheDocument();
     });
 
     test('shows "Unknown" when file size is not provided', () => {
@@ -62,8 +63,37 @@ describe('DownloadFormatIndicator', () => {
     });
   });
 
-  describe('Path stripping', () => {
-    test('strips Docker internal path prefix from video path in tooltip', async () => {
+  describe('Layout orientation', () => {
+    test('lays chips out horizontally by default', () => {
+      render(
+        <DownloadFormatIndicator
+          filePath="/videos/test.mp4"
+          fileSize={1073741824}
+          audioFilePath="/audio/test.mp3"
+          audioFileSize={52428800}
+        />
+      );
+
+      expect(screen.getByTestId('download-format-indicator')).not.toHaveClass('flex-col');
+    });
+
+    test('stacks chips vertically when orientation is vertical', () => {
+      render(
+        <DownloadFormatIndicator
+          filePath="/videos/test.mp4"
+          fileSize={1073741824}
+          audioFilePath="/audio/test.mp3"
+          audioFileSize={52428800}
+          orientation="vertical"
+        />
+      );
+
+      expect(screen.getByTestId('download-format-indicator')).toHaveClass('flex-col');
+    });
+  });
+
+  describe('Tooltip path', () => {
+    test('strips Docker internal path prefix but keeps the filename in the tooltip', async () => {
       const user = userEvent.setup();
       render(
         <DownloadFormatIndicator
@@ -76,12 +106,11 @@ describe('DownloadFormatIndicator', () => {
       await user.hover(chip);
 
       const tooltip = await screen.findByRole('tooltip');
-      expect(tooltip).toHaveTextContent('channel');
-      expect(tooltip).not.toHaveTextContent('video.mp4');
+      expect(tooltip).toHaveTextContent('channel/video.mp4');
       expect(tooltip).not.toHaveTextContent('/usr/src/app/data/');
     });
 
-    test('preserves non-Docker paths in tooltip', async () => {
+    test('shows the full non-Docker path including the filename in the tooltip', async () => {
       const user = userEvent.setup();
       render(
         <DownloadFormatIndicator
@@ -94,8 +123,7 @@ describe('DownloadFormatIndicator', () => {
       await user.hover(chip);
 
       const tooltip = await screen.findByRole('tooltip');
-      expect(tooltip).toHaveTextContent('/custom/path');
-      expect(tooltip).not.toHaveTextContent('video.mp4');
+      expect(tooltip).toHaveTextContent('/custom/path/video.mp4');
     });
   });
 });

--- a/client/src/hooks/__tests__/usePlaylistDetail.test.ts
+++ b/client/src/hooks/__tests__/usePlaylistDetail.test.ts
@@ -144,6 +144,8 @@ const makeVideo = (id: number, overrides = {}) => ({
   video_id: null,
   file_path: null,
   file_size: null,
+  audio_file_path: null,
+  audio_file_size: null,
   ...overrides,
 });
 

--- a/client/src/types/playlist.ts
+++ b/client/src/types/playlist.ts
@@ -48,6 +48,8 @@ export interface PlaylistVideo {
   video_id: number | null;
   file_path: string | null;
   file_size: number | null;
+  audio_file_path: string | null;
+  audio_file_size: number | null;
 }
 
 export interface MediaServerStatus {

--- a/server/routes/__tests__/playlists.test.js
+++ b/server/routes/__tests__/playlists.test.js
@@ -689,6 +689,8 @@ describe('GET /api/playlists/:playlistId/videos', () => {
         youtube_removed: false,
         filePath: '/videos/downloaded1.mp4',
         fileSize: 1024,
+        audioFilePath: '/videos/downloaded1.m4a',
+        audioFileSize: 2048,
       },
     ]);
 
@@ -711,9 +713,13 @@ describe('GET /api/playlists/:playlistId/videos', () => {
       video_id: 42,
       file_path: '/videos/downloaded1.mp4',
       file_size: 1024,
+      audio_file_path: '/videos/downloaded1.m4a',
+      audio_file_size: 2048,
     });
     expect(payload.videos[1]).toMatchObject({
       youtube_id: 'tracked2',
+      audio_file_path: null,
+      audio_file_size: null,
       title: 'A tracked video',
       duration: 456,
       published_at: '20260215',

--- a/server/routes/playlists.js
+++ b/server/routes/playlists.js
@@ -224,7 +224,7 @@ function createPlaylistRoutes({ verifyToken, playlistModule, downloadModule, m3u
       if (youtubeIds.length > 0 && Video) {
         const downloaded = await Video.findAll({
           where: { youtubeId: youtubeIds },
-          attributes: ['id', 'youtubeId', 'youTubeVideoName', 'youTubeChannelName', 'duration', 'originalDate', 'removed', 'youtube_removed', 'filePath', 'fileSize'],
+          attributes: ['id', 'youtubeId', 'youTubeVideoName', 'youTubeChannelName', 'duration', 'originalDate', 'removed', 'youtube_removed', 'filePath', 'fileSize', 'audioFilePath', 'audioFileSize'],
         });
         downloaded.forEach((v) => downloadedById.set(v.youtubeId, v));
       }
@@ -263,6 +263,8 @@ function createPlaylistRoutes({ verifyToken, playlistModule, downloadModule, m3u
           video_id: dl?.id ?? null,
           file_path: dl?.filePath ?? null,
           file_size: dl?.fileSize != null ? Number(dl.fileSize) : null,
+          audio_file_path: dl?.audioFilePath ?? null,
+          audio_file_size: dl?.audioFileSize != null ? Number(dl.audioFileSize) : null,
         };
       });
 


### PR DESCRIPTION
- Distinct video/audio icons in the indicator, full file path
  (with filename) in its tooltip, and a vertical stacking option
  for narrow table columns
- Use the indicator on playlist videos instead of a generic
  "Downloaded" chip; add audio file fields to the playlist endpoint
- stop download chip taps from selecting video on mobile
  (eg, the download chips should just show the file path)
