### PR TITLE
fix: restore utf8mb4_bin on jobs uuid fk columns

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -319,6 +319,37 @@ tables are still on the wrong character set.
 **Prevention**: If you run your own database, create it as `utf8mb4` from the start and this conversion
 never has to run. See the [External Database Guide](platforms/external-db.md).
 
+### Migration Fails Creating JobVideoDownloads (errno 150)
+
+**Problem**: A fresh install (or an upgrade of an older install) fails partway through migrations with:
+```
+Can't create table `youtarr`.`JobVideoDownloads` (errno: 150 "Foreign key constraint is incorrectly formed")
+```
+and the server starts in degraded mode.
+
+**Cause**: This happens when the database was not created with `utf8mb4` defaults - an external database,
+or a MariaDB service running without the compose file's `--character-set-server=utf8mb4` arguments. The
+`Jobs.id` and `JobVideos.job_id` columns are UUIDs stored as `CHAR(36)` with the binary collation
+`utf8mb4_bin`. When the utf8mb4 conversion above runs, `ALTER TABLE ... CONVERT TO CHARACTER SET` coerces
+them to `utf8mb4_unicode_ci`. The `JobVideoDownloads` migration then creates its `job_id` column as
+`utf8mb4_bin`, and InnoDB refuses the foreign key because the collations on the two sides no longer match.
+
+**Solution**: Update Youtarr. The migrations now restore the binary collation automatically - the utf8mb4
+conversion re-applies it right after converting, and the `JobVideoDownloads` migration repairs it before
+creating the table, so a restart on the latest image finishes the job.
+
+To fix it by hand instead, connect to the database as root and run:
+```sql
+SET FOREIGN_KEY_CHECKS = 0;
+ALTER TABLE Jobs MODIFY id CHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;
+ALTER TABLE JobVideos MODIFY job_id CHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;
+SET FOREIGN_KEY_CHECKS = 1;
+```
+then restart the Youtarr container; the remaining migrations will complete.
+
+**Prevention**: Same as the previous section - create your own database as `utf8mb4` from the start, or
+keep the charset arguments from the bundled `docker-compose.yml`.
+
 ### Database Connection Failed
 
 **Problem**: Cannot connect to database errors.
@@ -335,6 +366,21 @@ never has to run. See the [External Database Guide](platforms/external-db.md).
    ```
 
 3. Verify database credentials in environment
+
+### Stuck on "Waiting for database"
+
+**Problem**: The youtarr container loops `Waiting for database... (attempt N/30)` and finally exits with
+`Failed to connect to database after 30 attempts`, with no other error in its logs.
+
+**Cause**: Usually a credentials mismatch that stays silent because the startup wait loop only reports
+that the connection failed, not why. A common one when connecting as root: `DB_ROOT_PASSWORD` sets the
+bundled MariaDB's root password, while the app connects using `DB_PASSWORD`. Both default to the same
+value, so setting only one of them in `.env` makes the two sides disagree and the app can never log in.
+
+**Solution**: When connecting as root, set `DB_ROOT_PASSWORD` and `DB_PASSWORD` to the same value in
+`.env` (or set neither). If the database volume was already initialized with a different root password,
+either use that password or wipe the database directory and let it re-initialize (**this deletes all DB
+data**). `docker logs youtarr-db` will show `Access denied` warnings when it's a credentials problem.
 
 ### Access Denied for Custom Database User
 

--- a/migrations/20250907000000-upgrade-to-utf8mb4-if-needed.js
+++ b/migrations/20250907000000-upgrade-to-utf8mb4-if-needed.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { findStaleUuidColumns, repairUuidColumns } = require('./lib/jobsUuidCollation');
+
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   up: async (queryInterface, Sequelize) => {
@@ -103,6 +105,16 @@ module.exports = {
            AND migration_date = (SELECT MAX(migration_date) FROM _charset_migration_log AS l2 WHERE l2.table_name = ?)`,
           { transaction, replacements: [table.TABLE_NAME, table.TABLE_NAME] }
         );
+      }
+
+      // CONVERT TO coerces CHAR(36) BINARY (utf8mb4_bin) UUID columns to
+      // utf8mb4_unicode_ci, which breaks foreign keys created by later
+      // migrations. Restore the binary collation while foreign key checks
+      // are still off, so a converted schema matches one born utf8mb4.
+      const staleUuidColumns = await findStaleUuidColumns(queryInterface, { transaction });
+      if (staleUuidColumns.length > 0) {
+        console.log('Restoring utf8mb4_bin collation on UUID foreign key columns');
+        await repairUuidColumns(queryInterface, staleUuidColumns, { transaction });
       }
 
       await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });

--- a/migrations/20251010162434-add-jobvideodownloads-table.js
+++ b/migrations/20251010162434-add-jobvideodownloads-table.js
@@ -5,10 +5,16 @@ const {
   dropTableIfExists,
   addIndexIfMissing
 } = require('./helpers');
+const { ensureJobsUuidBinaryCollation } = require('./lib/jobsUuidCollation');
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up (queryInterface, Sequelize) {
+    // On databases converted to utf8mb4 by the 20250907 migration, Jobs.id and
+    // JobVideos.job_id lost their utf8mb4_bin collation, and the job_id FK
+    // below would fail with errno 150. Restore it first.
+    await ensureJobsUuidBinaryCollation(queryInterface);
+
     await createTableIfNotExists(queryInterface, 'JobVideoDownloads', {
       id: {
         type: Sequelize.INTEGER,

--- a/migrations/__tests__/jobsUuidCollation.test.js
+++ b/migrations/__tests__/jobsUuidCollation.test.js
@@ -1,0 +1,244 @@
+'use strict';
+
+// On databases not created with utf8mb4 defaults, the 20250907 conversion
+// migration coerced Jobs.id/JobVideos.job_id from their binary collation to
+// utf8mb4_unicode_ci, and the later JobVideoDownloads migration then failed
+// with errno 150 on its foreign key. There is no DDL harness in this repo, so
+// these tests record the queryInterface call sequence and assert the repair
+// statements are issued in an order that keeps the FK creatable.
+
+const { Sequelize } = require('sequelize');
+
+const {
+  findStaleUuidColumns,
+  repairUuidColumns,
+  ensureJobsUuidBinaryCollation,
+} = require('../lib/jobsUuidCollation');
+
+const jvdMigration = require('../20251010162434-add-jobvideodownloads-table');
+const utf8mb4Migration = require('../20250907000000-upgrade-to-utf8mb4-if-needed');
+
+// Minimal queryInterface double. `collations` maps 'Table.column' to a
+// collation name; a missing key means the table/column does not exist.
+// Every non-SELECT statement is recorded in order.
+function createDouble({
+  collations = {},
+  tables = [],
+  dbInfo = { name: 'youtarr', charset: 'utf8mb4', collation: 'utf8mb4_unicode_ci' },
+  tableCollations = [],
+  failOnSqlMatching = null,
+} = {}) {
+  const ops = [];
+  const transactions = [];
+
+  const sequelize = {
+    query: async (sql, options = {}) => {
+      if (/FROM information_schema\.COLUMNS/i.test(sql)) {
+        const [table, column] = options.replacements;
+        const key = `${table}.${column}`;
+        return key in collations ? [{ COLLATION_NAME: collations[key] }] : [];
+      }
+      if (/FROM information_schema\.SCHEMATA/i.test(sql)) {
+        return [dbInfo];
+      }
+      if (/FROM information_schema\.tables/i.test(sql)) {
+        return tableCollations;
+      }
+      if (failOnSqlMatching && failOnSqlMatching.test(sql)) {
+        ops.push({ sql });
+        throw new Error(`forced failure for: ${sql}`);
+      }
+      ops.push({ sql });
+      return [];
+    },
+    transaction: async () => {
+      const record = { committed: false, rolledBack: false };
+      transactions.push(record);
+      return {
+        commit: async () => {
+          record.committed = true;
+        },
+        rollback: async () => {
+          record.rolledBack = true;
+        },
+      };
+    },
+  };
+
+  return {
+    ops,
+    transactions,
+    sequelize,
+    showAllTables: async () => tables,
+    showIndex: async () => [],
+    createTable: async (name) => ops.push({ sql: `CREATE ${name}` }),
+    addIndex: async (table, fields, options = {}) =>
+      ops.push({ sql: `INDEX ${table} ${JSON.stringify(fields)} ${options.name || ''}` }),
+  };
+}
+
+const sqlIndex = (ops, pattern) => ops.findIndex((op) => pattern.test(op.sql));
+
+describe('findStaleUuidColumns', () => {
+  test('returns empty when every UUID FK column is already utf8mb4_bin', async () => {
+    const qi = createDouble({
+      collations: {
+        'Jobs.id': 'utf8mb4_bin',
+        'JobVideos.job_id': 'utf8mb4_bin',
+        'JobVideoDownloads.job_id': 'utf8mb4_bin',
+      },
+    });
+    expect(await findStaleUuidColumns(qi)).toEqual([]);
+  });
+
+  test('returns the columns whose collation was coerced away from utf8mb4_bin', async () => {
+    const qi = createDouble({
+      collations: {
+        'Jobs.id': 'utf8mb4_unicode_ci',
+        'JobVideos.job_id': 'utf8mb4_unicode_ci',
+      },
+    });
+    const stale = await findStaleUuidColumns(qi);
+    expect(stale).toEqual([
+      { table: 'Jobs', column: 'id' },
+      { table: 'JobVideos', column: 'job_id' },
+    ]);
+  });
+
+  test('skips tables that do not exist', async () => {
+    const qi = createDouble({ collations: { 'Jobs.id': 'utf8mb4_bin' } });
+    expect(await findStaleUuidColumns(qi)).toEqual([]);
+  });
+});
+
+describe('repairUuidColumns', () => {
+  test('issues a MODIFY to CHAR(36) utf8mb4_bin for each stale column', async () => {
+    const qi = createDouble();
+    await repairUuidColumns(qi, [
+      { table: 'Jobs', column: 'id' },
+      { table: 'JobVideos', column: 'job_id' },
+    ]);
+    expect(
+      sqlIndex(qi.ops, /ALTER TABLE `Jobs` MODIFY `id` CHAR\(36\).*COLLATE utf8mb4_bin NOT NULL/)
+    ).not.toBe(-1);
+    expect(
+      sqlIndex(qi.ops, /ALTER TABLE `JobVideos` MODIFY `job_id` CHAR\(36\).*COLLATE utf8mb4_bin NOT NULL/)
+    ).not.toBe(-1);
+  });
+});
+
+describe('ensureJobsUuidBinaryCollation', () => {
+  test('does nothing when no column is stale', async () => {
+    const qi = createDouble({
+      collations: { 'Jobs.id': 'utf8mb4_bin', 'JobVideos.job_id': 'utf8mb4_bin' },
+    });
+    const repaired = await ensureJobsUuidBinaryCollation(qi);
+    expect(repaired).toBe(false);
+    expect(qi.ops).toEqual([]);
+  });
+
+  test('repairs stale columns inside a FOREIGN_KEY_CHECKS=0 window and commits', async () => {
+    const qi = createDouble({
+      collations: { 'Jobs.id': 'utf8mb4_unicode_ci', 'JobVideos.job_id': 'utf8mb4_unicode_ci' },
+    });
+    const repaired = await ensureJobsUuidBinaryCollation(qi);
+    expect(repaired).toBe(true);
+
+    const fkOff = sqlIndex(qi.ops, /SET FOREIGN_KEY_CHECKS = 0/);
+    const alterJobs = sqlIndex(qi.ops, /ALTER TABLE `Jobs` MODIFY `id`/);
+    const alterJobVideos = sqlIndex(qi.ops, /ALTER TABLE `JobVideos` MODIFY `job_id`/);
+    const fkOn = sqlIndex(qi.ops, /SET FOREIGN_KEY_CHECKS = 1/);
+
+    expect(fkOff).not.toBe(-1);
+    expect(fkOn).not.toBe(-1);
+    expect(fkOff).toBeLessThan(alterJobs);
+    expect(fkOff).toBeLessThan(alterJobVideos);
+    expect(alterJobs).toBeLessThan(fkOn);
+    expect(alterJobVideos).toBeLessThan(fkOn);
+    expect(qi.transactions[0].committed).toBe(true);
+  });
+
+  test('re-enables foreign key checks and rolls back if a repair fails', async () => {
+    const qi = createDouble({
+      collations: { 'Jobs.id': 'utf8mb4_unicode_ci' },
+      failOnSqlMatching: /ALTER TABLE `Jobs`/,
+    });
+    await expect(ensureJobsUuidBinaryCollation(qi)).rejects.toThrow('forced failure');
+
+    const failedAlter = sqlIndex(qi.ops, /ALTER TABLE `Jobs`/);
+    const fkOn = sqlIndex(qi.ops, /SET FOREIGN_KEY_CHECKS = 1/);
+    expect(fkOn).toBeGreaterThan(failedAlter);
+    expect(qi.transactions[0].rolledBack).toBe(true);
+  });
+});
+
+describe('add-jobvideodownloads-table migration', () => {
+  test('repairs a coerced Jobs.id collation before creating the table', async () => {
+    const qi = createDouble({
+      tables: ['Jobs', 'JobVideos', 'Videos'],
+      collations: { 'Jobs.id': 'utf8mb4_unicode_ci', 'JobVideos.job_id': 'utf8mb4_unicode_ci' },
+    });
+    await jvdMigration.up(qi, Sequelize);
+
+    const alterJobs = sqlIndex(qi.ops, /ALTER TABLE `Jobs` MODIFY `id`/);
+    const createTable = sqlIndex(qi.ops, /^CREATE JobVideoDownloads$/);
+    expect(alterJobs).not.toBe(-1);
+    expect(createTable).not.toBe(-1);
+    expect(alterJobs).toBeLessThan(createTable);
+  });
+
+  test('creates the table without any repair when collations are already binary', async () => {
+    const qi = createDouble({
+      tables: ['Jobs', 'JobVideos', 'Videos'],
+      collations: { 'Jobs.id': 'utf8mb4_bin', 'JobVideos.job_id': 'utf8mb4_bin' },
+    });
+    await jvdMigration.up(qi, Sequelize);
+
+    expect(sqlIndex(qi.ops, /ALTER TABLE/)).toBe(-1);
+    expect(sqlIndex(qi.ops, /^CREATE JobVideoDownloads$/)).not.toBe(-1);
+  });
+});
+
+describe('upgrade-to-utf8mb4-if-needed migration', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('restores utf8mb4_bin on UUID FK columns after converting tables', async () => {
+    const qi = createDouble({
+      dbInfo: { name: 'youtarr', charset: 'latin1', collation: 'latin1_swedish_ci' },
+      tableCollations: [
+        { TABLE_NAME: 'Jobs', TABLE_COLLATION: 'latin1_swedish_ci' },
+        { TABLE_NAME: 'JobVideos', TABLE_COLLATION: 'latin1_swedish_ci' },
+      ],
+      // State as CONVERT TO leaves it: bin collation coerced to unicode_ci.
+      collations: { 'Jobs.id': 'utf8mb4_unicode_ci', 'JobVideos.job_id': 'utf8mb4_unicode_ci' },
+    });
+    await utf8mb4Migration.up(qi, Sequelize);
+
+    const convertJobs = sqlIndex(qi.ops, /ALTER TABLE `Jobs` CONVERT TO/);
+    const alterJobs = sqlIndex(qi.ops, /ALTER TABLE `Jobs` MODIFY `id`/);
+    const alterJobVideos = sqlIndex(qi.ops, /ALTER TABLE `JobVideos` MODIFY `job_id`/);
+    const fkOn = sqlIndex(qi.ops, /SET FOREIGN_KEY_CHECKS = 1/);
+
+    expect(alterJobs).toBeGreaterThan(convertJobs);
+    expect(alterJobVideos).toBeGreaterThan(convertJobs);
+    expect(fkOn).toBeGreaterThan(alterJobs);
+    expect(fkOn).toBeGreaterThan(alterJobVideos);
+  });
+
+  test('still skips entirely when the database is already utf8mb4', async () => {
+    const qi = createDouble({
+      dbInfo: { name: 'youtarr', charset: 'utf8mb4', collation: 'utf8mb4_unicode_ci' },
+      tableCollations: [],
+      collations: { 'Jobs.id': 'utf8mb4_bin', 'JobVideos.job_id': 'utf8mb4_bin' },
+    });
+    await utf8mb4Migration.up(qi, Sequelize);
+
+    expect(sqlIndex(qi.ops, /ALTER TABLE/)).toBe(-1);
+  });
+});

--- a/migrations/lib/jobsUuidCollation.js
+++ b/migrations/lib/jobsUuidCollation.js
@@ -1,0 +1,83 @@
+'use strict';
+
+// The Jobs FK chain uses Sequelize.UUID columns, which MySQL/MariaDB create as
+// CHAR(36) BINARY (the charset's *_bin collation). ALTER TABLE ... CONVERT TO
+// CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci coerces those columns to
+// utf8mb4_unicode_ci, and InnoDB then refuses foreign keys from any UUID
+// column created afterwards (errno 150). These helpers detect and
+// restore the canonical utf8mb4_bin collation so referencing and referenced
+// columns always match.
+
+const REQUIRED_COLLATION = 'utf8mb4_bin';
+
+const UUID_FK_COLUMNS = [
+  { table: 'Jobs', column: 'id' },
+  { table: 'JobVideos', column: 'job_id' },
+  { table: 'JobVideoDownloads', column: 'job_id' },
+];
+
+async function getColumnCollation(queryInterface, table, column, options = {}) {
+  const rows = await queryInterface.sequelize.query(
+    `SELECT COLLATION_NAME FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+    { replacements: [table, column], type: 'SELECT', transaction: options.transaction }
+  );
+  return rows.length > 0 ? rows[0].COLLATION_NAME : null;
+}
+
+// Missing tables/columns are skipped.
+async function findStaleUuidColumns(queryInterface, options = {}) {
+  const stale = [];
+  for (const { table, column } of UUID_FK_COLUMNS) {
+    const collation = await getColumnCollation(queryInterface, table, column, options);
+    if (collation && collation !== REQUIRED_COLLATION) {
+      stale.push({ table, column });
+    }
+  }
+  return stale;
+}
+
+// The caller must hold a FOREIGN_KEY_CHECKS=0 window on the same connection
+// (pass its transaction).
+async function repairUuidColumns(queryInterface, staleColumns, options = {}) {
+  for (const { table, column } of staleColumns) {
+    await queryInterface.sequelize.query(
+      `ALTER TABLE \`${table}\` MODIFY \`${column}\` CHAR(36) CHARACTER SET utf8mb4 COLLATE ${REQUIRED_COLLATION} NOT NULL`,
+      { transaction: options.transaction }
+    );
+  }
+}
+
+// Self-contained repair inside its own FOREIGN_KEY_CHECKS=0 window. A
+// transaction pins all statements to a single pooled connection (SET
+// FOREIGN_KEY_CHECKS is session-scoped); the DDL itself auto-commits in MariaDB.
+async function ensureJobsUuidBinaryCollation(queryInterface) {
+  const stale = await findStaleUuidColumns(queryInterface);
+  if (stale.length === 0) {
+    return false;
+  }
+
+  const transaction = await queryInterface.sequelize.transaction();
+  try {
+    await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS = 0', { transaction });
+    await repairUuidColumns(queryInterface, stale, { transaction });
+    await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });
+    await transaction.commit();
+    return true;
+  } catch (error) {
+    try {
+      await queryInterface.sequelize.query('SET FOREIGN_KEY_CHECKS = 1', { transaction });
+    } catch (resetError) {
+      // Connection is being released via rollback; nothing more to do.
+    }
+    await transaction.rollback();
+    throw error;
+  }
+}
+
+module.exports = {
+  UUID_FK_COLUMNS,
+  findStaleUuidColumns,
+  repairUuidColumns,
+  ensureJobsUuidBinaryCollation,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1686,16 +1686,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
@@ -1851,16 +1851,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
@@ -2100,16 +2100,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
@@ -3017,9 +3017,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3886,9 +3886,9 @@
       }
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5066,9 +5066,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5428,9 +5428,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -7711,16 +7711,16 @@
       }
     },
     "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/nodemon/node_modules/has-flag": {


### PR DESCRIPTION
On databases that weren't created as utf8mb4, migrations fail with errno 150 creating JobVideoDownloads: after the conversion migration, Jobs.id and JobVideos.job_id sit on utf8mb4_unicode_ci while the new table's job_id is utf8mb4_bin, and the FK won't create.

Restore the binary collation right after the conversion and again before creating JobVideoDownloads, so a restart on a fixed image finishes the job. Also add troubleshooting docs for this and for the silent "Waiting for database" loop when the two DB passwords disagree.

Refs: #752