### PR TITLE
feat: add year tag to video NFO files

### DIFF
--- a/docs/MEDIA_SERVERS.md
+++ b/docs/MEDIA_SERVERS.md
@@ -94,6 +94,7 @@ See [Youtarr Downloads Folder Structure](YOUTARR_DOWNLOADS_FOLDER_STRUCTURE.md)
 | `<title>`            | Title with channel prefix                 |
 | `<plot>`             | Full description of video from YouTube    |
 | `<premiered>`        | Original upload/release date              |
+| `<year>`             | Year of the upload/release date           |
 | `<studio>`           | Channel name                              |
 | `<credits>`          | Channel name                              |
 | `<genre>`            | YouTube categories                        |

--- a/docs/media-servers/emby.md
+++ b/docs/media-servers/emby.md
@@ -80,6 +80,7 @@ Emby reads comprehensive NFO files containing:
 - **Title**: Video title with channel name
 - **Plot**: Complete YouTube description
 - **Premiered**: Original upload date
+- **Year**: Upload year (keeps Emby's production year accurate for sorting)
 - **Studios**: Channel/creator name
 - **Genres**: YouTube categories
 - **Tags**: Video keywords and topics

--- a/docs/media-servers/jellyfin.md
+++ b/docs/media-servers/jellyfin.md
@@ -80,6 +80,7 @@ Jellyfin reads NFO files containing:
 - **Title**: Video title with channel prefix
 - **Plot**: Full YouTube description
 - **Premiered**: Original upload date
+- **Year**: Upload year
 - **Studios**: Channel name
 - **Genres**: YouTube categories
 - **Tags**: Video keywords

--- a/docs/media-servers/kodi.md
+++ b/docs/media-servers/kodi.md
@@ -52,6 +52,7 @@ Youtarr generates comprehensive NFO files containing:
 - **Title**: Video title with channel prefix
 - **Plot**: Full video description
 - **Premiered**: Original YouTube upload date
+- **Year**: Upload year
 - **Studio**: Channel name
 - **Genre**: YouTube categories
 - **Tag**: Video keywords (up to 10)

--- a/server/modules/__tests__/nfoGenerator.test.js
+++ b/server/modules/__tests__/nfoGenerator.test.js
@@ -441,5 +441,40 @@ describe('NfoGenerator', () => {
       expect(nfoContent).toContain('<dateadded>');
       expect(nfoContent).not.toContain('<premiered>');
     });
+
+    it('should include year element derived from the upload date', () => {
+      const jsonData = {
+        title: 'Test Video',
+        upload_date: '20231225'
+      };
+
+      nfoGenerator.writeVideoNfoFile(mockVideoPath, jsonData);
+
+      const nfoContent = fs.writeFileSync.mock.calls[0][1];
+      expect(nfoContent).toContain('<year>2023</year>');
+    });
+
+    it('should omit year when upload_date is missing', () => {
+      const jsonData = {
+        title: 'No Upload Date Video'
+      };
+
+      nfoGenerator.writeVideoNfoFile(mockVideoPath, jsonData);
+
+      const nfoContent = fs.writeFileSync.mock.calls[0][1];
+      expect(nfoContent).not.toContain('<year>');
+    });
+
+    it('should omit year when upload_date is invalid', () => {
+      const jsonData = {
+        title: 'Test Video',
+        upload_date: 'invalid-date'
+      };
+
+      nfoGenerator.writeVideoNfoFile(mockVideoPath, jsonData);
+
+      const nfoContent = fs.writeFileSync.mock.calls[0][1];
+      expect(nfoContent).not.toContain('<year>');
+    });
   });
 });

--- a/server/modules/nfoGenerator.js
+++ b/server/modules/nfoGenerator.js
@@ -146,6 +146,8 @@ class NfoGenerator {
       xml += '\n  <!-- Dates -->\n';
       if (premiered) {
         xml += `  <premiered>${premiered}</premiered>\n`;
+        // Without <year>, Emby guesses ProductionYear and breaks episode sorting
+        xml += `  <year>${premiered.substring(0, 4)}</year>\n`;
       }
       xml += `  <dateadded>${this.formatDateAdded()}</dateadded>\n`;
 


### PR DESCRIPTION
Emby was reported to fill in its own production year when the NFO does not provide one, which can leave episode views sorted out of order. Write a <year> element derived from the same validated upload date as <premiered> so the two always agree; it is omitted when the upload date is missing or invalid.

Kodi ignores <year> when <premiered> is present and Jellyfin derives the same value from the premiere date, so other supported servers are unaffected. Document the new field in the media server guides.