### PR TITLE
fix: fall back to cp -r on EPERM for cross-device move/copy on FUSE mounts

### DIFF
--- a/server/modules/__tests__/channelPoster.test.js
+++ b/server/modules/__tests__/channelPoster.test.js
@@ -104,7 +104,8 @@ describe('Channel Poster Functionality', () => {
       expect(fs.copySync).toHaveBeenCalledTimes(1);
       expect(fs.copySync).toHaveBeenCalledWith(
         '/images/channelthumb-UC123.jpg',
-        '/videos/Test Channel 1/poster.jpg'
+        '/videos/Test Channel 1/poster.jpg',
+        { overwrite: true }
       );
     });
 
@@ -141,7 +142,8 @@ describe('Channel Poster Functionality', () => {
       expect(fs.copySync).toHaveBeenCalledTimes(1);
       expect(fs.copySync).toHaveBeenCalledWith(
         '/images/channelthumb-UC456.jpg',
-        '/videos/Valid Channel/poster.jpg'
+        '/videos/Valid Channel/poster.jpg',
+        { overwrite: true }
       );
     });
 

--- a/server/modules/__tests__/videoDownloadPostProcessFiles.test.js
+++ b/server/modules/__tests__/videoDownloadPostProcessFiles.test.js
@@ -25,6 +25,8 @@ jest.mock('fs-extra', () => {
 jest.mock('child_process', () => ({
   execSync: jest.fn(),
   spawnSync: jest.fn(() => ({ status: 0, error: null })),
+  execFile: jest.fn((cmd, args, callback) => callback(null, '', '')),
+  execFileSync: jest.fn(),
 }));
 
 const mockConfig = {};
@@ -1321,7 +1323,7 @@ describe('videoDownloadPostProcessFiles', () => {
       await loadModule();
       await settleAsync();
 
-      expect(fs.copySync).toHaveBeenCalledWith(imagePath, fanartPath);
+      expect(fs.copySync).toHaveBeenCalledWith(imagePath, fanartPath, { overwrite: true });
       expect(logger.info).toHaveBeenCalledWith(
         { fanartPath },
         '[Post-Process] Created video fanart file'

--- a/server/modules/channelModule.js
+++ b/server/modules/channelModule.js
@@ -11,7 +11,7 @@ const MessageEmitter = require('./messageEmitter.js');
 const { Op, fn, col, where } = require('sequelize');
 const fileCheckModule = require('./fileCheckModule');
 const logger = require('../logger');
-const { sanitizeNameLikeYtDlp, GLOBAL_DEFAULT_SENTINEL } = require('./filesystem');
+const { sanitizeNameLikeYtDlp, GLOBAL_DEFAULT_SENTINEL, copySyncWithFallback } = require('./filesystem');
 const youtubeApi = require('./youtubeApi');
 const ratingMapper = require('./ratingMapper');
 const tempPathManager = require('./download/tempPathManager');
@@ -1005,7 +1005,7 @@ class ChannelModule {
 
           if (fs.existsSync(channelThumbPath)) {
             try {
-              fs.copySync(channelThumbPath, channelPosterPath);
+              copySyncWithFallback(channelThumbPath, channelPosterPath);
             } catch (copyErr) {
               logger.error({ err: copyErr, channelFolderName }, 'Error backfilling poster for channel');
             }

--- a/server/modules/filesystem/__tests__/fileOperations.test.js
+++ b/server/modules/filesystem/__tests__/fileOperations.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const fsPromises = require('fs').promises;
+const { execFile, execFileSync } = require('child_process');
 
 // Mock fs-extra and fs.promises
 jest.mock('fs-extra');
@@ -16,6 +17,12 @@ jest.mock('fs', () => ({
   utimesSync: jest.fn()
 }));
 
+// Mock child_process (used by the cp fallback for FUSE-mount EPERM errors)
+jest.mock('child_process', () => ({
+  execFile: jest.fn(),
+  execFileSync: jest.fn()
+}));
+
 // Mock logger
 jest.mock('../../../logger', () => ({
   debug: jest.fn(),
@@ -29,12 +36,20 @@ const {
   moveWithRetries,
   safeRemove,
   safeCopy,
+  copySyncWithFallback,
   pathExists,
   safeStat,
   setTimestamp,
   isFile,
   isDirectory
 } = require('../fileOperations');
+
+function eperm(syscall) {
+  const err = new Error('operation not permitted');
+  err.code = 'EPERM';
+  err.syscall = syscall;
+  return err;
+}
 
 describe('filesystem/fileOperations', () => {
   beforeEach(() => {
@@ -104,6 +119,95 @@ describe('filesystem/fileOperations', () => {
       await moveWithRetries('/src', '/dest', { overwrite: false });
 
       expect(fs.move).toHaveBeenCalledWith('/src', '/dest', { overwrite: false });
+    });
+
+    it('should fall back to cp -r on EPERM copyfile error from FUSE mounts', async () => {
+      fs.move.mockRejectedValueOnce(eperm('copyfile'));
+      fs.remove.mockResolvedValue();
+      execFile.mockImplementation((cmd, args, callback) => callback(null, '', ''));
+
+      await moveWithRetries('/src', '/dest');
+
+      expect(execFile).toHaveBeenCalledWith('cp', ['-r', '--', '/src', '/dest'], expect.any(Function));
+      expect(fs.remove).toHaveBeenCalledWith('/src');
+    });
+
+    it('should remove destination before falling back when overwrite is true', async () => {
+      fs.move.mockRejectedValueOnce(eperm('copyfile'));
+      fs.remove.mockResolvedValue();
+      execFile.mockImplementation((cmd, args, callback) => callback(null, '', ''));
+
+      await moveWithRetries('/src', '/dest', { overwrite: true });
+
+      expect(fs.remove).toHaveBeenCalledWith('/dest');
+    });
+
+    it('should throw the fallback error when cp -r also fails', async () => {
+      fs.move.mockRejectedValueOnce(eperm('copyfile'));
+      fs.remove.mockResolvedValue();
+      const cpError = new Error('cp: cannot create fifo');
+      execFile.mockImplementation((cmd, args, callback) => callback(cpError));
+
+      await expect(moveWithRetries('/src', '/dest')).rejects.toThrow('cp: cannot create fifo');
+    });
+
+    it('should not use the cp fallback for EPERM errors from other syscalls', async () => {
+      jest.useFakeTimers();
+      const error = eperm('rename');
+      fs.move.mockRejectedValue(error);
+
+      const promise = moveWithRetries('/src', '/dest', { retries: 1, delayMs: 10 });
+      for (let i = 0; i < 2; i++) {
+        await Promise.resolve();
+        jest.advanceTimersByTime(1000);
+      }
+
+      await expect(promise).rejects.toThrow(error);
+      expect(execFile).not.toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+  });
+
+  describe('copySyncWithFallback', () => {
+    it('should copy synchronously without fallback on success', () => {
+      fs.copySync.mockReturnValueOnce();
+
+      copySyncWithFallback('/src', '/dest');
+
+      expect(fs.copySync).toHaveBeenCalledWith('/src', '/dest', { overwrite: true });
+      expect(execFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to cp -r on EPERM copyfile error', () => {
+      fs.copySync.mockImplementationOnce(() => {
+        throw eperm('copyfile');
+      });
+      fs.removeSync.mockReturnValueOnce();
+
+      copySyncWithFallback('/src', '/dest');
+
+      expect(fs.removeSync).toHaveBeenCalledWith('/dest');
+      expect(execFileSync).toHaveBeenCalledWith('cp', ['-r', '--', '/src', '/dest']);
+    });
+
+    it('should not remove the destination first when overwrite is false', () => {
+      fs.copySync.mockImplementationOnce(() => {
+        throw eperm('copyfile');
+      });
+
+      copySyncWithFallback('/src', '/dest', { overwrite: false });
+
+      expect(fs.removeSync).not.toHaveBeenCalled();
+      expect(execFileSync).toHaveBeenCalledWith('cp', ['-r', '--', '/src', '/dest']);
+    });
+
+    it('should rethrow errors that are not the FUSE-mount EPERM case', () => {
+      fs.copySync.mockImplementationOnce(() => {
+        throw eperm('rename');
+      });
+
+      expect(() => copySyncWithFallback('/src', '/dest')).toThrow();
+      expect(execFileSync).not.toHaveBeenCalled();
     });
   });
 

--- a/server/modules/filesystem/fileOperations.js
+++ b/server/modules/filesystem/fileOperations.js
@@ -67,7 +67,7 @@ async function moveWithRetries(src, dest, { retries = 5, delayMs = 200, overwrit
           logger.warn({ src, dest }, 'Move succeeded via cp fallback after EPERM from fs.move');
           return;
         } catch (fallbackErr) {
-          logger.warn({ src, dest, fallbackErr }, 'cp fallback for cross-device move also failed');
+          logger.warn({ err: fallbackErr, src, dest }, 'cp fallback for cross-device move also failed');
           throw fallbackErr;
         }
       }

--- a/server/modules/filesystem/fileOperations.js
+++ b/server/modules/filesystem/fileOperations.js
@@ -5,6 +5,9 @@
 
 const fs = require('fs-extra');
 const fsPromises = require('fs').promises;
+const { execFile, execFileSync } = require('child_process');
+const { promisify } = require('util');
+const execFileAsync = promisify(execFile);
 const logger = require('../../logger');
 
 /**
@@ -14,6 +17,29 @@ const logger = require('../../logger');
  */
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Some FUSE-backed filesystems (e.g. rclone mounts) return EPERM instead of
+ * EXDEV/EOPNOTSUPP when Node's copy_file_range-based fs.copyFile is used for
+ * a cross-device copy, and fs-extra doesn't fall back to a plain read/write
+ * copy in that case. The system 'cp' binary handles this correctly, so shell
+ * out to it as a last resort.
+ *
+ * @param {string} src - Source path
+ * @param {string} dest - Destination path
+ * @param {boolean} overwrite - Whether to overwrite an existing destination
+ * @returns {Promise<void>}
+ */
+async function moveViaCpFallback(src, dest, overwrite) {
+  if (overwrite) {
+    await fs.remove(dest);
+  }
+  // Plain recursive copy, no -a/--preserve: some FUSE mounts (e.g. rclone)
+  // reject utimes()/chown() on the destination with EPERM even though the
+  // actual data copy is allowed.
+  await execFileAsync('cp', ['-r', '--', src, dest]);
+  await fs.remove(src);
 }
 
 /**
@@ -35,6 +61,16 @@ async function moveWithRetries(src, dest, { retries = 5, delayMs = 200, overwrit
       await fs.move(src, dest, { overwrite });
       return;
     } catch (err) {
+      if (err && err.code === 'EPERM' && err.syscall === 'copyfile') {
+        try {
+          await moveViaCpFallback(src, dest, overwrite);
+          logger.warn({ src, dest }, 'Move succeeded via cp fallback after EPERM from fs.move');
+          return;
+        } catch (fallbackErr) {
+          logger.warn({ src, dest, fallbackErr }, 'cp fallback for cross-device move also failed');
+          throw fallbackErr;
+        }
+      }
       if (attempt === retries) {
         throw err;
       }
@@ -59,6 +95,30 @@ async function safeRemove(filePath) {
     if (err && err.code !== 'ENOENT') {
       logger.warn({ err, filePath }, 'Error deleting file');
     }
+  }
+}
+
+/**
+ * Synchronous copy with the same EPERM/copy_file_range fallback as
+ * moveWithRetries, for call sites that use fs.copySync directly.
+ *
+ * @param {string} src - Source path
+ * @param {string} dest - Destination path
+ * @param {Object} options - Options
+ * @param {boolean} options.overwrite - Whether to overwrite existing (default: true)
+ */
+function copySyncWithFallback(src, dest, { overwrite = true } = {}) {
+  try {
+    fs.copySync(src, dest, { overwrite });
+  } catch (err) {
+    if (err && err.code === 'EPERM' && err.syscall === 'copyfile') {
+      if (overwrite) {
+        fs.removeSync(dest);
+      }
+      execFileSync('cp', ['-r', '--', src, dest]);
+      return;
+    }
+    throw err;
   }
 }
 
@@ -205,6 +265,7 @@ module.exports = {
   moveWithRetries,
   safeRemove,
   safeCopy,
+  copySyncWithFallback,
   pathExists,
   safeStat,
   setTimestamp,

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -11,7 +11,7 @@ const { JobVideoDownload } = require('../models');
 const videoPersistence = require('./videoPersistence');
 const { VIDEO_PERSISTED_MARKER } = require('./constants/outputMarkers');
 const logger = require('../logger');
-const { buildChannelPath, cleanupEmptyParents, moveWithRetries, ensureDirWithRetries } = require('./filesystem');
+const { buildChannelPath, cleanupEmptyParents, moveWithRetries, ensureDirWithRetries, copySyncWithFallback } = require('./filesystem');
 
 const activeJobId = process.env.YOUTARR_JOB_ID;
 
@@ -122,7 +122,7 @@ async function copyChannelPosterIfNeeded(channelId, channelFolderPath) {
       );
 
       if (fs.existsSync(channelThumbPath)) {
-        fs.copySync(channelThumbPath, channelPosterPath);
+        copySyncWithFallback(channelThumbPath, channelPosterPath);
         logger.info({ channelFolderPath }, 'Channel poster.jpg created');
       }
     }
@@ -493,7 +493,7 @@ async function resolveTrackedOwnerChannelId(youtubeId, metadataChannelId) {
         newImagePath,
         `videothumb-${id}-small.jpg`
       ); // define the new path for image thumbnail
-      fs.copySync(imagePath, newImageFullPath, { overwrite: true }); // copy the image thumbnail
+      copySyncWithFallback(imagePath, newImageFullPath, { overwrite: true }); // copy the image thumbnail
 
       // Resize the image using ffmpeg with proper settings to avoid deprecated format warnings
       // Using -loglevel error to suppress the deprecated pixel format warnings but still show actual errors

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -757,7 +757,7 @@ async function resolveTrackedOwnerChannelId(youtubeId, metadataChannelId) {
 
         // Copy the video thumbnail as fanart (if the thumbnail exists in the final location and -fanart doesn't already exist)
         if (fs.existsSync(finalImagePath) && !fs.existsSync(fanartPath)) {
-          fs.copySync(finalImagePath, fanartPath);
+          copySyncWithFallback(finalImagePath, fanartPath);
           logger.info({ fanartPath }, '[Post-Process] Created video fanart file');
         } else {
           logger.debug({ finalImagePath }, '[Post-Process] No image copied for fanart creation');


### PR DESCRIPTION
## Summary
- Fixes #693: on FUSE mounts (observed with rclone; likely applies to other backends too, cf. #370) that return `EPERM` instead of `EXDEV`/`EOPNOTSUPP` for Node's `copy_file_range`-based `fs.copyFile`, video downloads succeeded but the post-process move into the final library location failed, and channel poster backfills failed the same way.
- Adds a small `cp -r` fallback (triggered only on `EPERM` + `syscall === 'copyfile'`) in `fileOperations.js`'s `moveWithRetries`, plus a new `copySyncWithFallback()` helper used at the two other `fs.copySync` call sites hitting the same issue (`videoDownloadPostProcessFiles.js` channel poster + video thumbnail copy, `channelModule.js` poster backfill).
- Deliberately uses `cp -r`, not `cp -a`: `-a` additionally fails on this class of mount because it tries to preserve timestamps/ownership, which is also rejected with `EPERM` even though the data copy itself succeeds.

## Test plan
- [x] Verified in isolation (unsandboxed and under the app's systemd hardening) that `fs.copyFileSync` throws `EPERM` on the affected FUSE mount while `cp`/`cp -r` succeed, and that `cp -a` also fails (on `utimes`) while `cp -r` doesn't
- [x] Confirmed on a real deployment (YunoHost package, non-Docker) that a full video download + move into a FUSE-mounted library directory, and a channel poster backfill, both succeed with this patch and fail without it
- [ ] Existing unit tests for `fileOperations.js` / `videoDownloadPostProcessFiles.js` / `channelModule.js` (didn't have a full dev environment set up to run the suite here — please let me know if anything needs adjusting)