### PR TITLE
feat: bulk re-download from videos page selection

### DIFF
--- a/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/DownloadSettingsDialog.tsx
@@ -52,6 +52,10 @@ interface DownloadSettingsDialogProps {
   onConfirm: (settings: DownloadSettings | null) => void;
   videoCount?: number; // For manual downloads
   missingVideoCount?: number; // Number of videos that were previously downloaded but are now missing
+  // Number of selected videos whose file exists on disk and will be overwritten
+  replaceVideoCount?: number;
+  // Number of selected videos excluded because they are no longer on YouTube
+  unavailableVideoCount?: number;
   defaultResolution?: string;
   defaultVideoCount?: number; // For channel downloads
   mode?: 'manual' | 'channel'; // To differentiate between modes
@@ -70,6 +74,8 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
   onConfirm,
   videoCount,
   missingVideoCount = 0,
+  replaceVideoCount = 0,
+  unavailableVideoCount = 0,
   defaultResolution = '1080',
   defaultVideoCount = 3,
   mode = 'manual',
@@ -136,14 +142,14 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
       setChannelVideoCount(defaultVideoCount);
       setAudioFormat(null);
       // Open the custom section too so the user can see the re-download toggle is on.
-      if (missingVideoCount > 0 && !hideRedownloadOption) {
+      if ((missingVideoCount > 0 || replaceVideoCount > 0) && !hideRedownloadOption) {
         setAllowRedownload(true);
         setUseCustomSettings(true);
       } else {
         setAllowRedownload(false);
       }
     }
-  }, [open, hasUserInteracted, mode, missingVideoCount, defaultVideoCount, hideRedownloadOption]);
+  }, [open, hasUserInteracted, mode, missingVideoCount, replaceVideoCount, defaultVideoCount, hideRedownloadOption]);
 
   useEffect(() => {
     if (!open) {
@@ -293,6 +299,26 @@ const DownloadSettingsDialog: React.FC<DownloadSettingsDialogProps> = ({
                     ? 'Re-downloading 1 previously downloaded video.'
                     : `Re-downloading ${missingVideoCount} previously downloaded videos.`
                 )}
+              </Typography>
+            </Alert>
+          )}
+
+          {replaceVideoCount > 0 && (
+            <Alert severity="warning" className="mb-4">
+              <Typography variant="body2">
+                {replaceVideoCount === 1
+                  ? '1 video already exists on disk and will be re-downloaded and replaced.'
+                  : `${replaceVideoCount} videos already exist on disk and will be re-downloaded and replaced.`}
+              </Typography>
+            </Alert>
+          )}
+
+          {unavailableVideoCount > 0 && (
+            <Alert severity="info" className="mb-4">
+              <Typography variant="body2">
+                {unavailableVideoCount === 1
+                  ? '1 selected video is no longer available on YouTube and will be skipped.'
+                  : `${unavailableVideoCount} selected videos are no longer available on YouTube and will be skipped.`}
               </Typography>
             </Alert>
           )}

--- a/client/src/components/DownloadManager/ManualDownload/__tests__/DownloadSettingsDialog.test.tsx
+++ b/client/src/components/DownloadManager/ManualDownload/__tests__/DownloadSettingsDialog.test.tsx
@@ -1273,4 +1273,70 @@ describe('DownloadSettingsDialog', () => {
       expect(videoCountSelect).toHaveTextContent('8 videos');
     });
   });
+
+  describe('Replace and unavailable counts', () => {
+    test('shows singular replace warning when replaceVideoCount is 1', () => {
+      render(<DownloadSettingsDialog {...defaultProps} replaceVideoCount={1} />);
+
+      expect(
+        screen.getByText('1 video already exists on disk and will be re-downloaded and replaced.')
+      ).toBeInTheDocument();
+    });
+
+    test('shows plural replace warning when replaceVideoCount is greater than 1', () => {
+      render(<DownloadSettingsDialog {...defaultProps} replaceVideoCount={4} />);
+
+      expect(
+        screen.getByText('4 videos already exist on disk and will be re-downloaded and replaced.')
+      ).toBeInTheDocument();
+    });
+
+    test('auto-opens custom settings and enables re-download when replaceVideoCount > 0', () => {
+      render(<DownloadSettingsDialog {...defaultProps} replaceVideoCount={2} />);
+
+      const customToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      expect(customToggle).toBeChecked();
+
+      const redownloadToggle = screen.getByRole('checkbox', { name: /Allow re-downloading/i });
+      expect(redownloadToggle).toBeChecked();
+    });
+
+    test('emits allowRedownload when auto-enabled via replaceVideoCount and confirmed untouched', () => {
+      render(<DownloadSettingsDialog {...defaultProps} replaceVideoCount={2} mode="manual" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Start Download/i }));
+
+      expect(mockOnConfirm).toHaveBeenCalledWith({ allowRedownload: true });
+    });
+
+    test('shows singular skip note when unavailableVideoCount is 1', () => {
+      render(<DownloadSettingsDialog {...defaultProps} unavailableVideoCount={1} />);
+
+      expect(
+        screen.getByText('1 selected video is no longer available on YouTube and will be skipped.')
+      ).toBeInTheDocument();
+    });
+
+    test('shows plural skip note when unavailableVideoCount is greater than 1', () => {
+      render(<DownloadSettingsDialog {...defaultProps} unavailableVideoCount={3} />);
+
+      expect(
+        screen.getByText('3 selected videos are no longer available on YouTube and will be skipped.')
+      ).toBeInTheDocument();
+    });
+
+    test('unavailableVideoCount alone does not auto-enable re-download', () => {
+      render(<DownloadSettingsDialog {...defaultProps} unavailableVideoCount={2} />);
+
+      const customToggle = screen.getByRole('checkbox', { name: /Use custom settings/i });
+      expect(customToggle).not.toBeChecked();
+    });
+
+    test('renders neither new alert when the new props are omitted', () => {
+      render(<DownloadSettingsDialog {...defaultProps} />);
+
+      expect(screen.queryByText(/already exists? on disk/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/no longer available on YouTube/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/client/src/components/VideosPage/components/VideoCard.tsx
+++ b/client/src/components/VideosPage/components/VideoCard.tsx
@@ -49,7 +49,6 @@ function VideoCard({
   onImageError,
   onAddChannel,
 }: VideoCardProps) {
-  const isSelectable = !video.removed;
   const channelId = getEnabledChannelId(video.youTubeChannelName, video.channel_id, enabledChannels);
   const mediaTypeInfo = getMediaTypeInfo(video.media_type);
   const fileSizeNumber = video.fileSize
@@ -168,26 +167,24 @@ function VideoCard({
           </Box>
         )}
 
-        {isSelectable && (
-          <Checkbox
-            checked={selected}
-            onClick={(e) => e.stopPropagation()}
-            onChange={(event) => {
-              event.stopPropagation();
-              onToggleSelect(video.id);
-            }}
-            inputProps={{ 'aria-label': `Select ${video.youTubeVideoName}` }}
-            style={{
-              position: 'absolute',
-              top: 4,
-              left: 4,
-              backgroundColor: 'var(--media-overlay-background)',
-              color: 'var(--media-overlay-foreground)',
-              transition: 'all 0.2s',
-              zIndex: 3,
-            }}
-          />
-        )}
+        <Checkbox
+          checked={selected}
+          onClick={(e) => e.stopPropagation()}
+          onChange={(event) => {
+            event.stopPropagation();
+            onToggleSelect(video.id);
+          }}
+          inputProps={{ 'aria-label': `Select ${video.youTubeVideoName}` }}
+          style={{
+            position: 'absolute',
+            top: 4,
+            left: 4,
+            backgroundColor: 'var(--media-overlay-background)',
+            color: 'var(--media-overlay-foreground)',
+            transition: 'all 0.2s',
+            zIndex: 3,
+          }}
+        />
 
         {!video.removed && (
           <ProtectionShieldButton

--- a/client/src/components/VideosPage/components/VideosListMobile.tsx
+++ b/client/src/components/VideosPage/components/VideosListMobile.tsx
@@ -55,7 +55,6 @@ function VideosListMobile({
   return (
     <Box>
       {videos.map((video) => {
-        const isSelectable = !video.removed;
         const isSelected = selectedVideos.includes(video.id);
         const channelId = getEnabledChannelId(
           video.youTubeChannelName,
@@ -72,13 +71,11 @@ function VideosListMobile({
         return (
           <Box
             key={video.id}
-            role={isSelectable ? 'button' : undefined}
-            tabIndex={isSelectable ? 0 : undefined}
-            onClick={() => {
-              if (isSelectable) onToggleSelect(video.id);
-            }}
+            role="button"
+            tabIndex={0}
+            onClick={() => onToggleSelect(video.id)}
             onKeyDown={(event) => {
-              if (isSelectable && (event.key === 'Enter' || event.key === ' ')) {
+              if (event.key === 'Enter' || event.key === ' ') {
                 event.preventDefault();
                 onToggleSelect(video.id);
               }
@@ -88,7 +85,7 @@ function VideosListMobile({
               gap: 10,
               padding: '10px 4px',
               borderBottom: '1px solid var(--border)',
-              cursor: isSelectable ? 'pointer' : 'default',
+              cursor: 'pointer',
               backgroundColor: isSelected ? 'var(--muted)' : undefined,
               transition: 'background-color 0.15s ease',
               alignItems: 'flex-start',
@@ -201,26 +198,24 @@ function VideosListMobile({
                   }}
                 />
               ) : null}
-              {isSelectable && (
-                <Checkbox
-                  checked={isSelected}
-                  onClick={(e) => e.stopPropagation()}
-                  onChange={(event) => {
-                    event.stopPropagation();
-                    onToggleSelect(video.id);
-                  }}
-                  inputProps={{ 'aria-label': `Select ${video.youTubeVideoName}` }}
-                  style={{
-                    position: 'absolute',
-                    top: 2,
-                    left: 2,
-                    padding: 2,
-                    backgroundColor: 'var(--media-overlay-background)',
-                    color: 'var(--media-overlay-foreground)',
-                    zIndex: 3,
-                  }}
-                />
-              )}
+              <Checkbox
+                checked={isSelected}
+                onClick={(e) => e.stopPropagation()}
+                onChange={(event) => {
+                  event.stopPropagation();
+                  onToggleSelect(video.id);
+                }}
+                inputProps={{ 'aria-label': `Select ${video.youTubeVideoName}` }}
+                style={{
+                  position: 'absolute',
+                  top: 2,
+                  left: 2,
+                  padding: 2,
+                  backgroundColor: 'var(--media-overlay-background)',
+                  color: 'var(--media-overlay-foreground)',
+                  zIndex: 3,
+                }}
+              />
               {!video.removed && (
                 <ProtectionShieldButton
                   isProtected={video.protected || false}

--- a/client/src/components/VideosPage/components/VideosTable.tsx
+++ b/client/src/components/VideosPage/components/VideosTable.tsx
@@ -69,12 +69,10 @@ function VideosTable({
   onImageError,
   onAddChannel,
 }: VideosTableProps) {
-  const selectableVideos = videos.filter((v) => !v.removed);
-  const selectableIds = selectableVideos.map((v) => v.id);
-  const allSelectableSelected =
-    selectableIds.length > 0 && selectableIds.every((id) => selectedVideos.includes(id));
-  const someSelectableSelected =
-    !allSelectableSelected && selectableIds.some((id) => selectedVideos.includes(id));
+  const allIds = videos.map((v) => v.id);
+  const allSelected =
+    allIds.length > 0 && allIds.every((id) => selectedVideos.includes(id));
+  const someSelected = !allSelected && allIds.some((id) => selectedVideos.includes(id));
 
   return (
     <Paper style={{ overflow: 'hidden' }}>
@@ -84,8 +82,8 @@ function VideosTable({
             <TableRow>
               <TableCell component="th" style={{ width: 48 }}>
                 <Checkbox
-                  indeterminate={someSelectableSelected}
-                  checked={allSelectableSelected}
+                  indeterminate={someSelected}
+                  checked={allSelected}
                   onChange={(event) => onSelectAll(event.target.checked)}
                   inputProps={{ 'aria-label': 'Select all videos' }}
                 />
@@ -120,7 +118,6 @@ function VideosTable({
           </TableHead>
           <TableBody>
             {videos.map((video) => {
-              const isSelectable = !video.removed;
               const isSelected = selectedVideos.includes(video.id);
               const channelId = getEnabledChannelId(
                 video.youTubeChannelName,
@@ -139,18 +136,15 @@ function VideosTable({
                   key={video.id}
                   hover
                   style={{
-                    cursor: isSelectable ? 'pointer' : 'default',
+                    cursor: 'pointer',
                     backgroundColor: isSelected ? 'var(--muted)' : undefined,
                     transition: 'background-color 0.15s ease',
                   }}
-                  onClick={() => {
-                    if (isSelectable) onToggleSelect(video.id);
-                  }}
+                  onClick={() => onToggleSelect(video.id)}
                 >
                   <TableCell>
                     <Checkbox
                       checked={isSelected}
-                      disabled={!isSelectable}
                       onClick={(e) => e.stopPropagation()}
                       onChange={() => onToggleSelect(video.id)}
                       inputProps={{ 'aria-label': `Select ${video.youTubeVideoName}` }}

--- a/client/src/components/VideosPage/components/__tests__/VideoCard.test.tsx
+++ b/client/src/components/VideosPage/components/__tests__/VideoCard.test.tsx
@@ -111,9 +111,11 @@ describe('VideoCard', () => {
     expect(onToggleSelect).toHaveBeenCalledWith(1);
   });
 
-  test('omits selection checkbox when video is removed', () => {
-    renderCard({ video: { ...baseVideo, removed: true } });
-    expect(screen.queryByRole('checkbox', { name: /Select Test Video/ })).not.toBeInTheDocument();
+  test('renders selection checkbox when video is removed', () => {
+    const { onToggleSelect } = renderCard({ video: { ...baseVideo, removed: true } });
+    const checkbox = screen.getByRole('checkbox', { name: /Select Test Video/ });
+    fireEvent.click(checkbox);
+    expect(onToggleSelect).toHaveBeenCalledWith(1);
   });
 
   test('shows Available chip for present files and Missing chip for removed', () => {

--- a/client/src/components/VideosPage/components/__tests__/VideosListMobile.test.tsx
+++ b/client/src/components/VideosPage/components/__tests__/VideosListMobile.test.tsx
@@ -74,14 +74,14 @@ describe('VideosListMobile', () => {
     expect(onToggleSelect).toHaveBeenCalledWith(1);
   });
 
-  test('omits checkbox and row-click for removed videos', () => {
+  test('renders checkbox and row-click for removed videos', () => {
     const { onToggleSelect } = renderList({
       videos: [{ ...sampleVideo, removed: true }],
     });
-    expect(screen.queryByRole('checkbox', { name: /Select Compact Row Video/ })).not.toBeInTheDocument();
-    // Row should not be a button when not selectable.
-    expect(screen.queryByRole('button', { name: /Compact Row Video/ })).not.toBeInTheDocument();
-    expect(onToggleSelect).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('checkbox', { name: /Select Compact Row Video/ }));
+    expect(onToggleSelect).toHaveBeenCalledWith(1);
+    fireEvent.click(screen.getByRole('button', { name: /Compact Row Video/ }));
+    expect(onToggleSelect).toHaveBeenCalledTimes(2);
   });
 
   test('allows selection for audio-only downloads with no video fileSize', () => {

--- a/client/src/components/VideosPage/components/__tests__/VideosTable.test.tsx
+++ b/client/src/components/VideosPage/components/__tests__/VideosTable.test.tsx
@@ -104,10 +104,12 @@ describe('VideosTable', () => {
     expect(screen.getByText('1080p')).toBeInTheDocument();
   });
 
-  test('removed video has a disabled checkbox', () => {
-    renderTable();
+  test('removed video has an enabled checkbox that toggles selection', () => {
+    const { onToggleSelect } = renderTable();
     const removedRowCheckbox = screen.getByRole('checkbox', { name: /Select Removed Video/ });
-    expect(removedRowCheckbox).toBeDisabled();
+    expect(removedRowCheckbox).toBeEnabled();
+    fireEvent.click(removedRowCheckbox);
+    expect(onToggleSelect).toHaveBeenCalledWith(2);
   });
 
   test('clicking the Published header fires onSortChange with published', () => {

--- a/client/src/components/VideosPage/index.tsx
+++ b/client/src/components/VideosPage/index.tsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 import { useSwipeable } from 'react-swipeable';
 import { Alert, Box, Grid, Snackbar, Typography } from '../ui';
-import { Trash2 as DeleteIcon, Star as RatingIcon } from '../../lib/icons';
+import { Trash2 as DeleteIcon, Star as RatingIcon, Download as DownloadIcon } from '../../lib/icons';
 import { useMediaQuery } from '../../hooks/useMediaQuery';
 import { useConfig } from '../../hooks/useConfig';
 import { useDownloadListingsRefresh } from '../../hooks/useDownloadListingsRefresh';
+import { useTriggerDownloads } from '../../hooks/useTriggerDownloads';
 import { VideoData } from '../../types/VideoData';
 import AddChannelDialog from '../shared/AddChannelDialog';
 import DeleteVideosDialog from '../shared/DeleteVideosDialog';
@@ -14,6 +16,8 @@ import ChangeRatingDialog from '../shared/ChangeRatingDialog';
 import { useVideoProtection } from '../shared/useVideoProtection';
 import VideoModal from '../shared/VideoModal';
 import { VideoModalData } from '../shared/VideoModal/types';
+import DownloadSettingsDialog from '../DownloadManager/ManualDownload/DownloadSettingsDialog';
+import { DownloadSettings } from '../DownloadManager/ManualDownload/types';
 import VideoCard from './components/VideoCard';
 import VideosTable from './components/VideosTable';
 import VideosListMobile from './components/VideosListMobile';
@@ -38,6 +42,15 @@ interface VideosPageProps {
 }
 
 const VIEW_MODE_STORAGE_KEY = 'youtarr:videosPageViewMode';
+
+const YOUTUBE_CHANNEL_ID_PATTERN = /^UC[a-zA-Z0-9_-]{22}$/;
+
+interface VideoSelectionMeta {
+  youtubeId: string;
+  channelId: string | null;
+  removed: boolean;
+  youtubeRemoved: boolean;
+}
 
 function videoDataToModalData(video: VideoData): VideoModalData {
   return {
@@ -95,6 +108,10 @@ function VideosPage({ token }: VideosPageProps) {
     []
   );
 
+  const navigate = useNavigate();
+  const [downloadDialogOpen, setDownloadDialogOpen] = useState(false);
+  const { triggerDownloads } = useTriggerDownloads(token);
+
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const { deleteVideos, loading: deleteLoading } = useVideoDeletion();
@@ -142,6 +159,19 @@ function VideosPage({ token }: VideosPageProps) {
     useInfiniteScroll,
   });
 
+  const videoMetaRef = useRef<Map<number, VideoSelectionMeta>>(new Map());
+
+  useEffect(() => {
+    for (const video of videos) {
+      videoMetaRef.current.set(video.id, {
+        youtubeId: video.youtubeId,
+        channelId: video.channel_id || null,
+        removed: Boolean(video.removed),
+        youtubeRemoved: Boolean(video.youtube_removed),
+      });
+    }
+  }, [videos]);
+
   useDownloadListingsRefresh(refetch);
 
   useEffect(() => {
@@ -186,7 +216,12 @@ function VideosPage({ token }: VideosPageProps) {
 
   const handleDeleteConfirm = async (selectedIds: number[]) => {
     setDeleteDialogOpen(false);
-    const result = await deleteVideos(selectedIds, token);
+    const deletableIds = selectedIds.filter((id) => {
+      const meta = videoMetaRef.current.get(id);
+      return Boolean(meta && !meta.removed);
+    });
+    if (deletableIds.length === 0) return;
+    const result = await deleteVideos(deletableIds, token);
     if (result.success) {
       setSuccessMessage(
         `Successfully deleted ${result.deleted.length} video${result.deleted.length !== 1 ? 's' : ''}`
@@ -235,6 +270,18 @@ function VideosPage({ token }: VideosPageProps) {
   const selectionActions = useMemo<SelectionAction<number>[]>(
     () => [
       {
+        id: 'download',
+        label: 'Download',
+        icon: <DownloadIcon size={14} />,
+        intent: 'success',
+        disabled: (ids) =>
+          !ids.some((id) => {
+            const meta = videoMetaRef.current.get(id);
+            return Boolean(meta && !meta.youtubeRemoved);
+          }),
+        onClick: () => setDownloadDialogOpen(true),
+      },
+      {
         id: 'rating',
         label: 'Rating',
         icon: <RatingIcon size={14} />,
@@ -246,7 +293,12 @@ function VideosPage({ token }: VideosPageProps) {
         label: 'Delete',
         icon: <DeleteIcon size={14} />,
         intent: 'danger',
-        disabled: () => deleteLoading,
+        disabled: (ids) =>
+          deleteLoading ||
+          !ids.some((id) => {
+            const meta = videoMetaRef.current.get(id);
+            return Boolean(meta && !meta.removed);
+          }),
         onClick: () => setDeleteDialogOpen(true),
       },
     ],
@@ -278,11 +330,81 @@ function VideosPage({ token }: VideosPageProps) {
 
   const handleSelectAll = (checked: boolean) => {
     if (checked) {
-      const selectable = videos.filter((v) => !v.removed).map((v) => v.id);
-      selection.set(selectable);
+      selection.set(videos.map((v) => v.id));
     } else {
       selection.clear();
     }
+  };
+
+  const getDownloadCounts = () => {
+    let missing = 0;
+    let replace = 0;
+    let unavailable = 0;
+    for (const id of selection.selectedIds) {
+      const meta = videoMetaRef.current.get(id);
+      if (!meta) continue;
+      if (meta.youtubeRemoved) {
+        unavailable += 1;
+      } else if (meta.removed) {
+        missing += 1;
+      } else {
+        replace += 1;
+      }
+    }
+    return { missing, replace, unavailable, eligible: missing + replace };
+  };
+
+  const downloadCounts = downloadDialogOpen
+    ? getDownloadCounts()
+    : { missing: 0, replace: 0, unavailable: 0, eligible: 0 };
+
+  const getDeleteCounts = () => {
+    let deletable = 0;
+    let skipped = 0;
+    for (const id of selection.selectedIds) {
+      const meta = videoMetaRef.current.get(id);
+      if (meta && !meta.removed) {
+        deletable += 1;
+      } else {
+        skipped += 1;
+      }
+    }
+    return { deletable, skipped };
+  };
+  const deleteCounts = getDeleteCounts();
+
+  const handleDownloadConfirm = async (settings: DownloadSettings | null) => {
+    setDownloadDialogOpen(false);
+    const eligible = selection.selectedIds
+      .map((id) => videoMetaRef.current.get(id))
+      .filter((meta): meta is VideoSelectionMeta => Boolean(meta && !meta.youtubeRemoved));
+    if (eligible.length === 0) return;
+
+    const urls = eligible.map((meta) => `https://www.youtube.com/watch?v=${meta.youtubeId}`);
+    const videoChannelMap: Record<string, string> = {};
+    for (const meta of eligible) {
+      if (meta.channelId && YOUTUBE_CHANNEL_ID_PATTERN.test(meta.channelId)) {
+        videoChannelMap[meta.youtubeId] = meta.channelId;
+      }
+    }
+    const overrideSettings = settings
+      ? {
+          resolution: settings.resolution,
+          allowRedownload: settings.allowRedownload,
+          subfolder: settings.subfolder,
+          audioFormat: settings.audioFormat,
+          rating: settings.rating,
+          skipVideoFolder: settings.skipVideoFolder,
+        }
+      : undefined;
+
+    const success = await triggerDownloads({ urls, overrideSettings, videoChannelMap });
+    if (!success) {
+      setErrorMessage('Failed to queue selected videos for download. Please try again.');
+      return;
+    }
+    selection.clear();
+    navigate('/downloads/activity');
   };
 
   const handleDeleteSingleVideo = (videoId: number) => {
@@ -511,7 +633,8 @@ function VideosPage({ token }: VideosPageProps) {
         open={deleteDialogOpen}
         onClose={() => setDeleteDialogOpen(false)}
         onConfirm={() => handleDeleteConfirm(selection.selectedIds)}
-        videoCount={selection.count}
+        videoCount={deleteCounts.deletable}
+        skippedCount={deleteCounts.skipped}
       />
 
       <ChangeRatingDialog
@@ -519,6 +642,20 @@ function VideosPage({ token }: VideosPageProps) {
         onClose={() => setRatingDialogOpen(false)}
         onApply={(rating) => handleApplyRating(rating, selection.selectedIds)}
         selectedCount={selection.count}
+      />
+
+      <DownloadSettingsDialog
+        open={downloadDialogOpen}
+        onClose={() => setDownloadDialogOpen(false)}
+        onConfirm={handleDownloadConfirm}
+        videoCount={downloadCounts.eligible}
+        missingVideoCount={downloadCounts.missing}
+        replaceVideoCount={downloadCounts.replace}
+        unavailableVideoCount={downloadCounts.unavailable}
+        defaultResolution={configState?.config?.preferredResolution || '1080'}
+        defaultResolutionSource="global"
+        mode="manual"
+        token={token}
       />
 
       <Snackbar

--- a/client/src/components/__tests__/VideosPage.test.tsx
+++ b/client/src/components/__tests__/VideosPage.test.tsx
@@ -33,6 +33,47 @@ jest.mock('../../hooks/useConfig', () => ({
   })),
 }));
 
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockTriggerDownloads = jest.fn();
+jest.mock('../../hooks/useTriggerDownloads', () => ({
+  useTriggerDownloads: () => ({
+    triggerDownloads: mockTriggerDownloads,
+    loading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('../DownloadManager/ManualDownload/DownloadSettingsDialog', () => ({
+  __esModule: true,
+  default: function MockDownloadSettingsDialog(props: any) {
+    const React = require('react');
+    if (!props.open) return null;
+    return React.createElement(
+      'div',
+      { 'data-testid': 'download-settings-dialog' },
+      React.createElement('div', { 'data-testid': 'download-video-count' }, String(props.videoCount ?? 0)),
+      React.createElement('div', { 'data-testid': 'download-missing-count' }, String(props.missingVideoCount ?? 0)),
+      React.createElement('div', { 'data-testid': 'download-replace-count' }, String(props.replaceVideoCount ?? 0)),
+      React.createElement('div', { 'data-testid': 'download-unavailable-count' }, String(props.unavailableVideoCount ?? 0)),
+      React.createElement(
+        'button',
+        { 'data-testid': 'download-dialog-confirm', onClick: () => props.onConfirm({ allowRedownload: true }) },
+        'Start Download'
+      ),
+      React.createElement(
+        'button',
+        { 'data-testid': 'download-dialog-close', onClick: props.onClose },
+        'Close'
+      )
+    );
+  },
+}));
+
 jest.mock('../shared/DeleteVideosDialog', () => ({
   __esModule: true,
   default: function MockDeleteVideosDialog(props: any) {
@@ -41,6 +82,7 @@ jest.mock('../shared/DeleteVideosDialog', () => ({
       'data-testid': 'delete-videos-dialog',
       'data-open': props.open,
       'data-video-count': props.videoCount,
+      'data-skipped-count': props.skippedCount,
     }, [
       React.createElement('button', {
         key: 'cancel',
@@ -384,6 +426,8 @@ describe('VideosPage Component', () => {
       loading: false,
       error: null
     });
+
+    mockTriggerDownloads.mockResolvedValue(true);
   });
 
   // Helper: force a particular view mode before rendering.
@@ -1118,13 +1162,13 @@ describe('VideosPage Component', () => {
         });
       });
 
-      test('select all checkbox selects all non-removed videos', async () => {
+      test('select all checkbox selects all videos including removed ones', async () => {
         const user = setupUser();
         const videosWithRemoved = [
           ...mockVideos,
           {
             id: 4,
-            youtubeId: 'removed123',
+            youtubeId: 'removed12345',
             youTubeChannelName: 'Test Channel',
             youTubeVideoName: 'Removed Video',
             timeCreated: '2024-01-15T10:30:00',
@@ -1148,9 +1192,8 @@ describe('VideosPage Component', () => {
 
         await user.click(selectAllCheckbox);
 
-        // Should show that 3 videos are selected (excluding the removed one)
         await waitFor(() => {
-          expect(screen.getByText(/3 videos selected/)).toBeInTheDocument();
+          expect(screen.getByText(/4 videos selected/)).toBeInTheDocument();
         });
       });
 
@@ -1267,7 +1310,8 @@ describe('VideosPage Component', () => {
         expect(dialog.getAttribute('data-video-count')).toBe('1');
       });
 
-      test('removed videos cannot be selected', async () => {
+      test('removed videos can be selected', async () => {
+        const user = setupUser();
         const removedVideo = {
           ...mockVideos[0],
           removed: true
@@ -1282,8 +1326,13 @@ describe('VideosPage Component', () => {
 
         const checkboxes = screen.getAllByRole('checkbox');
         const videoCheckbox = checkboxes[1]; // First video checkbox (after select all)
+        expect(videoCheckbox).toBeEnabled();
 
-        expect(videoCheckbox).toBeDisabled();
+        await user.click(videoCheckbox);
+
+        await waitFor(() => {
+          expect(screen.getByText(/1 video selected/)).toBeInTheDocument();
+        });
       });
     });
 
@@ -1641,6 +1690,231 @@ describe('VideosPage Component', () => {
         await waitFor(() => {
           expect(screen.getByText(/Failed to delete videos: Network error/)).toBeInTheDocument();
         });
+      });
+    });
+  });
+
+  describe('Bulk download', () => {
+    const CHANNEL_ID = 'UCabcdefghijklmnopqrstuv';
+    const downloadVideos: VideoData[] = [
+      {
+        id: 11,
+        youtubeId: 'missing0001',
+        youTubeChannelName: 'Tech Channel',
+        youTubeVideoName: 'Missing Video',
+        timeCreated: '2024-01-15T10:30:00',
+        originalDate: '20240110',
+        duration: 600,
+        description: null,
+        removed: true,
+        fileSize: null,
+        channel_id: CHANNEL_ID,
+      },
+      {
+        id: 12,
+        youtubeId: 'present0001',
+        youTubeChannelName: 'Tech Channel',
+        youTubeVideoName: 'Present Video',
+        timeCreated: '2024-01-14T10:30:00',
+        originalDate: '20240109',
+        duration: 600,
+        description: null,
+        removed: false,
+        fileSize: '1073741824',
+        channel_id: CHANNEL_ID,
+      },
+      {
+        id: 13,
+        youtubeId: 'gone0000001',
+        youTubeChannelName: 'Tech Channel',
+        youTubeVideoName: 'Gone Video',
+        timeCreated: '2024-01-13T10:30:00',
+        originalDate: '20240108',
+        duration: 600,
+        description: null,
+        removed: true,
+        youtube_removed: true,
+        fileSize: null,
+        channel_id: CHANNEL_ID,
+      },
+    ];
+
+    const selectByName = async (user: ReturnType<typeof setupUser>, name: string) => {
+      await user.click(screen.getByRole('checkbox', { name: `Select ${name}` }));
+    };
+
+    const renderWithDownloadVideos = async () => {
+      useTableView();
+      axios.get.mockResolvedValue({ data: mockPaginatedResponse(downloadVideos) });
+      render(<VideosPage token={mockToken} />);
+      await waitFor(() => {
+        expect(screen.getByText('Missing Video')).toBeInTheDocument();
+      });
+    };
+
+    test('download action opens the dialog with eligible, missing, replace and unavailable counts', async () => {
+      const user = setupUser();
+      await renderWithDownloadVideos();
+
+      await selectByName(user, 'Missing Video');
+      await selectByName(user, 'Present Video');
+      await selectByName(user, 'Gone Video');
+
+      await user.click(screen.getByRole('button', { name: 'Download' }));
+
+      expect(screen.getByTestId('download-settings-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('download-video-count')).toHaveTextContent('2');
+      expect(screen.getByTestId('download-missing-count')).toHaveTextContent('1');
+      expect(screen.getByTestId('download-replace-count')).toHaveTextContent('1');
+      expect(screen.getByTestId('download-unavailable-count')).toHaveTextContent('1');
+    });
+
+    test('confirming posts eligible urls with videoChannelMap, clears selection and navigates', async () => {
+      const user = setupUser();
+      await renderWithDownloadVideos();
+
+      await selectByName(user, 'Missing Video');
+      await selectByName(user, 'Present Video');
+      await selectByName(user, 'Gone Video');
+
+      await user.click(screen.getByRole('button', { name: 'Download' }));
+      await user.click(screen.getByTestId('download-dialog-confirm'));
+
+      await waitFor(() => {
+        expect(mockTriggerDownloads).toHaveBeenCalledWith({
+          urls: [
+            'https://www.youtube.com/watch?v=missing0001',
+            'https://www.youtube.com/watch?v=present0001',
+          ],
+          overrideSettings: {
+            resolution: undefined,
+            allowRedownload: true,
+            subfolder: undefined,
+            audioFormat: undefined,
+            rating: undefined,
+            skipVideoFolder: undefined,
+          },
+          videoChannelMap: {
+            missing0001: CHANNEL_ID,
+            present0001: CHANNEL_ID,
+          },
+        });
+      });
+      expect(mockNavigate).toHaveBeenCalledWith('/downloads/activity');
+      expect(screen.queryByText(/videos selected/)).not.toBeInTheDocument();
+    });
+
+    test('videos without a valid channel id are downloaded but omitted from videoChannelMap', async () => {
+      const user = setupUser();
+      useTableView();
+      axios.get.mockResolvedValue({
+        data: mockPaginatedResponse([
+          { ...downloadVideos[0], channel_id: null },
+        ]),
+      });
+      render(<VideosPage token={mockToken} />);
+      await waitFor(() => {
+        expect(screen.getByText('Missing Video')).toBeInTheDocument();
+      });
+
+      await selectByName(user, 'Missing Video');
+      await user.click(screen.getByRole('button', { name: 'Download' }));
+      await user.click(screen.getByTestId('download-dialog-confirm'));
+
+      await waitFor(() => {
+        expect(mockTriggerDownloads).toHaveBeenCalledWith(
+          expect.objectContaining({
+            urls: ['https://www.youtube.com/watch?v=missing0001'],
+            videoChannelMap: {},
+          })
+        );
+      });
+    });
+
+    test('Download is disabled when only videos gone from YouTube are selected', async () => {
+      const user = setupUser();
+      await renderWithDownloadVideos();
+
+      await selectByName(user, 'Gone Video');
+
+      expect(screen.getByRole('button', { name: 'Download' })).toBeDisabled();
+    });
+
+    test('Delete stays enabled for a mixed selection and Rating stays enabled', async () => {
+      const user = setupUser();
+      await renderWithDownloadVideos();
+
+      await selectByName(user, 'Missing Video');
+      await selectByName(user, 'Present Video');
+
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+      expect(screen.getByRole('button', { name: 'Rating' })).toBeEnabled();
+    });
+
+    test('Delete is disabled when only missing videos are selected', async () => {
+      const user = setupUser();
+      await renderWithDownloadVideos();
+
+      await selectByName(user, 'Missing Video');
+      await selectByName(user, 'Gone Video');
+
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();
+    });
+
+    test('Delete stays enabled when only present videos are selected', async () => {
+      const user = setupUser();
+      await renderWithDownloadVideos();
+
+      await selectByName(user, 'Present Video');
+
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+    });
+
+    test('shows an error and keeps selection when the trigger fails', async () => {
+      const user = setupUser();
+      mockTriggerDownloads.mockResolvedValue(false);
+      await renderWithDownloadVideos();
+
+      await selectByName(user, 'Missing Video');
+      await user.click(screen.getByRole('button', { name: 'Download' }));
+      await user.click(screen.getByTestId('download-dialog-confirm'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Failed to queue selected videos for download. Please try again.')
+        ).toBeInTheDocument();
+      });
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(screen.getByText(/1 video selected/)).toBeInTheDocument();
+    });
+
+    test('delete dialog shows deletable count and skipped count for a mixed selection', async () => {
+      const user = setupUser();
+      await renderWithDownloadVideos();
+
+      await selectByName(user, 'Missing Video');
+      await selectByName(user, 'Present Video');
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+      const dialog = screen.getByTestId('delete-videos-dialog');
+      expect(dialog.getAttribute('data-video-count')).toBe('1');
+      expect(dialog.getAttribute('data-skipped-count')).toBe('1');
+    });
+
+    test('confirming deletion passes only on-disk video ids to deleteVideos', async () => {
+      const user = setupUser();
+      mockDeleteVideos.mockResolvedValue({ success: true, deleted: [12], failed: [] });
+      await renderWithDownloadVideos();
+
+      await selectByName(user, 'Missing Video');
+      await selectByName(user, 'Present Video');
+
+      await user.click(screen.getByRole('button', { name: 'Delete' }));
+      await user.click(screen.getByTestId('dialog-confirm'));
+
+      await waitFor(() => {
+        expect(mockDeleteVideos).toHaveBeenCalledWith([12], mockToken);
       });
     });
   });

--- a/client/src/components/shared/DeleteVideosDialog.tsx
+++ b/client/src/components/shared/DeleteVideosDialog.tsx
@@ -18,13 +18,16 @@ interface DeleteVideosDialogProps {
   onClose: () => void;
   onConfirm: () => void;
   videoCount: number;
+  // Selected videos excluded from deletion because their file is already missing
+  skippedCount?: number;
 }
 
 const DeleteVideosDialog: React.FC<DeleteVideosDialogProps> = ({
   open,
   onClose,
   onConfirm,
-  videoCount
+  videoCount,
+  skippedCount = 0
 }) => {
   return (
     <Dialog
@@ -33,9 +36,11 @@ const DeleteVideosDialog: React.FC<DeleteVideosDialogProps> = ({
       maxWidth="sm"
       fullWidth
     >
-      <DialogTitle style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <WarningIcon size={20} data-testid="WarningIcon" />
-        Confirm Video Deletion
+      <DialogTitle>
+        <span className="flex items-center gap-2">
+          <WarningIcon size={20} data-testid="WarningIcon" />
+          Confirm Video Deletion
+        </span>
       </DialogTitle>
 
       <DialogContent>
@@ -45,6 +50,16 @@ const DeleteVideosDialog: React.FC<DeleteVideosDialogProps> = ({
               You are about to permanently delete {videoCount} {videoCount === 1 ? 'video' : 'videos'} from disk.
             </Typography>
           </Alert>
+
+          {skippedCount > 0 && (
+            <Alert severity="info" style={{ marginBottom: 16 }}>
+              <Typography variant="body2">
+                {skippedCount === 1
+                  ? '1 selected video will not be affected because its file is already missing from disk.'
+                  : `${skippedCount} selected videos will not be affected because their files are already missing from disk.`}
+              </Typography>
+            </Alert>
+          )}
 
           <Typography variant="body2" color="text.secondary" style={{ marginBottom: 16 }}>
             This action will:

--- a/client/src/components/shared/__tests__/DeleteVideosDialog.test.tsx
+++ b/client/src/components/shared/__tests__/DeleteVideosDialog.test.tsx
@@ -154,4 +154,32 @@ describe('DeleteVideosDialog', () => {
       expect(screen.getByRole('button', { name: 'Delete Videos' })).toBeInTheDocument();
     });
   });
+
+  describe('Skipped Videos Notice', () => {
+    test('shows singular skipped notice when skippedCount is 1', () => {
+      render(<DeleteVideosDialog {...defaultProps} videoCount={2} skippedCount={1} />);
+
+      expect(
+        screen.getByText(
+          '1 selected video will not be affected because its file is already missing from disk.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    test('shows plural skipped notice when skippedCount is greater than 1', () => {
+      render(<DeleteVideosDialog {...defaultProps} videoCount={3} skippedCount={2} />);
+
+      expect(
+        screen.getByText(
+          '2 selected videos will not be affected because their files are already missing from disk.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    test('renders no skipped notice when skippedCount is omitted', () => {
+      render(<DeleteVideosDialog {...defaultProps} />);
+
+      expect(screen.queryByText(/will not be affected/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/client/src/hooks/__tests__/useTriggerDownloads.test.ts
+++ b/client/src/hooks/__tests__/useTriggerDownloads.test.ts
@@ -97,6 +97,36 @@ describe('useTriggerDownloads', () => {
     expect(body.channelId).toBe('UCabc');
   });
 
+  test('includes videoChannelMap in the request body when non-empty', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    const { result } = renderHook(() => useTriggerDownloads(token));
+
+    await act(async () => {
+      await result.current.triggerDownloads({
+        urls: ['https://www.youtube.com/watch?v=abc123def45'],
+        videoChannelMap: { abc123def45: 'UCabcdefghijklmnopqrstuv' },
+      });
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body.videoChannelMap).toEqual({ abc123def45: 'UCabcdefghijklmnopqrstuv' });
+  });
+
+  test('omits videoChannelMap from the request body when empty', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    const { result } = renderHook(() => useTriggerDownloads(token));
+
+    await act(async () => {
+      await result.current.triggerDownloads({
+        urls: ['https://www.youtube.com/watch?v=abc123def45'],
+        videoChannelMap: {},
+      });
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(body).not.toHaveProperty('videoChannelMap');
+  });
+
   test('returns false and sets error when response is not ok', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, statusText: 'Bad Request' });
     const { result } = renderHook(() => useTriggerDownloads(token));

--- a/client/src/hooks/useTriggerDownloads.ts
+++ b/client/src/hooks/useTriggerDownloads.ts
@@ -13,6 +13,7 @@ interface TriggerDownloadsParams {
   urls: string[];
   overrideSettings?: DownloadOverrideSettings;
   channelId?: string | null;
+  videoChannelMap?: Record<string, string>;
 }
 
 interface UseTriggerDownloadsResult {
@@ -26,7 +27,7 @@ export function useTriggerDownloads(token: string | null): UseTriggerDownloadsRe
   const [error, setError] = useState<Error | null>(null);
 
   const triggerDownloads = useCallback(
-    async ({ urls, overrideSettings, channelId }: TriggerDownloadsParams): Promise<boolean> => {
+    async ({ urls, overrideSettings, channelId, videoChannelMap }: TriggerDownloadsParams): Promise<boolean> => {
       if (!token) {
         setError(new Error('No authentication token provided'));
         return false;
@@ -51,6 +52,10 @@ export function useTriggerDownloads(token: string | null): UseTriggerDownloadsRe
 
         if (channelId) {
           requestBody.channelId = channelId;
+        }
+
+        if (videoChannelMap && Object.keys(videoChannelMap).length > 0) {
+          requestBody.videoChannelMap = videoChannelMap;
         }
 
         const response = await fetch('/triggerspecificdownloads', {

--- a/docs/media-servers/emby.md
+++ b/docs/media-servers/emby.md
@@ -49,12 +49,17 @@ In the library configuration:
 1. **NFO** (enable and move to top)
 2. Disable all internet providers (TheMovieDb, etc.)
 
+**Metadata savers**:
+- **Disable**: Nfo ("Save metadata to NFO")
+
+> **Warning**: Do NOT enable Emby's NFO metadata saver. Youtarr generates and maintains the `.nfo` file for every video it downloads. If the saver is enabled, Emby will update and overwrite those files with its own data (for example, incorrectly guessed season/episode tags), which can cause problems for your library.
+
 **Image fetchers**:
 - **Local Images** (enable)
 - Disable all internet image providers
 
 **Advanced Settings**:
-- **Save artwork and metadata into media folders**: Yes
+- **Save artwork and metadata into media folders**: No (see the NFO saver warning above)
 - **Prefer embedded metadata**: Yes
 - **Enable real-time monitoring**: Optional
 
@@ -164,7 +169,7 @@ Configure in Advanced settings:
 
 **Metadata Settings**:
 - **Prefer local metadata**: Yes
-- **Save metadata within media folders**: Yes
+- **Save metadata within media folders**: No (Emby would overwrite Youtarr's `.nfo` files; see the NFO saver warning in [Library Setup](#library-setup))
 - **Save subtitles within media folders**: Yes (if using)
 
 **Image Settings**:

--- a/docs/media-servers/jellyfin.md
+++ b/docs/media-servers/jellyfin.md
@@ -58,6 +58,8 @@ In the library settings:
 **Metadata savers**:
 - **Disable**: Nfo
 
+> **Warning**: Do NOT enable the Nfo metadata saver. Youtarr generates and maintains the `.nfo` file for every video it downloads. If the saver is enabled, Jellyfin will update and overwrite those files with its own data, which can cause problems for your library.
+
 **Image fetchers**:
 - Disable all internet fetchers
 - Local images will be used automatically


### PR DESCRIPTION
Add a Download action to the Videos page multi-select. Missing files are re-fetched, on-disk files replaced, and videos gone from YouTube skipped, with per-group counts in the download dialog. Removed videos are now selectable in all views, bulk Delete skips already-missing files, and channel attribution is sent via videoChannelMap.

Refs: #578

Also: warn against enabling nfo metadata savers

Emby's "Save metadata to NFO" option was reported to rewrite
Youtarr-generated .nfo files with guessed season/episode tags. Warn
in the Emby and Jellyfin guides that the NFO saver should stay
disabled, and flip the Emby settings that recommended it to No.

Refs: #696