### PR TITLE
feat: auto-refresh download history page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 ### Implementation notes (non-obvious behaviors)
 - **Plex integration** uses OAuth; the user must be the Plex server admin. The target Plex library must be "Other Videos" with the "Personal Media" agent.
 - **Video downloads**: yt-dlp writes to a temp location, then post-processing finalizes files into the channel's target directory. Resume-on-partial-download is supported.
-- **WebSocket server** shares the HTTP server port (3011 in container, 3087 on host) via the `ws` library; there is no separate WS port. Broadcast message types include `downloadProgress`, `downloadComplete`, and `videosUpdated` (emitted per video mid-batch after its DB rows are persisted; listing pages subscribe via `client/src/hooks/useDownloadListingsRefresh.ts` to refetch in near real time).
+- **WebSocket server** shares the HTTP server port (3011 in container, 3087 on host) via the `ws` library; there is no separate WS port. Broadcast message types include `downloadProgress`, `downloadComplete`, `jobsUpdated` (emitted when a download job is enqueued or flips to In Progress), and `videosUpdated` (emitted per video mid-batch after its DB rows are persisted); listing pages and the Download History page subscribe via `client/src/hooks/useDownloadListingsRefresh.ts` to refetch in near real time.
 - **Deno** is installed in the container; yt-dlp uses it automatically for JS-heavy extractors.
 
 ## Code Quality Standards (for new and rewritten code)

--- a/client/src/components/DownloadManager.tsx
+++ b/client/src/components/DownloadManager.tsx
@@ -13,6 +13,7 @@ import DownloadNew from './DownloadManager/DownloadNew';
 import DownloadProgress from './DownloadManager/DownloadProgress';
 import DownloadHistory from './DownloadManager/DownloadHistory';
 import WebSocketContext from '../contexts/WebSocketContext';
+import { useDownloadListingsRefresh } from '../hooks/useDownloadListingsRefresh';
 import { Job } from '../types/Job';
 
 interface DownloadManagerProps {
@@ -35,14 +36,6 @@ function DownloadManager({ token }: DownloadManagerProps) {
 
   const isMobile = useMediaQuery('(max-width: 599px)');
 
-  const { subscribe, unsubscribe } = wsContext;
-
-  const filter = useCallback((message: any) => {
-    return (
-      message.destination === 'broadcast' && message.type === 'downloadComplete'
-    );
-  }, []);
-
   const fetchRunningJobs = useCallback(() => {
     if (token) {
       axios
@@ -59,20 +52,11 @@ function DownloadManager({ token }: DownloadManagerProps) {
     }
   }, [token]);
 
-  const processMessagesCallback = useCallback(
-    (payload: any) => {
-      fetchRunningJobs();
-    },
-    [fetchRunningJobs]
-  );
-
   useEffect(() => {
     fetchRunningJobs();
-    subscribe(filter, processMessagesCallback);
-    return () => {
-      unsubscribe(processMessagesCallback);
-    };
-  }, [subscribe, unsubscribe, filter, processMessagesCallback]);
+  }, [fetchRunningJobs]);
+
+  useDownloadListingsRefresh(fetchRunningJobs);
 
   useEffect(() => {
     const timer = setInterval(() => {

--- a/client/src/components/__tests__/DownloadManager.test.tsx
+++ b/client/src/components/__tests__/DownloadManager.test.tsx
@@ -257,38 +257,83 @@ describe('DownloadManager', () => {
       expect(mockUnsubscribe).toHaveBeenCalledWith(expect.any(Function));
     });
 
-    test('filter function correctly identifies download complete messages', () => {
+    test('filter function matches job lifecycle and video broadcasts', () => {
       renderWithContext(<DownloadManager token={mockToken} />);
 
       const [filterFunction] = mockSubscribe.mock.calls[0];
 
       expect(filterFunction({ destination: 'broadcast', type: 'downloadComplete' })).toBe(true);
-      expect(filterFunction({ destination: 'broadcast', type: 'other' })).toBe(false);
+      expect(filterFunction({ destination: 'broadcast', type: 'jobsUpdated' })).toBe(true);
+      expect(filterFunction({ destination: 'broadcast', type: 'videosUpdated' })).toBe(true);
+      expect(filterFunction({ destination: 'broadcast', type: 'downloadProgress' })).toBe(false);
       expect(filterFunction({ destination: 'private', type: 'downloadComplete' })).toBe(false);
     });
 
-    test('processes download complete message by fetching jobs', async () => {
-      mockedAxios.get.mockResolvedValueOnce({ data: [] });
+    test('processes download complete message by fetching jobs after debounce', async () => {
+      jest.useFakeTimers();
+      try {
+        mockedAxios.get.mockResolvedValueOnce({ data: [] });
 
-      renderWithContext(<DownloadManager token={mockToken} />, '/history');
+        renderWithContext(<DownloadManager token={mockToken} />, '/history');
 
-      await waitFor(() => {
+        await waitFor(() => {
+          expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+        });
+
+        const [, processCallback] = mockSubscribe.mock.calls[0];
+
+        mockedAxios.get.mockResolvedValueOnce({ data: mockJobs });
+
+        act(() => {
+          processCallback({ type: 'downloadComplete' });
+        });
         expect(mockedAxios.get).toHaveBeenCalledTimes(1);
-      });
 
-      const [, processCallback] = mockSubscribe.mock.calls[0];
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
 
-      mockedAxios.get.mockResolvedValueOnce({ data: mockJobs });
-
-      await act(async () => {
-        processCallback({ type: 'downloadComplete' });
-      });
-
-      await waitFor(() => {
         expect(mockedAxios.get).toHaveBeenCalledTimes(2);
-      });
+        expect(screen.getByText('Jobs Count: 2')).toBeInTheDocument();
+      } finally {
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
+        jest.useRealTimers();
+      }
+    });
 
-      expect(screen.getByText('Jobs Count: 2')).toBeInTheDocument();
+    test('refetches jobs when a jobsUpdated broadcast arrives', async () => {
+      jest.useFakeTimers();
+      try {
+        mockedAxios.get.mockResolvedValueOnce({ data: [] });
+
+        renderWithContext(<DownloadManager token={mockToken} />, '/history');
+
+        await waitFor(() => {
+          expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+        });
+
+        const [, processCallback] = mockSubscribe.mock.calls[0];
+
+        mockedAxios.get.mockResolvedValueOnce({ data: mockJobs });
+
+        act(() => {
+          processCallback({ jobId: 'job-1', status: 'In Progress' });
+        });
+
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+
+        expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+        expect(screen.getByText('Jobs Count: 2')).toBeInTheDocument();
+      } finally {
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/client/src/hooks/__tests__/useDownloadListingsRefresh.test.tsx
+++ b/client/src/hooks/__tests__/useDownloadListingsRefresh.test.tsx
@@ -62,6 +62,20 @@ describe('useDownloadListingsRefresh', () => {
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 
+  test('calls onRefresh for jobsUpdated broadcasts', () => {
+    const onRefresh = jest.fn();
+    renderHook(() => useDownloadListingsRefresh(onRefresh), { wrapper });
+
+    emitMessage({
+      destination: 'broadcast',
+      type: 'jobsUpdated',
+      payload: { jobId: 'job-1', status: 'In Progress' },
+    });
+    jest.advanceTimersByTime(1000);
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
   test('coalesces a burst of messages into a single refresh', () => {
     const onRefresh = jest.fn();
     renderHook(() => useDownloadListingsRefresh(onRefresh), { wrapper });

--- a/client/src/hooks/useDownloadListingsRefresh.ts
+++ b/client/src/hooks/useDownloadListingsRefresh.ts
@@ -9,9 +9,10 @@ interface BroadcastMessage {
 }
 
 /**
- * Calls onRefresh (debounced) when a download batch persists a video
- * (videosUpdated) or a job finishes (downloadComplete), so listing pages
- * can refetch without a manual reload.
+ * Calls onRefresh (debounced) when a download job is enqueued or starts
+ * (jobsUpdated), a download batch persists a video (videosUpdated), or a
+ * job finishes (downloadComplete), so listing pages can refetch without
+ * a manual reload.
  */
 export function useDownloadListingsRefresh(onRefresh: () => void): void {
   const wsContext = useContext(WebSocketContext);
@@ -28,7 +29,9 @@ export function useDownloadListingsRefresh(onRefresh: () => void): void {
 
     const filter = (message: BroadcastMessage) =>
       message.destination === 'broadcast' &&
-      (message.type === 'videosUpdated' || message.type === 'downloadComplete');
+      (message.type === 'videosUpdated' ||
+        message.type === 'downloadComplete' ||
+        message.type === 'jobsUpdated');
 
     const callback = () => {
       if (debounceTimer) {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -583,6 +583,7 @@ router.get('/api/your-endpoint', verifyToken, async (req, res) => {
 WebSocket shares the HTTP port (3011 in container, 3087 on host) and emits:
 - `downloadProgress` - Download progress updates
 - `downloadComplete` - Video download finished
+- `jobsUpdated` - Download job enqueued or started
 - `channelsUpdated` - Channel list changed
 
 ## Contributing

--- a/server/modules/__tests__/jobModule.test.js
+++ b/server/modules/__tests__/jobModule.test.js
@@ -949,6 +949,38 @@ describe('JobModule', () => {
       expect(result).toBeUndefined();
 
     });
+
+    test('should emit jobsUpdated when flipping next job to In Progress', async () => {
+      JobModule.jobs = {};
+
+      const jobData = { id: 'next-job', jobType: 'download' };
+      await JobModule.addOrUpdateJob(jobData, true);
+
+      expect(MessageEmitter.emitMessage).toHaveBeenCalledWith(
+        'broadcast',
+        null,
+        'download',
+        'jobsUpdated',
+        { jobId: 'next-job', status: 'In Progress' }
+      );
+    });
+
+    test('should not emit jobsUpdated when next job cannot start', async () => {
+      JobModule.jobs = {
+        'existing-job': { status: 'In Progress' }
+      };
+
+      const jobData = { id: 'next-job', jobType: 'download' };
+      await JobModule.addOrUpdateJob(jobData, true);
+
+      expect(MessageEmitter.emitMessage).not.toHaveBeenCalledWith(
+        'broadcast',
+        null,
+        'download',
+        'jobsUpdated',
+        expect.anything()
+      );
+    });
   });
 
   describe('addJob', () => {
@@ -991,6 +1023,33 @@ describe('JobModule', () => {
 
       expect(logger.error).toHaveBeenCalled();
 
+    });
+
+    test('should emit jobsUpdated broadcast after creating the job', async () => {
+      const jobData = { jobType: 'Channel Downloads', status: 'Pending' };
+      await JobModule.addJob(jobData);
+
+      expect(MessageEmitter.emitMessage).toHaveBeenCalledWith(
+        'broadcast',
+        null,
+        'download',
+        'jobsUpdated',
+        { jobId: 'generated-uuid', status: 'Pending' }
+      );
+    });
+
+    test('should not emit jobsUpdated when saving the job fails', async () => {
+      Job.create.mockRejectedValue(new Error('Save failed'));
+
+      await expect(JobModule.addJob({ jobType: 'download' })).rejects.toThrow('Save failed');
+
+      expect(MessageEmitter.emitMessage).not.toHaveBeenCalledWith(
+        'broadcast',
+        null,
+        'download',
+        'jobsUpdated',
+        expect.anything()
+      );
     });
   });
 

--- a/server/modules/jobModule.js
+++ b/server/modules/jobModule.js
@@ -451,6 +451,7 @@ class JobModule {
         timeInitiated: Date.now(),
       });
       jobId = jobData.id;
+      this.emitJobsUpdated(jobId, 'In Progress');
     } else {
       logger.warn('Cannot start next job as a job is already in progress');
     }
@@ -912,6 +913,14 @@ class JobModule {
     return this.jobs;
   }
 
+  // Lets listing pages (e.g. Download History) refetch when a job is enqueued or starts.
+  emitJobsUpdated(jobId, status) {
+    MessageEmitter.emitMessage('broadcast', null, 'download', 'jobsUpdated', {
+      jobId,
+      status,
+    });
+  }
+
   async addJob(job) {
     const jobId = uuidv4(); // Generate a new UUID
     job.timeInitiated = Date.now();
@@ -929,6 +938,7 @@ class JobModule {
         timeInitiated: job.timeInitiated,
         timeCreated: job.timeCreated,
       });
+      this.emitJobsUpdated(jobId, job.status);
       return jobId;
     } catch (error) {
       logger.error({ err: error }, 'Error saving job');


### PR DESCRIPTION
The Download History page only refetched jobs on downloadComplete broadcasts, so a job that started while the page was open did not appear until it finished, and an in-progress job's video list never grew mid-run.

Emit a jobsUpdated broadcast when a job is created or flips to In Progress, and add it to the useDownloadListingsRefresh filter. DownloadManager now subscribes through that shared hook (debounced) instead of its own downloadComplete-only subscription, so the page refetches when a job is first queued, starts, persists a video, or completes.