### PR TITLE
feat: suggest playlists for releases-only channels

### DIFF
--- a/server/modules/channel/__tests__/channelProvisioning.test.js
+++ b/server/modules/channel/__tests__/channelProvisioning.test.js
@@ -534,6 +534,50 @@ describe('channelProvisioning', () => {
     });
   });
 
+  describe('getChannelInfo with empty channel', () => {
+    const setupEmptyChannel = (metadata) => {
+      const channelIdentity = require('../channelIdentity');
+      const channelMetadataFetcher = require('../channelMetadataFetcher');
+      const tabManager = require('../tabManager');
+
+      jest.spyOn(channelIdentity, 'findChannelByUrlOrId').mockResolvedValue({
+        foundChannel: null,
+        channelUrl: 'https://www.youtube.com/@artistchan',
+      });
+      jest.spyOn(channelMetadataFetcher, 'fetchChannelMetadata').mockResolvedValue(metadata);
+      return jest.spyOn(tabManager, 'checkTabExistsViaYtdlp');
+    };
+
+    test('throws CHANNEL_RELEASES_ONLY when a channel with no videos has a releases tab', async () => {
+      const releasesProbe = setupEmptyChannel({ channel_id: 'UC999', entries: [] })
+        .mockResolvedValue(true);
+
+      await expect(
+        channelProvisioning.getChannelInfo('https://www.youtube.com/@artistchan', false)
+      ).rejects.toMatchObject({ code: 'CHANNEL_RELEASES_ONLY' });
+
+      expect(releasesProbe).toHaveBeenCalledWith('UC999', 'releases');
+    });
+
+    test('throws CHANNEL_EMPTY when a channel with no videos has no releases tab', async () => {
+      setupEmptyChannel({ channel_id: 'UC999', entries: [] }).mockResolvedValue(false);
+
+      await expect(
+        channelProvisioning.getChannelInfo('https://www.youtube.com/@artistchan', false)
+      ).rejects.toMatchObject({ code: 'CHANNEL_EMPTY' });
+    });
+
+    test('throws CHANNEL_EMPTY without probing when metadata has no channel id', async () => {
+      const releasesProbe = setupEmptyChannel({ entries: [] }).mockResolvedValue(true);
+
+      await expect(
+        channelProvisioning.getChannelInfo('https://www.youtube.com/@artistchan', false)
+      ).rejects.toMatchObject({ code: 'CHANNEL_EMPTY' });
+
+      expect(releasesProbe).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getChannelInfo with new channel', () => {
     test('caches the channel banner after processing the thumbnail', async () => {
       const channelIdentity = require('../channelIdentity');

--- a/server/modules/channel/channelProvisioning.js
+++ b/server/modules/channel/channelProvisioning.js
@@ -127,8 +127,20 @@ class ChannelProvisioning {
     const channelData = await channelMetadataFetcher.fetchChannelMetadata(channelUrl);
     logger.info('Channel metadata fetched successfully');
 
-    // Reject channels with no videos - these can't be usefully added
+    // Reject channels with no videos - these can't be usefully added.
+    // Verified Artist channels can have an empty Videos tab with all content
+    // published as album playlists on the Releases tab; distinguish that case
+    // so the UI can point the user at playlist subscriptions instead.
     if (!channelData.entries || channelData.entries.length === 0) {
+      const emptyChannelId = channelData.channel_id || channelData.id;
+      const hasReleases = emptyChannelId
+        ? await tabManager.checkTabExistsViaYtdlp(emptyChannelId, 'releases')
+        : false;
+      if (hasReleases) {
+        const error = new Error('Channel has no videos but has a releases tab');
+        error.code = 'CHANNEL_RELEASES_ONLY';
+        throw error;
+      }
       const error = new Error('Channel has no videos');
       error.code = 'CHANNEL_EMPTY';
       throw error;

--- a/server/modules/channel/tabManager.js
+++ b/server/modules/channel/tabManager.js
@@ -14,7 +14,7 @@ class TabManager {
    * Check if a tab exists for a channel by probing with yt-dlp.
    * Attempts to fetch 1 entry from the tab URL. If entries exist, the tab is available.
    * @param {string} channelId - Channel ID
-   * @param {string} tabType - Tab type to check ('videos', 'shorts', or 'streams')
+   * @param {string} tabType - Tab path to check ('videos', 'shorts', 'streams', or 'releases')
    * @returns {Promise<boolean>} - True if tab exists
    */
   async checkTabExistsViaYtdlp(channelId, tabType) {

--- a/server/routes/__tests__/channels.addChannelInfo.test.js
+++ b/server/routes/__tests__/channels.addChannelInfo.test.js
@@ -1,0 +1,104 @@
+/* eslint-env jest */
+
+// channels.js requires these directly at factory top; mock them so requiring
+// the route file does not pull in the real database or logger transport.
+jest.mock('../../modules/channelSettingsModule', () => ({
+  validateSubFolder: jest.fn().mockReturnValue({ valid: true }),
+}));
+jest.mock('../../models/channelvideo', () => ({}));
+jest.mock('../../logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+}));
+
+const express = require('express');
+const createChannelRoutes = require('../channels');
+const { findRouteHandler } = require('../../__tests__/testUtils');
+
+const ADD_PATH = '/addchannelinfo';
+
+const loggerMock = {
+  info: jest.fn(),
+  error: jest.fn(),
+};
+
+const createResponse = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+};
+
+const buildDeps = () => ({
+  verifyToken: (req, res, next) => next(),
+  channelModule: {
+    getChannelInfo: jest.fn(),
+  },
+  archiveModule: {},
+  channelDownloadAllModule: {},
+  ratingMapper: require('../../modules/ratingMapper'),
+});
+
+const getHandler = (deps) => {
+  const router = createChannelRoutes(deps);
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  return findRouteHandler(app, 'post', ADD_PATH);
+};
+
+const rejectWithCode = (code) => {
+  const error = new Error(code);
+  error.code = code;
+  return Promise.reject(error);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('POST /addchannelinfo error mapping', () => {
+  test('returns 422 pointing at playlist subscriptions for a releases-only channel', async () => {
+    const deps = buildDeps();
+    deps.channelModule.getChannelInfo.mockImplementation(() =>
+      rejectWithCode('CHANNEL_RELEASES_ONLY')
+    );
+
+    const handler = getHandler(deps);
+    const req = { body: { url: 'https://www.youtube.com/@artistchan' }, log: loggerMock };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        message: expect.stringContaining('Playlists page'),
+      })
+    );
+  });
+
+  test('returns 422 with the no-videos message for an empty channel', async () => {
+    const deps = buildDeps();
+    deps.channelModule.getChannelInfo.mockImplementation(() =>
+      rejectWithCode('CHANNEL_EMPTY')
+    );
+
+    const handler = getHandler(deps);
+    const req = { body: { url: 'https://www.youtube.com/@emptychan' }, log: loggerMock };
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        message: 'This channel has no videos to download.',
+      })
+    );
+  });
+});

--- a/server/routes/channels.js
+++ b/server/routes/channels.js
@@ -228,6 +228,8 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
    *         description: Cookies required
    *       404:
    *         description: Channel not found
+   *       422:
+   *         description: Channel has no downloadable videos; for Releases-only artist channels the message suggests subscribing to its release playlists instead
    *       503:
    *         description: Unable to connect to YouTube
    */
@@ -267,6 +269,12 @@ module.exports = function createChannelRoutes({ verifyToken, channelModule, arch
         return res.status(503).json({
           status: 'error',
           message: 'Unable to connect to YouTube. Please try again later.',
+          error: error.message
+        });
+      } else if (error.code === 'CHANNEL_RELEASES_ONLY') {
+        return res.status(422).json({
+          status: 'error',
+          message: 'This looks like a music/artist channel that publishes albums on its Releases tab instead of videos, so it can\'t be added as a channel. You can still get its music: copy the album playlist links from the channel\'s Releases tab on YouTube and add them on the Playlists page.',
           error: error.message
         });
       } else if (error.code === 'CHANNEL_EMPTY') {


### PR DESCRIPTION
Trying to add a Verified Artist channel just said "This channel has no videos to download" and left you stuck. The music is all in album playlists on the Releases tab, and playlist subscriptions already handle those.

Now when a channel has no videos but has a Releases tab, the error points you at the Playlists page instead.

<img width="853" height="429" alt="image" src="https://github.com/user-attachments/assets/3d4701af-8eb2-470b-8b4c-3073a31b7751" />


Refs: #616