### PR TITLE
feat: support mp3 playback in video modal

### DIFF
--- a/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
+++ b/client/src/components/shared/VideoModal/components/VideoPlayer.tsx
@@ -37,8 +37,12 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
   }, [video.youtubeId]);
 
   const canStream = video.isDownloaded && video.status !== 'missing';
+  const playbackType: 'video' | 'audio' =
+    !video.filePath && video.audioFilePath ? 'audio' : 'video';
   const streamUrl = token
-    ? `/api/videos/${video.youtubeId}/stream?token=${encodeURIComponent(token)}`
+    ? `/api/videos/${video.youtubeId}/stream?token=${encodeURIComponent(token)}${
+        playbackType === 'audio' ? '&type=audio' : ''
+      }`
     : null;
 
   const handlePlay = useCallback(() => {
@@ -63,10 +67,12 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
 
   const youtubeUrl = `${YOUTUBE_URL_BASE}${video.youtubeId}`;
   const isPlaying = canStream && playbackStarted && streamUrl && !streamError;
+  const isPlayingVideo = isPlaying && playbackType === 'video';
+  const isPlayingAudio = isPlaying && playbackType === 'audio';
   const fallbackAspectRatio = video.mediaType === 'short'
     ? DEFAULT_PORTRAIT_ASPECT_RATIO
     : DEFAULT_LANDSCAPE_ASPECT_RATIO;
-  const displayAspectRatio = isPlaying
+  const displayAspectRatio = isPlayingVideo
     ? (streamAspectRatio ?? fallbackAspectRatio)
     : fallbackAspectRatio;
   const maxPlayerHeight = isMobile
@@ -80,7 +86,7 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
         display: 'block',
         width: `min(100%, calc(${maxPlayerHeight} * ${displayAspectRatio}))`,
         maxWidth: '100%',
-        ...(isPlaying ? {} : { aspectRatio: `${displayAspectRatio}` }),
+        ...(isPlayingVideo ? {} : { aspectRatio: `${displayAspectRatio}` }),
         padding: 0,
         backgroundColor: 'transparent',
         border: 'none',
@@ -92,7 +98,7 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
       }}
     >
       {/* Video element - absolutely positioned when playing */}
-      {isPlaying && (
+      {isPlayingVideo && (
         <Box
           component="video"
           data-testid="video-stream-element"
@@ -113,7 +119,8 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
         />
       )}
 
-      {!isPlaying && (
+      {/* Thumbnail stays visible during audio playback - there is no video frame to show */}
+      {!isPlayingVideo && (
         <Box
           component="img"
           src={video.thumbnailUrl}
@@ -126,6 +133,25 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
             height: '100%',
             objectFit: 'cover',
             borderRadius: 'inherit',
+          }}
+        />
+      )}
+
+      {/* Audio bar overlaid on the thumbnail when playing an audio-only download */}
+      {isPlayingAudio && (
+        <Box
+          component="audio"
+          data-testid="audio-stream-element"
+          src={streamUrl}
+          controls
+          autoPlay
+          onError={handleStreamError}
+          style={{
+            position: 'absolute',
+            bottom: 8,
+            left: 8,
+            width: 'calc(100% - 16px)',
+            zIndex: 2,
           }}
         />
       )}
@@ -149,7 +175,7 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
             <>
               <CloudOffIcon size={48} color="white" />
               <Typography variant="body2" sx={{ color: 'common.white' }}>
-                Unable to stream video
+                {playbackType === 'audio' ? 'Unable to stream audio' : 'Unable to stream video'}
               </Typography>
               <Link
                 href={youtubeUrl}
@@ -165,7 +191,7 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
           ) : canStream ? (
             <IconButton
               onClick={handlePlay}
-              aria-label="Play video"
+              aria-label={playbackType === 'audio' ? 'Play audio' : 'Play video'}
               style={{
                 backgroundColor: 'var(--video-modal-overlay-action-background, var(--media-overlay-background-strong))',
                 color: 'var(--video-modal-overlay-action-foreground, var(--media-overlay-foreground))',
@@ -303,7 +329,7 @@ function VideoPlayer({ video, token, onDownloadClick, isMobile }: VideoPlayerPro
                   }}
                 >
                   <Typography variant="caption" style={{ display: 'block', lineHeight: 1.5 }}>
-                    Video is served directly without transcoding. Playback may buffer on slow connections.
+                    {playbackType === 'audio' ? 'Audio' : 'Video'} is served directly without transcoding. Playback may buffer on slow connections.
                   </Typography>
                 </Box>
               )}

--- a/client/src/components/shared/VideoModal/components/__tests__/VideoPlayer.test.tsx
+++ b/client/src/components/shared/VideoModal/components/__tests__/VideoPlayer.test.tsx
@@ -177,6 +177,67 @@ describe('VideoPlayer', () => {
     );
   });
 
+  describe('MP3-only playback', () => {
+    const mp3OnlyOverride: Partial<VideoModalData> = {
+      filePath: null,
+      fileSize: null,
+      audioFilePath: '/audio/test.mp3',
+      audioFileSize: 1048576,
+    };
+
+    test('shows play button labeled "Play audio" when only an audio file exists', () => {
+      renderPlayer(mp3OnlyOverride);
+
+      expect(screen.getByRole('button', { name: 'Play audio' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Play video' })).not.toBeInTheDocument();
+    });
+
+    test('clicking play streams audio with type=audio and keeps thumbnail visible', async () => {
+      const user = userEvent.setup();
+      renderPlayer(mp3OnlyOverride);
+
+      await user.click(screen.getByRole('button', { name: 'Play audio' }));
+
+      const audioEl = screen.getByTestId('audio-stream-element');
+      expect(audioEl).toHaveAttribute(
+        'src',
+        '/api/videos/abc123/stream?token=my-test-token&type=audio'
+      );
+      expect(screen.getByRole('img', { name: 'Test Video' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Stop playback' })).toBeInTheDocument();
+      expect(screen.queryByTestId('video-stream-element')).not.toBeInTheDocument();
+    });
+
+    test('audio stream error shows fallback UI with YouTube link', async () => {
+      const user = userEvent.setup();
+      renderPlayer(mp3OnlyOverride);
+
+      await user.click(screen.getByRole('button', { name: 'Play audio' }));
+      fireEvent.error(screen.getByTestId('audio-stream-element'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Unable to stream audio')).toBeInTheDocument();
+      });
+      expect(screen.getByRole('link', { name: 'Open in YouTube' })).toHaveAttribute(
+        'href',
+        'https://www.youtube.com/watch?v=abc123'
+      );
+    });
+
+    test('plays the video stream when both video and audio files exist', async () => {
+      const user = userEvent.setup();
+      renderPlayer({ audioFilePath: '/audio/test.mp3', audioFileSize: 1048576 });
+
+      await user.click(screen.getByRole('button', { name: 'Play video' }));
+
+      expect(screen.getByTestId('video-stream-element')).toHaveAttribute(
+        'src',
+        '/api/videos/abc123/stream?token=my-test-token'
+      );
+      expect(screen.queryByTestId('audio-stream-element')).not.toBeInTheDocument();
+    });
+  });
+
   test('state resets when video.youtubeId changes', async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
Playing an MP3-only download failed with "Unable to stream video"; the player only ever requested the video stream. When only an audio file exists, stream it with type=audio through an audio bar overlaid on the thumbnail. Downloads with both files still play the video.