### PR TITLE
feat: add download activity indicator to header

### DIFF
--- a/client/src/components/layout/DownloadActivityIndicator.tsx
+++ b/client/src/components/layout/DownloadActivityIndicator.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { IconButton, Tooltip } from '../ui';
+import { ArrowDownward, Loader2 } from '../../lib/icons';
+import { useActiveDownloads } from '../../hooks/useActiveDownloads';
+
+const INDICATOR_SIZE = 22;
+const ARROW_SIZE = 11;
+
+interface DownloadActivityIndicatorProps {
+  token: string | null;
+}
+
+/**
+ * Stays animated even when the user prefers reduced motion, same as the
+ * app's .loading-spinner: the motion is the status signal.
+ */
+export function DownloadActivityIndicator({ token }: DownloadActivityIndicatorProps) {
+  const { active } = useActiveDownloads(token);
+  const navigate = useNavigate();
+
+  if (!active) {
+    return null;
+  }
+
+  return (
+    <Tooltip title="Video downloads are in progress" placement="bottom" arrow>
+      <IconButton
+        aria-label="Video downloads are in progress"
+        color="primary"
+        className="mr-1"
+        onClick={() => navigate('/downloads/activity')}
+      >
+        <span
+          className="relative inline-flex items-center justify-center"
+          style={{ width: INDICATOR_SIZE, height: INDICATOR_SIZE }}
+        >
+          <Loader2
+            size={INDICATOR_SIZE}
+            className="absolute inset-0 animate-spin"
+            data-testid="download-activity-spinner"
+            aria-hidden="true"
+          />
+          <ArrowDownward
+            size={ARROW_SIZE}
+            strokeWidth={3}
+            className="animate-download-arrow-drop"
+            data-testid="download-activity-arrow"
+            aria-hidden="true"
+          />
+        </span>
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/client/src/components/layout/NavHeaderActions.tsx
+++ b/client/src/components/layout/NavHeaderActions.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../lib/icons';
 import { ThemeLayoutPolicy } from '../../themes';
 import { StorageHeaderWidget } from './StorageHeaderWidget';
+import { DownloadActivityIndicator } from './DownloadActivityIndicator';
 
 interface NavHeaderActionsProps {
   layoutPolicy: ThemeLayoutPolicy;
@@ -140,6 +141,8 @@ export const NavHeaderActions: React.FC<NavHeaderActionsProps> = ({
           </Box>
         </Tooltip>
       )}
+
+      <DownloadActivityIndicator token={token} />
 
       {hasAnyUpdate && sharedUpdateTooltip && (
         <Tooltip title={sharedUpdateTooltip} placement="bottom" arrow>

--- a/client/src/components/layout/__tests__/DownloadActivityIndicator.test.tsx
+++ b/client/src/components/layout/__tests__/DownloadActivityIndicator.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { DownloadActivityIndicator } from '../DownloadActivityIndicator';
+import { TooltipProvider } from '../../ui/tooltip';
+import { useActiveDownloads } from '../../../hooks/useActiveDownloads';
+
+jest.mock('../../../hooks/useActiveDownloads', () => ({
+  useActiveDownloads: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockUseActiveDownloads = useActiveDownloads as jest.Mock;
+
+function renderIndicator(token: string | null = 'test-token') {
+  return render(
+    <MemoryRouter>
+      <TooltipProvider>
+        <DownloadActivityIndicator token={token} />
+      </TooltipProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('DownloadActivityIndicator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders nothing when no downloads are active', () => {
+    mockUseActiveDownloads.mockReturnValue({ active: false });
+
+    renderIndicator();
+
+    expect(
+      screen.queryByRole('button', { name: /downloads.*in progress/i })
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows the indicator button when downloads are active', () => {
+    mockUseActiveDownloads.mockReturnValue({ active: true });
+
+    renderIndicator();
+
+    expect(
+      screen.getByRole('button', { name: /downloads.*in progress/i })
+    ).toBeInTheDocument();
+  });
+
+  test('passes the token through to the hook', () => {
+    mockUseActiveDownloads.mockReturnValue({ active: false });
+
+    renderIndicator('abc-123');
+
+    expect(mockUseActiveDownloads).toHaveBeenCalledWith('abc-123');
+  });
+
+  test('navigates to the downloads activity page when clicked', async () => {
+    mockUseActiveDownloads.mockReturnValue({ active: true });
+    const user = userEvent.setup();
+
+    renderIndicator();
+
+    await user.click(
+      screen.getByRole('button', { name: /downloads.*in progress/i })
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith('/downloads/activity');
+  });
+
+  test('keeps both animations running regardless of reduced-motion preferences', () => {
+    mockUseActiveDownloads.mockReturnValue({ active: true });
+
+    renderIndicator();
+
+    const spinner = screen.getByTestId('download-activity-spinner');
+    const arrow = screen.getByTestId('download-activity-arrow');
+    expect(spinner).toHaveClass('animate-spin');
+    expect(spinner).not.toHaveClass('motion-reduce:animate-none');
+    expect(arrow).toHaveClass('animate-download-arrow-drop');
+  });
+
+  test('shows an explanatory tooltip on hover', async () => {
+    mockUseActiveDownloads.mockReturnValue({ active: true });
+    const user = userEvent.setup();
+
+    renderIndicator();
+
+    await user.hover(
+      screen.getByRole('button', { name: /downloads.*in progress/i })
+    );
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip).toHaveTextContent(/video downloads are in progress/i);
+  });
+});

--- a/client/src/components/layout/__tests__/NavHeader.test.tsx
+++ b/client/src/components/layout/__tests__/NavHeader.test.tsx
@@ -12,6 +12,12 @@ jest.mock('../StorageHeaderWidget', () => ({
   StorageHeaderWidget: () => <div data-testid="storage-header-widget" />,
 }));
 
+jest.mock('../DownloadActivityIndicator', () => ({
+  DownloadActivityIndicator: () => (
+    <div data-testid="download-activity-indicator" />
+  ),
+}));
+
 const NAV_ITEMS = [
   {
     key: 'channels',
@@ -165,6 +171,20 @@ describe('NavHeader shared update indicator', () => {
     renderHeader({ layoutPolicy: resolveThemeLayoutPolicy(getThemeById('playful'), 'mobile') });
 
     expect(screen.getByTestId('storage-header-widget')).toBeInTheDocument();
+  });
+
+  it('renders the download activity indicator in the desktop header actions', () => {
+    renderHeader();
+
+    expect(screen.getByTestId('download-activity-indicator')).toBeInTheDocument();
+  });
+
+  it('renders the download activity indicator in the playful mobile header', () => {
+    localStorage.setItem('uiThemeMode', 'playful');
+
+    renderHeader({ layoutPolicy: resolveThemeLayoutPolicy(getThemeById('playful'), 'mobile') });
+
+    expect(screen.getByTestId('download-activity-indicator')).toBeInTheDocument();
   });
 
   it('renders the header wordmark 30 percent larger across themes', () => {

--- a/client/src/hooks/__tests__/useActiveDownloads.test.tsx
+++ b/client/src/hooks/__tests__/useActiveDownloads.test.tsx
@@ -1,0 +1,300 @@
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useActiveDownloads } from '../useActiveDownloads';
+import WebSocketContext from '../../contexts/WebSocketContext';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+const axios = require('axios');
+
+type Filter = (message: { destination?: string; type?: string }) => boolean;
+type Callback = (data: unknown) => void;
+
+describe('useActiveDownloads', () => {
+  const mockToken = 'test-token-123';
+
+  let subscriptions: Array<{ filter: Filter; callback: Callback }>;
+  let subscribe: jest.Mock;
+  let unsubscribe: jest.Mock;
+
+  const emitMessage = (message: {
+    destination?: string;
+    type?: string;
+    payload?: unknown;
+  }) => {
+    act(() => {
+      subscriptions.forEach((sub) => {
+        if (sub.filter(message)) {
+          sub.callback(message.payload);
+        }
+      });
+    });
+  };
+
+  const advanceTimers = (ms: number) => {
+    act(() => {
+      jest.advanceTimersByTime(ms);
+    });
+  };
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WebSocketContext.Provider value={{ socket: null, subscribe, unsubscribe }}>
+      {children}
+    </WebSocketContext.Provider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    subscriptions = [];
+    subscribe = jest.fn((filter: Filter, callback: Callback) => {
+      subscriptions.push({ filter, callback });
+    });
+    unsubscribe = jest.fn((callback: Callback) => {
+      subscriptions = subscriptions.filter((sub) => sub.callback !== callback);
+    });
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('is inactive and does not fetch when token is null', () => {
+    const { result } = renderHook(() => useActiveDownloads(null), { wrapper });
+
+    expect(result.current.active).toBe(false);
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test('probes /runningjobs with the auth token on mount', async () => {
+    axios.get.mockResolvedValueOnce({ data: [] });
+
+    renderHook(() => useActiveDownloads(mockToken), { wrapper });
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith('/runningjobs', {
+        headers: { 'x-access-token': mockToken },
+      });
+    });
+  });
+
+  test('becomes active when /runningjobs returns an In Progress job', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: [{ id: 'a', status: 'In Progress' }],
+    });
+
+    const { result } = renderHook(() => useActiveDownloads(mockToken), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.active).toBe(true);
+    });
+  });
+
+  test('becomes active when /runningjobs returns a queued Pending job', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: [{ id: 'a', status: 'Pending' }],
+    });
+
+    const { result } = renderHook(() => useActiveDownloads(mockToken), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.active).toBe(true);
+    });
+  });
+
+  test('stays inactive when /runningjobs returns only finished jobs', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: [
+        { id: 'a', status: 'Complete' },
+        { id: 'b', status: 'Terminated' },
+      ],
+    });
+
+    const { result } = renderHook(() => useActiveDownloads(mockToken), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.active).toBe(false);
+  });
+
+  test('stays inactive when the /runningjobs request fails', async () => {
+    axios.get.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderHook(() => useActiveDownloads(mockToken), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current.active).toBe(false);
+  });
+
+  test('becomes active when a downloadProgress broadcast reports an active state', async () => {
+    axios.get.mockResolvedValueOnce({ data: [] });
+
+    const { result } = renderHook(() => useActiveDownloads(mockToken), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    emitMessage({
+      destination: 'broadcast',
+      type: 'downloadProgress',
+      payload: { progress: { state: 'downloading' } },
+    });
+
+    await waitFor(() => {
+      expect(result.current.active).toBe(true);
+    });
+  });
+
+  test('refetches after downloadComplete and clears active when no jobs remain', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: [{ id: 'a', status: 'In Progress' }],
+    });
+
+    const { result } = renderHook(() => useActiveDownloads(mockToken), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.active).toBe(true);
+    });
+
+    axios.get.mockResolvedValueOnce({
+      data: [{ id: 'a', status: 'Complete' }],
+    });
+    emitMessage({
+      destination: 'broadcast',
+      type: 'downloadComplete',
+      payload: { videos: [] },
+    });
+    advanceTimers(1000);
+
+    await waitFor(() => {
+      expect(result.current.active).toBe(false);
+    });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  test('stays active after downloadComplete when a chained job is still queued', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: [{ id: 'a', status: 'In Progress' }],
+    });
+
+    const { result } = renderHook(() => useActiveDownloads(mockToken), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.active).toBe(true);
+    });
+
+    axios.get.mockResolvedValueOnce({
+      data: [
+        { id: 'a', status: 'Complete' },
+        { id: 'b', status: 'Pending' },
+      ],
+    });
+    emitMessage({
+      destination: 'broadcast',
+      type: 'downloadComplete',
+      payload: { videos: [] },
+    });
+    advanceTimers(1000);
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(2);
+    });
+    expect(result.current.active).toBe(true);
+  });
+
+  test('coalesces terminal signals into a single refetch', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: [{ id: 'a', status: 'In Progress' }],
+    });
+
+    renderHook(() => useActiveDownloads(mockToken), { wrapper });
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    axios.get.mockResolvedValueOnce({ data: [] });
+    emitMessage({
+      destination: 'broadcast',
+      type: 'downloadProgress',
+      payload: { progress: { state: 'complete' }, finalSummary: { totalDownloaded: 1 } },
+    });
+    advanceTimers(500);
+    emitMessage({
+      destination: 'broadcast',
+      type: 'downloadComplete',
+      payload: { videos: [] },
+    });
+    advanceTimers(1000);
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  test('ignores throttled downloadProgress messages without a state change', async () => {
+    axios.get.mockResolvedValueOnce({ data: [] });
+
+    const { result } = renderHook(() => useActiveDownloads(mockToken), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    emitMessage({
+      destination: 'broadcast',
+      type: 'downloadProgress',
+      payload: { text: 'some log line' },
+    });
+    advanceTimers(2000);
+
+    expect(result.current.active).toBe(false);
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  test('unsubscribes and cancels a pending refetch on unmount', async () => {
+    axios.get.mockResolvedValueOnce({ data: [] });
+
+    const { unmount } = renderHook(() => useActiveDownloads(mockToken), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    emitMessage({
+      destination: 'broadcast',
+      type: 'downloadComplete',
+      payload: { videos: [] },
+    });
+    unmount();
+    advanceTimers(1000);
+
+    expect(unsubscribe).toHaveBeenCalled();
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/hooks/useActiveDownloads.ts
+++ b/client/src/hooks/useActiveDownloads.ts
@@ -1,0 +1,112 @@
+import { useCallback, useContext, useEffect, useState } from 'react';
+import axios from 'axios';
+import WebSocketContext from '../contexts/WebSocketContext';
+
+const REFETCH_DEBOUNCE_MS = 1000;
+const ACTIVE_JOB_STATUSES = ['In Progress', 'Pending'];
+const ACTIVE_PROGRESS_STATES = ['initiating', 'downloading', 'stalled'];
+const TERMINAL_PROGRESS_STATES = ['complete', 'error', 'terminated'];
+
+interface RunningJob {
+  status?: string;
+}
+
+interface BroadcastMessage {
+  destination?: string;
+  type?: string;
+}
+
+interface DownloadProgressPayload {
+  progress?: { state?: string };
+  finalSummary?: unknown;
+}
+
+/**
+ * The /runningjobs probe covers initial state: WebSocket reconnects only
+ * replay final states, so a page opened mid-download would start blank.
+ * Terminal signals re-probe instead of clearing because a finished job
+ * can hand off to a queued Pending job.
+ */
+export function useActiveDownloads(token: string | null): { active: boolean } {
+  const [active, setActive] = useState(false);
+  const wsContext = useContext(WebSocketContext);
+  const subscribe = wsContext?.subscribe;
+  const unsubscribe = wsContext?.unsubscribe;
+
+  const fetchActive = useCallback(async () => {
+    if (!token) {
+      return;
+    }
+    try {
+      const response = await axios.get<RunningJob[]>('/runningjobs', {
+        headers: { 'x-access-token': token },
+      });
+      const jobs = Array.isArray(response.data) ? response.data : [];
+      setActive(
+        jobs.some(
+          (job) => job.status !== undefined && ACTIVE_JOB_STATUSES.includes(job.status)
+        )
+      );
+    } catch {
+      // Leave the current value; the next broadcast or probe corrects it.
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (!token) {
+      setActive(false);
+      return;
+    }
+    fetchActive();
+  }, [token, fetchActive]);
+
+  useEffect(() => {
+    if (!subscribe || !unsubscribe) {
+      return;
+    }
+
+    let refetchTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleRefetch = () => {
+      if (refetchTimer) {
+        clearTimeout(refetchTimer);
+      }
+      refetchTimer = setTimeout(() => {
+        refetchTimer = null;
+        fetchActive();
+      }, REFETCH_DEBOUNCE_MS);
+    };
+
+    const progressFilter = (message: BroadcastMessage) =>
+      message.destination === 'broadcast' && message.type === 'downloadProgress';
+    const progressCallback = (payload: DownloadProgressPayload) => {
+      const state = payload?.progress?.state;
+      if (state !== undefined && ACTIVE_PROGRESS_STATES.includes(state)) {
+        setActive(true);
+        return;
+      }
+      if (
+        payload?.finalSummary ||
+        (state !== undefined && TERMINAL_PROGRESS_STATES.includes(state))
+      ) {
+        scheduleRefetch();
+      }
+    };
+
+    const completeFilter = (message: BroadcastMessage) =>
+      message.destination === 'broadcast' && message.type === 'downloadComplete';
+    const completeCallback = () => scheduleRefetch();
+
+    subscribe(progressFilter, progressCallback);
+    subscribe(completeFilter, completeCallback);
+
+    return () => {
+      unsubscribe(progressCallback);
+      unsubscribe(completeCallback);
+      if (refetchTimer) {
+        clearTimeout(refetchTimer);
+      }
+    };
+  }, [subscribe, unsubscribe, fetchActive]);
+
+  return { active };
+}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -116,6 +116,12 @@ module.exports = {
           '0%': { transform: 'translateY(-8px)', opacity: '0' },
           '100%': { transform: 'translateY(0)', opacity: '1' },
         },
+        'download-arrow-drop': {
+          '0%': { transform: 'translateY(-4px)', opacity: '0' },
+          '30%': { opacity: '1' },
+          '70%': { opacity: '1' },
+          '100%': { transform: 'translateY(4px)', opacity: '0' },
+        },
       },
       animation: {
         wiggle: 'wiggle 320ms var(--transition-bouncy)',
@@ -123,6 +129,7 @@ module.exports = {
         'fade-in': 'fade-in 150ms ease',
         'slide-up': 'slide-up 150ms ease',
         'slide-down': 'slide-down 150ms ease',
+        'download-arrow-drop': 'download-arrow-drop 1.1s ease-in-out infinite',
         spin: 'spin 1s linear infinite',
       },
     },


### PR DESCRIPTION
Show an animated header indicator whenever a download job is running or queued, linking to the activity page. A useActiveDownloads hook probes /runningjobs on mount and tracks download broadcasts, with a debounced re-probe on terminal signals since a finished job can hand off to a queued one.