### PR TITLE
feat: update video listings during batch downloads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 ### Implementation notes (non-obvious behaviors)
 - **Plex integration** uses OAuth; the user must be the Plex server admin. The target Plex library must be "Other Videos" with the "Personal Media" agent.
 - **Video downloads**: yt-dlp writes to a temp location, then post-processing finalizes files into the channel's target directory. Resume-on-partial-download is supported.
-- **WebSocket server** shares the HTTP server port (3011 in container, 3087 on host) via the `ws` library; there is no separate WS port.
+- **WebSocket server** shares the HTTP server port (3011 in container, 3087 on host) via the `ws` library; there is no separate WS port. Broadcast message types include `downloadProgress`, `downloadComplete`, and `videosUpdated` (emitted per video mid-batch after its DB rows are persisted; listing pages subscribe via `client/src/hooks/useDownloadListingsRefresh.ts` to refetch in near real time).
 - **Deno** is installed in the container; yt-dlp uses it automatically for JS-heavy extractors.
 
 ## Code Quality Standards (for new and rewritten code)

--- a/client/src/components/ChannelPage/ChannelVideos.tsx
+++ b/client/src/components/ChannelPage/ChannelVideos.tsx
@@ -35,6 +35,7 @@ import { useChannelFetchStatus } from './hooks/useChannelFetchStatus';
 import { useChannelVideoFilters } from './hooks/useChannelVideoFilters';
 import { useConfig } from '../../hooks/useConfig';
 import { useTriggerDownloads } from '../../hooks/useTriggerDownloads';
+import { useDownloadListingsRefresh } from '../../hooks/useDownloadListingsRefresh';
 import VideoModal from '../shared/VideoModal';
 import { VideoModalData } from '../shared/VideoModal/types';
 import { ChannelVideo } from '../../types/ChannelVideo';
@@ -333,6 +334,8 @@ function ChannelVideos({
     ignoredFilter,
     onFirstLoad: onVideosLoaded,
   });
+
+  useDownloadListingsRefresh(refetchVideos);
 
   useEffect(() => {
     if (availableTabsFromVideos && availableTabsFromVideos.length > 0) {

--- a/client/src/components/PlaylistPage.tsx
+++ b/client/src/components/PlaylistPage.tsx
@@ -15,6 +15,7 @@ import {
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { useConfig } from '../hooks/useConfig';
 import { usePlaylistDetail, PlaylistSortOrder } from '../hooks/usePlaylistDetail';
+import { useDownloadListingsRefresh } from '../hooks/useDownloadListingsRefresh';
 import { usePlaylistMutations } from '../hooks/usePlaylistMutations';
 import { useMediaServerStatus } from '../hooks/useMediaServerStatus';
 import { MediaServerType, PlaylistSubscribeSettings, PlaylistVideo } from '../types/playlist';
@@ -96,6 +97,8 @@ function PlaylistPage({ token }: PlaylistPageProps) {
     regenerateM3U,
     triggerDownload,
   } = usePlaylistDetail({ token, playlistId, sortOrder });
+
+  useDownloadListingsRefresh(refetch);
 
   const {
     status: serverStatus,

--- a/client/src/components/VideosPage/index.tsx
+++ b/client/src/components/VideosPage/index.tsx
@@ -5,6 +5,7 @@ import { Alert, Box, Grid, Snackbar, Typography } from '../ui';
 import { Trash2 as DeleteIcon, Star as RatingIcon } from '../../lib/icons';
 import { useMediaQuery } from '../../hooks/useMediaQuery';
 import { useConfig } from '../../hooks/useConfig';
+import { useDownloadListingsRefresh } from '../../hooks/useDownloadListingsRefresh';
 import { VideoData } from '../../types/VideoData';
 import DeleteVideosDialog from '../shared/DeleteVideosDialog';
 import { useVideoDeletion } from '../shared/useVideoDeletion';
@@ -132,6 +133,8 @@ function VideosPage({ token }: VideosPageProps) {
     missingFilter,
     useInfiniteScroll,
   });
+
+  useDownloadListingsRefresh(refetch);
 
   useEffect(() => {
     setVideos([]);

--- a/client/src/hooks/__tests__/useDownloadListingsRefresh.test.tsx
+++ b/client/src/hooks/__tests__/useDownloadListingsRefresh.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { useDownloadListingsRefresh } from '../useDownloadListingsRefresh';
+import WebSocketContext from '../../contexts/WebSocketContext';
+
+type Filter = (message: { destination?: string; type?: string }) => boolean;
+type Callback = (data: unknown) => void;
+
+describe('useDownloadListingsRefresh', () => {
+  let subscriptions: Array<{ filter: Filter; callback: Callback }>;
+  let subscribe: jest.Mock;
+  let unsubscribe: jest.Mock;
+
+  const emitMessage = (message: { destination?: string; type?: string; payload?: unknown }) => {
+    subscriptions.forEach((sub) => {
+      if (sub.filter(message)) {
+        sub.callback(message.payload);
+      }
+    });
+  };
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WebSocketContext.Provider value={{ socket: null, subscribe, unsubscribe }}>
+      {children}
+    </WebSocketContext.Provider>
+  );
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    subscriptions = [];
+    subscribe = jest.fn((filter: Filter, callback: Callback) => {
+      subscriptions.push({ filter, callback });
+    });
+    unsubscribe = jest.fn((callback: Callback) => {
+      subscriptions = subscriptions.filter((sub) => sub.callback !== callback);
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('calls onRefresh after a videosUpdated broadcast, debounced', () => {
+    const onRefresh = jest.fn();
+    renderHook(() => useDownloadListingsRefresh(onRefresh), { wrapper });
+
+    emitMessage({ destination: 'broadcast', type: 'videosUpdated', payload: { youtubeId: 'abc' } });
+    expect(onRefresh).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1000);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onRefresh for downloadComplete broadcasts', () => {
+    const onRefresh = jest.fn();
+    renderHook(() => useDownloadListingsRefresh(onRefresh), { wrapper });
+
+    emitMessage({ destination: 'broadcast', type: 'downloadComplete', payload: { videos: [] } });
+    jest.advanceTimersByTime(1000);
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test('coalesces a burst of messages into a single refresh', () => {
+    const onRefresh = jest.fn();
+    renderHook(() => useDownloadListingsRefresh(onRefresh), { wrapper });
+
+    emitMessage({ destination: 'broadcast', type: 'videosUpdated' });
+    jest.advanceTimersByTime(500);
+    emitMessage({ destination: 'broadcast', type: 'videosUpdated' });
+    jest.advanceTimersByTime(500);
+    emitMessage({ destination: 'broadcast', type: 'downloadComplete' });
+    jest.advanceTimersByTime(1000);
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores unrelated message types', () => {
+    const onRefresh = jest.fn();
+    renderHook(() => useDownloadListingsRefresh(onRefresh), { wrapper });
+
+    emitMessage({ destination: 'broadcast', type: 'downloadProgress' });
+    jest.advanceTimersByTime(1000);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  test('uses the latest onRefresh callback without resubscribing', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const { rerender } = renderHook(
+      ({ cb }: { cb: () => void }) => useDownloadListingsRefresh(cb),
+      { wrapper, initialProps: { cb: first } }
+    );
+
+    rerender({ cb: second });
+    emitMessage({ destination: 'broadcast', type: 'videosUpdated' });
+    jest.advanceTimersByTime(1000);
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test('unsubscribes and cancels a pending refresh on unmount', () => {
+    const onRefresh = jest.fn();
+    const { unmount } = renderHook(() => useDownloadListingsRefresh(onRefresh), { wrapper });
+
+    emitMessage({ destination: 'broadcast', type: 'videosUpdated' });
+    unmount();
+    jest.advanceTimersByTime(1000);
+
+    expect(unsubscribe).toHaveBeenCalled();
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/useDownloadListingsRefresh.ts
+++ b/client/src/hooks/useDownloadListingsRefresh.ts
@@ -1,0 +1,51 @@
+import { useContext, useEffect, useRef } from 'react';
+import WebSocketContext from '../contexts/WebSocketContext';
+
+const REFRESH_DEBOUNCE_MS = 1000;
+
+interface BroadcastMessage {
+  destination?: string;
+  type?: string;
+}
+
+/**
+ * Calls onRefresh (debounced) when a download batch persists a video
+ * (videosUpdated) or a job finishes (downloadComplete), so listing pages
+ * can refetch without a manual reload.
+ */
+export function useDownloadListingsRefresh(onRefresh: () => void): void {
+  const wsContext = useContext(WebSocketContext);
+  const subscribe = wsContext?.subscribe;
+  const unsubscribe = wsContext?.unsubscribe;
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+
+  useEffect(() => {
+    if (!subscribe || !unsubscribe) {
+      return;
+    }
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const filter = (message: BroadcastMessage) =>
+      message.destination === 'broadcast' &&
+      (message.type === 'videosUpdated' || message.type === 'downloadComplete');
+
+    const callback = () => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        onRefreshRef.current();
+      }, REFRESH_DEBOUNCE_MS);
+    };
+
+    subscribe(filter, callback);
+    return () => {
+      unsubscribe(callback);
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+    };
+  }, [subscribe, unsubscribe]);
+}

--- a/server/modules/__tests__/videoDownloadPostProcessFiles.test.js
+++ b/server/modules/__tests__/videoDownloadPostProcessFiles.test.js
@@ -80,6 +80,12 @@ jest.mock('../../models', () => ({
   Channel: mockChannel
 }));
 
+const mockVideoPersistence = {
+  persistDownloadedVideoForJob: jest.fn(() => Promise.resolve(null))
+};
+
+jest.mock('../videoPersistence', () => mockVideoPersistence);
+
 jest.mock('../../logger');
 
 // downloadSettingsResolver is intentionally not mocked: it is a pure function, so these
@@ -130,6 +136,7 @@ describe('videoDownloadPostProcessFiles', () => {
     logger.warn.mockClear();
     logger.error.mockClear();
     JobVideoDownload.update.mockResolvedValue([0]);
+    mockVideoPersistence.persistDownloadedVideoForJob.mockResolvedValue(null);
     Channel.findOne.mockResolvedValue(null);
     Channel.findAll.mockResolvedValue([]);
     ChannelVideo.findAll.mockResolvedValue([]);
@@ -435,6 +442,80 @@ describe('videoDownloadPostProcessFiles', () => {
       'Error updating JobVideoDownload status'
     );
     expect(process.exit).not.toHaveBeenCalled(); // Should not fail entire post-processing
+  });
+
+  it('persists the downloaded video for mid-batch listing updates', async () => {
+    await loadModule();
+    await settleAsync();
+
+    expect(mockVideoPersistence.persistDownloadedVideoForJob).toHaveBeenCalledWith({
+      jobId: 'test-job-id',
+      youtubeId: 'abc123'
+    });
+  });
+
+  it('emits the persisted control marker on stdout after a successful persist', async () => {
+    mockVideoPersistence.persistDownloadedVideoForJob.mockResolvedValue({ id: 7 });
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      await loadModule();
+      await settleAsync();
+
+      expect(stdoutSpy).toHaveBeenCalledWith('[Youtarr:videoPersisted] abc123\n');
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
+
+  it('does not emit the control marker when the persist was skipped', async () => {
+    mockVideoPersistence.persistDownloadedVideoForJob.mockResolvedValue(null);
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      await loadModule();
+      await settleAsync();
+
+      expect(stdoutSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('[Youtarr:videoPersisted]')
+      );
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
+
+  it('skips mid-batch persistence when job ID is not available', async () => {
+    delete process.env.YOUTARR_JOB_ID;
+
+    await loadModule();
+    await settleAsync();
+
+    expect(mockVideoPersistence.persistDownloadedVideoForJob).not.toHaveBeenCalled();
+  });
+
+  it('does not fail post-processing when mid-batch persistence throws', async () => {
+    mockVideoPersistence.persistDownloadedVideoForJob.mockRejectedValueOnce(
+      new Error('db down')
+    );
+    JobVideoDownload.update.mockResolvedValueOnce([1]);
+
+    await loadModule();
+    await settleAsync();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'abc123' }),
+      'Error persisting downloaded video during post-processing'
+    );
+    expect(JobVideoDownload.update).toHaveBeenCalledWith(
+      { status: 'completed', file_path: videoPath },
+      {
+        where: {
+          job_id: 'test-job-id',
+          youtube_id: 'abc123'
+        }
+      }
+    );
+    expect(process.exit).not.toHaveBeenCalled();
   });
 
   describe('tempPathManager integration', () => {

--- a/server/modules/__tests__/videoPersistence.test.js
+++ b/server/modules/__tests__/videoPersistence.test.js
@@ -1,0 +1,233 @@
+/* eslint-env jest */
+
+jest.mock('../../models/job');
+jest.mock('../../models/video');
+jest.mock('../../models/jobvideo');
+jest.mock('../../models/channelvideo');
+jest.mock('../channelVideoReanchor', () => ({
+  applyExactDateForGroup: jest.fn().mockResolvedValue(undefined),
+  applyExactDateForVideo: jest.fn().mockResolvedValue(undefined),
+}));
+// Factory mock, not a bare automock: the automock loads the real module,
+// which starts configModule's fs.watch and keeps Jest from exiting.
+jest.mock('../download/videoMetadataProcessor', () => ({
+  processVideoMetadata: jest.fn(),
+}));
+jest.mock('../../logger');
+
+describe('videoPersistence', () => {
+  let videoPersistence;
+  let VideoMetadataProcessor;
+  let Job;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    VideoMetadataProcessor = require('../download/videoMetadataProcessor');
+    Job = require('../../models/job');
+    videoPersistence = require('../videoPersistence');
+  });
+
+  describe('uploadDateToIso', () => {
+    test('converts a YYYYMMDD upload_date to an ISO string', () => {
+      expect(videoPersistence.uploadDateToIso('20240101')).toBe('2024-01-01T00:00:00.000Z');
+    });
+
+    test('returns null for an invalid or empty upload_date', () => {
+      expect(videoPersistence.uploadDateToIso('')).toBeNull();
+      expect(videoPersistence.uploadDateToIso(null)).toBeNull();
+      expect(videoPersistence.uploadDateToIso('bad')).toBeNull();
+    });
+  });
+
+  describe('prepareVideoDataForSave', () => {
+    test('sets last_downloaded_at and removed=false when the file is verified', () => {
+      const data = videoPersistence.prepareVideoDataForSave({
+        youtubeId: 'abc123',
+        filePath: '/videos/a.mp4',
+        fileSize: '1000',
+      }, true);
+
+      expect(data.removed).toBe(false);
+      expect(data.last_downloaded_at).toBeInstanceOf(Date);
+    });
+
+    test('does not set last_downloaded_at when no file is verified', () => {
+      const data = videoPersistence.prepareVideoDataForSave({
+        youtubeId: 'abc123',
+        filePath: null,
+        fileSize: null,
+      }, true);
+
+      expect(data.last_downloaded_at).toBeUndefined();
+    });
+
+    test('sets last_downloaded_at and removed=false for a verified audio-only download', () => {
+      const data = videoPersistence.prepareVideoDataForSave({
+        youtubeId: 'abc123',
+        filePath: null,
+        fileSize: null,
+        audioFilePath: '/videos/a.mp3',
+        audioFileSize: '500',
+      }, true);
+
+      expect(data.removed).toBe(false);
+      expect(data.last_downloaded_at).toBeInstanceOf(Date);
+      expect(data.audioFilePath).toBe('/videos/a.mp3');
+    });
+
+    test('does not overwrite existing file fields of the other format on update', () => {
+      const data = videoPersistence.prepareVideoDataForSave({
+        youtubeId: 'abc123',
+        filePath: '/videos/a.mp4',
+        fileSize: '1000',
+        audioFilePath: null,
+        audioFileSize: null,
+      }, false);
+
+      expect(data.filePath).toBe('/videos/a.mp4');
+      expect(data.audioFilePath).toBeUndefined();
+      expect(data.audioFileSize).toBeUndefined();
+    });
+
+    test('leaves all file fields untouched on update when nothing is verified', () => {
+      const data = videoPersistence.prepareVideoDataForSave({
+        youtubeId: 'abc123',
+        filePath: null,
+        fileSize: null,
+        audioFilePath: null,
+        audioFileSize: null,
+      }, false);
+
+      expect(data.filePath).toBeUndefined();
+      expect(data.fileSize).toBeUndefined();
+      expect(data.audioFilePath).toBeUndefined();
+      expect(data.audioFileSize).toBeUndefined();
+      expect(data.removed).toBeUndefined();
+      expect(data.last_downloaded_at).toBeUndefined();
+    });
+  });
+
+  describe('persistDownloadedVideoForJob', () => {
+    const metadata = {
+      youtubeId: 'abc123',
+      youTubeChannelName: 'Test Channel',
+      youTubeVideoName: 'Test Video',
+      duration: 300,
+      originalDate: '20240101',
+      channel_id: 'chan1',
+      media_type: 'video',
+      filePath: '/videos/Test Channel/Test Video [abc123].mp4',
+      fileSize: '1000',
+      audioFilePath: null,
+      audioFileSize: null,
+    };
+
+    test('persists the video and channel video for a completed download', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([metadata]);
+      Job.findOne.mockResolvedValue({ id: 'job1' });
+      const upsertVideoSpy = jest
+        .spyOn(videoPersistence, 'upsertVideoForJob')
+        .mockResolvedValue({ id: 7, youtubeId: 'abc123' });
+      const upsertChannelSpy = jest
+        .spyOn(videoPersistence, 'upsertChannelVideoFromInfo')
+        .mockResolvedValue(undefined);
+
+      const result = await videoPersistence.persistDownloadedVideoForJob({
+        jobId: 'job1',
+        youtubeId: 'abc123',
+      });
+
+      expect(VideoMetadataProcessor.processVideoMetadata).toHaveBeenCalledWith(['youtu.be/abc123']);
+      expect(upsertVideoSpy).toHaveBeenCalledWith(metadata, { id: 'job1' });
+      expect(upsertChannelSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'abc123',
+          title: 'Test Video',
+          duration: 300,
+          upload_date: '20240101',
+          channel_id: 'chan1',
+          media_type: 'video',
+        })
+      );
+      expect(result).toEqual({ id: 7, youtubeId: 'abc123' });
+    });
+
+    test('persists audio-only downloads (audioFilePath set, filePath null)', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        { ...metadata, filePath: null, fileSize: null, audioFilePath: '/a.mp3', audioFileSize: '500' },
+      ]);
+      Job.findOne.mockResolvedValue({ id: 'job1' });
+      const upsertVideoSpy = jest
+        .spyOn(videoPersistence, 'upsertVideoForJob')
+        .mockResolvedValue({ id: 8 });
+      jest.spyOn(videoPersistence, 'upsertChannelVideoFromInfo').mockResolvedValue(undefined);
+
+      const result = await videoPersistence.persistDownloadedVideoForJob({
+        jobId: 'job1',
+        youtubeId: 'abc123',
+      });
+
+      expect(upsertVideoSpy).toHaveBeenCalled();
+      expect(result).toEqual({ id: 8 });
+    });
+
+    test('returns null without touching the DB when jobId is missing', async () => {
+      const upsertVideoSpy = jest.spyOn(videoPersistence, 'upsertVideoForJob');
+
+      const result = await videoPersistence.persistDownloadedVideoForJob({
+        jobId: null,
+        youtubeId: 'abc123',
+      });
+
+      expect(result).toBeNull();
+      expect(VideoMetadataProcessor.processVideoMetadata).not.toHaveBeenCalled();
+      expect(upsertVideoSpy).not.toHaveBeenCalled();
+    });
+
+    test('returns null without creating an empty row when no file path was resolved', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([
+        { ...metadata, filePath: null, audioFilePath: null },
+      ]);
+      const upsertVideoSpy = jest.spyOn(videoPersistence, 'upsertVideoForJob');
+
+      const result = await videoPersistence.persistDownloadedVideoForJob({
+        jobId: 'job1',
+        youtubeId: 'abc123',
+      });
+
+      expect(result).toBeNull();
+      expect(upsertVideoSpy).not.toHaveBeenCalled();
+    });
+
+    test('returns null when the job no longer exists', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([metadata]);
+      Job.findOne.mockResolvedValue(null);
+      const upsertVideoSpy = jest.spyOn(videoPersistence, 'upsertVideoForJob');
+
+      const result = await videoPersistence.persistDownloadedVideoForJob({
+        jobId: 'missing',
+        youtubeId: 'abc123',
+      });
+
+      expect(result).toBeNull();
+      expect(upsertVideoSpy).not.toHaveBeenCalled();
+    });
+
+    test('still returns the video when the channel video upsert fails', async () => {
+      VideoMetadataProcessor.processVideoMetadata.mockResolvedValue([metadata]);
+      Job.findOne.mockResolvedValue({ id: 'job1' });
+      jest.spyOn(videoPersistence, 'upsertVideoForJob').mockResolvedValue({ id: 9 });
+      jest
+        .spyOn(videoPersistence, 'upsertChannelVideoFromInfo')
+        .mockRejectedValue(new Error('cv fail'));
+
+      const result = await videoPersistence.persistDownloadedVideoForJob({
+        jobId: 'job1',
+        youtubeId: 'abc123',
+      });
+
+      expect(result).toEqual({ id: 9 });
+    });
+  });
+});

--- a/server/modules/constants/outputMarkers.js
+++ b/server/modules/constants/outputMarkers.js
@@ -1,0 +1,6 @@
+// Control markers passed from the per-video yt-dlp --exec post-processor
+// (a separate Node process) to the parent via the yt-dlp stdout stream.
+// YtdlpOutputRouter watches for these lines; they are not yt-dlp output.
+const VIDEO_PERSISTED_MARKER = '[Youtarr:videoPersisted] ';
+
+module.exports = { VIDEO_PERSISTED_MARKER };

--- a/server/modules/download/YtdlpOutputRouter.js
+++ b/server/modules/download/YtdlpOutputRouter.js
@@ -7,6 +7,7 @@ const logger = require('../../logger');
 const MessageEmitter = require('../messageEmitter');
 const filesystem = require('../filesystem');
 const { JobVideoDownload } = require('../../models');
+const { VIDEO_PERSISTED_MARKER } = require('../constants/outputMarkers');
 
 const PROGRESS_THROTTLE_MS = 250;
 
@@ -40,6 +41,15 @@ class YtdlpOutputRouter {
         logger.info({ source: 'yt-dlp' }, line);
 
         this.timeoutController.noteLine(line);
+
+        // Control marker from the per-video post-processor: its DB rows are
+        // committed, so tell listing pages to refetch. Not yt-dlp output;
+        // skip progress parsing for this line.
+        if (line.startsWith(VIDEO_PERSISTED_MARKER)) {
+          const youtubeId = line.slice(VIDEO_PERSISTED_MARKER.length).trim();
+          MessageEmitter.emitMessage('broadcast', null, 'download', 'videosUpdated', { youtubeId });
+          return;
+        }
 
         // Track current video being processed
         if (line.includes('[youtube] Extracting URL:') && !line.includes('[youtube:tab]')) {

--- a/server/modules/download/__tests__/YtdlpOutputRouter.test.js
+++ b/server/modules/download/__tests__/YtdlpOutputRouter.test.js
@@ -97,6 +97,20 @@ describe('YtdlpOutputRouter', () => {
       });
     });
 
+    it('broadcasts videosUpdated for a video-persisted control marker line', () => {
+      router.handleStdoutChunk('[Youtarr:videoPersisted] abc123XYZ_d\n');
+
+      expect(MessageEmitter.emitMessage).toHaveBeenCalledWith(
+        'broadcast',
+        null,
+        'download',
+        'videosUpdated',
+        { youtubeId: 'abc123XYZ_d' }
+      );
+      // Marker lines are control messages, not yt-dlp output
+      expect(monitor.processProgress).not.toHaveBeenCalled();
+    });
+
     it('routes ERROR lines to the error tracker and suppresses consumed lines', () => {
       errorTracker.handleErrorLine.mockReturnValue(true);
 

--- a/server/modules/jobModule.js
+++ b/server/modules/jobModule.js
@@ -7,8 +7,7 @@ const Video = require('../models/video');
 const JobVideo = require('../models/jobvideo');
 const JobVideoDownload = require('../models/jobvideodownload');
 const ChannelVideo = require('../models/channelvideo');
-const channelVideoReanchor = require('./channelVideoReanchor');
-const { PUBLISHED_AT_SOURCE } = require('./constants/publishedAtSource');
+const videoPersistence = require('./videoPersistence');
 const cron = require('node-cron');
 const MessageEmitter = require('./messageEmitter.js'); // import the helper function
 const configModule = require('./configModule');
@@ -462,33 +461,7 @@ class JobModule {
    * Prepares video data for database save, setting last_downloaded_at if file is verified
    */
   prepareVideoDataForSave(video, isNewVideo = false) {
-    const data = { ...video };
-    const hasVerifiedFile = Boolean(
-      video.filePath && video.fileSize !== null && video.fileSize !== undefined
-    );
-
-    if (hasVerifiedFile) {
-      // Always set these fields when file is verified
-      data.filePath = video.filePath;
-      data.fileSize = video.fileSize;
-      data.removed = false;
-      data.last_downloaded_at = new Date();
-      logger.debug({ youtubeId: video.youtubeId, fileSize: video.fileSize, isNewVideo }, 'Setting last_downloaded_at - file verified');
-    } else {
-      if (!isNewVideo) {
-        // For updates, delete fields to leave them untouched
-        delete data.filePath;
-        delete data.fileSize;
-        delete data.removed;
-      }
-      logger.debug({ youtubeId: video.youtubeId, filePath: video.filePath, fileSize: video.fileSize, isNewVideo }, 'NOT setting last_downloaded_at - hasVerifiedFile is false');
-    }
-
-    if (!video.media_type) {
-      delete data.media_type;
-    }
-
-    return data;
+    return videoPersistence.prepareVideoDataForSave(video, isNewVideo);
   }
 
   /**
@@ -498,67 +471,7 @@ class JobModule {
    * @param {boolean} alwaysCreateJobVideo - Always create JobVideo relationship even if video exists (for recovery)
    */
   async upsertVideoForJob(video, jobInstance, alwaysCreateJobVideo = false) {
-    let videoInstance = await Video.findOne({
-      where: { youtubeId: video.youtubeId },
-    });
-
-    let videoExisted = !!videoInstance;
-
-    if (videoInstance) {
-      // During recovery (alwaysCreateJobVideo=true), treat updates like new videos
-      // to ensure file metadata and last_downloaded_at are set
-      const updateData = this.prepareVideoDataForSave(video, alwaysCreateJobVideo);
-      await videoInstance.update(updateData);
-    } else {
-      // Try to create the video
-      try {
-        const createData = this.prepareVideoDataForSave(video, true);
-        videoInstance = await Video.create(createData);
-      } catch (err) {
-        // If unique constraint error, the video was created by another process (like backfill)
-        // Query for it again
-        if (err.name === 'SequelizeUniqueConstraintError' || err.original?.code === 'ER_DUP_ENTRY') {
-          logger.info({ youtubeId: video.youtubeId }, 'Video already exists (created by another process), fetching it');
-          videoInstance = await Video.findOne({
-            where: { youtubeId: video.youtubeId },
-          });
-          videoExisted = true;
-
-          if (!videoInstance) {
-            // This shouldn't happen, but if it does, re-throw the error
-            throw new Error(`Failed to find video ${video.youtubeId} after unique constraint error`);
-          }
-        } else {
-          // Some other error, re-throw it
-          throw err;
-        }
-      }
-    }
-
-    // Create JobVideo relationship if needed
-    const shouldCreateJobVideo = alwaysCreateJobVideo || !videoExisted;
-
-    if (shouldCreateJobVideo) {
-      // Check if JobVideo relationship already exists
-      const existingJobVideo = await JobVideo.findOne({
-        where: {
-          job_id: jobInstance.id,
-          video_id: videoInstance.id
-        }
-      });
-
-      if (!existingJobVideo) {
-        await JobVideo.create({
-          job_id: jobInstance.id,
-          video_id: videoInstance.id,
-        });
-        logger.debug({ youtubeId: video.youtubeId, job_id: jobInstance.id, video_id: videoInstance.id }, 'Created JobVideo relationship');
-      } else {
-        logger.debug({ youtubeId: video.youtubeId }, 'JobVideo relationship already exists');
-      }
-    }
-
-    return videoInstance;
+    return videoPersistence.upsertVideoForJob(video, jobInstance, alwaysCreateJobVideo);
   }
 
   // Save a single job and its video data to the database
@@ -698,86 +611,12 @@ class JobModule {
 
   // Convert yt-dlp upload_date (YYYYMMDD) to ISO string
   uploadDateToIso(upload_date) {
-    if (!upload_date || typeof upload_date !== 'string' || upload_date.length < 8) {
-      return null;
-    }
-    const year = upload_date.substring(0, 4);
-    const month = upload_date.substring(4, 6);
-    const day = upload_date.substring(6, 8);
-    const d = new Date(`${year}-${month}-${day}T00:00:00Z`);
-    return isNaN(d.getTime()) ? null : d.toISOString();
+    return videoPersistence.uploadDateToIso(upload_date);
   }
 
   // Upsert into channelvideos using info.json-like fields
-  async upsertChannelVideoFromInfo(info, { skipUpdateIfExists = false } = {}) {
-    const youtube_id = info.id || info.youtubeId;
-    const channel_id = info.channel_id || info.channelId;
-    if (!youtube_id || !channel_id) return;
-
-    const title = info.title || info.youTubeVideoName || 'Untitled';
-    const duration = typeof info.duration === 'number' ? info.duration : null;
-    const publishedAt = info.upload_date ? this.uploadDateToIso(info.upload_date) : null;
-    const availability = info.availability || null;
-    const media_type = info.media_type || 'video';
-    const thumbnail = `https://i.ytimg.com/vi/${youtube_id}/mqdefault.jpg`;
-    const content_rating = info.content_rating || null;
-    const age_limit = info.age_limit ?? null;
-    const normalized_rating = info.normalized_rating || null;
-
-    const defaults = {
-      title,
-      thumbnail,
-      duration,
-      publishedAt,
-      published_at_source: publishedAt ? PUBLISHED_AT_SOURCE.EXACT : null,
-      availability,
-      media_type,
-      ignored: false,
-      ignored_at: null
-    };
-    if (content_rating != null) defaults.content_rating = content_rating;
-    if (age_limit != null) defaults.age_limit = age_limit;
-    if (normalized_rating != null) defaults.normalized_rating = normalized_rating;
-
-    const [record, created] = await ChannelVideo.findOrCreate({
-      where: { youtube_id, channel_id },
-      defaults,
-    });
-    if (!created && !skipUpdateIfExists) {
-      // Clear ignored flag when video is downloaded - user action shows they want this video
-      const updates = {
-        title,
-        thumbnail,
-        duration,
-        availability,
-        media_type,
-        ignored: false,
-        ignored_at: null
-      };
-      if (content_rating != null) updates.content_rating = content_rating;
-      if (age_limit != null) updates.age_limit = age_limit;
-      if (normalized_rating != null) updates.normalized_rating = normalized_rating;
-      await record.update(updates);
-
-      // The .info.json upload_date is authoritative; it replaces estimated and
-      // approximate dates from flat-playlist fetches. Delegated to the re-anchor
-      // module (which owns the publishedAt write) so the row's existing position
-      // is read first and neighbouring synthetic dates are shifted to keep the
-      // channel in YouTube order. On create the date is set via defaults above;
-      // a brand-new row has no prior position to preserve, so no re-anchor.
-      if (publishedAt) {
-        try {
-          await channelVideoReanchor.applyExactDateForGroup({
-            channelId: channel_id,
-            mediaType: media_type,
-            youtubeId: youtube_id,
-            exactIso: publishedAt,
-          });
-        } catch (reanchorErr) {
-          logger.error({ err: reanchorErr, youtube_id }, 'Error re-anchoring channel video order after download');
-        }
-      }
-    }
+  async upsertChannelVideoFromInfo(info, options) {
+    return videoPersistence.upsertChannelVideoFromInfo(info, options);
   }
 
   // Backfill Videos and channelvideos tables from complete.list and jobs info JSON

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -8,6 +8,8 @@ const tempPathManager = require('./download/tempPathManager');
 const downloadSettingsResolver = require('./download/downloadSettingsResolver');
 const YtdlpCommandBuilder = require('./download/ytdlpCommandBuilder');
 const { JobVideoDownload } = require('../models');
+const videoPersistence = require('./videoPersistence');
+const { VIDEO_PERSISTED_MARKER } = require('./constants/outputMarkers');
 const logger = require('../logger');
 const { buildChannelPath, cleanupEmptyParents, moveWithRetries, ensureDirWithRetries } = require('./filesystem');
 
@@ -747,6 +749,22 @@ async function resolveTrackedOwnerChannelId(youtubeId, metadataChannelId) {
       : path.dirname(path.dirname(finalVideoPath));
     if (jsonData.channel_id) {
       await copyChannelPosterIfNeeded(jsonData.channel_id, finalChannelFolderPath);
+    }
+
+    // Save to the videos + channelvideos tables now so listing pages can show
+    // this video mid-batch. The end-of-batch save still runs; a failure here
+    // must not fail the download.
+    if (activeJobId) {
+      try {
+        const persisted = await videoPersistence.persistDownloadedVideoForJob({ jobId: activeJobId, youtubeId: id });
+        if (persisted) {
+          // Control marker, not a log line: stdout flows through yt-dlp to
+          // YtdlpOutputRouter, which broadcasts videosUpdated to the listing pages.
+          process.stdout.write(`${VIDEO_PERSISTED_MARKER}${id}\n`);
+        }
+      } catch (err) {
+        logger.error({ err, id }, 'Error persisting downloaded video during post-processing');
+      }
     }
 
     // Mark this video as completed in the JobVideoDownload tracking table

--- a/server/modules/videoPersistence.js
+++ b/server/modules/videoPersistence.js
@@ -1,0 +1,259 @@
+const Job = require('../models/job');
+const Video = require('../models/video');
+const JobVideo = require('../models/jobvideo');
+const ChannelVideo = require('../models/channelvideo');
+const channelVideoReanchor = require('./channelVideoReanchor');
+const { PUBLISHED_AT_SOURCE } = require('./constants/publishedAtSource');
+const VideoMetadataProcessor = require('./download/videoMetadataProcessor');
+const logger = require('../logger');
+
+/**
+ * Persistence of downloaded videos into the videos + channelvideos tables.
+ *
+ * This is intentionally a side-effect-free module (no constructor work, no
+ * timers, no job orchestration) so it can be required both by jobModule (the
+ * end-of-batch finalizer) and by the per-video yt-dlp --exec post-processor,
+ * which runs in a separate Node process. jobModule must NOT be required from
+ * that child process because its constructor migrates jobs, terminates
+ * in-progress jobs and starts the next one.
+ */
+class VideoPersistence {
+  /**
+   * Prepares video data for database save, setting last_downloaded_at if file is verified
+   */
+  prepareVideoDataForSave(video, isNewVideo = false) {
+    const data = { ...video };
+    const hasVerifiedVideoFile = Boolean(
+      video.filePath && video.fileSize !== null && video.fileSize !== undefined
+    );
+    const hasVerifiedAudioFile = Boolean(
+      video.audioFilePath && video.audioFileSize !== null && video.audioFileSize !== undefined
+    );
+    const hasVerifiedFile = hasVerifiedVideoFile || hasVerifiedAudioFile;
+
+    // Only write a format's path fields when that format was verified on disk;
+    // otherwise an update would overwrite an existing path with null.
+    if (!hasVerifiedVideoFile && !isNewVideo) {
+      delete data.filePath;
+      delete data.fileSize;
+    }
+    if (!hasVerifiedAudioFile && !isNewVideo) {
+      delete data.audioFilePath;
+      delete data.audioFileSize;
+    }
+
+    if (hasVerifiedFile) {
+      data.removed = false;
+      data.last_downloaded_at = new Date();
+      logger.debug({ youtubeId: video.youtubeId, fileSize: video.fileSize, audioFileSize: video.audioFileSize, isNewVideo }, 'Setting last_downloaded_at - file verified');
+    } else {
+      if (!isNewVideo) {
+        delete data.removed;
+      }
+      logger.debug({ youtubeId: video.youtubeId, filePath: video.filePath, fileSize: video.fileSize, isNewVideo }, 'NOT setting last_downloaded_at - hasVerifiedFile is false');
+    }
+
+    if (!video.media_type) {
+      delete data.media_type;
+    }
+
+    return data;
+  }
+
+  /**
+   * Upserts a video and creates JobVideo relationship
+   * @param {Object} video - Video data
+   * @param {Object} jobInstance - Job instance
+   * @param {boolean} alwaysCreateJobVideo - Always create JobVideo relationship even if video exists (for recovery)
+   */
+  async upsertVideoForJob(video, jobInstance, alwaysCreateJobVideo = false) {
+    let videoInstance = await Video.findOne({
+      where: { youtubeId: video.youtubeId },
+    });
+
+    let videoExisted = !!videoInstance;
+
+    if (videoInstance) {
+      // During recovery (alwaysCreateJobVideo=true), treat updates like new videos
+      // to ensure file metadata and last_downloaded_at are set
+      const updateData = this.prepareVideoDataForSave(video, alwaysCreateJobVideo);
+      await videoInstance.update(updateData);
+    } else {
+      try {
+        const createData = this.prepareVideoDataForSave(video, true);
+        videoInstance = await Video.create(createData);
+      } catch (err) {
+        // If unique constraint error, the video was created by another process (like backfill)
+        if (err.name === 'SequelizeUniqueConstraintError' || err.original?.code === 'ER_DUP_ENTRY') {
+          logger.info({ youtubeId: video.youtubeId }, 'Video already exists (created by another process), fetching it');
+          videoInstance = await Video.findOne({
+            where: { youtubeId: video.youtubeId },
+          });
+          videoExisted = true;
+
+          if (!videoInstance) {
+            // This shouldn't happen, but if it does, re-throw the error
+            throw new Error(`Failed to find video ${video.youtubeId} after unique constraint error`);
+          }
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    // Create JobVideo relationship if needed
+    const shouldCreateJobVideo = alwaysCreateJobVideo || !videoExisted;
+
+    if (shouldCreateJobVideo) {
+      const existingJobVideo = await JobVideo.findOne({
+        where: {
+          job_id: jobInstance.id,
+          video_id: videoInstance.id
+        }
+      });
+
+      if (!existingJobVideo) {
+        await JobVideo.create({
+          job_id: jobInstance.id,
+          video_id: videoInstance.id,
+        });
+        logger.debug({ youtubeId: video.youtubeId, job_id: jobInstance.id, video_id: videoInstance.id }, 'Created JobVideo relationship');
+      } else {
+        logger.debug({ youtubeId: video.youtubeId }, 'JobVideo relationship already exists');
+      }
+    }
+
+    return videoInstance;
+  }
+
+  // Convert yt-dlp upload_date (YYYYMMDD) to ISO string
+  uploadDateToIso(upload_date) {
+    if (!upload_date || typeof upload_date !== 'string' || upload_date.length < 8) {
+      return null;
+    }
+    const year = upload_date.substring(0, 4);
+    const month = upload_date.substring(4, 6);
+    const day = upload_date.substring(6, 8);
+    const d = new Date(`${year}-${month}-${day}T00:00:00Z`);
+    return isNaN(d.getTime()) ? null : d.toISOString();
+  }
+
+  // Upsert into channelvideos using info.json-like fields
+  async upsertChannelVideoFromInfo(info, { skipUpdateIfExists = false } = {}) {
+    const youtube_id = info.id || info.youtubeId;
+    const channel_id = info.channel_id || info.channelId;
+    if (!youtube_id || !channel_id) return;
+
+    const title = info.title || info.youTubeVideoName || 'Untitled';
+    const duration = typeof info.duration === 'number' ? info.duration : null;
+    const publishedAt = info.upload_date ? this.uploadDateToIso(info.upload_date) : null;
+    const availability = info.availability || null;
+    const media_type = info.media_type || 'video';
+    const thumbnail = `https://i.ytimg.com/vi/${youtube_id}/mqdefault.jpg`;
+    const content_rating = info.content_rating || null;
+    const age_limit = info.age_limit ?? null;
+    const normalized_rating = info.normalized_rating || null;
+
+    const defaults = {
+      title,
+      thumbnail,
+      duration,
+      publishedAt,
+      published_at_source: publishedAt ? PUBLISHED_AT_SOURCE.EXACT : null,
+      availability,
+      media_type,
+      ignored: false,
+      ignored_at: null
+    };
+    if (content_rating != null) defaults.content_rating = content_rating;
+    if (age_limit != null) defaults.age_limit = age_limit;
+    if (normalized_rating != null) defaults.normalized_rating = normalized_rating;
+
+    const [record, created] = await ChannelVideo.findOrCreate({
+      where: { youtube_id, channel_id },
+      defaults,
+    });
+    if (!created && !skipUpdateIfExists) {
+      // Clear ignored flag when video is downloaded - user action shows they want this video
+      const updates = {
+        title,
+        thumbnail,
+        duration,
+        availability,
+        media_type,
+        ignored: false,
+        ignored_at: null
+      };
+      if (content_rating != null) updates.content_rating = content_rating;
+      if (age_limit != null) updates.age_limit = age_limit;
+      if (normalized_rating != null) updates.normalized_rating = normalized_rating;
+      await record.update(updates);
+
+      // The .info.json upload_date is authoritative; it replaces estimated and
+      // approximate dates from flat-playlist fetches. Delegated to the re-anchor
+      // module (which owns the publishedAt write) so the row's existing position
+      // is read first and neighbouring synthetic dates are shifted to keep the
+      // channel in YouTube order. On create the date is set via defaults above;
+      // a brand-new row has no prior position to preserve, so no re-anchor.
+      if (publishedAt) {
+        try {
+          await channelVideoReanchor.applyExactDateForGroup({
+            channelId: channel_id,
+            mediaType: media_type,
+            youtubeId: youtube_id,
+            exactIso: publishedAt,
+          });
+        } catch (reanchorErr) {
+          logger.error({ err: reanchorErr, youtube_id }, 'Error re-anchoring channel video order after download');
+        }
+      }
+    }
+  }
+
+  /**
+   * Persist a single just-completed download into the videos + channelvideos
+   * tables so listing pages can show it mid-batch. Mirrors one iteration of
+   * the end-of-batch loop, which still runs afterwards and is idempotent.
+   *
+   * Reuses VideoMetadataProcessor so the channelvideos row gets the info.json
+   * channel_id, same as the batch path; otherwise VEVO/Topic uploads would
+   * get two divergent rows.
+   */
+  async persistDownloadedVideoForJob({ jobId, youtubeId }) {
+    if (!jobId || !youtubeId) {
+      return null;
+    }
+
+    const [metadata] = await VideoMetadataProcessor.processVideoMetadata([`youtu.be/${youtubeId}`]);
+    // Skip until a real media file was resolved; the end-of-batch save still runs.
+    if (!metadata || (!metadata.filePath && !metadata.audioFilePath)) {
+      return null;
+    }
+
+    const jobInstance = await Job.findOne({ where: { id: jobId } });
+    if (!jobInstance) {
+      return null;
+    }
+
+    const videoInstance = await this.upsertVideoForJob(metadata, jobInstance);
+
+    // Upsert the channelvideos row too (creates it for manual downloads, clears
+    // ignored otherwise). A failure must not lose the videos write above.
+    try {
+      await this.upsertChannelVideoFromInfo({
+        id: metadata.youtubeId,
+        title: metadata.youTubeVideoName,
+        duration: metadata.duration,
+        upload_date: metadata.originalDate,
+        channel_id: metadata.channel_id,
+        media_type: metadata.media_type || 'video',
+      });
+    } catch (cvErr) {
+      logger.error({ err: cvErr, youtubeId }, 'Error upserting channel video during per-video persist');
+    }
+
+    return videoInstance;
+  }
+}
+
+module.exports = new VideoPersistence();

--- a/server/routes/__tests__/playlists.test.js
+++ b/server/routes/__tests__/playlists.test.js
@@ -803,6 +803,43 @@ describe('GET /api/playlists/:playlistId/videos', () => {
     });
   });
 
+  test('flags an audio-only download (no video filePath) as downloaded', async () => {
+    const deps = buildDeps();
+    deps.models.PlaylistVideo.findAndCountAll.mockResolvedValue({
+      count: 1,
+      rows: [
+        { id: 1, playlist_id: 'PLtest123', youtube_id: 'audio1', position: 1, ignored: false, ignored_at: null, added_at: null, channel_id: null },
+      ],
+    });
+    deps.models.Video.findAll.mockResolvedValue([
+      {
+        id: 9,
+        youtubeId: 'audio1',
+        youTubeVideoName: 'An mp3-only download',
+        removed: false,
+        youtube_removed: false,
+        filePath: null,
+        fileSize: null,
+        audioFilePath: '/videos/audio1.mp3',
+        audioFileSize: 512,
+      },
+    ]);
+
+    const handler = getHandler('get', '/api/playlists/:playlistId/videos', deps);
+    const req = { params: { playlistId: 'PLtest123' }, query: {}, log: loggerMock };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.videos[0]).toMatchObject({
+      youtube_id: 'audio1',
+      downloaded: true,
+      previously_downloaded: false,
+      audio_file_path: '/videos/audio1.mp3',
+    });
+  });
+
   test('orders by position DESC when sortOrder=desc', async () => {
     const deps = buildDeps();
     deps.models.PlaylistVideo.findAndCountAll.mockResolvedValue({ count: 0, rows: [] });

--- a/server/routes/playlists.js
+++ b/server/routes/playlists.js
@@ -242,7 +242,7 @@ function createPlaylistRoutes({ verifyToken, playlistModule, downloadModule, m3u
       const videos = rows.map((row) => {
         const dl = downloadedById.get(row.youtube_id);
         const youtubeId = row.youtube_id;
-        const isDownloaded = !!(dl && !dl.removed && dl.filePath);
+        const isDownloaded = !!(dl && !dl.removed && (dl.filePath || dl.audioFilePath));
         // Has a Videos row but no usable file: previously downloaded, then
         // deleted/lost. doPlaylistDownloads skips these unless allowRedownload is set.
         const previouslyDownloaded = !!dl && !isDownloaded;


### PR DESCRIPTION
Videos previously appeared on the Videos, Channel, and Playlist pages only after an entire download batch finished.

- Move video/channelvideo persistence from jobModule into a new videoPersistence module and call it per video from the download post-processor. The end-of-batch save still runs.
- Broadcast videosUpdated over WebSocket as each video is persisted; listing pages refetch via a new useDownloadListingsRefresh hook.
- Treat a verified audio file as downloaded: audio-only downloads had no last_downloaded_at and showed as not downloaded on playlists.