### PR TITLE
feat: add global flat folder structure option

### DIFF
--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -5,7 +5,12 @@ import {
   DialogContent,
   DialogActions,
   Button,
+  FormControl,
   FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
   Switch,
   TextField,
   CircularProgress,
@@ -581,23 +586,29 @@ function ChannelSettingsDialog({
               helperText={settings.audio_format ? 'MP3 files are saved at 192kbps in the same folder as videos.' : undefined}
             />
 
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={!!settings.skip_video_folder}
-                  onChange={(e) => setSettings({
+            <div className="mt-2">
+              <FormControl fullWidth>
+                <InputLabel id="video-file-structure-label">Video File Structure</InputLabel>
+                <Select
+                  labelId="video-file-structure-label"
+                  value={settings.skip_video_folder === null ? 'default' : settings.skip_video_folder ? 'flat' : 'subfolders'}
+                  onChange={(e: SelectChangeEvent<string>) => setSettings({
                     ...settings,
-                    skip_video_folder: e.target.checked ? true : null
+                    skip_video_folder: e.target.value === 'default' ? null : e.target.value === 'flat'
                   })}
-                  color="primary"
-                />
-              }
-              label="Flat file structure (no video subfolders)"
-              style={{ marginTop: 8 }}
-            />
-            <Typography variant="caption" color="text.secondary" style={{ marginTop: -4, marginBottom: 8, display: 'block' }}>
-              When enabled, video files are saved directly in the channel folder instead of individual video subfolders. Only affects new downloads.
-            </Typography>
+                  label="Video File Structure"
+                >
+                  <MenuItem value="default">
+                    Use global setting ({config.defaultSkipVideoFolder ? 'Flat' : 'Video subfolders'})
+                  </MenuItem>
+                  <MenuItem value="flat">Flat (no video subfolders)</MenuItem>
+                  <MenuItem value="subfolders">Video subfolders</MenuItem>
+                </Select>
+              </FormControl>
+              <Typography variant="caption" color="text.secondary" className="mt-1 mb-2 block">
+                Flat saves video files directly in the channel folder instead of individual video subfolders. Only affects new downloads.
+              </Typography>
+            </div>
 
             <Alert severity="info" style={{ marginBottom: 16 }}>
               <Typography variant="body2" style={{ fontWeight: 'bold', marginBottom: 8 }}>

--- a/client/src/components/ChannelPage/__tests__/ChannelSettingsDialog.test.tsx
+++ b/client/src/components/ChannelPage/__tests__/ChannelSettingsDialog.test.tsx
@@ -65,6 +65,33 @@ describe('ChannelSettingsDialog', () => {
 
   const mockSubfolders = ['__Sports', '__Music', '__Tech'];
 
+  const buildUseConfigResult = (configOverrides: Partial<typeof DEFAULT_CONFIG> = {}) => ({
+    config: { ...DEFAULT_CONFIG, preferredResolution: '1080', ...configOverrides },
+    refetch: mockRefetchConfig,
+    loading: false,
+    error: null,
+    initialConfig: null,
+    isPlatformManaged: {
+      plexUrl: false,
+      authEnabled: true,
+      useTmpForDownloads: false,
+      ytdlpUpdates: false
+    },
+    deploymentEnvironment: {
+      platform: null,
+      isWsl: false,
+    },
+    setConfig: jest.fn(),
+    setInitialConfig: jest.fn(),
+  });
+
+  type FetchCall = [input: RequestInfo | URL, init?: RequestInit];
+
+  const findChannelSettingsPutCall = (): FetchCall | undefined =>
+    (mockFetch.mock.calls as FetchCall[]).find(
+      ([url, init]) => url === '/api/channels/channel123/settings' && init?.method === 'PUT'
+    );
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetch = jest.fn();
@@ -73,25 +100,7 @@ describe('ChannelSettingsDialog', () => {
     mockAxios.isAxiosError.mockReturnValue(false);
     mockRefetchConfig.mockResolvedValue(undefined);
     // Reset mockUseConfig to default
-    mockUseConfig.mockReturnValue({
-      config: { ...DEFAULT_CONFIG, preferredResolution: '1080' },
-      refetch: mockRefetchConfig,
-      loading: false,
-      error: null,
-      initialConfig: null,
-      isPlatformManaged: {
-        plexUrl: false,
-        authEnabled: true,
-        useTmpForDownloads: false,
-        ytdlpUpdates: false
-      },
-      deploymentEnvironment: {
-        platform: null,
-        isWsl: false,
-      },
-      setConfig: jest.fn(),
-      setInitialConfig: jest.fn(),
-    });
+    mockUseConfig.mockReturnValue(buildUseConfigResult());
   });
 
   async function openSettingsSection(sectionName: 'General' | 'Auto Download' | 'Filters' | 'Ratings') {
@@ -1243,13 +1252,15 @@ describe('ChannelSettingsDialog', () => {
     });
   });
 
-  describe('Skip Video Folder Toggle', () => {
-    test('renders the flat file structure toggle', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(mockChannelSettings),
-        });
+  describe('Video File Structure Select', () => {
+    // The ui Select trigger's accessible name is its InputLabel text
+    // ("Video File Structure"), not the selected option, because it's
+    // labeled via labelId. Same query idiom as PlaylistSettingsDialog.test.tsx.
+    test('shows "Use global setting (Video subfolders)" when channel setting is null and global default is off', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockChannelSettings),
+      });
 
       render(<ChannelSettingsDialog {...defaultProps} />);
 
@@ -1257,17 +1268,17 @@ describe('ChannelSettingsDialog', () => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
       });
 
-      expect(screen.getByLabelText('Flat file structure (no video subfolders)')).toBeInTheDocument();
+      expect(screen.getByLabelText('Video File Structure')).toHaveTextContent(
+        'Use global setting (Video subfolders)'
+      );
     });
 
-    test('toggles skip_video_folder when switch is clicked', async () => {
-      const user = userEvent.setup();
-
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(mockChannelSettings),
-        });
+    test('shows "Use global setting (Flat)" when the global flat default is on', async () => {
+      mockUseConfig.mockReturnValue(buildUseConfigResult({ defaultSkipVideoFolder: true }));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockChannelSettings),
+      });
 
       render(<ChannelSettingsDialog {...defaultProps} />);
 
@@ -1275,20 +1286,33 @@ describe('ChannelSettingsDialog', () => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
       });
 
-      const toggle = screen.getByRole('checkbox', { name: /Flat file structure/i });
-      expect(toggle).not.toBeChecked();
-
-      await user.click(toggle);
-      expect(toggle).toBeChecked();
-
-      // Save button should now be enabled since there's a change
-      const saveButton = screen.getByRole('button', { name: 'Save' });
-      expect(saveButton).not.toBeDisabled();
+      expect(screen.getByLabelText('Video File Structure')).toHaveTextContent(
+        'Use global setting (Flat)'
+      );
     });
 
-    test('sends skip_video_folder in the API save call', async () => {
-      const user = userEvent.setup();
+    test('loads skip_video_folder true from server and shows Flat selected', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce({
+          ...mockChannelSettings,
+          skip_video_folder: true,
+        }),
+      });
 
+      render(<ChannelSettingsDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText('Video File Structure')).toHaveTextContent(
+        'Flat (no video subfolders)'
+      );
+    });
+
+    test('saves true when Flat is selected', async () => {
+      const user = userEvent.setup();
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
@@ -1307,33 +1331,32 @@ describe('ChannelSettingsDialog', () => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
       });
 
-      // Toggle the flat file structure switch
-      const toggle = screen.getByRole('checkbox', { name: /Flat file structure/i });
-      await user.click(toggle);
+      await user.click(screen.getByLabelText('Video File Structure'));
+      const flatOption = await screen.findByRole('option', { name: 'Flat (no video subfolders)' });
+      await user.click(flatOption);
 
-      // Click save
-      const saveButton = screen.getByRole('button', { name: 'Save' });
-      await user.click(saveButton);
+      await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      // Verify the PUT call includes skip_video_folder: true
-      let putCall: any[];
+      let putCall: ReturnType<typeof findChannelSettingsPutCall>;
       await waitFor(() => {
-        putCall = mockFetch.mock.calls.find(
-          (call: any[]) => call[0] === '/api/channels/channel123/settings' && call[1]?.method === 'PUT'
-        );
+        putCall = findChannelSettingsPutCall();
         expect(putCall).toBeDefined();
       });
-      const body = JSON.parse(putCall![1].body);
+      const body = JSON.parse(String(putCall![1]?.body));
       expect(body.skip_video_folder).toBe(true);
     });
 
-    test('loads skip_video_folder true from server and shows toggle checked', async () => {
+    test('saves false when Video subfolders is selected explicitly', async () => {
+      const user = userEvent.setup();
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockChannelSettings),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
           json: jest.fn().mockResolvedValueOnce({
-            ...mockChannelSettings,
-            skip_video_folder: true,
+            settings: { ...mockChannelSettings, skip_video_folder: false },
           }),
         });
 
@@ -1343,8 +1366,57 @@ describe('ChannelSettingsDialog', () => {
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
       });
 
-      const toggle = screen.getByRole('checkbox', { name: /Flat file structure/i });
-      expect(toggle).toBeChecked();
+      await user.click(screen.getByLabelText('Video File Structure'));
+      const subfoldersOption = await screen.findByRole('option', { name: 'Video subfolders' });
+      await user.click(subfoldersOption);
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      let putCall: ReturnType<typeof findChannelSettingsPutCall>;
+      await waitFor(() => {
+        putCall = findChannelSettingsPutCall();
+        expect(putCall).toBeDefined();
+      });
+      const body = JSON.parse(String(putCall![1]?.body));
+      expect(body.skip_video_folder).toBe(false);
+    });
+
+    test('saves null when Use global setting is selected to clear an override', async () => {
+      const user = userEvent.setup();
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            ...mockChannelSettings,
+            skip_video_folder: true,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce({
+            settings: { ...mockChannelSettings, skip_video_folder: null },
+          }),
+        });
+
+      render(<ChannelSettingsDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText('Video File Structure'));
+      const useGlobalOption = await screen.findByRole('option', { name: /Use global setting/ });
+      await user.click(useGlobalOption);
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      let putCall: ReturnType<typeof findChannelSettingsPutCall>;
+      await waitFor(() => {
+        putCall = findChannelSettingsPutCall();
+        expect(putCall).toBeDefined();
+      });
+      const body = JSON.parse(String(putCall![1]?.body));
+      expect(body.skip_video_folder).toBeNull();
     });
   });
 

--- a/client/src/components/Configuration/sections/CoreSettingsSection.tsx
+++ b/client/src/components/Configuration/sections/CoreSettingsSection.tsx
@@ -125,6 +125,52 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
     setShowAffectedList(false);
   };
 
+  const [pendingFlatDefault, setPendingFlatDefault] = useState<boolean | null>(null);
+  const [showFlatConfirmDialog, setShowFlatConfirmDialog] = useState(false);
+  const [flatAffectedChannels, setFlatAffectedChannels] = useState<{ count: number; channelNames: string[] } | null>(null);
+  const [loadingFlatAffectedChannels, setLoadingFlatAffectedChannels] = useState(false);
+  const [showFlatAffectedList, setShowFlatAffectedList] = useState(false);
+
+  const handleFlatDefaultChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.checked;
+    if (newValue === config.defaultSkipVideoFolder) {
+      return;
+    }
+
+    setPendingFlatDefault(newValue);
+    setShowFlatConfirmDialog(true);
+    setLoadingFlatAffectedChannels(true);
+    setFlatAffectedChannels(null);
+
+    try {
+      const response = await fetch('/api/channels/using-global-file-structure', {
+        headers: { 'x-access-token': token || '' },
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setFlatAffectedChannels(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch affected channels:', err);
+      setFlatAffectedChannels(null);
+    } finally {
+      setLoadingFlatAffectedChannels(false);
+    }
+  };
+
+  const handleConfirmFlatDefault = () => {
+    onConfigChange({ defaultSkipVideoFolder: pendingFlatDefault === true });
+    setShowFlatConfirmDialog(false);
+    setPendingFlatDefault(null);
+    setShowFlatAffectedList(false);
+  };
+
+  const handleCancelFlatDefault = () => {
+    setShowFlatConfirmDialog(false);
+    setPendingFlatDefault(null);
+    setShowFlatAffectedList(false);
+  };
+
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
     let parsedValue: any = value;
@@ -556,6 +602,25 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
                   </Box>
                 </Grid>
 
+                <Grid item xs={12} md={6}>
+                  <Box className="flex items-center">
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          name="defaultSkipVideoFolder"
+                          checked={config.defaultSkipVideoFolder}
+                          onChange={handleFlatDefaultChange}
+                        />
+                      }
+                      label="Flat file structure by default"
+                    />
+                    <InfoTooltip
+                      text="When enabled, new downloads are saved directly in each channel folder instead of individual per-video subfolders. Channels can override this in their own settings (Flat or Video subfolders). Only affects new downloads; existing files are not moved."
+                      onMobileClick={onMobileTooltipClick}
+                    />
+                  </Box>
+                </Grid>
+
                 <Grid item xs={12}>
                   <Box className="border-t pt-3">
                     <VideoFilenameTemplate
@@ -776,6 +841,69 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
         <DialogActions>
           <Button onClick={handleCancelDefaultSubfolder}>Cancel</Button>
           <Button onClick={handleConfirmDefaultSubfolder} variant="contained" color="primary">
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={showFlatConfirmDialog} onClose={handleCancelFlatDefault}>
+        <DialogTitle>Change default file structure?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {pendingFlatDefault
+              ? 'New downloads for channels using the global setting will be saved directly in the channel folder (flat structure, no per-video subfolders).'
+              : 'New downloads for channels using the global setting will be saved in individual per-video subfolders.'}
+          </DialogContentText>
+
+          <Box className="mt-4 mb-4">
+            {loadingFlatAffectedChannels ? (
+              <Box className="flex items-center gap-2">
+                <CircularProgress size={16} />
+                <span>Checking affected channels...</span>
+              </Box>
+            ) : flatAffectedChannels === null ? (
+              <DialogContentText style={{ color: 'var(--warning)' }}>
+                Could not determine how many channels are affected. You can still continue, but the
+                affected channel count is unknown.
+              </DialogContentText>
+            ) : flatAffectedChannels.count === 0 ? (
+              <DialogContentText>
+                No tracked channels are currently using the global setting.
+              </DialogContentText>
+            ) : (
+              <>
+                <DialogContentText>
+                  {flatAffectedChannels.count} tracked channel{flatAffectedChannels.count !== 1 ? 's' : ''} follow{flatAffectedChannels.count === 1 ? 's' : ''} the global setting and will be affected.
+                </DialogContentText>
+                <Link
+                  component="button"
+                  variant="body2"
+                  onClick={() => setShowFlatAffectedList(!showFlatAffectedList)}
+                  className="mt-1 block cursor-pointer"
+                >
+                  {showFlatAffectedList ? 'Hide affected channels ▲' : 'Show affected channels ▼'}
+                </Link>
+                <Collapse in={showFlatAffectedList}>
+                  <Box
+                    component="ul"
+                    className="mt-2 pl-4 max-h-[200px] overflow-auto bg-muted/50 rounded py-2"
+                  >
+                    {flatAffectedChannels.channelNames.map((name, index) => (
+                      <li key={index}>{name}</li>
+                    ))}
+                  </Box>
+                </Collapse>
+              </>
+            )}
+          </Box>
+
+          <DialogContentText>
+            Previously downloaded videos are not affected. Existing files will not be moved or renamed; only new downloads use the new structure.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCancelFlatDefault}>Cancel</Button>
+          <Button onClick={handleConfirmFlatDefault} variant="contained" color="primary" disabled={loadingFlatAffectedChannels}>
             Confirm
           </Button>
         </DialogActions>

--- a/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { CoreSettingsSection } from '../CoreSettingsSection';
@@ -651,6 +651,181 @@ describe('CoreSettingsSection Component', () => {
       renderWithProviders(<CoreSettingsSection {...props} />);
       expect(screen.queryByText('Platform Managed')).not.toBeInTheDocument();
       expect(screen.queryByText('Managed by Elfhosted')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Flat File Structure Default Checkbox', () => {
+    test('renders unchecked by default', () => {
+      const props = createSectionProps();
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      const toggle = screen.getByRole('checkbox', { name: /Flat file structure by default/i });
+      expect(toggle).not.toBeChecked();
+    });
+
+    test('renders checked when defaultSkipVideoFolder is true', () => {
+      const props = createSectionProps({ config: createConfig({ defaultSkipVideoFolder: true }) });
+      renderWithProviders(<CoreSettingsSection {...props} />);
+      const toggle = screen.getByRole('checkbox', { name: /Flat file structure by default/i });
+      expect(toggle).toBeChecked();
+    });
+
+    describe('confirmation dialog', () => {
+      let mockFetch: jest.SpyInstance;
+
+      beforeEach(() => {
+        mockFetch = jest.spyOn(global, 'fetch');
+      });
+
+      afterEach(() => {
+        mockFetch.mockRestore();
+      });
+
+      test('calls onConfigChange with defaultSkipVideoFolder true when toggled on', async () => {
+        const user = userEvent.setup();
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ count: 0, channelNames: [] })
+        } as unknown as Response);
+
+        const props = createSectionProps();
+        renderWithProviders(<CoreSettingsSection {...props} />);
+        const toggle = screen.getByRole('checkbox', { name: /Flat file structure by default/i });
+        await user.click(toggle);
+
+        await screen.findByText('Change default file structure?');
+        const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+        await waitFor(() => expect(confirmButton).toBeEnabled());
+        await user.click(confirmButton);
+
+        expect(props.onConfigChange).toHaveBeenCalledWith({ defaultSkipVideoFolder: true });
+      });
+
+      test('does not call onConfigChange when the confirmation is cancelled', async () => {
+        const user = userEvent.setup();
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ count: 0, channelNames: [] })
+        } as unknown as Response);
+
+        const props = createSectionProps();
+        renderWithProviders(<CoreSettingsSection {...props} />);
+        const toggle = screen.getByRole('checkbox', { name: /Flat file structure by default/i });
+        await user.click(toggle);
+
+        await screen.findByText('Change default file structure?');
+        const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+        await user.click(cancelButton);
+
+        expect(props.onConfigChange).not.toHaveBeenCalled();
+        expect(screen.queryByText('Change default file structure?')).not.toBeInTheDocument();
+      });
+
+      test('shows the affected channel count from the API', async () => {
+        const user = userEvent.setup();
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ count: 3, channelNames: ['A', 'B', 'C'] })
+        } as unknown as Response);
+
+        const props = createSectionProps();
+        renderWithProviders(<CoreSettingsSection {...props} />);
+        const toggle = screen.getByRole('checkbox', { name: /Flat file structure by default/i });
+        await user.click(toggle);
+
+        await screen.findByText(/3 tracked channels/);
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          '/api/channels/using-global-file-structure',
+          { headers: { 'x-access-token': 'test-token' } }
+        );
+      });
+
+      test('states that previously downloaded videos are not affected', async () => {
+        const user = userEvent.setup();
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ count: 0, channelNames: [] })
+        } as unknown as Response);
+
+        const props = createSectionProps();
+        renderWithProviders(<CoreSettingsSection {...props} />);
+        const toggle = screen.getByRole('checkbox', { name: /Flat file structure by default/i });
+        await user.click(toggle);
+
+        await screen.findByText('Change default file structure?');
+        expect(screen.getByText(/Previously downloaded videos are not affected/)).toBeInTheDocument();
+      });
+
+      test('describes per-video subfolders when disabling', async () => {
+        const user = userEvent.setup();
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ count: 0, channelNames: [] })
+        } as unknown as Response);
+
+        const props = createSectionProps({ config: createConfig({ defaultSkipVideoFolder: true }) });
+        renderWithProviders(<CoreSettingsSection {...props} />);
+        const toggle = screen.getByRole('checkbox', { name: /Flat file structure by default/i });
+        await user.click(toggle);
+
+        await screen.findByText('Change default file structure?');
+        expect(
+          screen.getByText(/New downloads for channels using the global setting will be saved in individual per-video subfolders\./)
+        ).toBeInTheDocument();
+      });
+
+      test('disables Confirm while the affected-channel lookup is loading', async () => {
+        const user = userEvent.setup();
+        mockFetch.mockReturnValue(new Promise(() => {}));
+
+        const props = createSectionProps();
+        renderWithProviders(<CoreSettingsSection {...props} />);
+        const toggle = screen.getByRole('checkbox', { name: /Flat file structure by default/i });
+        await user.click(toggle);
+
+        await screen.findByText('Change default file structure?');
+        expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+      });
+
+      test('shows a warning instead of a zero count when the lookup fails', async () => {
+        const user = userEvent.setup();
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        mockFetch.mockRejectedValue(new Error('Network error'));
+
+        const props = createSectionProps();
+        renderWithProviders(<CoreSettingsSection {...props} />);
+        const toggle = screen.getByRole('checkbox', { name: /Flat file structure by default/i });
+        await user.click(toggle);
+
+        await screen.findByText('Change default file structure?');
+        await screen.findByText(/Could not determine how many channels are affected/);
+        expect(
+          screen.queryByText('No tracked channels are currently using the global setting.')
+        ).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+
+        consoleSpy.mockRestore();
+      });
+
+      test('shows a warning instead of a zero count when the lookup returns non-OK', async () => {
+        const user = userEvent.setup();
+        mockFetch.mockResolvedValue({
+          ok: false,
+          json: jest.fn().mockResolvedValueOnce({ count: 0, channelNames: [] })
+        } as unknown as Response);
+
+        const props = createSectionProps();
+        renderWithProviders(<CoreSettingsSection {...props} />);
+        const toggle = screen.getByRole('checkbox', { name: /Flat file structure by default/i });
+        await user.click(toggle);
+
+        await screen.findByText('Change default file structure?');
+        await screen.findByText(/Could not determine how many channels are affected/);
+        expect(
+          screen.queryByText('No tracked channels are currently using the global setting.')
+        ).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+      });
     });
   });
 

--- a/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
@@ -35,6 +35,8 @@ import { RESOLUTION_OPTIONS } from '../../../utils/downloadOptions';
 
 const LARGE_DOWNLOAD_WARNING_THRESHOLD = 50;
 
+type FileStructureChoice = 'inherit' | 'flat' | 'subfolders';
+
 interface DownloadSettingsDialogProps {
   open: boolean;
   onClose: () => void;
@@ -78,7 +80,7 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
   const [subfolderOverride, setSubfolderOverride] = useState<string | null>(null);
   const [audioFormat, setAudioFormat] = useState<string | null>(null);
   const [rating, setRating] = useState<string | null>(null);
-  const [skipVideoFolder, setSkipVideoFolder] = useState(false);
+  const [fileStructure, setFileStructure] = useState<FileStructureChoice>('inherit');
 
   // Fetch available subfolders
   const { subfolders, loading: subfoldersLoading, createSubfolder } = useSubfolders(token);
@@ -122,7 +124,7 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
       setSubfolderOverride(null);
       setAudioFormat(null);
       setRating(null);
-      setSkipVideoFolder(false);
+      setFileStructure('inherit');
     }
   }, [open]);
 
@@ -189,8 +191,8 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
         if (audioFormat !== null) {
           override.audioFormat = audioFormat;
         }
-        if (skipVideoFolder) {
-          override.skipVideoFolder = true;
+        if (fileStructure !== 'inherit') {
+          override.skipVideoFolder = fileStructure === 'flat';
         }
       }
       if (rating !== null) {
@@ -457,23 +459,30 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
                     showBadge
                   />
 
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={skipVideoFolder}
-                        onChange={(e) => {
-                          setSkipVideoFolder(e.target.checked);
-                          setHasUserInteracted(true);
-                        }}
-                        color="primary"
-                      />
-                    }
-                    label="Force flat file structure (no video subfolders)"
-                    className="mb-1"
-                  />
+                  <Typography variant="subtitle2" color="text.secondary" className="mb-2 mt-4">
+                    File Structure Override
+                  </Typography>
+
+                  <FormControl fullWidth className="mb-1">
+                    <InputLabel id="download-file-structure-label">Video File Structure</InputLabel>
+                    <Select
+                      labelId="download-file-structure-label"
+                      value={fileStructure}
+                      onChange={(e: SelectChangeEvent<string>) => {
+                        setFileStructure(e.target.value as FileStructureChoice);
+                        setHasUserInteracted(true);
+                      }}
+                      label="Video File Structure"
+                    >
+                      <MenuItem value="inherit">Use channel/global settings</MenuItem>
+                      <MenuItem value="flat">Force flat (no video subfolders)</MenuItem>
+                      <MenuItem value="subfolders">Force individual video subfolders</MenuItem>
+                    </Select>
+                  </FormControl>
                   <Typography variant="caption" color="text.secondary" className="mb-4 block">
-                    Save files directly in the channel folder instead of individual video subfolders.
-                    When off, each channel&apos;s own setting applies.
+                    Flat saves files directly in the channel folder; individual subfolders creates a
+                    folder per video. &quot;Use channel/global settings&quot; applies each channel&apos;s own
+                    setting, or the global default.
                   </Typography>
                 </>
               )}

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/DownloadSettingsDialog.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/DownloadSettingsDialog.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import DownloadSettingsDialog from '../DownloadSettingsDialog';
 
@@ -880,97 +881,124 @@ describe('DownloadSettingsDialog', () => {
     });
   });
 
-  describe('Skip Video Folder Toggle', () => {
-    test('renders skipVideoFolder toggle when custom settings enabled in manual mode', () => {
-      render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
-
-      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
-      fireEvent.click(toggle);
-
-      expect(screen.getByLabelText('Force flat file structure (no video subfolders)')).toBeInTheDocument();
-    });
-
-    test('skipVideoFolder defaults to false', () => {
-      render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
-
-      const toggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
-      fireEvent.click(toggle);
-
-      const skipToggle = screen.getByRole('checkbox', { name: /Flat file structure/i });
-      expect(skipToggle).not.toBeChecked();
-    });
-
-    test('calls onConfirm with skipVideoFolder true when toggled on', () => {
-      render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
-
-      // Enable custom settings
+  describe('File Structure Override Select', () => {
+    const openCustomSettings = () => {
       const customToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
       fireEvent.click(customToggle);
+    };
 
-      // Toggle skipVideoFolder
-      const skipToggle = screen.getByRole('checkbox', { name: /Flat file structure/i });
-      fireEvent.click(skipToggle);
-      expect(skipToggle).toBeChecked();
+    test('renders the file structure select when custom settings enabled in manual mode', () => {
+      render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
+      openCustomSettings();
 
-      // Confirm
-      const confirmButton = screen.getByRole('button', { name: /Start Download/i });
-      fireEvent.click(confirmButton);
+      expect(screen.getByLabelText('Video File Structure')).toBeInTheDocument();
+    });
 
-      expect(mockOnConfirm).toHaveBeenCalledWith(
-        expect.objectContaining({
-          skipVideoFolder: true,
-        })
+    test('defaults to Use channel/global settings', () => {
+      render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
+      openCustomSettings();
+
+      expect(screen.getByLabelText('Video File Structure')).toHaveTextContent(
+        'Use channel/global settings'
       );
     });
 
-    test('omits skipVideoFolder when custom settings are disabled', () => {
-      render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
-
+    test('does not render the file structure select in channel mode', () => {
+      render(<DownloadSettingsDialog {...defaultProps} mode="channel" />);
       const customToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
       fireEvent.click(customToggle);
 
-      const skipToggle = screen.getByRole('checkbox', { name: /Flat file structure/i });
-      fireEvent.click(skipToggle);
-      expect(skipToggle).toBeChecked();
+      expect(screen.queryByLabelText('Video File Structure')).not.toBeInTheDocument();
+    });
+
+    test('calls onConfirm with skipVideoFolder true when Force flat is selected', async () => {
+      const user = userEvent.setup();
+      render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
+      openCustomSettings();
+
+      await user.click(screen.getByLabelText('Video File Structure'));
+      await user.click(screen.getByRole('option', { name: /Force flat/i }));
+
+      fireEvent.click(screen.getByRole('button', { name: /Start Download/i }));
+
+      expect(mockOnConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({ skipVideoFolder: true })
+      );
+    });
+
+    test('calls onConfirm with skipVideoFolder false when Force individual video subfolders is selected', async () => {
+      const user = userEvent.setup();
+      render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
+      openCustomSettings();
+
+      await user.click(screen.getByLabelText('Video File Structure'));
+      await user.click(screen.getByRole('option', { name: /Force individual video subfolders/i }));
+
+      fireEvent.click(screen.getByRole('button', { name: /Start Download/i }));
+
+      expect(mockOnConfirm).toHaveBeenCalledWith(
+        expect.objectContaining({ skipVideoFolder: false })
+      );
+    });
+
+    test('omits skipVideoFolder when returned to Use channel/global settings', async () => {
+      const user = userEvent.setup();
+      render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
+      openCustomSettings();
+
+      await user.click(screen.getByLabelText('Video File Structure'));
+      await user.click(screen.getByRole('option', { name: /Force flat/i }));
+      await user.click(screen.getByLabelText('Video File Structure'));
+      await user.click(screen.getByRole('option', { name: /Use channel\/global settings/i }));
 
       const redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
       fireEvent.click(redownloadToggle);
 
-      // Disable custom settings again
-      fireEvent.click(customToggle);
-
-      const confirmButton = screen.getByRole('button', { name: /Start Download/i });
-      fireEvent.click(confirmButton);
+      fireEvent.click(screen.getByRole('button', { name: /Start Download/i }));
 
       const payload = mockOnConfirm.mock.calls[0][0];
       expect(payload).toEqual({ allowRedownload: true });
       expect(payload).not.toHaveProperty('skipVideoFolder');
     });
 
-    test('resets skipVideoFolder when dialog is closed and reopened', () => {
-      const { rerender } = render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
+    test('omits skipVideoFolder when custom settings are disabled', async () => {
+      const user = userEvent.setup();
+      render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
+      openCustomSettings();
 
-      // Enable custom settings and toggle skipVideoFolder
+      await user.click(screen.getByLabelText('Video File Structure'));
+      await user.click(screen.getByRole('option', { name: /Force flat/i }));
+
+      const redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
+      fireEvent.click(redownloadToggle);
+
+      // Disable custom settings again
       const customToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
       fireEvent.click(customToggle);
 
-      const skipToggle = screen.getByRole('checkbox', { name: /Flat file structure/i });
-      fireEvent.click(skipToggle);
-      expect(skipToggle).toBeChecked();
+      fireEvent.click(screen.getByRole('button', { name: /Start Download/i }));
 
-      // Close dialog
+      const payload = mockOnConfirm.mock.calls[0][0];
+      expect(payload).toEqual({ allowRedownload: true });
+      expect(payload).not.toHaveProperty('skipVideoFolder');
+    });
+
+    test('resets file structure when dialog is closed and reopened', async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(<DownloadSettingsDialog {...defaultProps} mode="manual" />);
+      openCustomSettings();
+
+      await user.click(screen.getByLabelText('Video File Structure'));
+      await user.click(screen.getByRole('option', { name: /Force flat/i }));
+      expect(screen.getByLabelText('Video File Structure')).toHaveTextContent('Force flat');
+
       rerender(<DownloadSettingsDialog {...defaultProps} open={false} mode="manual" />);
-
-      // Reopen dialog
       rerender(<DownloadSettingsDialog {...defaultProps} open={true} mode="manual" />);
 
-      // Enable custom settings again
-      const newCustomToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
-      fireEvent.click(newCustomToggle);
-
-      // skipVideoFolder should be reset to false
-      const newSkipToggle = screen.getByRole('checkbox', { name: /Flat file structure/i });
-      expect(newSkipToggle).not.toBeChecked();
+      openCustomSettings();
+      expect(screen.getByLabelText('Video File Structure')).toHaveTextContent(
+        'Use channel/global settings'
+      );
     });
   });
 

--- a/client/src/config/configSchema.ts
+++ b/client/src/config/configSchema.ts
@@ -31,6 +31,7 @@ export const CONFIG_FIELDS = {
   preferredResolution: { default: '1080', trackChanges: true },
   videoCodec: { default: 'default', trackChanges: true },
   defaultSubfolder: { default: '', trackChanges: true },
+  defaultSkipVideoFolder: { default: false, trackChanges: true },
   videoFilenamePrefix: {
     default: '%(uploader,channel,uploader_id).80B - %(title).64B',
     trackChanges: true,
@@ -182,6 +183,7 @@ export const DEFAULT_CONFIG: ConfigState = {
   preferredResolution: CONFIG_FIELDS.preferredResolution.default,
   videoCodec: CONFIG_FIELDS.videoCodec.default,
   defaultSubfolder: CONFIG_FIELDS.defaultSubfolder.default,
+  defaultSkipVideoFolder: CONFIG_FIELDS.defaultSkipVideoFolder.default,
   videoFilenamePrefix: CONFIG_FIELDS.videoFilenamePrefix.default,
   plexApiKey: CONFIG_FIELDS.plexApiKey.default,
   plexYoutubeLibraryId: CONFIG_FIELDS.plexYoutubeLibraryId.default,

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -6,6 +6,7 @@
   "preferredResolution": "1080",
   "videoCodec": "default",
   "defaultSubfolder": "",
+  "defaultSkipVideoFolder": false,
   "videoFilenamePrefix": "%(uploader,channel,uploader_id).80B - %(title).64B",
   "plexIP": "",
   "plexPort": "32400",

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -114,6 +114,17 @@ Configuration can be modified through:
   - Set a default location while allowing individual channels to override
   - Explicitly place specific channels in the root directory using "No Subfolder"
 
+### Flat File Structure Default
+- **Config Key**: `defaultSkipVideoFolder`
+- **Type**: `boolean`
+- **Default**: `false`
+- **Description**: When `true`, new downloads are saved directly in the channel folder (flat structure) instead of an individual per-video subfolder, for every channel that has not chosen its own File Structure setting.
+- **Channel Override Semantics** (channel setting `skip_video_folder`, edited via the channel's "Video File Structure" select):
+  - **"Use global setting"** (NULL in database): channel follows this global default
+  - **"Flat (no video subfolders)"** (`true`): channel always uses flat structure
+  - **"Video subfolders"** (`false`): channel always uses per-video subfolders, even when the global default is flat
+- **Note**: Only affects new downloads; existing files are not moved. The manual download dialog can override the structure for a single download ("Force flat" or "Force individual video subfolders"); its default option ("Use channel/global settings") follows the channel setting and this global default.
+
 ### Video Filename Template
 - **Config Key**: `videoFilenamePrefix`
 - **Type**: `string`

--- a/server/modules/__tests__/channelDownloadGrouper.test.js
+++ b/server/modules/__tests__/channelDownloadGrouper.test.js
@@ -28,6 +28,7 @@ describe('ChannelDownloadGrouper', () => {
     jest.clearAllMocks();
     configModule.getConfig.mockReturnValue({});
     configModule.config.preferredResolution = '1080';
+    configModule.config.defaultSkipVideoFolder = false;
   });
 
   describe('ChannelFilterConfig', () => {
@@ -162,6 +163,47 @@ describe('ChannelDownloadGrouper', () => {
         expect(filterConfig.minDuration).toBe(300);
         expect(filterConfig.maxDuration).toBeNull();
         expect(filterConfig.titleFilterRegex).toBeNull();
+      });
+    });
+
+    describe('fromChannel with global flat default', () => {
+      const baseChannel = {
+        min_duration: null,
+        max_duration: null,
+        title_filter_regex: null,
+        audio_format: null,
+      };
+
+      it('inherits the global default when channel setting is null', () => {
+        const filterConfig = ChannelFilterConfig.fromChannel(
+          { ...baseChannel, skip_video_folder: null },
+          { defaultSkipVideoFolder: true }
+        );
+        expect(filterConfig.skipVideoFolder).toBe(true);
+      });
+
+      it('keeps per-video subfolders when channel explicitly sets false', () => {
+        const filterConfig = ChannelFilterConfig.fromChannel(
+          { ...baseChannel, skip_video_folder: false },
+          { defaultSkipVideoFolder: true }
+        );
+        expect(filterConfig.skipVideoFolder).toBe(false);
+      });
+
+      it('stays flat when channel sets true and global default is off', () => {
+        const filterConfig = ChannelFilterConfig.fromChannel(
+          { ...baseChannel, skip_video_folder: true },
+          { defaultSkipVideoFolder: false }
+        );
+        expect(filterConfig.skipVideoFolder).toBe(true);
+      });
+
+      it('defaults to configModule.config when no config argument is given', () => {
+        configModule.config.defaultSkipVideoFolder = true;
+        const filterConfig = ChannelFilterConfig.fromChannel(
+          { ...baseChannel, skip_video_folder: null }
+        );
+        expect(filterConfig.skipVideoFolder).toBe(true);
       });
     });
   });
@@ -477,6 +519,20 @@ describe('ChannelDownloadGrouper', () => {
 
       expect(groups).toHaveLength(1);
       expect(groups[0].quality).toBe('1080');
+    });
+
+    it('separates explicitly-nested channels from inheriting channels when global flat is on', () => {
+      configModule.config.defaultSkipVideoFolder = true;
+      const channels = [
+        { channel_id: 'a', uploader: 'A', sub_folder: null, video_quality: null, min_duration: null, max_duration: null, title_filter_regex: null, audio_format: null, skip_video_folder: null },
+        { channel_id: 'b', uploader: 'B', sub_folder: null, video_quality: null, min_duration: null, max_duration: null, title_filter_regex: null, audio_format: null, skip_video_folder: false },
+      ];
+
+      const groups = channelDownloadGrouper.groupChannels(channels, '1080');
+
+      expect(groups).toHaveLength(2);
+      const flags = groups.map((g) => g.filterConfig.skipVideoFolder).sort();
+      expect(flags).toEqual([false, true]);
     });
   });
 

--- a/server/modules/__tests__/channelSettingsModule.test.js
+++ b/server/modules/__tests__/channelSettingsModule.test.js
@@ -388,6 +388,40 @@ describe('ChannelSettingsModule', () => {
     });
   });
 
+  describe('getChannelsUsingGlobalFileStructure', () => {
+    test('returns count and channelNames for enabled channels inheriting the global setting', async () => {
+      Channel.findAll.mockResolvedValue([
+        { uploader: 'Channel A' },
+        { uploader: 'Channel B' }
+      ]);
+
+      const result = await channelSettingsModule.getChannelsUsingGlobalFileStructure();
+
+      expect(Channel.findAll).toHaveBeenCalledWith({
+        attributes: ['uploader'],
+        where: {
+          enabled: true,
+          skip_video_folder: null
+        }
+      });
+      expect(result).toEqual({
+        count: 2,
+        channelNames: ['Channel A', 'Channel B']
+      });
+    });
+
+    test('caps channelNames at 10 while count reflects the real total', async () => {
+      const channels = Array.from({ length: 12 }, (_, i) => ({ uploader: `Channel ${i + 1}` }));
+      Channel.findAll.mockResolvedValue(channels);
+
+      const result = await channelSettingsModule.getChannelsUsingGlobalFileStructure();
+
+      expect(result.count).toBe(12);
+      expect(result.channelNames).toHaveLength(10);
+      expect(result.channelNames).toEqual(channels.slice(0, 10).map(ch => ch.uploader));
+    });
+  });
+
   describe('previewTitleFilter', () => {
     const mockChannelVideos = [
       {

--- a/server/modules/__tests__/downloadModule.test.js
+++ b/server/modules/__tests__/downloadModule.test.js
@@ -135,6 +135,9 @@ describe('DownloadModule', () => {
     const channelDownloadGrouperMock = require('../channelDownloadGrouper');
     channelDownloadGrouperMock.generateDownloadGroups = jest.fn().mockResolvedValue(null);
 
+    const configModuleMock = require('../configModule');
+    configModuleMock.config.defaultSkipVideoFolder = false;
+
     logger = require('../../logger');
     logger.info.mockClear();
     logger.error.mockClear();
@@ -1561,6 +1564,62 @@ describe('DownloadModule', () => {
           overrideSettings: {
             skipVideoFolder: false
           }
+        }
+      };
+
+      await downloadModule.doSpecificDownloads(request);
+
+      expect(YtdlpCommandBuilderMock.getBaseCommandArgsForManualDownload).toHaveBeenCalledWith('1080', false, null, false);
+      expect(mockDownloadExecutor.doDownload).toHaveBeenCalledWith(
+        expect.any(Array),
+        mockJobId,
+        'Manually Added Urls',
+        1,
+        ['https://youtube.com/watch?v=test'],
+        false,
+        false,
+        { subfolderOverride: null, subfolderFallback: null, ratingOverride: undefined, ratingFallback: null, skipVideoFolder: false, ownerChannelId: 'UC123456', ownerChannelMap: null }
+      );
+    });
+
+    it('should use global defaultSkipVideoFolder when channel has no explicit setting', async () => {
+      const configModuleMock = require('../configModule');
+      configModuleMock.config.defaultSkipVideoFolder = true;
+      jobModuleMock.getJob.mockReturnValue({ status: 'In Progress' });
+      ChannelModelMock.findOne.mockResolvedValue({ video_quality: null, audio_format: null, skip_video_folder: null });
+
+      const request = {
+        body: {
+          urls: ['https://youtube.com/watch?v=test'],
+          channelId: 'UC123456'
+        }
+      };
+
+      await downloadModule.doSpecificDownloads(request);
+
+      expect(YtdlpCommandBuilderMock.getBaseCommandArgsForManualDownload).toHaveBeenCalledWith('1080', false, null, true);
+      expect(mockDownloadExecutor.doDownload).toHaveBeenCalledWith(
+        expect.any(Array),
+        mockJobId,
+        'Manually Added Urls',
+        1,
+        ['https://youtube.com/watch?v=test'],
+        false,
+        false,
+        { subfolderOverride: null, subfolderFallback: null, ratingOverride: undefined, ratingFallback: null, skipVideoFolder: true, ownerChannelId: 'UC123456', ownerChannelMap: null }
+      );
+    });
+
+    it('should honor channel explicit false over a global flat default', async () => {
+      const configModuleMock = require('../configModule');
+      configModuleMock.config.defaultSkipVideoFolder = true;
+      jobModuleMock.getJob.mockReturnValue({ status: 'In Progress' });
+      ChannelModelMock.findOne.mockResolvedValue({ video_quality: null, audio_format: null, skip_video_folder: false });
+
+      const request = {
+        body: {
+          urls: ['https://youtube.com/watch?v=test'],
+          channelId: 'UC123456'
         }
       };
 

--- a/server/modules/channelDownloadGrouper.js
+++ b/server/modules/channelDownloadGrouper.js
@@ -2,6 +2,7 @@ const Channel = require('../models/channel');
 const configModule = require('./configModule');
 const channelSettingsModule = require('./channelSettingsModule');
 const { buildOutputTemplate, buildThumbnailTemplate } = require('./filesystem');
+const downloadSettingsResolver = require('./download/downloadSettingsResolver');
 
 /**
  * Encapsulates channel filter settings for download filtering
@@ -50,15 +51,16 @@ class ChannelFilterConfig {
   /**
    * Create a ChannelFilterConfig from a channel record
    * @param {Object} channel - Channel record from database
+   * @param {Object} [config] - Global config (defaults to configModule.config)
    * @returns {ChannelFilterConfig} - New filter config instance
    */
-  static fromChannel(channel) {
+  static fromChannel(channel, config = configModule.config) {
     return new ChannelFilterConfig(
       channel.min_duration,
       channel.max_duration,
       channel.title_filter_regex,
       channel.audio_format,
-      channel.skip_video_folder
+      downloadSettingsResolver.resolveSkipVideoFolder({ channel, config })
     );
   }
 }

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -337,6 +337,27 @@ class ChannelSettingsModule {
   }
 
   /**
+   * Get channels that follow the global file-structure setting
+   * (skip_video_folder is NULL = inherit). Only enabled channels are counted:
+   * disabled channels include hidden auto-created playlist source channels.
+   * @returns {Promise<Object>} - { count, channelNames }
+   */
+  async getChannelsUsingGlobalFileStructure() {
+    const channels = await Channel.findAll({
+      attributes: ['uploader'],
+      where: {
+        enabled: true,
+        skip_video_folder: null
+      }
+    });
+
+    return {
+      count: channels.length,
+      channelNames: channels.map(ch => ch.uploader).slice(0, 10) // First 10 for display
+    };
+  }
+
+  /**
    * Get all known subfolders (with __ prefix), sourced from the subfolder registry
    * unioned with the in-memory config default and Plex mappings.
    * @returns {Promise<Array<string>>}

--- a/server/modules/download/__tests__/downloadSettingsResolver.test.js
+++ b/server/modules/download/__tests__/downloadSettingsResolver.test.js
@@ -37,6 +37,15 @@ describe('resolveCommandSettings', () => {
     const out = resolver.resolveCommandSettings({ override: {}, channel: null, playlist: {}, config: {} });
     expect(out).toEqual({ resolution: '1080', audioFormat: null, skipVideoFolder: false });
   });
+
+  test('skipVideoFolder falls through to global default when channel value is null', () => {
+    const channel = { video_quality: null, audio_format: null, skip_video_folder: null };
+    const out = resolver.resolveCommandSettings({
+      override: {}, channel, playlist: {},
+      config: { preferredResolution: '1080', defaultSkipVideoFolder: true },
+    });
+    expect(out.skipVideoFolder).toBe(true);
+  });
 });
 
 describe('buildRoutingDirectives', () => {
@@ -71,6 +80,52 @@ describe('buildRoutingDirectives', () => {
   test('passes the global-default sentinel through unchanged', () => {
     const out = resolver.buildRoutingDirectives({ override: {}, playlist: { default_sub_folder: GLOBAL_DEFAULT_SENTINEL } });
     expect(out).toEqual({ subfolderFallback: GLOBAL_DEFAULT_SENTINEL });
+  });
+});
+
+describe('resolveSkipVideoFolder', () => {
+  test('override wins over channel and global', () => {
+    expect(resolver.resolveSkipVideoFolder({
+      override: { skipVideoFolder: false },
+      channel: { skip_video_folder: true },
+      config: { defaultSkipVideoFolder: true },
+    })).toBe(false);
+  });
+
+  test('channel explicit true beats global false', () => {
+    expect(resolver.resolveSkipVideoFolder({
+      override: {},
+      channel: { skip_video_folder: true },
+      config: { defaultSkipVideoFolder: false },
+    })).toBe(true);
+  });
+
+  test('channel explicit false beats global true', () => {
+    expect(resolver.resolveSkipVideoFolder({
+      override: {},
+      channel: { skip_video_folder: false },
+      config: { defaultSkipVideoFolder: true },
+    })).toBe(false);
+  });
+
+  test('channel null inherits global true', () => {
+    expect(resolver.resolveSkipVideoFolder({
+      override: {},
+      channel: { skip_video_folder: null },
+      config: { defaultSkipVideoFolder: true },
+    })).toBe(true);
+  });
+
+  test('missing channel inherits global true', () => {
+    expect(resolver.resolveSkipVideoFolder({
+      override: {},
+      channel: null,
+      config: { defaultSkipVideoFolder: true },
+    })).toBe(true);
+  });
+
+  test('defaults to false when config lacks defaultSkipVideoFolder', () => {
+    expect(resolver.resolveSkipVideoFolder({ override: {}, channel: null, config: {} })).toBe(false);
   });
 });
 

--- a/server/modules/download/downloadSettingsResolver.js
+++ b/server/modules/download/downloadSettingsResolver.js
@@ -9,7 +9,8 @@ const DEFAULT_RESOLUTION = '1080';
  * Two timing classes:
  * - Command settings (resolution, audioFormat, skipVideoFolder) are built into the
  *   yt-dlp invocation pre-download and drive grouping. Resolved here from whatever
- *   channel info is available pre-download.
+ *   channel info is available pre-download. skipVideoFolder resolves override > channel
+ *   (explicit true/false) > global defaultSkipVideoFolder.
  * - Routing settings (subfolder, rating) are applied per-video at finalize time by the
  *   post-processor, which reads the true channel from .info.json. The grouper only
  *   forwards the dialog override (hard) and the playlist default (soft); channel and
@@ -35,16 +36,26 @@ class DownloadSettingsResolver {
         ? ov.audioFormat
         : (channel && channel.audio_format) || pl.audio_format || null;
 
-    let skipVideoFolder;
-    if (ov.skipVideoFolder !== undefined) {
-      skipVideoFolder = !!ov.skipVideoFolder;
-    } else if (channel && channel.skip_video_folder) {
-      skipVideoFolder = true;
-    } else {
-      skipVideoFolder = false;
-    }
+    const skipVideoFolder = this.resolveSkipVideoFolder({ override: ov, channel, config: cfg });
 
     return { resolution, audioFormat, skipVideoFolder };
+  }
+
+  /**
+   * Flat-structure precedence: override > channel explicit true/false > global default.
+   * channel.skip_video_folder is tri-state: true = flat, false = explicitly per-video
+   * subfolders, null/undefined = inherit the global defaultSkipVideoFolder setting.
+   */
+  resolveSkipVideoFolder({ override = {}, channel = null, config = null } = {}) {
+    const cfg = config || configModule.config || {};
+    const ov = override || {};
+    if (ov.skipVideoFolder !== undefined) {
+      return !!ov.skipVideoFolder;
+    }
+    if (channel && channel.skip_video_folder !== null && channel.skip_video_folder !== undefined) {
+      return !!channel.skip_video_folder;
+    }
+    return !!cfg.defaultSkipVideoFolder;
   }
 
   buildRoutingDirectives({ override = {}, playlist = {} } = {}) {

--- a/server/modules/downloadModule.js
+++ b/server/modules/downloadModule.js
@@ -4,6 +4,7 @@ const plexModule = require('./plexModule');
 const DownloadExecutor = require('./download/downloadExecutor');
 const YtdlpCommandBuilder = require('./download/ytdlpCommandBuilder');
 const tempPathManager = require('./download/tempPathManager');
+const downloadSettingsResolver = require('./download/downloadSettingsResolver');
 const { MANUAL_DOWNLOAD_LABEL, playlistJobLabel, autoRetryJobLabel } = require('./download/jobTypes');
 const ChannelVideo = require('../models/channelvideo');
 const logger = require('../logger');
@@ -680,13 +681,12 @@ class DownloadModule {
       // Persist resolved quality for any subsequent retries of this job
       this.setJobDataValue(jobData, 'effectiveQuality', resolution);
 
-      // Determine skipVideoFolder from override settings or channel setting
-      let skipVideoFolder = false;
-      if (overrideSettings.skipVideoFolder !== undefined) {
-        skipVideoFolder = !!overrideSettings.skipVideoFolder;
-      } else if (channelRecord && channelRecord.skip_video_folder) {
-        skipVideoFolder = true;
-      }
+      // Flat-structure precedence: override > channel explicit setting > global default
+      const skipVideoFolder = downloadSettingsResolver.resolveSkipVideoFolder({
+        override: overrideSettings,
+        channel: channelRecord,
+        config: configModule.config,
+      });
 
       // For manual downloads, we don't apply duration filters but still exclude members-only
       // Subfolder override is passed to post-processor via environment variable

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -17,6 +17,7 @@ const parseFilterMode = (value) =>
  */
 module.exports = function createChannelRoutes({ verifyToken, channelModule, archiveModule, channelDownloadAllModule, ratingMapper }) {
   const router = express.Router();
+  const logger = require('../logger');
   const channelSettingsModule = require('../modules/channelSettingsModule');
   const ChannelVideo = require('../models/channelvideo');
   const { VALID_TAB_TYPES } = require('../modules/tabsUtils');
@@ -622,6 +623,42 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
       res.json(result);
     } catch (error) {
       console.error('Error getting channels using default subfolder:', error);
+      res.status(500).json({ error: error.message });
+    }
+  });
+
+  /**
+   * @swagger
+   * /api/channels/using-global-file-structure:
+   *   get:
+   *     summary: Get channels using the global file structure setting
+   *     description: Get count and names of enabled channels that inherit the global flat-folder-structure default (no per-channel override).
+   *     tags: [Channels]
+   *     responses:
+   *       200:
+   *         description: Count and names of channels inheriting the global file structure
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 count:
+   *                   type: integer
+   *                   description: Total number of channels inheriting the global setting
+   *                 channelNames:
+   *                   type: array
+   *                   items:
+   *                     type: string
+   *                   description: Channel names for display, capped at the first 10; count reflects the true total
+   *       500:
+   *         description: Failed to get count
+   */
+  router.get('/api/channels/using-global-file-structure', verifyToken, async (req, res) => {
+    try {
+      const result = await channelSettingsModule.getChannelsUsingGlobalFileStructure();
+      res.json(result);
+    } catch (error) {
+      logger.error({ err: error }, 'Error getting channels using global file structure');
       res.status(500).json({ error: error.message });
     }
   });


### PR DESCRIPTION
Add a defaultSkipVideoFolder config setting for channels without their own choice. Channel settings and the manual download dialog now offer a three-way choice: use global, flat, or video subfolders. Changing the global default shows a confirmation listing affected channels. Only new downloads are affected; existing files and explicit per-channel settings are unchanged.

Refs: #692