### PR TITLE
fix: ignore disabled channel download settings

### DIFF
--- a/server/modules/__tests__/playlistDownloadGrouper.test.js
+++ b/server/modules/__tests__/playlistDownloadGrouper.test.js
@@ -47,6 +47,30 @@ test('uses channel command settings when the channel is configured', async () =>
   });
 });
 
+test('only loads enabled channels for settings resolution', async () => {
+  await grouper.buildGroups(playlist, [{ youtube_id: 'b', channel_id: 'UCc' }], {});
+  expect(Channel.findAll).toHaveBeenCalledWith(
+    expect.objectContaining({ where: { channel_id: ['UCc'], enabled: true } })
+  );
+});
+
+test('falls through to playlist settings when the channel is disabled', async () => {
+  // The enabled filter excludes the row, so findAll returns nothing and resolution
+  // falls through to playlist -> global.
+  Channel.findAll.mockResolvedValue([]);
+  const groups = await grouper.buildGroups(
+    { ...playlist, audio_format: 'video_mp3' },
+    [{ youtube_id: 'b', channel_id: 'UCdisabled' }],
+    {}
+  );
+  expect(groups[0]).toEqual({
+    resolution: '720',
+    audioFormat: 'video_mp3',
+    skipVideoFolder: false,
+    youtubeIds: ['b'],
+  });
+});
+
 test('override beats channel and playlist for command settings', async () => {
   Channel.findAll.mockResolvedValue([
     { channel_id: 'UCc', video_quality: '1080', audio_format: 'mp3_only', skip_video_folder: true },

--- a/server/modules/__tests__/videoDownloadPostProcessFiles.test.js
+++ b/server/modules/__tests__/videoDownloadPostProcessFiles.test.js
@@ -305,7 +305,8 @@ describe('videoDownloadPostProcessFiles', () => {
       sub_folder: null,
       uploader: 'Channel',
       folder_name: 'Channel',
-      default_rating: 'PG-13'
+      default_rating: 'PG-13',
+      enabled: true
     });
 
     await loadModule();
@@ -649,7 +650,8 @@ describe('videoDownloadPostProcessFiles', () => {
         sub_folder: 'Kids',
         uploader: 'Channel',
         folder_name: 'Channel',
-        default_rating: null
+        default_rating: null,
+        enabled: true
       });
       process.env.YOUTARR_SUBFOLDER_FALLBACK = 'PLFolder';
       delete process.env.YOUTARR_SUBFOLDER_OVERRIDE;
@@ -700,6 +702,76 @@ describe('videoDownloadPostProcessFiles', () => {
         expect.any(Object)
       );
     });
+
+    it('disabled channel sub_folder falls through to the playlist soft fallback', async () => {
+      // Disabled channel settings shouldn't override the playlist.
+      Channel.findOne.mockResolvedValue({
+        id: 1,
+        sub_folder: 'Kids',
+        uploader: 'Channel',
+        folder_name: 'Channel',
+        default_rating: null,
+        enabled: false
+      });
+      process.env.YOUTARR_SUBFOLDER_FALLBACK = 'PLFolder';
+      delete process.env.YOUTARR_SUBFOLDER_OVERRIDE;
+
+      const tempVideoPath = '/tmp/youtarr-downloads/Channel/Video Title [abc123]/Video Title [abc123].mp4';
+      const tempVideoDir = '/tmp/youtarr-downloads/Channel/Video Title [abc123]';
+      process.argv = ['node', 'script', tempVideoPath];
+
+      tempPathManager.isEnabled.mockReturnValue(true);
+      tempPathManager.isTempPath.mockReturnValue(true);
+      tempPathManager.convertTempToFinal.mockImplementation((p) => p.replace('/tmp/youtarr-downloads', '/library'));
+
+      const tempJsonPath = '/tmp/youtarr-downloads/Channel/Video Title [abc123]/Video Title [abc123].info.json';
+      fs.existsSync.mockImplementation((p) => {
+        return p === tempJsonPath || p.includes('/library/__PLFolder/Channel');
+      });
+      fs.pathExists.mockResolvedValue(false);
+
+      await loadModule();
+      await settleAsync();
+
+      // Routes to PLFolder (playlist fallback), not Kids (disabled channel setting)
+      expect(fs.move).toHaveBeenCalledWith(
+        tempVideoDir,
+        expect.stringContaining('/library/__PLFolder/Channel/Video Title [abc123]')
+      );
+      expect(fs.move).not.toHaveBeenCalledWith(
+        tempVideoDir,
+        expect.stringContaining('Kids')
+      );
+    });
+
+    it('disabled channel default_rating falls through to the rating soft fallback', async () => {
+      Channel.findOne.mockResolvedValue({
+        id: 1,
+        sub_folder: null,
+        uploader: 'Channel',
+        folder_name: 'Channel',
+        default_rating: 'R',
+        enabled: false
+      });
+      process.env.YOUTARR_RATING_FALLBACK = 'PG';
+      delete process.env.YOUTARR_OVERRIDE_RATING;
+
+      await loadModule();
+      await settleAsync();
+
+      // The playlist fallback PG is used, not the disabled channel's R rating
+      expect(childProcess.spawnSync).toHaveBeenCalledWith(
+        '/usr/bin/AtomicParsley',
+        expect.arrayContaining([
+          '--rDNSatom', 'mpaa|PG|', 'name=iTunEXTC', 'domain=com.apple.iTunes'
+        ]),
+        expect.any(Object)
+      );
+      const ratingArgs = childProcess.spawnSync.mock.calls
+        .filter((c) => c[0] === '/usr/bin/AtomicParsley')
+        .flatMap((c) => c[1]);
+      expect(ratingArgs).not.toContain('mpaa|R|');
+    });
   });
 
   describe('owner channel id resolution (VEVO/Topic channel fix)', () => {
@@ -715,7 +787,7 @@ describe('videoDownloadPostProcessFiles', () => {
       // the subscription the user actually downloaded from.
       process.env.YOUTARR_OWNER_CHANNEL_ID = 'UC-subscription';
       Channel.findOne.mockResolvedValue({
-        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null
+        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null, enabled: true
       });
 
       await loadModule();
@@ -729,7 +801,7 @@ describe('videoDownloadPostProcessFiles', () => {
     it('routes the video into the owner channel subfolder even when info.json channel_id differs', async () => {
       process.env.YOUTARR_OWNER_CHANNEL_ID = 'UC-subscription';
       Channel.findOne.mockResolvedValue({
-        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null
+        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null, enabled: true
       });
 
       const tempVideoPath = '/tmp/youtarr-downloads/Channel/Video Title [abc123]/Video Title [abc123].mp4';
@@ -771,7 +843,7 @@ describe('videoDownloadPostProcessFiles', () => {
       delete process.env.YOUTARR_OWNER_CHANNEL_ID;
       process.env.YOUTARR_OWNER_CHANNEL_MAP = JSON.stringify({ abc123: 'UC-artist' });
       Channel.findOne.mockResolvedValue({
-        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null
+        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null, enabled: true
       });
 
       await loadModule();
@@ -799,7 +871,7 @@ describe('videoDownloadPostProcessFiles', () => {
       process.env.YOUTARR_OWNER_CHANNEL_ID = 'UC-explicit';
       process.env.YOUTARR_OWNER_CHANNEL_MAP = JSON.stringify({ abc123: 'UC-mapped' });
       Channel.findOne.mockResolvedValue({
-        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null
+        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null, enabled: true
       });
 
       await loadModule();
@@ -836,7 +908,7 @@ describe('videoDownloadPostProcessFiles', () => {
       // Of the candidates, only UC-artist is a tracked channel.
       Channel.findAll.mockResolvedValue([{ channel_id: 'UC-artist' }]);
       Channel.findOne.mockResolvedValue({
-        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null
+        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null, enabled: true
       });
 
       await loadModule();
@@ -872,7 +944,7 @@ describe('videoDownloadPostProcessFiles', () => {
       ChannelVideo.findAll.mockResolvedValue([{ channel_id: 'UC-other' }]);
       Channel.findAll.mockResolvedValue([{ channel_id: 'UC-other' }]);
       Channel.findOne.mockResolvedValue({
-        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null
+        id: 1, sub_folder: 'Library2', uploader: 'Channel', folder_name: 'Channel', default_rating: null, enabled: true
       });
 
       await loadModule();
@@ -920,7 +992,8 @@ describe('videoDownloadPostProcessFiles', () => {
 
       Channel.findOne.mockResolvedValue({
         sub_folder: 'Entertainment',
-        uploader: 'Channel'
+        uploader: 'Channel',
+        enabled: true
       });
 
       tempPathManager.isEnabled.mockReturnValue(true);
@@ -961,7 +1034,8 @@ describe('videoDownloadPostProcessFiles', () => {
 
       Channel.findOne.mockResolvedValue({
         sub_folder: 'Entertainment',
-        uploader: 'Channel'
+        uploader: 'Channel',
+        enabled: true
       });
 
       tempPathManager.isEnabled.mockReturnValue(true);
@@ -996,7 +1070,8 @@ describe('videoDownloadPostProcessFiles', () => {
 
       Channel.findOne.mockResolvedValue({
         sub_folder: 'Music',
-        uploader: rawChannelName
+        uploader: rawChannelName,
+        enabled: true
       });
 
       tempPathManager.isEnabled.mockReturnValue(true);
@@ -1046,7 +1121,8 @@ describe('videoDownloadPostProcessFiles', () => {
 
       Channel.findOne.mockResolvedValue({
         sub_folder: 'Education',
-        uploader: rawChannelName
+        uploader: rawChannelName,
+        enabled: true
       });
 
       tempPathManager.isEnabled.mockReturnValue(true);
@@ -1122,7 +1198,8 @@ describe('videoDownloadPostProcessFiles', () => {
 
       Channel.findOne.mockResolvedValue({
         sub_folder: 'Music',
-        uploader: channelName
+        uploader: channelName,
+        enabled: true
       });
 
       fs.readFileSync.mockReturnValue(JSON.stringify({

--- a/server/modules/playlistDownloadGrouper.js
+++ b/server/modules/playlistDownloadGrouper.js
@@ -13,8 +13,12 @@ class PlaylistDownloadGrouper {
   async loadChannelMap(channelIds) {
     const ids = [...new Set(channelIds.filter(Boolean))];
     if (ids.length === 0) return new Map();
+    // Only enabled channels contribute settings. Disabled channels (including the hidden
+    // source channels auto-created during playlist sync) are invisible in the UI, so their
+    // settings shouldn't override the playlist. Treat them as untracked: resolution falls
+    // through to playlist -> global.
     const channels = await Channel.findAll({
-      where: { channel_id: ids },
+      where: { channel_id: ids, enabled: true },
       attributes: ['channel_id', 'video_quality', 'audio_format', 'skip_video_folder'],
     });
     const map = new Map();

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -266,7 +266,7 @@ async function resolveTrackedOwnerChannelId(youtubeId, metadataChannelId) {
         const channelId = lookupChannelId;
         channelRecord = await Channel.findOne({
           where: { channel_id: channelId },
-          attributes: ['id', 'sub_folder', 'title', 'uploader', 'folder_name', 'default_rating']
+          attributes: ['id', 'sub_folder', 'title', 'uploader', 'folder_name', 'default_rating', 'enabled']
         });
 
         logger.info({ channelId, ownerProvided: !!ownerChannelId, found: !!channelRecord }, 'Post-process channel lookup');
@@ -307,6 +307,12 @@ async function resolveTrackedOwnerChannelId(youtubeId, metadataChannelId) {
       }
     }
 
+    // Only an enabled channel contributes routing settings (rating, subfolder). A disabled
+    // channel is invisible in the UI, so treat it as untracked and fall through to the
+    // playlist fallback -> global. channelRecord above is still used for metadata backfill
+    // regardless of enabled state.
+    const settingsChannelRecord = channelRecord && channelRecord.enabled ? channelRecord : null;
+
     // Determine effective rating using strict priority order:
     // 1. Manual Override
     // 2. Channel Default
@@ -318,7 +324,7 @@ async function resolveTrackedOwnerChannelId(youtubeId, metadataChannelId) {
 
     const effectiveRating = ratingMapper.determineEffectiveRating(
       jsonData,
-      channelRecord ? channelRecord.default_rating : null,
+      settingsChannelRecord ? settingsChannelRecord.default_rating : null,
       manualOverride,
       ratingFallbackEnv
     );
@@ -336,7 +342,7 @@ async function resolveTrackedOwnerChannelId(youtubeId, metadataChannelId) {
     // Per-video subfolder precedence; see resolveFinalSubfolder for the full contract.
     channelSubFolder = downloadSettingsResolver.resolveFinalSubfolder({
       hardOverride: subfolderOverride,
-      channelRecord,
+      channelRecord: settingsChannelRecord,
       softFallback: subfolderFallbackEnv,
       globalDefault: configModule.getDefaultSubfolder(),
     });


### PR DESCRIPTION
Disabled channels, including the hidden source channels auto-created during playlist sync, were contributing their resolution, audio format, subfolder, and rating settings during download. Those settings overrode the playlist and global defaults even though disabled channels are invisible in the UI, so users had no way to change them.

Filter the playlist grouper's channel lookup to enabled channels only, and gate the post-processor's rating and subfolder resolution on the channel's enabled state. Resolution now falls through to playlist then global. Channel metadata backfill still runs regardless of that state.

Refs: #663