### PR TITLE
fix: surface emby/jellyfin api key auth failures

### DIFF
--- a/client/src/components/Configuration/sections/MediaServerPlaylistSection.tsx
+++ b/client/src/components/Configuration/sections/MediaServerPlaylistSection.tsx
@@ -48,6 +48,9 @@ const truncateId = (id: string): string =>
     ? `${id.slice(0, ID_PREFIX_LEN)}...${id.slice(-ID_SUFFIX_LEN)}`
     : id;
 
+// Emby/Jellyfin user IDs are GUIDs: 32 hex chars, with or without dashes.
+const SERVER_USER_ID_PATTERN = /^[0-9a-f]{32}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 type EnabledKey = 'jellyfinEnabled' | 'embyEnabled';
 type UrlKey = 'jellyfinUrl' | 'embyUrl';
 type ApiKeyKey = 'jellyfinApiKey' | 'embyApiKey';
@@ -217,6 +220,8 @@ export const MediaServerPlaylistSection: React.FC<MediaServerPlaylistSectionProp
       ? `Enter the ${label} URL and API key above, then open this dropdown to load users.`
       : userId
       ? `Account that will own Youtarr-managed playlists. ID: ${truncateId(userId)}`
+      : manualEntry
+      ? `The user's internal ID from ${label}, not the username.`
       : 'Account that will own Youtarr-managed playlists.';
 
   const chipLabel = !enabled
@@ -224,7 +229,7 @@ export const MediaServerPlaylistSection: React.FC<MediaServerPlaylistSectionProp
     : testStatus === 'ok'
     ? 'Connected'
     : testStatus === 'error'
-    ? 'Unreachable'
+    ? 'Connection Failed'
     : 'Not Tested';
   const chipColor: 'default' | 'success' | 'error' | 'warning' =
     !enabled
@@ -365,6 +370,12 @@ export const MediaServerPlaylistSection: React.FC<MediaServerPlaylistSectionProp
           )}
 
           <FormHelperText>{userHelperText}</FormHelperText>
+
+          {userId.trim() !== '' && !SERVER_USER_ID_PATTERN.test(userId.trim()) && (
+            <FormHelperText error>
+              {`This doesn't look like ${kind === 'emby' ? 'an' : 'a'} ${label} user ID; IDs are 32-character codes, not usernames. If you can't load the user list, fix the URL/API key above, then pick the user from the dropdown.`}
+            </FormHelperText>
+          )}
 
           <Button
             variant="link"

--- a/client/src/components/Configuration/sections/WatchStatusSection.tsx
+++ b/client/src/components/Configuration/sections/WatchStatusSection.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import {
   Accordion,
   AccordionDetails,
@@ -166,8 +167,11 @@ export function WatchStatusSection({ config, token, onConfigChange }: WatchStatu
       )}
       {!statusLoading && !statusError && !anyConfigured && (
         <Alert severity="info" className="mb-4">
-          No media servers connected. Configure Plex, Jellyfin, or Emby first; watch status sync
-          has nothing to do until then.
+          No media servers connected. Watch status sync needs at least one; connect{' '}
+          <RouterLink to="/settings/plex" className="underline font-medium">Plex</RouterLink>,{' '}
+          <RouterLink to="/settings/jellyfin" className="underline font-medium">Jellyfin</RouterLink>, or{' '}
+          <RouterLink to="/settings/emby" className="underline font-medium">Emby</RouterLink>{' '}
+          in Settings first.
         </Alert>
       )}
       {/* useMediaServerStatus keeps the last successful status when a later

--- a/client/src/components/Configuration/sections/__tests__/MediaServerPlaylistSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/MediaServerPlaylistSection.test.tsx
@@ -354,4 +354,75 @@ describe('MediaServerPlaylistSection', () => {
 
     expect(await screen.findByText('No users found')).toBeInTheDocument();
   });
+
+  test('shows Connection Failed on the chip after a failed test', async () => {
+    axios.post.mockRejectedValueOnce(new Error('boom'));
+    renderWithProviders(
+      <MediaServerPlaylistSection
+        kind="emby"
+        config={baseConfig()}
+        token="tok"
+        onConfigChange={jest.fn()}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /test connection/i }));
+    expect(await screen.findByText('Connection Failed')).toBeInTheDocument();
+  });
+
+  test('warns when the saved user ID does not look like a server user ID', async () => {
+    // A non-empty saved userId triggers the mount-time eager fetch; resolve it so the
+    // effect settles inside the test instead of leaking a state update past teardown.
+    axios.post.mockResolvedValueOnce({ data: { users: [] } });
+
+    renderWithProviders(
+      <MediaServerPlaylistSection
+        kind="emby"
+        config={baseConfig({ embyUserId: 'admin' })}
+        token="tok"
+        onConfigChange={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/mediaservers/emby/users',
+        {
+          embyUrl: 'http://192.168.1.174:8096',
+          embyApiKey: 'secret-key',
+          embyUserId: 'admin',
+        },
+        { headers: { 'x-access-token': 'tok' } }
+      );
+    });
+
+    expect(screen.getByText(/doesn't look like an Emby user ID/i)).toBeInTheDocument();
+  });
+
+  test('does not warn for a 32-character hex user ID', async () => {
+    const hexUserId = 'a'.repeat(32);
+    axios.post.mockResolvedValueOnce({ data: { users: [] } });
+
+    renderWithProviders(
+      <MediaServerPlaylistSection
+        kind="emby"
+        config={baseConfig({ embyUserId: hexUserId })}
+        token="tok"
+        onConfigChange={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/mediaservers/emby/users',
+        {
+          embyUrl: 'http://192.168.1.174:8096',
+          embyApiKey: 'secret-key',
+          embyUserId: hexUserId,
+        },
+        { headers: { 'x-access-token': 'tok' } }
+      );
+    });
+
+    expect(screen.queryByText(/doesn't look like an Emby user ID/i)).not.toBeInTheDocument();
+  });
 });

--- a/client/src/components/Configuration/sections/__tests__/WatchStatusSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/WatchStatusSection.test.tsx
@@ -74,6 +74,15 @@ describe('WatchStatusSection', () => {
     expect(screen.getByText(/no media servers connected/i)).toBeInTheDocument();
   });
 
+  test('the no-servers warning links to each server settings page', () => {
+    mediaServerStatusReturn.status = { plex: false, jellyfin: false, emby: false };
+    mediaServerStatusReturn.anyConfigured = false;
+    renderWithProviders(<WatchStatusSection {...defaultProps} />);
+    expect(screen.getByRole('link', { name: 'Plex' })).toHaveAttribute('href', '/settings/plex');
+    expect(screen.getByRole('link', { name: 'Jellyfin' })).toHaveAttribute('href', '/settings/jellyfin');
+    expect(screen.getByRole('link', { name: 'Emby' })).toHaveAttribute('href', '/settings/emby');
+  });
+
   test('does not claim "no servers" while the status is still loading', () => {
     mediaServerStatusReturn.status = { plex: false, jellyfin: false, emby: false };
     mediaServerStatusReturn.anyConfigured = false;

--- a/server/modules/mediaServers/adapters/__tests__/embyAdapter.test.js
+++ b/server/modules/mediaServers/adapters/__tests__/embyAdapter.test.js
@@ -11,6 +11,22 @@ describe('EmbyAdapter', () => {
 
   beforeEach(() => jest.clearAllMocks());
 
+  test('normalizes a URL with a trailing slash and whitespace around the key', () => {
+    const adapter = new EmbyAdapter({
+      embyUrl: 'http://emby:8096/ ',
+      embyApiKey: ' KEY \n',
+      embyUserId: ' USR ',
+    });
+    expect(adapter.url).toBe('http://emby:8096');
+    expect(adapter.apiKey).toBe('KEY');
+    expect(adapter.userId).toBe('USR');
+  });
+
+  test('leaves userId undefined when not configured', () => {
+    const adapter = new EmbyAdapter({ embyUrl: 'http://emby:8096', embyApiKey: 'KEY' });
+    expect(adapter.userId).toBeUndefined();
+  });
+
   test('exposes the serverType contract used by orchestration', () => {
     expect(new EmbyAdapter(cfg).serverType).toBe('emby');
   });
@@ -22,11 +38,47 @@ describe('EmbyAdapter', () => {
     expect(result.ok).toBe(true);
   });
 
+  test('testConnection pings the authenticated System/Info endpoint', async () => {
+    axios.get.mockResolvedValueOnce({ data: { Version: '4.9.2' } });
+    const adapter = new EmbyAdapter(cfg);
+    const result = await adapter.testConnection();
+    expect(result).toEqual({ ok: true, version: '4.9.2' });
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://emby:8096/System/Info',
+      expect.objectContaining({ headers: { 'X-Emby-Token': 'KEY' } })
+    );
+  });
+
+  test('testConnection reports a rejected API key distinctly from an unreachable server', async () => {
+    axios.get.mockRejectedValueOnce({ isAxiosError: true, response: { status: 401 }, message: 'Request failed with status code 401' });
+    const adapter = new EmbyAdapter(cfg);
+    const result = await adapter.testConnection();
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/rejected the API key/i);
+  });
+
+  test('testConnection still reports connection errors by message', async () => {
+    axios.get.mockRejectedValueOnce(Object.assign(new Error('connect ECONNREFUSED'), { isAxiosError: true, code: 'ECONNREFUSED' }));
+    const adapter = new EmbyAdapter(cfg);
+    const result = await adapter.testConnection();
+    expect(result).toEqual({ ok: false, error: 'connect ECONNREFUSED' });
+  });
+
   test('listUsers returns user list', async () => {
     axios.get.mockResolvedValueOnce({ data: [{ Id: 'u1', Name: 'Alice' }, { Id: 'u2', Name: 'Bob' }] });
     const adapter = new EmbyAdapter(cfg);
     const users = await adapter.listUsers();
     expect(users).toEqual([{ id: 'u1', name: 'Alice' }, { id: 'u2', name: 'Bob' }]);
+  });
+
+  test('listUsers throws on failure instead of returning an empty list', async () => {
+    const authError = Object.assign(new Error('Request failed with status code 401'), {
+      isAxiosError: true,
+      response: { status: 401 },
+    });
+    axios.get.mockRejectedValueOnce(authError);
+    const adapter = new EmbyAdapter(cfg);
+    await expect(adapter.listUsers()).rejects.toBe(authError);
   });
 
   test('createPlaylist POSTs with query params and CSV Ids (Emby-style)', async () => {
@@ -145,7 +197,7 @@ describe('EmbyAdapter', () => {
     const adapter = new EmbyAdapter(cfg);
     await adapter.testConnection();
     expect(axios.get).toHaveBeenCalledWith(
-      expect.stringContaining('/System/Info/Public'),
+      expect.stringContaining('/System/Info'),
       expect.objectContaining({ timeout: REQUEST_TIMEOUT_MS })
     );
   });

--- a/server/modules/mediaServers/adapters/__tests__/jellyfinAdapter.test.js
+++ b/server/modules/mediaServers/adapters/__tests__/jellyfinAdapter.test.js
@@ -11,6 +11,22 @@ describe('JellyfinAdapter', () => {
 
   beforeEach(() => jest.clearAllMocks());
 
+  test('normalizes a URL with a trailing slash and whitespace around the key', () => {
+    const adapter = new JellyfinAdapter({
+      jellyfinUrl: 'http://jf:8096/ ',
+      jellyfinApiKey: ' KEY \n',
+      jellyfinUserId: ' USR ',
+    });
+    expect(adapter.url).toBe('http://jf:8096');
+    expect(adapter.apiKey).toBe('KEY');
+    expect(adapter.userId).toBe('USR');
+  });
+
+  test('leaves userId undefined when not configured', () => {
+    const adapter = new JellyfinAdapter({ jellyfinUrl: 'http://jf:8096', jellyfinApiKey: 'KEY' });
+    expect(adapter.userId).toBeUndefined();
+  });
+
   test('exposes the serverType contract used by orchestration', () => {
     expect(new JellyfinAdapter(cfg).serverType).toBe('jellyfin');
   });
@@ -22,11 +38,47 @@ describe('JellyfinAdapter', () => {
     expect(result.ok).toBe(true);
   });
 
+  test('testConnection pings the authenticated System/Info endpoint', async () => {
+    axios.get.mockResolvedValueOnce({ data: { Version: '10.9.2' } });
+    const adapter = new JellyfinAdapter(cfg);
+    const result = await adapter.testConnection();
+    expect(result).toEqual({ ok: true, version: '10.9.2' });
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://jf:8096/System/Info',
+      expect.objectContaining({ headers: { 'X-Emby-Token': 'KEY' } })
+    );
+  });
+
+  test('testConnection reports a rejected API key distinctly from an unreachable server', async () => {
+    axios.get.mockRejectedValueOnce({ isAxiosError: true, response: { status: 401 }, message: 'Request failed with status code 401' });
+    const adapter = new JellyfinAdapter(cfg);
+    const result = await adapter.testConnection();
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/rejected the API key/i);
+  });
+
+  test('testConnection still reports connection errors by message', async () => {
+    axios.get.mockRejectedValueOnce(Object.assign(new Error('connect ECONNREFUSED'), { isAxiosError: true, code: 'ECONNREFUSED' }));
+    const adapter = new JellyfinAdapter(cfg);
+    const result = await adapter.testConnection();
+    expect(result).toEqual({ ok: false, error: 'connect ECONNREFUSED' });
+  });
+
   test('listUsers returns user list', async () => {
     axios.get.mockResolvedValueOnce({ data: [{ Id: 'u1', Name: 'Alice' }, { Id: 'u2', Name: 'Bob' }] });
     const adapter = new JellyfinAdapter(cfg);
     const users = await adapter.listUsers();
     expect(users).toEqual([{ id: 'u1', name: 'Alice' }, { id: 'u2', name: 'Bob' }]);
+  });
+
+  test('listUsers throws on failure instead of returning an empty list', async () => {
+    const authError = Object.assign(new Error('Request failed with status code 401'), {
+      isAxiosError: true,
+      response: { status: 401 },
+    });
+    axios.get.mockRejectedValueOnce(authError);
+    const adapter = new JellyfinAdapter(cfg);
+    await expect(adapter.listUsers()).rejects.toBe(authError);
   });
 
   test('createPlaylist POSTs with Name/Ids/UserId/MediaType/IsPublic', async () => {
@@ -106,7 +158,7 @@ describe('JellyfinAdapter', () => {
     const adapter = new JellyfinAdapter(cfg);
     await adapter.testConnection();
     expect(axios.get).toHaveBeenCalledWith(
-      'http://jf:8096/System/Info/Public',
+      'http://jf:8096/System/Info',
       expect.objectContaining({ timeout: REQUEST_TIMEOUT_MS })
     );
   });

--- a/server/modules/mediaServers/adapters/baseAdapter.js
+++ b/server/modules/mediaServers/adapters/baseAdapter.js
@@ -114,6 +114,14 @@ class WatchStateFetchError extends Error {
   }
 }
 
+/**
+ * Normalize a user-entered media server base URL: trim whitespace and strip
+ * trailing slashes so `${url}/Users` never produces `//Users`.
+ */
+function normalizeBaseUrl(value) {
+  return String(value || '').trim().replace(/\/+$/, '');
+}
+
 // True when an axios error means the server itself is unreachable or not
 // responding, rather than a normal "queried fine, no such item" result. No
 // response at all (ECONNREFUSED / ETIMEDOUT / ENOTFOUND / timeout) or any 5xx
@@ -139,6 +147,7 @@ module.exports = BaseAdapter;
 module.exports.extractBasename = extractBasename;
 module.exports.pathSegments = pathSegments;
 module.exports.trailingSegmentMatch = trailingSegmentMatch;
+module.exports.normalizeBaseUrl = normalizeBaseUrl;
 module.exports.REQUEST_TIMEOUT_MS = REQUEST_TIMEOUT_MS;
 module.exports.MediaServerUnavailableError = MediaServerUnavailableError;
 module.exports.WatchStateFetchError = WatchStateFetchError;

--- a/server/modules/mediaServers/adapters/embyAdapter.js
+++ b/server/modules/mediaServers/adapters/embyAdapter.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const BaseAdapter = require('./baseAdapter');
 const {
   extractBasename,
+  normalizeBaseUrl,
   REQUEST_TIMEOUT_MS,
   isServerUnavailableError,
   describeHttpError,
@@ -16,9 +17,9 @@ class EmbyAdapter extends BaseAdapter {
   constructor(config) {
     super(config);
     this.serverType = 'emby';
-    this.url = config.embyUrl;
-    this.apiKey = config.embyApiKey;
-    this.userId = config.embyUserId;
+    this.url = normalizeBaseUrl(config.embyUrl);
+    this.apiKey = String(config.embyApiKey || '').trim();
+    this.userId = String(config.embyUserId || '').trim() || undefined;
     this.allUsers = config.embyWatchStatusAllUsers !== false;
   }
 
@@ -26,21 +27,23 @@ class EmbyAdapter extends BaseAdapter {
 
   async testConnection() {
     try {
-      const res = await axios.get(`${this.url}/System/Info/Public`, { headers: this._headers(), timeout: REQUEST_TIMEOUT_MS });
+      const res = await axios.get(`${this.url}/System/Info`, { headers: this._headers(), timeout: REQUEST_TIMEOUT_MS });
       return { ok: true, version: res.data?.Version };
     } catch (err) {
+      const status = err.response?.status;
+      if (status === 401 || status === 403) {
+        return {
+          ok: false,
+          error: 'The server is reachable but rejected the API key. Re-copy the key from the server dashboard (select only the key itself) and try again.',
+        };
+      }
       return { ok: false, error: err.message };
     }
   }
 
   async listUsers() {
-    try {
-      const res = await axios.get(`${this.url}/Users`, { headers: this._headers(), timeout: REQUEST_TIMEOUT_MS });
-      return (res.data || []).map((u) => ({ id: u.Id, name: u.Name }));
-    } catch (err) {
-      logger.error({ err }, 'emby listUsers failed');
-      return [];
-    }
+    const res = await axios.get(`${this.url}/Users`, { headers: this._headers(), timeout: REQUEST_TIMEOUT_MS });
+    return (res.data || []).map((u) => ({ id: u.Id, name: u.Name }));
   }
 
   async triggerLibraryScan() {

--- a/server/modules/mediaServers/adapters/jellyfinAdapter.js
+++ b/server/modules/mediaServers/adapters/jellyfinAdapter.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const BaseAdapter = require('./baseAdapter');
 const {
   extractBasename,
+  normalizeBaseUrl,
   REQUEST_TIMEOUT_MS,
   isServerUnavailableError,
   describeHttpError,
@@ -16,9 +17,9 @@ class JellyfinAdapter extends BaseAdapter {
   constructor(config) {
     super(config);
     this.serverType = 'jellyfin';
-    this.url = config.jellyfinUrl;
-    this.apiKey = config.jellyfinApiKey;
-    this.userId = config.jellyfinUserId;
+    this.url = normalizeBaseUrl(config.jellyfinUrl);
+    this.apiKey = String(config.jellyfinApiKey || '').trim();
+    this.userId = String(config.jellyfinUserId || '').trim() || undefined;
     this.allUsers = config.jellyfinWatchStatusAllUsers !== false;
   }
 
@@ -26,21 +27,23 @@ class JellyfinAdapter extends BaseAdapter {
 
   async testConnection() {
     try {
-      const res = await axios.get(`${this.url}/System/Info/Public`, { headers: this._headers(), timeout: REQUEST_TIMEOUT_MS });
+      const res = await axios.get(`${this.url}/System/Info`, { headers: this._headers(), timeout: REQUEST_TIMEOUT_MS });
       return { ok: true, version: res.data?.Version };
     } catch (err) {
+      const status = err.response?.status;
+      if (status === 401 || status === 403) {
+        return {
+          ok: false,
+          error: 'The server is reachable but rejected the API key. Re-copy the key from the server dashboard (select only the key itself) and try again.',
+        };
+      }
       return { ok: false, error: err.message };
     }
   }
 
   async listUsers() {
-    try {
-      const res = await axios.get(`${this.url}/Users`, { headers: this._headers(), timeout: REQUEST_TIMEOUT_MS });
-      return (res.data || []).map((u) => ({ id: u.Id, name: u.Name }));
-    } catch (err) {
-      logger.error({ err }, 'jellyfin listUsers failed');
-      return [];
-    }
+    const res = await axios.get(`${this.url}/Users`, { headers: this._headers(), timeout: REQUEST_TIMEOUT_MS });
+    return (res.data || []).map((u) => ({ id: u.Id, name: u.Name }));
   }
 
   async triggerLibraryScan() {

--- a/server/routes/__tests__/mediaServers.test.js
+++ b/server/routes/__tests__/mediaServers.test.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const createMediaServerRoutes = require('../mediaServers');
 const { findRouteHandler } = require('../../__tests__/testUtils');
+const BaseAdapter = require('../../modules/mediaServers/adapters/baseAdapter');
 
 const loggerMock = {
   info: jest.fn(),
@@ -43,6 +44,7 @@ const buildDeps = (overrides = {}) => ({
       JellyfinAdapter: MockJellyfinAdapter,
       EmbyAdapter: MockEmbyAdapter,
       PlexAdapter: MockPlexAdapter,
+      BaseAdapter,
     },
     serverRegistry: {
       getEnabledAdapters: jest.fn().mockReturnValue([]),
@@ -174,6 +176,44 @@ describe('POST /api/mediaservers/jellyfin/users', () => {
     expect(res.json).toHaveBeenCalledWith({ users: [{ id: 'u1', name: 'Alice' }] });
   });
 
+  test('maps an upstream 401 to a clear API-key error', async () => {
+    const deps = buildDeps();
+    deps.mediaServers.adapters.JellyfinAdapter = class {
+      async listUsers() {
+        throw Object.assign(new Error('Request failed with status code 401'), {
+          isAxiosError: true,
+          response: { status: 401 },
+        });
+      }
+    };
+    const handler = getHandler('post', '/api/mediaservers/jellyfin/users', deps);
+    const res = createResponse();
+    await handler({ body: {}, log: loggerMock }, res);
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.stringMatching(/rejected the API key/i),
+    });
+  });
+
+  test('maps an unreachable server to a 502 with the connection message', async () => {
+    const deps = buildDeps();
+    deps.mediaServers.adapters.JellyfinAdapter = class {
+      async listUsers() {
+        throw Object.assign(new Error('connect ECONNREFUSED'), {
+          isAxiosError: true,
+          code: 'ECONNREFUSED',
+        });
+      }
+    };
+    const handler = getHandler('post', '/api/mediaservers/jellyfin/users', deps);
+    const res = createResponse();
+    await handler({ body: {}, log: loggerMock }, res);
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.stringContaining('connect ECONNREFUSED'),
+    });
+  });
+
   test('returns 500 when adapter throws', async () => {
     const deps = buildDeps();
     class ThrowingJellyfinAdapter {
@@ -234,6 +274,69 @@ describe('POST /api/mediaservers/emby/users', () => {
     await handler(req, res);
 
     expect(res.json).toHaveBeenCalledWith({ users: [{ id: 'u2', name: 'Bob' }] });
+  });
+
+  test('maps an upstream 401 to a clear API-key error', async () => {
+    const deps = buildDeps();
+    deps.mediaServers.adapters.EmbyAdapter = class {
+      async listUsers() {
+        throw Object.assign(new Error('Request failed with status code 401'), {
+          isAxiosError: true,
+          response: { status: 401 },
+        });
+      }
+    };
+    const handler = getHandler('post', '/api/mediaservers/emby/users', deps);
+    const res = createResponse();
+    await handler({ body: {}, log: loggerMock }, res);
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.stringMatching(/rejected the API key/i),
+    });
+  });
+
+  test('maps an unreachable server to a 502 with the connection message', async () => {
+    const deps = buildDeps();
+    deps.mediaServers.adapters.EmbyAdapter = class {
+      async listUsers() {
+        throw Object.assign(new Error('connect ECONNREFUSED'), {
+          isAxiosError: true,
+          code: 'ECONNREFUSED',
+        });
+      }
+    };
+    const handler = getHandler('post', '/api/mediaservers/emby/users', deps);
+    const res = createResponse();
+    await handler({ body: {}, log: loggerMock }, res);
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.stringContaining('connect ECONNREFUSED'),
+    });
+  });
+
+  test('logs a token-free error description, never the raw axios error', async () => {
+    const deps = buildDeps();
+    deps.mediaServers.adapters.EmbyAdapter = class {
+      async listUsers() {
+        throw Object.assign(new Error('connect ECONNREFUSED'), {
+          isAxiosError: true,
+          code: 'ECONNREFUSED',
+          config: { headers: { 'X-Emby-Token': 'SECRET' } },
+        });
+      }
+    };
+    const handler = getHandler('post', '/api/mediaservers/emby/users', deps);
+    const res = createResponse();
+    await handler({ body: {}, log: loggerMock }, res);
+
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.not.objectContaining({ err: expect.anything() }),
+      'list users failed'
+    );
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.objectContaining({ status: null, code: 'ECONNREFUSED', message: 'connect ECONNREFUSED' }),
+      'list users failed'
+    );
   });
 });
 

--- a/server/routes/mediaServers.js
+++ b/server/routes/mediaServers.js
@@ -2,7 +2,8 @@ const express = require('express');
 
 function createMediaServerRoutes({ verifyToken, configModule, mediaServers }) {
   const router = express.Router();
-  const { JellyfinAdapter, EmbyAdapter } = mediaServers.adapters;
+  const { JellyfinAdapter, EmbyAdapter, BaseAdapter } = mediaServers.adapters;
+  const { describeHttpError } = BaseAdapter;
 
   router.get('/api/mediaservers/status', verifyToken, async (req, res) => {
     try {
@@ -37,7 +38,16 @@ function createMediaServerRoutes({ verifyToken, configModule, mediaServers }) {
       const users = await adapter.listUsers();
       res.json({ users });
     } catch (err) {
-      reqLog.error({ err }, 'list users failed');
+      const status = err.response?.status;
+      if (status === 401 || status === 403) {
+        return res.status(502).json({
+          error: 'The server rejected the API key, so users could not be listed. Re-copy the key from the server dashboard (select only the key itself) and try again.',
+        });
+      }
+      reqLog.error(describeHttpError(err), 'list users failed');
+      if (err.isAxiosError) {
+        return res.status(502).json({ error: `Could not reach the server: ${err.message}` });
+      }
       res.status(500).json({ error: 'Failed to list users' });
     }
   }


### PR DESCRIPTION
A bad API key could pass Test Connection (it pinged an unauthenticated endpoint), and a 401 on the users dropdown just showed "No users found", so the first visible error was a confusing watch status sync failure.

Test Connection now hits the authenticated /System/Info, the users route returns the real auth error, adapters trim keys/URLs and strip trailing slashes, the settings page warns on non-GUID user ids, and the Watch Status no-servers notice links to each server's settings page. Also log via describeHttpError so the API token can't leak into the logs.