### PR TITLE
feat: add additional tags support per-channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ https://github.com/user-attachments/assets/a80548fc-bcf9-4ad0-889c-dbd5aac250ee
 - **Unraid Ready**: Community Applications template (via DialmasterOrg repo) with headless-friendly credential presets
 - **Powered by yt-dlp**: Uses [yt-dlp](https://github.com/yt-dlp/yt-dlp) under the hood for YouTube integration and downloads
 - **Content Ratings**: Add per-video and per-channel content ratings (normalized to common media-server values like `G`, `PG`, `PG-13`, `R`, `NC-17`, `TV-*`). Ratings can be set per-download, via channel defaults, or derived from yt-dlp metadata; they show up as badges and can be used for automated policies.
+- **Additional Tags**: Add per-channel tags that are in addition to tags found from the YouTube video
 
 ## How Youtarr compares
 

--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -52,6 +52,7 @@ interface ChannelSettings {
   min_duration: number | null;
   max_duration: number | null;
   title_filter_regex: string | null;
+  additional_tags: string | null;
   default_rating: string | null;
   auto_download_enabled_tabs: string | null;
   audio_format: string | null;
@@ -138,6 +139,7 @@ function ChannelSettingsDialog({
     min_duration: null,
     max_duration: null,
     title_filter_regex: null,
+    additional_tags: null,
     default_rating: null,
     audio_format: null,
     auto_download_enabled_tabs: null,
@@ -154,6 +156,7 @@ function ChannelSettingsDialog({
     min_duration: null,
     max_duration: null,
     title_filter_regex: null,
+    additional_tags: null,
     default_rating: null,
     audio_format: null,
     auto_download_enabled_tabs: null,
@@ -242,6 +245,7 @@ function ChannelSettingsDialog({
           min_duration: settingsData.min_duration || null,
           max_duration: settingsData.max_duration || null,
           title_filter_regex: settingsData.title_filter_regex || null,
+          additional_tags: settingsData.additional_tags || null,
           auto_download_enabled_tabs: settingsData.auto_download_enabled_tabs ?? 'video',
           audio_format: settingsData.audio_format || null,
           default_rating: Object.prototype.hasOwnProperty.call(settingsData, 'default_rating')
@@ -303,6 +307,7 @@ function ChannelSettingsDialog({
           min_duration: settings.min_duration,
           max_duration: settings.max_duration,
           title_filter_regex: settings.title_filter_regex || null,
+          additional_tags: settings.additional_tags || null,
           default_rating: settings.default_rating || null,
           audio_format: settings.audio_format || null,
           auto_download_enabled_tabs: settings.auto_download_enabled_tabs,
@@ -349,6 +354,7 @@ function ChannelSettingsDialog({
         min_duration: result?.settings?.min_duration ?? settings.min_duration ?? null,
         max_duration: result?.settings?.max_duration ?? settings.max_duration ?? null,
         title_filter_regex: result?.settings?.title_filter_regex ?? settings.title_filter_regex ?? null,
+        additional_tags: result?.settings?.additional_tags ?? settings.additional_tags ?? null,
         audio_format: result?.settings?.audio_format ?? settings.audio_format ?? null,
         default_rating: result?.settings && Object.prototype.hasOwnProperty.call(result.settings, 'default_rating')
           ? result.settings.default_rating
@@ -410,6 +416,7 @@ function ChannelSettingsDialog({
            settings.min_duration !== originalSettings.min_duration ||
            settings.max_duration !== originalSettings.max_duration ||
            settings.title_filter_regex !== originalSettings.title_filter_regex ||
+           settings.additional_tags !== originalSettings.additional_tags ||
            settings.audio_format !== originalSettings.audio_format ||
            settings.default_rating !== originalSettings.default_rating ||
            settings.auto_download_enabled_tabs !== originalSettings.auto_download_enabled_tabs ||
@@ -953,10 +960,10 @@ function ChannelSettingsDialog({
             </Alert>
             <TextField
                   label='Video Tags (multiple should be separated by "|")'
-                  value={settings.title_filter_regex || ''}
+                  value={settings.additional_tags || ''}
                   onChange={(e) => setSettings({
                     ...settings,
-                    title_filter_regex: e.target.value || null
+                    additional_tags: e.target.value || null
                   })}
                   placeholder="e.g., (?i)podcast|interview"
                   fullWidth

--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -965,7 +965,6 @@ function ChannelSettingsDialog({
                     ...settings,
                     additional_tags: e.target.value || null
                   })}
-                  placeholder="e.g., (?i)podcast|interview"
                   fullWidth
                   size="small"
                   InputLabelProps={{ shrink: true }}

--- a/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
+++ b/client/src/components/ChannelPage/ChannelSettingsDialog.tsx
@@ -197,6 +197,7 @@ function ChannelSettingsDialog({
     { id: 'general', label: 'General', icon: <SettingsIcon size={18} /> },
     { id: 'filters', label: 'Filters', icon: <FilterAltIcon size={18} /> },
     { id: 'ratings', label: 'Ratings', icon: <RatingIcon size={18} /> },
+    { id: 'tags', label: 'Tags', icon: <RatingIcon size={18} /> },
     { id: 'autoremoval', label: 'Auto-Removal', icon: <AutoRemovalIcon size={18} /> }
   ];
 
@@ -935,6 +936,37 @@ function ChannelSettingsDialog({
                 rating={effectiveRatingLabel}
                 size="small"
               />
+            </div>
+          </div>
+        );
+      }
+      case 'tags': {
+        return (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <Typography variant="subtitle2" gutterBottom style={{ fontWeight: 600 }}>
+              Video Tags
+            </Typography>
+            <Alert severity="info">
+              <Typography variant="body2">
+                Set a default tag additional to the found tags for videos from this channel.
+              </Typography>
+            </Alert>
+            <TextField
+                  label='Video Tags (multiple should be separated by "|")'
+                  value={settings.title_filter_regex || ''}
+                  onChange={(e) => setSettings({
+                    ...settings,
+                    title_filter_regex: e.target.value || null
+                  })}
+                  placeholder="e.g., (?i)podcast|interview"
+                  fullWidth
+                  size="small"
+                  InputLabelProps={{ shrink: true }}
+                />
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+              <Typography variant="caption" color="text.secondary">
+                These can be useful in Jellyfin for organization and parental controls.
+              </Typography>
             </div>
           </div>
         );

--- a/migrations/20260822202153-add-channel-additional-tags.js
+++ b/migrations/20260822202153-add-channel-additional-tags.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { addColumnIfMissing, removeColumnIfExists } = require('./helpers');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    // Add title_filter_regex column for filtering videos by title using regex
+    await addColumnIfMissing(queryInterface, 'channels', 'additional_tags', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+      defaultValue: null
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await removeColumnIfExists(queryInterface, 'channels', 'additional_tags');
+  }
+};

--- a/server/models/channel.js
+++ b/server/models/channel.js
@@ -81,6 +81,11 @@ Channel.init(
       allowNull: true,
       defaultValue: null,
     },
+    additional_tags: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      defaultValue: null,
+    },
     title_filter_regex: {
       type: DataTypes.TEXT,
       allowNull: true,

--- a/server/modules/channelSettingsModule.js
+++ b/server/modules/channelSettingsModule.js
@@ -176,6 +176,31 @@ class ChannelSettingsModule {
   }
 
   /**
+   * Validate title filter regex pattern (Python regex syntax)
+   * Uses Python directly to test regex validity - same as yt-dlp
+   * @param {string|null} additionalTags - Python regex pattern to validate
+   * @returns {Object} - { valid: boolean, error?: string }
+   */
+  validateAdditionalTags(additionalTags) {
+    // NULL or empty string is valid (no title filtering)
+    if (!additionalTags || additionalTags.trim() === '') {
+      return { valid: true };
+    }
+
+    const trimmed = additionalTags.trim();
+
+    // Check length
+    if (trimmed.length > 1000) {
+      return {
+        valid: false,
+        error: 'Additional tags must be 1000 characters or less',
+      };
+    }
+
+    return { valid: true };
+  }
+
+  /**
    * Validate audio format setting
    * @param {string|null} audioFormat - Audio format setting to validate
    * @returns {Object} - { valid: boolean, error?: string }
@@ -534,6 +559,7 @@ class ChannelSettingsModule {
       min_duration: channel.min_duration,
       max_duration: channel.max_duration,
       title_filter_regex: channel.title_filter_regex,
+      additional_tags: channel.additional_tags,
       audio_format: channel.audio_format,
       default_rating: channel.default_rating,
       skip_video_folder: channel.skip_video_folder,
@@ -653,6 +679,14 @@ class ChannelSettingsModule {
     // Validate title filter regex if provided
     if (settings.title_filter_regex !== undefined) {
       const validation = this.validateTitleRegex(settings.title_filter_regex);
+      if (!validation.valid) {
+        throw new Error(validation.error);
+      }
+    }
+
+    // Validate additional tags if provided
+    if (settings.additional_tags !== undefined) {
+      const validation = this.validateAdditionalTags(settings.additional_tags);
       if (!validation.valid) {
         throw new Error(validation.error);
       }
@@ -783,6 +817,11 @@ class ChannelSettingsModule {
         ? settings.title_filter_regex.trim()
         : null;
     }
+    if (settings.additional_tags !== undefined) {
+      updateData.additional_tags = settings.additional_tags
+        ? settings.additional_tags.trim()
+        : null;
+    }
     if (settings.default_rating !== undefined) {
       updateData.default_rating = normalizedDefaultRating;
     }
@@ -902,6 +941,7 @@ class ChannelSettingsModule {
         min_duration: updatedChannel.min_duration,
         max_duration: updatedChannel.max_duration,
         title_filter_regex: updatedChannel.title_filter_regex,
+        additional_tags: updatedChannel.additional_tags,
         audio_format: updatedChannel.audio_format,
         default_rating: updatedChannel.default_rating,
         skip_video_folder: updatedChannel.skip_video_folder,

--- a/server/modules/nfoGenerator.js
+++ b/server/modules/nfoGenerator.js
@@ -85,9 +85,10 @@ class NfoGenerator {
    * Generates and writes an NFO file for a video
    * @param {string} videoPath - Path to the video file
    * @param {object} jsonData - Parsed .info.json data
+   * @param {string} additional_tags - Optional additional tags for the video
    * @returns {boolean} True if successful, false otherwise
    */
-  writeVideoNfoFile(videoPath, jsonData) {
+  writeVideoNfoFile(videoPath, jsonData, additional_tags) {
     logger.info({ videoPath }, 'Writing NFO file for video');
     try {
       // Generate NFO path (same as video but with .nfo extension)
@@ -123,8 +124,15 @@ class NfoGenerator {
         .map(cat => `  <genre>${this.escapeXml(cat)}</genre>`)
         .join('\n');
 
-      // Build tag elements from tags array
-      const tags = (jsonData.tags || [])
+      // Parse additional_tags (pipe-separated string) into an array,
+      // trimming whitespace and dropping empty entries. Handles null/undefined/empty safely.
+      const additionalTagsArray = (additional_tags || '')
+        .split('|')
+        .map(t => t.trim())
+        .filter(t => t.length > 0);
+
+      // Build tag elements from jsonData.tags merged with additional_tags
+      const tags = [...(jsonData.tags || []), ...additionalTagsArray]
         .map(tag => `  <tag>${this.escapeXml(tag)}</tag>`)
         .join('\n');
 

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -319,7 +319,7 @@ async function resolveTrackedOwnerChannelId(youtubeId, metadataChannelId) {
         const channelId = lookupChannelId;
         channelRecord = await Channel.findOne({
           where: { channel_id: channelId },
-          attributes: ['id', 'sub_folder', 'title', 'uploader', 'folder_name', 'default_rating', 'enabled', 'skip_video_folder']
+          attributes: ['id', 'sub_folder', 'title', 'uploader', 'folder_name', 'default_rating', 'enabled', 'skip_video_folder', 'additional_tags']
         });
 
         logger.info({ channelId, ownerProvided: !!ownerChannelId, found: !!channelRecord }, 'Post-process channel lookup');
@@ -456,7 +456,7 @@ async function resolveTrackedOwnerChannelId(youtubeId, metadataChannelId) {
 
     // Generate NFO file for Jellyfin/Kodi/Emby compatibility if enabled
     if (shouldWriteVideoNfoFiles()) {
-      nfoGenerator.writeVideoNfoFile(videoPath, jsonData);
+      nfoGenerator.writeVideoNfoFile(videoPath, jsonData, channelRecord.additional_tags);
     }
 
     // Check if this is an audio file (MP3) - skip video-specific metadata embedding

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -456,7 +456,7 @@ async function resolveTrackedOwnerChannelId(youtubeId, metadataChannelId) {
 
     // Generate NFO file for Jellyfin/Kodi/Emby compatibility if enabled
     if (shouldWriteVideoNfoFiles()) {
-      nfoGenerator.writeVideoNfoFile(videoPath, jsonData, channelRecord.additional_tags);
+      nfoGenerator.writeVideoNfoFile(videoPath, jsonData, ...(channelRecord ? [channelRecord.additional_tags] : []));
     }
 
     // Check if this is an audio file (MP3) - skip video-specific metadata embedding


### PR DESCRIPTION
This will add a new tab to the channel settings dialog that lets you add additional tags separated by | which will automatically add those new tags to the .nfo files that get created when a video downloads.