### PR TITLE
feat: clarify subfolder add flow in settings

### DIFF
--- a/client/src/components/Configuration/sections/CoreSettingsSection.tsx
+++ b/client/src/components/Configuration/sections/CoreSettingsSection.tsx
@@ -31,6 +31,8 @@ import SubtitleLanguageSelector from '../SubtitleLanguageSelector';
 import { VideoFilenameTemplate } from './components/VideoFilenameTemplate';
 import { SubfolderAutocomplete } from '../../shared/SubfolderAutocomplete';
 import { ManageSubfoldersDialog } from '../../shared/ManageSubfoldersDialog';
+import { AddSubfolderDialog } from '../../shared/AddSubfolderDialog';
+import { Plus as AddIcon, Settings as SettingsIcon } from '../../../lib/icons';
 import { useSubfolders } from '../../../hooks/useSubfolders';
 import { ConfigState, DeploymentEnvironment, PlatformManagedState } from '../types';
 import { reverseFrequencyMapping, getChannelFilesOptions } from '../helpers';
@@ -62,14 +64,21 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
 
   // State for confirmation dialog when setting default subfolder
   const [manageOpen, setManageOpen] = useState(false);
+  const [addSubfolderOpen, setAddSubfolderOpen] = useState(false);
   const [pendingDefaultSubfolder, setPendingDefaultSubfolder] = useState<string | null>(null);
+  // True when the pending value came from the Add Subfolder dialog (already persisted);
+  // the confirmation dialog copy changes so Cancel doesn't read as undoing the add.
+  const [pendingIsNewSubfolder, setPendingIsNewSubfolder] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [affectedChannels, setAffectedChannels] = useState<{ count: number; channelNames: string[] }>({ count: 0, channelNames: [] });
   const [loadingAffectedChannels, setLoadingAffectedChannels] = useState(false);
   const [showAffectedList, setShowAffectedList] = useState(false);
 
   // Handle default subfolder change with confirmation
-  const handleDefaultSubfolderChange = async (newValue: string | null) => {
+  const handleDefaultSubfolderChange = async (
+    newValue: string | null,
+    meta?: { isNewlyCreated?: boolean }
+  ) => {
     const currentValue = config.defaultSubfolder || '';
     const newValueNormalized = newValue || '';
 
@@ -80,6 +89,7 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
 
     // Show dialog immediately with loading state
     setPendingDefaultSubfolder(newValue);
+    setPendingIsNewSubfolder(meta?.isNewlyCreated === true);
     setShowConfirmDialog(true);
     setLoadingAffectedChannels(true);
     setAffectedChannels({ count: 0, channelNames: [] });
@@ -105,13 +115,25 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
     onConfigChange({ defaultSubfolder: pendingDefaultSubfolder || '' });
     setShowConfirmDialog(false);
     setPendingDefaultSubfolder(null);
+    setPendingIsNewSubfolder(false);
     setShowAffectedList(false);
   };
 
   const handleCancelDefaultSubfolder = () => {
     setShowConfirmDialog(false);
     setPendingDefaultSubfolder(null);
+    setPendingIsNewSubfolder(false);
     setShowAffectedList(false);
+  };
+
+  // Page-level Add Subfolder action: persist the new name, then offer to set
+  // it as the default via the confirmation dialog
+  const handleAddSubfolderFromPage = (name: string) => {
+    setAddSubfolderOpen(false);
+    createSubfolder(name).catch((err) => {
+      console.error('Failed to persist subfolder:', err);
+    });
+    handleDefaultSubfolderChange(name, { isNewlyCreated: true });
   };
 
   const [pendingFlatDefault, setPendingFlatDefault] = useState<boolean | null>(null);
@@ -559,9 +581,9 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
                       onChange={handleDefaultSubfolderChange}
                       subfolders={subfolders}
                       loading={subfoldersLoading}
-                      createSubfolder={createSubfolder}
                       label="Default Subfolder"
                       helperText="Default download location for channels using 'Default Subfolder'"
+                      showAddAction={false}
                     />
                     <Box className="flex items-center min-h-[48px] mt-5">
                       <InfoTooltip
@@ -570,9 +592,30 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
                       />
                     </Box>
                   </Box>
-                  <Button variant="text" size="sm" onClick={() => setManageOpen(true)}>
-                    Manage Subfolders
-                  </Button>
+                  <Box className="mt-1 flex flex-wrap items-center gap-2">
+                    <Button
+                      variant="text"
+                      size="sm"
+                      startIcon={<AddIcon size={14} />}
+                      onClick={() => setAddSubfolderOpen(true)}
+                    >
+                      Add Subfolder
+                    </Button>
+                    <Button
+                      variant="text"
+                      size="sm"
+                      startIcon={<SettingsIcon size={14} />}
+                      onClick={() => setManageOpen(true)}
+                    >
+                      Manage Subfolders
+                    </Button>
+                  </Box>
+                  <AddSubfolderDialog
+                    open={addSubfolderOpen}
+                    onClose={() => setAddSubfolderOpen(false)}
+                    onAdd={handleAddSubfolderFromPage}
+                    existingSubfolders={subfolders}
+                  />
                   <ManageSubfoldersDialog
                     open={manageOpen}
                     onClose={() => setManageOpen(false)}
@@ -652,10 +695,20 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
 
       {/* Confirmation Dialog for Default Subfolder */}
       <Dialog open={showConfirmDialog} onClose={handleCancelDefaultSubfolder}>
-        <DialogTitle>Set Default Subfolder?</DialogTitle>
+        <DialogTitle>
+          {pendingIsNewSubfolder ? 'Set New Subfolder as Default?' : 'Set Default Subfolder?'}
+        </DialogTitle>
         <DialogContent>
+          {pendingIsNewSubfolder && (
+            <DialogContentText className="mb-2">
+              Subfolder <strong>{`__${pendingDefaultSubfolder}`}</strong> has been created and is
+              available anywhere subfolders can be selected.
+            </DialogContentText>
+          )}
           <DialogContentText>
-            Setting a default subfolder will affect where videos are downloaded for:
+            {pendingIsNewSubfolder
+              ? 'Would you also like to make it the default subfolder? This will affect where videos are downloaded for:'
+              : 'Setting a default subfolder will affect where videos are downloaded for:'}
           </DialogContentText>
           <Box component="ul" className="mt-2 pl-4">
             <li>Untracked channels (manual URL downloads)</li>
@@ -707,13 +760,15 @@ export const CoreSettingsSection: React.FC<CoreSettingsSectionProps> = ({
             </strong>
           </DialogContentText>
           <DialogContentText className="mt-2" style={{ fontStyle: 'italic' }}>
-            Existing videos will not be moved. Continue?
+            Existing videos will not be moved.
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleCancelDefaultSubfolder}>Cancel</Button>
+          <Button onClick={handleCancelDefaultSubfolder}>
+            {pendingIsNewSubfolder ? "Don't Set as Default" : 'Cancel'}
+          </Button>
           <Button onClick={handleConfirmDefaultSubfolder} variant="contained" color="primary">
-            Confirm
+            Set as Default
           </Button>
         </DialogActions>
       </Dialog>

--- a/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/CoreSettingsSection.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { CoreSettingsSection } from '../CoreSettingsSection';
@@ -8,13 +8,14 @@ import { ConfigState, DeploymentEnvironment, PlatformManagedState } from '../../
 import { DEFAULT_CONFIG } from '../../../../config/configSchema';
 
 // Mock useSubfolders hook to prevent network requests
+const mockCreateSubfolder = jest.fn(() => Promise.resolve());
 jest.mock('../../../../hooks/useSubfolders', () => ({
   useSubfolders: () => ({
     subfolders: ['__Sports', '__Music', '__Tech'],
     loading: false,
     error: null,
     refetch: jest.fn(),
-    createSubfolder: jest.fn(() => Promise.resolve()),
+    createSubfolder: mockCreateSubfolder,
     deleteSubfolder: jest.fn(() => Promise.resolve()),
   }),
 }));
@@ -41,7 +42,7 @@ jest.mock('../../SubtitleLanguageSelector', () => ({
 jest.mock('../../../shared/SubfolderAutocomplete', () => ({
   SubfolderAutocomplete: function MockSubfolderAutocomplete(props: {
     value: string | null;
-    onChange: (value: string | null) => void;
+    onChange: (value: string | null, meta?: { isNewlyCreated?: boolean }) => void;
     label: string;
   }) {
     const React = require('react');
@@ -94,6 +95,8 @@ const createSectionProps = (
 describe('CoreSettingsSection Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Jest's resetMocks wipes the implementation before each test; restore it
+    mockCreateSubfolder.mockResolvedValue(undefined);
   });
 
   describe('Component Rendering', () => {
@@ -1314,7 +1317,7 @@ describe('CoreSettingsSection Component', () => {
       await screen.findByText('No tracked channels are currently using Default Subfolder.');
 
       // Click confirm
-      const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+      const confirmButton = screen.getByRole('button', { name: 'Set as Default' });
       await user.click(confirmButton);
 
       expect(onConfigChange).toHaveBeenCalledWith({ defaultSubfolder: 'NewFolder' });
@@ -1366,6 +1369,111 @@ describe('CoreSettingsSection Component', () => {
       await screen.findByText('No tracked channels are currently using Default Subfolder.');
 
       consoleSpy.mockRestore();
+    });
+
+    describe('when triggered by adding a new subfolder', () => {
+      // Drives the page-level Add Subfolder action: open the dialog, enter a
+      // name, and submit (scoped with within() because the page action and the
+      // dialog submit button share the accessible name 'Add Subfolder').
+      const openAddSubfolderDialog = async (user: ReturnType<typeof userEvent.setup>) => {
+        await user.click(screen.getByRole('button', { name: 'Add Subfolder' }));
+        const dialog = await screen.findByRole('dialog');
+        await user.type(within(dialog).getByLabelText('Subfolder Name'), 'NewFolder');
+        await user.click(within(dialog).getByRole('button', { name: 'Add Subfolder' }));
+      };
+
+      beforeEach(() => {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ count: 0, channelNames: [] })
+        });
+      });
+
+      test('renders Add Subfolder and Manage Subfolders as separate page actions', () => {
+        const props = createSectionProps();
+        renderWithProviders(<CoreSettingsSection {...props} />);
+
+        expect(screen.getByRole('button', { name: 'Add Subfolder' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Manage Subfolders' })).toBeInTheDocument();
+      });
+
+      test('persists the new subfolder via createSubfolder', async () => {
+        const user = userEvent.setup();
+        const props = createSectionProps({
+          config: createConfig({ defaultSubfolder: '' })
+        });
+        renderWithProviders(<CoreSettingsSection {...props} />);
+
+        await openAddSubfolderDialog(user);
+
+        await waitFor(() => expect(mockCreateSubfolder).toHaveBeenCalledWith('NewFolder'));
+      });
+
+      test('shows new-subfolder title and creation notice', async () => {
+        const user = userEvent.setup();
+        const props = createSectionProps({
+          config: createConfig({ defaultSubfolder: '' })
+        });
+        renderWithProviders(<CoreSettingsSection {...props} />);
+
+        await openAddSubfolderDialog(user);
+
+        await screen.findByText('Set New Subfolder as Default?');
+        expect(
+          screen.getByText(/has been created and is available anywhere subfolders can be selected/)
+        ).toBeInTheDocument();
+      });
+
+      test('"Don\'t Set as Default" closes the dialog without changing config', async () => {
+        const user = userEvent.setup();
+        const onConfigChange = jest.fn();
+        const props = createSectionProps({
+          config: createConfig({ defaultSubfolder: '' }),
+          onConfigChange
+        });
+        renderWithProviders(<CoreSettingsSection {...props} />);
+
+        await openAddSubfolderDialog(user);
+
+        await screen.findByText('Set New Subfolder as Default?');
+        await user.click(screen.getByRole('button', { name: "Don't Set as Default" }));
+
+        expect(onConfigChange).not.toHaveBeenCalled();
+        expect(screen.queryByText('Set New Subfolder as Default?')).not.toBeInTheDocument();
+      });
+
+      test('"Set as Default" applies the new subfolder as default', async () => {
+        const user = userEvent.setup();
+        const onConfigChange = jest.fn();
+        const props = createSectionProps({
+          config: createConfig({ defaultSubfolder: '' }),
+          onConfigChange
+        });
+        renderWithProviders(<CoreSettingsSection {...props} />);
+
+        await openAddSubfolderDialog(user);
+
+        await screen.findByText('Set New Subfolder as Default?');
+        await user.click(screen.getByRole('button', { name: 'Set as Default' }));
+
+        expect(onConfigChange).toHaveBeenCalledWith({ defaultSubfolder: 'NewFolder' });
+      });
+
+      test('selecting an existing subfolder keeps the standard title and Cancel button', async () => {
+        const user = userEvent.setup();
+        const props = createSectionProps({
+          config: createConfig({ defaultSubfolder: '' })
+        });
+        renderWithProviders(<CoreSettingsSection {...props} />);
+
+        await openSubfolderDialog(user);
+
+        await screen.findByText('Set Default Subfolder?');
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+        expect(
+          screen.queryByText(/has been created and is available anywhere subfolders can be selected/)
+        ).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/client/src/components/shared/SubfolderAutocomplete.tsx
+++ b/client/src/components/shared/SubfolderAutocomplete.tsx
@@ -32,8 +32,8 @@ type SubfolderMode = 'global' | 'channel' | 'download';
 interface SubfolderAutocompleteProps {
   /** Current value (clean, without __ prefix). null = root (backwards compat), ##USE_GLOBAL_DEFAULT## = use default */
   value: string | null | undefined;
-  /** Callback when value changes */
-  onChange: (value: string | null) => void;
+  /** Callback when value changes. meta.isNewlyCreated is true when the value came from the Add Subfolder dialog */
+  onChange: (value: string | null, meta?: { isNewlyCreated?: boolean }) => void;
   /** List of existing subfolders (with __ prefix from API) */
   subfolders: string[];
   /** Global default subfolder for display purposes (without __ prefix) */
@@ -50,6 +50,8 @@ interface SubfolderAutocompleteProps {
   label?: string;
   /** Optional callback to persist a newly added subfolder (e.g. via API) */
   createSubfolder?: (name: string) => Promise<void>;
+  /** Whether to render the inline "Add Subfolder" action (default true). Set false when the parent provides its own add flow */
+  showAddAction?: boolean;
 }
 
 const ADD_NEW_SENTINEL = '__ADD_NEW__';
@@ -72,6 +74,7 @@ export function SubfolderAutocomplete({
   helperText,
   label = 'Subfolder',
   createSubfolder,
+  showAddAction = true,
 }: SubfolderAutocompleteProps) {
   // State for the Add Subfolder dialog
   const [addDialogOpen, setAddDialogOpen] = useState(false);
@@ -267,7 +270,7 @@ export function SubfolderAutocomplete({
   const handleAddSubfolder = (newName: string) => {
     // Optimistically show it immediately.
     setLocalSubfolders((prev) => [...prev, addSubfolderPrefix(newName)]);
-    onChange(newName);
+    onChange(newName, { isNewlyCreated: true });
     setAddDialogOpen(false);
     // Persist so it survives navigation and is reusable everywhere.
     if (createSubfolder) {
@@ -382,43 +385,47 @@ export function SubfolderAutocomplete({
           );
         })}
       </Select>
-      {/* "Add Subfolder" lives outside the Radix portal so it sits inside the
-          Dialog's DOM subtree and keeps pointer-events: auto even when a parent
-          Radix Dialog has set body pointer-events to none. */}
-      <button
-        type="button"
-        aria-label="Open add subfolder dialog"
-        onClick={() => { setIsOpen(false); setPendingAddDialog(true); }}
-        style={{
-          marginTop: 4,
-          display: 'flex',
-          alignItems: 'center',
-          gap: 6,
-          background: 'none',
-          border: 'none',
-          cursor: 'pointer',
-          color: 'var(--primary)',
-          fontSize: '0.8rem',
-          fontWeight: 500,
-          padding: '2px 0',
-          pointerEvents: 'auto',
-        }}
-      >
-        <AddIcon size={14} style={{ color: 'var(--primary)' }} />
-        Add Subfolder
-      </button>
       {helperText && (
         <Typography variant="caption" color="text.secondary" style={{ marginTop: 4, display: 'block' }}>
           {helperText}
         </Typography>
       )}
+      {/* "Add Subfolder" lives outside the Radix portal so it sits inside the
+          Dialog's DOM subtree and keeps pointer-events: auto even when a parent
+          Radix Dialog has set body pointer-events to none. */}
+      {showAddAction && (
+        <button
+          type="button"
+          aria-label="Open add subfolder dialog"
+          onClick={() => { setIsOpen(false); setPendingAddDialog(true); }}
+          style={{
+            marginTop: 4,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: 'var(--primary)',
+            fontSize: '0.8rem',
+            fontWeight: 500,
+            padding: '2px 0',
+            pointerEvents: 'auto',
+          }}
+        >
+          <AddIcon size={14} style={{ color: 'var(--primary)' }} />
+          Add Subfolder
+        </button>
+      )}
       </div>
-      <AddSubfolderDialog
-        open={addDialogOpen}
-        onClose={() => setAddDialogOpen(false)}
-        onAdd={handleAddSubfolder}
-        existingSubfolders={allSubfolders}
-      />
+      {showAddAction && (
+        <AddSubfolderDialog
+          open={addDialogOpen}
+          onClose={() => setAddDialogOpen(false)}
+          onAdd={handleAddSubfolder}
+          existingSubfolders={allSubfolders}
+        />
+      )}
     </>
   );
 }

--- a/client/src/components/shared/__tests__/SubfolderAutocomplete.test.tsx
+++ b/client/src/components/shared/__tests__/SubfolderAutocomplete.test.tsx
@@ -313,7 +313,7 @@ describe('SubfolderAutocomplete', () => {
       expect(screen.queryByTestId('add-subfolder-dialog')).not.toBeInTheDocument();
     });
 
-    test('calls onChange and closes dialog when subfolder added', async () => {
+    test('calls onChange with isNewlyCreated meta and closes dialog when subfolder added', async () => {
       const user = userEvent.setup();
       render(
         <SubfolderAutocomplete
@@ -329,7 +329,7 @@ describe('SubfolderAutocomplete', () => {
       await user.click(screen.getByText('Add Subfolder'));
       await user.click(screen.getByTestId('dialog-add'));
 
-      expect(mockOnChange).toHaveBeenCalledWith('NewFolder');
+      expect(mockOnChange).toHaveBeenCalledWith('NewFolder', { isNewlyCreated: true });
       expect(screen.queryByTestId('add-subfolder-dialog')).not.toBeInTheDocument();
     });
 
@@ -356,6 +356,20 @@ describe('SubfolderAutocomplete', () => {
       expect(screen.getByText('__NewFolder')).toBeInTheDocument();
     });
 
+    test('hides the Add Subfolder action when showAddAction is false', () => {
+      render(
+        <SubfolderAutocomplete
+          mode="global"
+          value={null}
+          onChange={mockOnChange}
+          subfolders={defaultSubfolders}
+          showAddAction={false}
+        />
+      );
+
+      expect(screen.queryByText('Add Subfolder')).not.toBeInTheDocument();
+    });
+
     test('persists a newly added subfolder via createSubfolder when provided', async () => {
       const onChange = jest.fn();
       const createSubfolder = jest.fn().mockResolvedValue(undefined);
@@ -374,7 +388,7 @@ describe('SubfolderAutocomplete', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Add Subfolder' }));
 
       await waitFor(() => expect(createSubfolder).toHaveBeenCalledWith('Sports'));
-      expect(onChange).toHaveBeenCalledWith('Sports');
+      expect(onChange).toHaveBeenCalledWith('Sports', { isNewlyCreated: true });
     });
   });
 


### PR DESCRIPTION
Adding a subfolder from settings dumped you into the "Set Default Subfolder?" dialog with Confirm/Cancel buttons. Hitting Cancel looked like it threw away the new subfolder, but it was already saved. The "Add Subfolder" button also sat wedged between the Default Subfolder field and its helper text, so it read as part of the field.

Now the dialog knows when the subfolder was just created: it says so, and the buttons are "Set as Default" / "Don't Set as Default" so there's no ambiguity. Picking an existing subfolder keeps the old dialog, just with "Set as Default" instead of Confirm.

Also moved helper text directly under the select, added a showAddAction prop to SubfolderAutocomplete, and grouped "Add Subfolder" + "Manage Subfolders" into one action row on the settings page.