### PR TITLE
fix: repair jobs uuid fk collation on existing dbs

### DIFF
--- a/migrations/20260830191259-repair-jobs-uuid-fk-collation.js
+++ b/migrations/20260830191259-repair-jobs-uuid-fk-collation.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { ensureJobsUuidBinaryCollation } = require('./lib/jobsUuidCollation');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // The 20250907/20251010 migrations repair coerced UUID FK collations, but
+    // only for databases that had not yet applied them when the repair was
+    // added. A database that passed them earlier can still hold a mismatch
+    // (e.g. Jobs.id utf8mb4_bin vs JobVideos.job_id utf8mb4_unicode_ci from a
+    // partial CONVERT TO run). InnoDB then binds the JobVideos->Jobs foreign
+    // key unpredictably at each server start: some restarts leave it with no
+    // referenced index, and every JobVideos insert fails with
+    // ER_NO_REFERENCED_ROW_2 even though the Jobs row exists, so completed
+    // jobs show zero videos in Download History. Run the idempotent repair
+    // once unconditionally to restore utf8mb4_bin on all three columns.
+    await ensureJobsUuidBinaryCollation(queryInterface);
+  },
+
+  async down() {
+    // No-op: utf8mb4_bin is the canonical collation for these columns;
+    // restoring a coerced collation would only reintroduce the broken state.
+  },
+};

--- a/migrations/__tests__/jobsUuidCollation.test.js
+++ b/migrations/__tests__/jobsUuidCollation.test.js
@@ -17,6 +17,7 @@ const {
 
 const jvdMigration = require('../20251010162434-add-jobvideodownloads-table');
 const utf8mb4Migration = require('../20250907000000-upgrade-to-utf8mb4-if-needed');
+const repairMigration = require('../20260830191259-repair-jobs-uuid-fk-collation');
 
 // Minimal queryInterface double. `collations` maps 'Table.column' to a
 // collation name; a missing key means the table/column does not exist.
@@ -240,5 +241,51 @@ describe('upgrade-to-utf8mb4-if-needed migration', () => {
     await utf8mb4Migration.up(qi, Sequelize);
 
     expect(sqlIndex(qi.ops, /ALTER TABLE/)).toBe(-1);
+  });
+});
+
+describe('repair-jobs-uuid-fk-collation migration', () => {
+  test('repairs a mixed collation state left behind by earlier migrations', async () => {
+    // Only JobVideos.job_id was coerced; Jobs.id and JobVideoDownloads.job_id
+    // are already binary. This is the state a partial CONVERT TO run leaves.
+    const qi = createDouble({
+      collations: {
+        'Jobs.id': 'utf8mb4_bin',
+        'JobVideos.job_id': 'utf8mb4_unicode_ci',
+        'JobVideoDownloads.job_id': 'utf8mb4_bin',
+      },
+    });
+    await repairMigration.up(qi);
+
+    const fkOff = sqlIndex(qi.ops, /SET FOREIGN_KEY_CHECKS = 0/);
+    const alterJobVideos = sqlIndex(qi.ops, /ALTER TABLE `JobVideos` MODIFY `job_id`.*COLLATE utf8mb4_bin NOT NULL/);
+    const fkOn = sqlIndex(qi.ops, /SET FOREIGN_KEY_CHECKS = 1/);
+
+    expect(alterJobVideos).not.toBe(-1);
+    expect(fkOff).toBeLessThan(alterJobVideos);
+    expect(alterJobVideos).toBeLessThan(fkOn);
+    expect(sqlIndex(qi.ops, /ALTER TABLE `Jobs`/)).toBe(-1);
+    expect(sqlIndex(qi.ops, /ALTER TABLE `JobVideoDownloads`/)).toBe(-1);
+    expect(qi.transactions[0].committed).toBe(true);
+  });
+
+  test('does nothing when every UUID FK column is already utf8mb4_bin', async () => {
+    const qi = createDouble({
+      collations: {
+        'Jobs.id': 'utf8mb4_bin',
+        'JobVideos.job_id': 'utf8mb4_bin',
+        'JobVideoDownloads.job_id': 'utf8mb4_bin',
+      },
+    });
+    await repairMigration.up(qi);
+
+    expect(qi.ops).toEqual([]);
+  });
+
+  test('down is a no-op', async () => {
+    const qi = createDouble();
+    await repairMigration.down(qi);
+
+    expect(qi.ops).toEqual([]);
   });
 });


### PR DESCRIPTION
Databases that applied the 20250907/20251010 migrations before the 752 issue repair existed never ran it and can be left with mismatched collations on the Jobs UUID FK columns. JobVideos inserts then fail intermittently after a DB restart, so completed jobs show zero videos in Download History.

Most users are unlikely to have this
state; it was seen on a dev database mangled by local migration testing...

Rerun the existing idempotent repair once; no-op on healthy databases.