### PR TITLE
Release: Fix enabling auto-download for channels that do not have a "videos" tab

### DIFF
--- a/server/modules/__tests__/channelModule.test.js
+++ b/server/modules/__tests__/channelModule.test.js
@@ -3442,6 +3442,34 @@ describe('ChannelModule', () => {
         });
       });
 
+      test('reconciles the stale video default to the detected tab for a shorts-only channel', async () => {
+        // 'video' is the NOT NULL column default; detection should drop it and default to 'short'.
+        const mockChannel = {
+          ...mockChannelData,
+          available_tabs: null,
+          auto_download_enabled_tabs: 'video'
+        };
+        Channel.findOne.mockResolvedValue(mockChannel);
+        Channel.update.mockResolvedValue([1]);
+
+        ChannelModule.checkTabExistsViaYtdlp = jest.fn()
+          .mockImplementation(async (chId, tabType) => tabType === 'shorts');
+
+        const result = await ChannelModule.detectAndSaveChannelTabs('UC123');
+
+        expect(Channel.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            available_tabs: 'shorts',
+            auto_download_enabled_tabs: 'short'
+          }),
+          { where: { channel_id: 'UC123' } }
+        );
+        expect(result).toEqual({
+          availableTabs: ['shorts'],
+          autoDownloadEnabledTabs: 'short'
+        });
+      });
+
       test('should fallback to videos tab when all RSS checks fail', async () => {
         const mockChannel = {
           ...mockChannelData,

--- a/server/modules/__tests__/channelSettingsModule.test.js
+++ b/server/modules/__tests__/channelSettingsModule.test.js
@@ -934,28 +934,53 @@ describe('ChannelSettingsModule', () => {
         expect(channel.update).not.toHaveBeenCalled();
       });
 
-      test('rejects entries whose tab is not detected for the channel', async () => {
+      test('drops entries whose tab is not detected for the channel and keeps valid ones', async () => {
         const channel = buildChannel({ available_tabs: 'videos' });
         Channel.findOne.mockResolvedValue(channel);
 
-        await expect(
-          channelSettingsModule.updateChannelSettings('UC123456', {
-            auto_download_enabled_tabs: 'short'
-          })
-        ).rejects.toThrow(/'short' is not allowed/);
-        expect(channel.update).not.toHaveBeenCalled();
+        const result = await channelSettingsModule.updateChannelSettings('UC123456', {
+          auto_download_enabled_tabs: 'video,short'
+        });
+
+        expect(channel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ auto_download_enabled_tabs: 'video' })
+        );
+        expect(result.settings.auto_download_enabled_tabs).toBe('video');
       });
 
-      test('rejects entries whose tab will be hidden after the same update', async () => {
+      test('drops entries whose tab will be hidden after the same update', async () => {
         const channel = buildChannel();
         Channel.findOne.mockResolvedValue(channel);
 
-        await expect(
-          channelSettingsModule.updateChannelSettings('UC123456', {
-            hidden_tabs: ['shorts'],
-            auto_download_enabled_tabs: 'video,short'
-          })
-        ).rejects.toThrow(/'short' is not allowed/);
+        await channelSettingsModule.updateChannelSettings('UC123456', {
+          hidden_tabs: ['shorts'],
+          auto_download_enabled_tabs: 'video,short'
+        });
+
+        const autoCall = channel.update.mock.calls.find(
+          (call) => 'auto_download_enabled_tabs' in (call[0] || {})
+        );
+        expect(autoCall).toBeDefined();
+        expect(autoCall[0].auto_download_enabled_tabs).toBe('video');
+      });
+
+      test('enables shorts auto-download on a shorts-only channel carrying the stale video default', async () => {
+        // Channel carries the stale 'video' default; enabling shorts sends 'video,short',
+        // and the 'video' should be dropped rather than rejected.
+        const channel = buildChannel({
+          available_tabs: 'shorts',
+          auto_download_enabled_tabs: 'video'
+        });
+        Channel.findOne.mockResolvedValue(channel);
+
+        const result = await channelSettingsModule.updateChannelSettings('UC123456', {
+          auto_download_enabled_tabs: 'video,short'
+        });
+
+        expect(channel.update).toHaveBeenCalledWith(
+          expect.objectContaining({ auto_download_enabled_tabs: 'short' })
+        );
+        expect(result.settings.auto_download_enabled_tabs).toBe('short');
       });
 
       test('does not run hidden-tab strip side-effect when user supplies a validated value', async () => {

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -2255,16 +2255,22 @@ class ChannelModule {
       // the fallback-to-videos behavior if all probes fail.
       const availableTabs = await this._probeTabs(channelId);
 
-      // Determine auto_download_enabled_tabs: preserve existing user choice if set,
-      // otherwise pick a smart default based on available tabs
+      // Reconcile the stored value against the detected tabs: keep media types whose
+      // tab exists, drop the rest (this sheds the NOT NULL 'video' default on channels
+      // with no videos tab). An empty string means auto-download is off, so keep it.
+      const detectedMediaTypes = new Set(
+        availableTabs.map((tab) => MEDIA_TAB_TYPE_MAP[tab]).filter(Boolean)
+      );
       const existingEnabledTabs = channel.auto_download_enabled_tabs;
-      const hasUserChoice = existingEnabledTabs !== null && existingEnabledTabs !== undefined;
+      const reconciledTabs = parseTabCsv(existingEnabledTabs).filter((mt) => detectedMediaTypes.has(mt));
 
       let autoDownloadEnabledTabs;
-      if (hasUserChoice) {
-        // User already set a value (including empty string for "disabled") -- preserve it
-        autoDownloadEnabledTabs = existingEnabledTabs;
+      if (reconciledTabs.length > 0) {
+        autoDownloadEnabledTabs = reconciledTabs.join(',');
+      } else if (existingEnabledTabs === '') {
+        autoDownloadEnabledTabs = '';
       } else {
+        // Nothing survived: default to the videos tab, or the first available tab.
         autoDownloadEnabledTabs = 'video';
         if (!availableTabs.includes(TAB_TYPES.VIDEOS) && availableTabs.length > 0) {
           autoDownloadEnabledTabs = MEDIA_TAB_TYPE_MAP[availableTabs[0]] || 'video';

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -302,15 +302,10 @@ class ChannelSettingsModule {
         .map((tab) => MEDIA_TAB_TYPE_MAP[tab])
         .filter(Boolean)
     );
-    for (const part of parts) {
-      if (!effectiveMediaTypes.has(part)) {
-        return {
-          valid: false,
-          error: `auto_download_enabled_tabs entry '${part}' is not allowed: corresponding tab is not detected for this channel or is hidden`
-        };
-      }
-    }
-    const deduped = Array.from(new Set(parts));
+    // Drop entries whose tab isn't detected or is hidden instead of rejecting the
+    // whole save; this sheds a stale 'video' default riding along on a shorts-only channel.
+    const allowed = parts.filter((part) => effectiveMediaTypes.has(part));
+    const deduped = Array.from(new Set(allowed));
     return { valid: true, normalized: deduped.join(',') };
   }
 


### PR DESCRIPTION
This is just a small release to fix one functional bug:

- Enabling shorts auto-download on a Shorts-only channel failed to save with "auto_download_enabled_tabs entry video is not allowed" (#671)