### PR TITLE
fix: sync Jellyfin videos inside collections

### DIFF
--- a/docs/media-servers/jellyfin.md
+++ b/docs/media-servers/jellyfin.md
@@ -118,6 +118,8 @@ Once connected, open a playlist in Youtarr and turn on its Jellyfin sync chip. S
 
 Connecting Jellyfin also enables watch status sync: Youtarr periodically pulls per-video watch state (played, percent watched, last watched) for every user on the server and shows it as Watched chips and filters on its listing pages. It's one-way; Youtarr never marks anything watched on Jellyfin. Jellyfin decides when a video counts as played: **Maximum resume percentage** under Server -> Playback -> Resume. Settings live under **Settings -> Watch Status**; see [Track Watch Status from Media Servers](../USAGE_GUIDE.md#track-watch-status-from-media-servers).
 
+Videos inside Jellyfin Collections remain available for watch status and native playlist sync with **Group movies into collections** enabled. You do not need to change that display setting.
+
 ### Visibility
 
 A playlist marked **Public** in Youtarr is visible to all users on the server; a **Private** one is visible only to the configured user account.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3765,14 +3765,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -7324,9 +7316,10 @@
       }
     },
     "node_modules/lru.min": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.3.tgz",
-      "integrity": "sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
         "deno": ">=1.30.0",
@@ -7545,28 +7538,31 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.16.2.tgz",
-      "integrity": "sha512-JsqBpYNy7pH20lGfPuSyRSIcCxSeAIwxWADpV64nP9KeyN3ZKpHZgjKXuBKsh7dH6FbOvf1bOgoVKjSUPXRMTw==",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.2.tgz",
+      "integrity": "sha512-l9kXeKGwd6VCbSjmpO/bLWb+YCYpbvE4whte8ec6InXebvCNyEEydyRCnRU+TSHNqRLJ8B+Tk1uWb+vMCJgJzA==",
+      "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.2",
-        "denque": "^2.1.0",
         "generate-function": "^2.3.1",
-        "iconv-lite": "^0.7.2",
+        "iconv-lite": "^0.7.3",
         "long": "^5.3.2",
-        "lru.min": "^1.1.3",
+        "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.3"
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
       }
     },
     "node_modules/mysql2/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -8925,11 +8921,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
-    "node_modules/seq-queue": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
-    },
     "node_modules/sequelize": {
       "version": "6.37.8",
       "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.37.8.tgz",
@@ -9324,12 +9315,19 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "node_modules/sqlstring": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
-      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+    "node_modules/sql-escaper": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
     },
     "node_modules/stack-utils": {

--- a/server/modules/mediaServers/adapters/__tests__/jellyfinAdapter.test.js
+++ b/server/modules/mediaServers/adapters/__tests__/jellyfinAdapter.test.js
@@ -136,6 +136,17 @@ describe('JellyfinAdapter', () => {
     expect(id).toBe('X');
   });
 
+  test('resolves a movie inside a collection when grouping is enabled', async () => {
+    axios.get.mockImplementationOnce(async (_url, { params }) => ({
+      data: { Items: params.collapseBoxSetItems === false
+        ? [{ Id: 'movie', Type: 'Movie', Path: '/media/Chan/video.mp4' }]
+        : [{ Id: 'collection', Type: 'BoxSet', Path: '/collections/Chan [boxset]' }] },
+    }));
+
+    const adapter = new JellyfinAdapter(cfg);
+    await expect(adapter.resolveItemIdByFilepath('/youtube/Chan/video.mp4')).resolves.toBe('movie');
+  });
+
   test('replacePlaylistItems deletes old playlist and recreates, returning the new id', async () => {
     axios.delete.mockResolvedValueOnce({});
     axios.post.mockResolvedValueOnce({ data: { Id: 'new-pl-id' } });
@@ -257,6 +268,31 @@ describe('JellyfinAdapter', () => {
   describe('fetchWatchStates', () => {
     // Most tests run in single-user mode to keep one queued /Items response.
     const singleUserCfg = { ...cfg, jellyfinWatchStatusAllUsers: false };
+
+    test.each([false, true])('fetches individual movie watch states with collection grouping (allUsers=%s)', async (allUsers) => {
+      const groupedResponse = async (url, { params }) => {
+        if (url.endsWith('/Users')) {
+          return { data: [{ Id: 'u1', Name: 'Alice' }, { Id: 'u2', Name: 'Bob' }] };
+        }
+        return { data: { Items: params.collapseBoxSetItems === false
+          ? [{
+            Id: 'movie', Type: 'Movie', Path: '/media/Chan/video.mp4',
+            UserData: { Played: params.userId !== 'u2', PlayCount: params.userId !== 'u2' ? 1 : 0 },
+          }]
+          : [{ Id: 'collection', Type: 'BoxSet', Path: '/collections/Chan [boxset]' }] } };
+      };
+      for (let call = 0; call < (allUsers ? 3 : 1); call++) {
+        axios.get.mockImplementationOnce(groupedResponse);
+      }
+
+      const adapter = new JellyfinAdapter({ ...cfg, jellyfinWatchStatusAllUsers: allUsers });
+      const { entries } = await adapter.fetchWatchStates();
+      expect(entries.map(({ path, serverUserId, played }) => ({ path, serverUserId, played }))).toEqual(
+        (allUsers ? ['u1', 'u2'] : ['USR']).map((serverUserId) => ({
+          path: '/media/Chan/video.mp4', serverUserId, played: serverUserId !== 'u2',
+        }))
+      );
+    });
 
     test('maps UserData fields including ticks-to-ms conversion', async () => {
       axios.get.mockResolvedValueOnce({

--- a/server/modules/mediaServers/adapters/jellyfinAdapter.js
+++ b/server/modules/mediaServers/adapters/jellyfinAdapter.js
@@ -66,6 +66,8 @@ class JellyfinAdapter extends BaseAdapter {
       const params = {
         userId: this.userId,
         includeItemTypes: isAudio ? 'Audio' : 'Video,Movie,Episode',
+        // Data lookups need individual movies even when Jellyfin groups collections.
+        collapseBoxSetItems: false,
         recursive: true,
         fields: 'Path',
       };
@@ -103,6 +105,8 @@ class JellyfinAdapter extends BaseAdapter {
         const params = {
           userId: user.id,
           includeItemTypes: 'Video,Movie,Episode',
+          // Collection containers do not carry the individual videos' watch state.
+          collapseBoxSetItems: false,
           recursive: true,
           fields: 'Path',
           enableUserData: true,


### PR DESCRIPTION
Jellyfin can return collection containers instead of individual movies, leaving watch status sync with no matching videos and preventing watched-based cleanup.

Disable collection collapsing for watch state and file lookups so videos remain available for watch status and native playlist sync. Add tests and document collection support.

Refs: #794