### PR TITLE
feat: support externally managed cookie files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,12 @@ AUTH_ENABLED=true
 # Set TRUST_PROXY=1 or a trusted subnet when a reverse proxy should supply client IPs.
 # TRUST_PROXY=false
 
+# Optional externally managed YouTube cookies (unset keeps the upload workflow).
+# Put the file at config/cookies.external.txt to use the existing config mount.
+# Unusable files are skipped; operations continue without cookies with a warning.
+# Enable Cookies in Settings. Setup: docs/CONFIG.md#external-cookie-file
+# YOUTARR_COOKIES_FILE=/app/config/cookies.external.txt
+
 # Logging Configuration
 # Options: warn, info (default), debug
 # Use 'debug' for troubleshooting, 'info' for production, 'warn' for minimal logging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,23 @@ jobs:
         env:
           PYTHONDONTWRITEBYTECODE: '1'
 
+  test-cookie-validation:
+    name: yt-dlp Cookie Loader Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download the yt-dlp distribution used by the Docker image
+        run: curl --fail --location --retry 3 https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp --output "$RUNNER_TEMP/yt-dlp"
+
+      - name: Validate cookies with the actual yt-dlp parser
+        run: python3 -m unittest discover -s server/utils/__tests__ -p 'test_validate_cookies.py'
+        env:
+          YOUTARR_TEST_YTDLP: ${{ runner.temp }}/yt-dlp
+          PYTHONDONTWRITEBYTECODE: '1'
+
   test-backend:
     name: Backend Tests
     runs-on: ubuntu-latest
@@ -292,7 +309,7 @@ jobs:
   check-all:
     name: All Checks
     runs-on: ubuntu-latest
-    needs: [lint, test-backup-restore, test-backend, test-frontend, test-storybook, security-audit]
+    needs: [lint, test-backup-restore, test-cookie-validation, test-backend, test-frontend, test-storybook, security-audit]
     if: always()
     steps:
       - name: Check all results
@@ -300,6 +317,7 @@ jobs:
           echo "Checking results of all jobs..."
           echo "Lint: ${{ needs.lint.result }}"
           echo "Backup/Restore Tests: ${{ needs.test-backup-restore.result }}"
+          echo "Cookie Loader Tests: ${{ needs.test-cookie-validation.result }}"
           echo "Backend Tests: ${{ needs.test-backend.result }}"
           echo "Frontend Tests: ${{ needs.test-frontend.result }}"
           echo "Storybook Tests: ${{ needs.test-storybook.result }}"
@@ -307,6 +325,7 @@ jobs:
 
           if [ "${{ needs.lint.result }}" != "success" ] || \
              [ "${{ needs.test-backup-restore.result }}" != "success" ] || \
+             [ "${{ needs.test-cookie-validation.result }}" != "success" ] || \
              [ "${{ needs.test-backend.result }}" != "success" ] || \
              [ "${{ needs.test-frontend.result }}" != "success" ] || \
              [ "${{ needs.test-storybook.result }}" != "success" ] || \
@@ -317,6 +336,7 @@ jobs:
             echo "Failed checks:"
             [ "${{ needs.lint.result }}" != "success" ] && echo "  - Linting"
             [ "${{ needs.test-backup-restore.result }}" != "success" ] && echo "  - Backup/Restore Tests"
+            [ "${{ needs.test-cookie-validation.result }}" != "success" ] && echo "  - Cookie Loader Tests"
             [ "${{ needs.test-backend.result }}" != "success" ] && echo "  - Backend Tests"
             [ "${{ needs.test-frontend.result }}" != "success" ] && echo "  - Frontend Tests"
             [ "${{ needs.test-storybook.result }}" != "success" ] && echo "  - Storybook Tests"

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ config/jobs.json
 config/config.json
 config/config.json.*
 config/cookies.user.txt
+config/cookies.external.txt*
 config/setup-token
 config/*.env
 database

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ For multi-part requests (e.g., "review this PR AND explain WebSocket handling"),
 ## Architecture
 
 ### Backend (server/)
+- `modules/externalCookies.js`: validates external cookie snapshots through the installed yt-dlp parser in `utils/validate-cookies.py`, memoizes unchanged results, and reports unusable files for omission; `modules/ytdlpProcess.js` owns snapshot lifetime around yt-dlp processes. No persistent cookie fallback.
 - `server.js`: Express entry point. `db.js`: Sequelize setup. `logger.js`: Pino logger with request correlation.
 - `models/`: Sequelize models (channel, video, job, jobvideo, jobvideodownload, channelvideo, session, apikey, playlist, playlistvideo, playlistsyncstate, subfolder, videowatchstatus). Associations: Channel hasMany Videos, Job hasMany JobVideos, Playlist hasMany PlaylistVideos and hasMany PlaylistSyncStates.
 - `routes/`: API handlers (auth, channels, videos, videoDetail, videoSearch, channelSearch, config, jobs, plex, setup, subscriptions, apikeys, ytdlpOptions, health, maintenance, playlists, mediaServers, subfolders). All use the dependency injection factory pattern; wiring lives in `server/routes/index.js`.

--- a/client/src/components/Configuration/hooks/__tests__/useCookieManagement.test.ts
+++ b/client/src/components/Configuration/hooks/__tests__/useCookieManagement.test.ts
@@ -88,6 +88,44 @@ describe('useCookieManagement', () => {
   });
 
   describe('Cookie Status Fetching', () => {
+    test('refreshes external status periodically and stops polling on unmount', async () => {
+      jest.useFakeTimers();
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockReset();
+      const external = {
+        path: '/app/config/cookies.external.txt', ready: true,
+        lastModified: null, warning: null, error: null,
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ ...mockCookieStatus, external }),
+      } as unknown as Response);
+      const { result, unmount } = renderHook(() => useCookieManagement({
+        token: mockToken, setConfig: mockSetConfig, setSnackbar: mockSetSnackbar,
+      }));
+      try {
+        await waitFor(() => expect(result.current.cookieStatus?.external?.ready).toBe(true));
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            ...mockCookieStatus,
+            external: { ...external, ready: false, error: 'External cookies: the file was not found.' },
+          }),
+        } as unknown as Response);
+        await act(async () => { jest.advanceTimersByTime(30000); });
+        expect(result.current.cookieStatus?.external?.ready).toBe(false);
+        unmount();
+        const requests = mockFetch.mock.calls.length;
+        await act(async () => { jest.advanceTimersByTime(60000); });
+        expect(mockFetch).toHaveBeenCalledTimes(requests);
+      } finally {
+        unmount();
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+        mockFetch.mockReset();
+      }
+    });
+
     test('fetches cookie status on mount with valid token', async () => {
       const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
       mockFetch.mockResolvedValueOnce({

--- a/client/src/components/Configuration/hooks/useCookieManagement.ts
+++ b/client/src/components/Configuration/hooks/useCookieManagement.ts
@@ -15,10 +15,9 @@ export const useCookieManagement = ({
   const [cookieStatus, setCookieStatus] = useState<CookieStatus | null>(null);
   const [uploadingCookie, setUploadingCookie] = useState(false);
 
-  // Fetch cookie status on mount
-  useEffect(() => {
+  const refreshCookieStatus = useCallback(async () => {
     if (token) {
-      fetch('/api/cookies/status', {
+      await fetch('/api/cookies/status', {
         headers: {
           'x-access-token': token,
         },
@@ -30,6 +29,19 @@ export const useCookieManagement = ({
         .catch((error) => console.error('Error fetching cookie status:', error));
     }
   }, [token]);
+
+  // Fetch cookie status on mount; externally managed files can also be refreshed.
+  useEffect(() => {
+    void refreshCookieStatus();
+  }, [refreshCookieStatus]);
+
+  // Keep external-source warnings and recovery visible while Settings is open.
+  const externalPath = cookieStatus?.external?.path;
+  useEffect(() => {
+    if (!token || !externalPath) return;
+    const interval = setInterval(() => { void refreshCookieStatus(); }, 30000);
+    return () => clearInterval(interval);
+  }, [token, externalPath, refreshCookieStatus]);
 
   const uploadCookieFile = useCallback(async (file: File) => {
     setUploadingCookie(true);
@@ -112,6 +124,7 @@ export const useCookieManagement = ({
 
   return {
     cookieStatus,
+    refreshCookieStatus,
     uploadingCookie,
     uploadCookieFile,
     deleteCookies,

--- a/client/src/components/Configuration/sections/CookieConfigSection.tsx
+++ b/client/src/components/Configuration/sections/CookieConfigSection.tsx
@@ -6,6 +6,9 @@ import {
   Typography,
   Button,
   Chip,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
 } from '../../ui';
 import { ConfigurationAccordion } from '../common/ConfigurationAccordion';
 import { useCookieManagement } from '../hooks/useCookieManagement';
@@ -31,10 +34,13 @@ export const CookieConfigSection: React.FC<CookieConfigSectionProps> = ({
   const fileInputRef = React.useRef<HTMLInputElement | null>(null);
   const {
     cookieStatus,
+    refreshCookieStatus,
     uploadingCookie,
     uploadCookieFile,
     deleteCookies,
   } = useCookieManagement({ token, setConfig, setSnackbar });
+  const externalCookies = cookieStatus?.external;
+  const externalIssue = config.cookiesEnabled && externalCookies && (!externalCookies.ready || externalCookies.warning);
 
   const handleCookieUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -45,14 +51,15 @@ export const CookieConfigSection: React.FC<CookieConfigSectionProps> = ({
   return (
     <ConfigurationAccordion
       title="Cookie Configuration"
-      chipLabel={config.cookiesEnabled ? "Cookies Enabled" : "Cookies Disabled"}
-      chipColor={config.cookiesEnabled ? "success" : "default"}
+      chipLabel={externalIssue ? 'External cookie warning' : config.cookiesEnabled ? 'Cookies Enabled' : 'Cookies Disabled'}
+      chipColor={externalIssue ? 'warning' : config.cookiesEnabled ? 'success' : 'default'}
       statusBanner={{
         enabled: config.cookiesEnabled,
         label: 'Enable Cookies',
         onToggle: (enabled) => onConfigChange({ cookiesEnabled: enabled }),
-        onText: 'Cookies Enabled',
+        onText: externalCookies && !externalCookies.ready ? 'Cookies enabled; external file unavailable' : 'Cookies Enabled',
         offText: 'Cookies Disabled',
+        successWhenEnabled: !externalIssue,
       }}
       defaultExpanded={false}
     >
@@ -80,8 +87,93 @@ export const CookieConfigSection: React.FC<CookieConfigSectionProps> = ({
         </Typography>
       </Alert>
 
+      <Accordion className="mb-4">
+        <AccordionSummary>Refresh cookies automatically with YOUTARR_COOKIES_FILE</AccordionSummary>
+        <AccordionDetails className="space-y-3 text-sm">
+          <p>
+            Have a script or service refresh your cookie file on the server? Set{' '}
+            <code>YOUTARR_COOKIES_FILE</code> to its path inside the container and enable cookies here.
+          </p>
+          <ol className="list-decimal space-y-2 pl-5">
+            <li>
+              With the bundled Compose setup, have your script write a Netscape cookie file at{' '}
+              <code>config/cookies.external.txt</code> (up to 1 MB, readable by Youtarr).
+            </li>
+            <li>
+              Add <code className="break-all">YOUTARR_COOKIES_FILE=/app/config/cookies.external.txt</code>{' '}
+              to your <code>.env</code> file and recreate the container once. No Compose edits are needed for this location.
+            </li>
+            <li>Turn on Enable Cookies and save your configuration. No upload is needed.</li>
+          </ol>
+          <p>
+            New operations pick up updates automatically. Youtarr uses yt-dlp to check a private copy
+            and never modifies your source. Have your script write a temporary file and rename it over
+            the source when complete.
+          </p>
+          <p>
+            If the file cannot be used, operations continue without cookies and a warning appears here
+            and in the logs. Downloads needing authentication may fail. A valid replacement restores
+            cookie use automatically; validation does not verify your YouTube session.
+          </p>
+          <p>
+            This replaces uploads while the variable is set. Unset it and recreate the container to
+            return to uploaded cookies.
+          </p>
+          <a
+            href="https://github.com/DialmasterOrg/Youtarr/blob/dev/docs/CONFIG.md#external-cookie-file"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-primary underline"
+          >
+            Setup guide and other mount locations
+          </a>
+        </AccordionDetails>
+      </Accordion>
+
+      {externalCookies && (
+        <Alert severity={externalCookies.ready && !externalCookies.warning ? 'info' : 'warning'} className="mb-4">
+          <AlertTitle>Cookies managed externally</AlertTitle>
+          <Typography variant="body2" className="break-all">
+            Source: {externalCookies.path}
+          </Typography>
+          <Typography variant="body2">
+            {config.cookiesEnabled
+              ? 'Valid file updates apply to new operations without restarting. Youtarr does not modify the source file.'
+              : 'Enable Cookies and save your configuration to use this file.'}
+          </Typography>
+          <Typography variant="body2">
+            {externalCookies.error || 'yt-dlp loaded this file. This does not verify YouTube authentication.'}
+          </Typography>
+          {externalCookies.warning && (
+            <Typography variant="body2">
+              {externalCookies.warning}
+            </Typography>
+          )}
+          {!externalCookies.ready && (
+            <Typography variant="body2">
+              Operations {config.cookiesEnabled ? 'will continue' : 'would run'} without cookies until a usable file is available.
+              Downloads needing authentication may fail. Cookie use resumes automatically when enabled and a valid replacement is detected.
+            </Typography>
+          )}
+          {externalCookies.lastModified && (
+            <Typography variant="body2">
+              Source last modified: {new Date(externalCookies.lastModified).toLocaleString()}
+            </Typography>
+          )}
+          <Typography variant="body2">
+            Uploads are unavailable while YOUTARR_COOKIES_FILE is set. Any previously uploaded cookies are preserved.
+          </Typography>
+          <Typography variant="caption" className="block text-muted-foreground">
+            Status refreshes every 30 seconds while these settings are open.
+          </Typography>
+          <Button variant="outlined" size="small" onClick={refreshCookieStatus} className="mt-2">
+            Refresh file status
+          </Button>
+        </Alert>
+      )}
+
       <Grid container spacing={2}>
-        {config.cookiesEnabled && (
+        {config.cookiesEnabled && !externalCookies && (
           <>
             <Grid item xs={12}>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>

--- a/client/src/components/Configuration/sections/__tests__/CookieConfigSection.story.tsx
+++ b/client/src/components/Configuration/sections/__tests__/CookieConfigSection.story.tsx
@@ -54,3 +54,89 @@ export const EnableCookies: Story = {
     await expect(canvas.getByRole('button', { name: /upload cookie file/i })).toBeInTheDocument();
   },
 };
+
+export const ExternalCookies: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/cookies/status', () => HttpResponse.json({
+          cookiesEnabled: false,
+          customCookiesUploaded: false,
+          customFileExists: false,
+          external: {
+            path: '/app/config/cookies.external.txt',
+            ready: true,
+            lastModified: '2026-09-05T12:00:00.000Z',
+            warning: null,
+            error: null,
+          },
+        })),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText('Cookies managed externally')).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole('checkbox', { name: /enable cookies/i }));
+    await expect(canvas.getByRole('button', { name: /refresh file status/i })).toBeInTheDocument();
+    await expect(canvas.queryByRole('button', { name: /upload cookie file/i })).not.toBeInTheDocument();
+  },
+};
+
+export const MissingExternalCookies: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/cookies/status', () => HttpResponse.json({
+          cookiesEnabled: false,
+          customCookiesUploaded: false,
+          customFileExists: false,
+          external: {
+            path: '/app/config/cookies.external.txt',
+            ready: false,
+            lastModified: null,
+            warning: null,
+            error: 'External cookies: the file was not found. Check the directory mount and YOUTARR_COOKIES_FILE.',
+          },
+        })),
+      ],
+    },
+  },
+};
+
+export const ExternalCookieWarnings: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/cookies/status', () => HttpResponse.json({
+          cookiesEnabled: false,
+          customCookiesUploaded: false,
+          customFileExists: false,
+          external: {
+            path: '/app/config/cookies.external.txt',
+            ready: true,
+            lastModified: '2026-09-05T12:00:00.000Z',
+            warning: 'yt-dlp reported warnings while loading the file. Only the cookies it loaded will be used.',
+            error: null,
+          },
+        })),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('Cookies managed externally');
+    await userEvent.click(canvas.getByRole('checkbox', { name: /enable cookies/i }));
+    await expect(canvas.getByText(/yt-dlp reported warnings/)).toBeInTheDocument();
+  },
+};
+
+export const AutomaticRefreshSetup: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const help = canvas.getByRole('button', { name: /Refresh cookies automatically with YOUTARR_COOKIES_FILE/ });
+    await userEvent.click(help);
+    await expect(help).toHaveAttribute('aria-expanded', 'true');
+    await expect(canvas.getByText('YOUTARR_COOKIES_FILE=/app/config/cookies.external.txt')).toBeVisible();
+  },
+};

--- a/client/src/components/Configuration/sections/__tests__/CookieConfigSection.test.tsx
+++ b/client/src/components/Configuration/sections/__tests__/CookieConfigSection.test.tsx
@@ -15,6 +15,7 @@ jest.mock('../../hooks/useCookieManagement', () => ({
 
 type HookValue = {
   cookieStatus: CookieStatus | null;
+  refreshCookieStatus: jest.Mock;
   uploadingCookie: boolean;
   uploadCookieFile: jest.Mock;
   deleteCookies: jest.Mock;
@@ -23,6 +24,7 @@ type HookValue = {
 const createHookValue = (overrides: Partial<HookValue> = {}) => {
   const value: HookValue = {
     cookieStatus: null,
+    refreshCookieStatus: jest.fn(),
     uploadingCookie: false,
     uploadCookieFile: jest.fn(),
     deleteCookies: jest.fn(),
@@ -109,5 +111,107 @@ describe('CookieConfigSection', () => {
     await user.upload(fileInput, file);
 
     expect(hookValue.uploadCookieFile).toHaveBeenCalledWith(file);
+  });
+
+  test('shows external source status and refreshes it without upload or delete controls', async () => {
+    const user = userEvent.setup();
+    const hookValue = createHookValue({
+      cookieStatus: {
+        cookiesEnabled: true,
+        customCookiesUploaded: true,
+        customFileExists: true,
+        external: {
+          path: '/app/external-cookies/cookies.txt',
+          ready: true,
+          lastModified: '2026-09-05T12:00:00.000Z',
+          warning: null,
+          error: null,
+        },
+      },
+    });
+    renderWithProviders(<CookieConfigSection {...createSectionProps({
+      config: createConfig({ cookiesEnabled: true }),
+    })} />);
+
+    expect(screen.getByText('Cookies managed externally')).toBeInTheDocument();
+    expect(screen.getByText(/Source: \/app\/external-cookies\/cookies.txt/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /upload cookie file/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete custom cookies/i })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /refresh file status/i }));
+    expect(hookValue.refreshCookieStatus).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows external errors and the enable instruction even while cookies are disabled', () => {
+    createHookValue({
+      cookieStatus: {
+        cookiesEnabled: false,
+        customCookiesUploaded: false,
+        customFileExists: false,
+        external: {
+          path: '/app/external-cookies/cookies.txt',
+          ready: false,
+          lastModified: null,
+          warning: null,
+          error: 'External cookies: the file was not found.',
+        },
+      },
+    });
+    renderWithProviders(<CookieConfigSection {...createSectionProps()} />);
+    expect(screen.getByText('External cookies: the file was not found.')).toBeInTheDocument();
+    expect(screen.getByText('Enable Cookies and save your configuration to use this file.')).toBeInTheDocument();
+    expect(screen.getByText(/Operations would run without cookies/)).toBeInTheDocument();
+  });
+
+  test('explains that an unusable external file is skipped while cookies stay enabled', () => {
+    createHookValue({
+      cookieStatus: {
+        cookiesEnabled: true,
+        customCookiesUploaded: false,
+        customFileExists: false,
+        external: {
+          path: '/app/config/cookies.external.txt',
+          ready: false,
+          lastModified: null,
+          warning: null,
+          error: 'External cookies: yt-dlp could not load the file.',
+        },
+      },
+    });
+    renderWithProviders(<CookieConfigSection {...createSectionProps({
+      config: createConfig({ cookiesEnabled: true }),
+    })} />);
+    expect(screen.getByText(/Operations will continue without cookies/)).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /enable cookies/i })).toBeChecked();
+    expect(screen.getByText('External cookie warning')).toBeInTheDocument();
+  });
+
+  test('shows parser warnings even when cookies can be loaded', () => {
+    const warning = 'yt-dlp reported warnings while loading the file. Only the cookies it loaded will be used.';
+    createHookValue({
+      cookieStatus: {
+        cookiesEnabled: true,
+        customCookiesUploaded: false,
+        customFileExists: false,
+        external: { path: '/app/config/cookies.external.txt', ready: true, lastModified: null, warning, error: null },
+      },
+    });
+    renderWithProviders(<CookieConfigSection {...createSectionProps({
+      config: createConfig({ cookiesEnabled: true }),
+    })} />);
+    expect(screen.getByText(warning)).toBeInTheDocument();
+    expect(screen.queryByText(/Operations will continue without cookies/)).not.toBeInTheDocument();
+  });
+
+  test('offers expandable external-file setup instructions before cookies are enabled', async () => {
+    const user = userEvent.setup();
+    createHookValue();
+    renderWithProviders(<CookieConfigSection {...createSectionProps()} />);
+    const help = screen.getByRole('button', { name: /Refresh cookies automatically with YOUTARR_COOKIES_FILE/ });
+    expect(help).toHaveAttribute('aria-expanded', 'false');
+    await user.click(help);
+    expect(help).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('YOUTARR_COOKIES_FILE=/app/config/cookies.external.txt')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Setup guide and other mount locations/ })).toHaveAttribute('href',
+      'https://github.com/DialmasterOrg/Youtarr/blob/dev/docs/CONFIG.md#external-cookie-file');
   });
 });

--- a/client/src/components/Configuration/types.ts
+++ b/client/src/components/Configuration/types.ts
@@ -91,6 +91,13 @@ export interface CookieStatus {
   cookiesEnabled: boolean;
   customCookiesUploaded: boolean;
   customFileExists: boolean;
+  external?: {
+    path: string;
+    ready: boolean;
+    lastModified: string | null;
+    warning: string | null;
+    error: string | null;
+  };
 }
 
 export interface SnackbarState {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -49,6 +49,8 @@ services:
       - AUTH_PRESET_USERNAME=${AUTH_PRESET_USERNAME:-}
       - AUTH_PRESET_PASSWORD=${AUTH_PRESET_PASSWORD:-}
       - TRUST_PROXY=${TRUST_PROXY:-}
+      # Optional external cookies; /app/config uses the existing mount (see docs/CONFIG.md).
+      - YOUTARR_COOKIES_FILE=${YOUTARR_COOKIES_FILE:-}
       # Platform-spoof env vars (used by ./scripts/start-dev.sh --as-elfhosted and full Elfhosted spoofs).
       # Empty when unset on the host, so non-Elfhosted dev runs are unaffected.
       - PLATFORM=${PLATFORM:-}

--- a/docker-compose.external-db.yml
+++ b/docker-compose.external-db.yml
@@ -44,6 +44,8 @@ services:
       AUTH_PRESET_PASSWORD: ${AUTH_PRESET_PASSWORD:-}
       # Optional: Configure Express proxy header trust
       TRUST_PROXY: ${TRUST_PROXY:-}
+      # Optional external cookies; /app/config uses the existing mount (see docs/CONFIG.md).
+      YOUTARR_COOKIES_FILE: ${YOUTARR_COOKIES_FILE:-}
       # Logging configuration
       LOG_LEVEL: ${LOG_LEVEL:-info}
       # This is just informational and lets the app know where the videos will be stored on the host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,8 @@ services:
       AUTH_PRESET_PASSWORD: ${AUTH_PRESET_PASSWORD:-}
       # Optional: Configure Express proxy header trust
       TRUST_PROXY: ${TRUST_PROXY:-}
+      # Optional external cookies; /app/config uses the existing mount (see docs/CONFIG.md).
+      YOUTARR_COOKIES_FILE: ${YOUTARR_COOKIES_FILE:-}
       # Logging configuration
       LOG_LEVEL: ${LOG_LEVEL:-info}
       # This is just informational and lets the app know where the videos will be stored on the host

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -396,6 +396,87 @@ Sync is one-way (server -> Youtarr). Non-owner Plex users come from the server's
 - **Description**: Indicates if custom cookies.txt file has been uploaded
 - **Note**: Managed automatically by the application
 
+### External Cookie File
+
+To refresh cookies from an external script or service, set the optional
+`YOUTARR_COOKIES_FILE` environment variable to an absolute path **inside the
+container**. Leave it unset to keep the existing upload workflow.
+
+**Recommended setup — no Compose edits:** the bundled Compose files already
+mount the host's `config` directory at `/app/config` and pass through the
+environment variable from `.env`.
+
+1. Have your external process write a Netscape-format file (maximum 1 MB) at
+   `config/cookies.external.txt`. Keep it separate from `cookies.user.txt`, which
+   belongs to the existing upload workflow. The container user must be able to
+   read the file.
+2. Add this to `.env`:
+
+   ```dotenv
+   YOUTARR_COOKIES_FILE=/app/config/cookies.external.txt
+   ```
+3. Recreate the container once to apply the environment change. In Settings →
+   Cookie Configuration, enable **Enable Cookies** and save. No initial upload
+   is needed. The external-file status shows whether yt-dlp can load the file.
+   It refreshes every 30 seconds while these settings are open; use
+   **Refresh file status** to check immediately.
+
+Your external process should write a temporary file such as
+`config/cookies.external.txt.tmp` in the same host directory and rename it over
+the source file only after writing is complete. Preserve
+readable permissions when replacing it. Subsequent updates need no restart.
+
+Each new yt-dlp operation that uses configured cookies reads the current file
+into its own private, writable temporary copy. Running operations finish with
+their existing copy; subsequent operations pick up updates without a restart.
+Youtarr and yt-dlp never modify the external source, and working copies are
+removed when the process closes. This applies wherever configured cookies are
+already used, including downloads, channel/metadata lookups, and thumbnails;
+one-time subscription imports retain their separate upload workflow.
+
+**Validation and failures.** Youtarr uses the installed yt-dlp cookie loader to
+check the private copy locally, without contacting YouTube. It uses the cookies
+yt-dlp successfully loads; malformed entries that yt-dlp skips are left out of
+the working copy and produce a warning. At least one cookie must load.
+
+If the source is missing, unreadable, rejected, or contains no loadable cookies,
+operations **continue without cookies**. The same applies if validation or
+creation of the private copy fails. Settings shows the reason and Youtarr logs
+a warning without cookie contents. Repeated identical warnings are suppressed.
+Downloads requiring authentication or encountering bot challenges may still fail.
+
+A usable replacement automatically restores cookie use for new operations.
+Youtarr checks the current contents each time and reuses validation results
+only while those contents and the installed yt-dlp are unchanged. It does not
+fall back to an older file or to uploaded cookies.
+
+Validation does **not** confirm that YouTube accepts the session. Expired or
+revoked login sessions can still fail even when the file loads successfully;
+refreshing the cookies remains the external process's responsibility.
+
+The external file takes precedence over uploaded cookies while **Enable
+Cookies** is on. Uploads and deletion are unavailable while the environment
+variable is set.
+Previously uploaded cookies and their settings are preserved: unset
+`YOUTARR_COOKIES_FILE` and recreate the container to return to them. Turning off
+**Enable Cookies** disables cookie use for either source.
+
+**Advanced: another host directory.** To keep the source outside `config`, add
+a dedicated directory mount and set the container path in `.env`, for example
+`YOUTARR_COOKIES_FILE=/app/external-cookies/cookies.txt`:
+
+```yaml
+services:
+  youtarr:
+    volumes:
+      - /mnt/server/youtarr-cookies:/app/external-cookies:ro
+```
+
+Merge this into your existing service without removing its other volumes, then
+recreate the container. Mount the **directory**, not the individual file, so
+atomic replacements remain visible. The container user needs read access to
+the file and access to the directory; the source mount can be read-only.
+
 ## Notifications
 
 Youtarr uses [Apprise](https://github.com/caronc/apprise) to send notifications when new videos are downloaded, supporting 100+ notification services.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -459,6 +459,24 @@ npm run test:coverage
 npm run test:watch
 ```
 
+### External Cookie Validation Tests
+
+The backend Jest suites cover external-file handling and process cleanup. A
+separate Python suite checks the helper against yt-dlp's actual cookie loader,
+including malformed records and suppression of cookie values in diagnostics.
+It runs locally without contacting YouTube or downloading videos:
+
+```bash
+python3 -m unittest discover -s server/utils/__tests__ -p 'test_validate_cookies.py'
+```
+
+This requires Python and yt-dlp's platform-independent zipimport executable on
+`PATH`, the distribution used by the Docker image. Alternatively, set
+`YOUTARR_TEST_YTDLP` to that executable's absolute path. CI downloads the current
+release and runs this suite in the **yt-dlp Cookie Loader Tests** job, required
+by **All Checks**. The helper imports that executable so the parser follows
+yt-dlp updates; it does not maintain a separate installation or format parser.
+
 ### Frontend Tests
 
 ```bash

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -7,6 +7,7 @@ This document provides a comprehensive reference for all environment variables s
 - [Application Access](#application-access)
 - [Database Configuration](#database-configuration)
 - [Authentication](#authentication)
+- [YouTube Cookies](#youtube-cookies)
 - [User and Permissions](#user-and-permissions)
 - [Platform Deployment](#platform-deployment)
 - [Development and Debugging](#development-and-debugging)
@@ -126,6 +127,23 @@ To use an external database:
 - Leave unset only if you want the historical Express proxy-header trust behavior; Youtarr's rate-limit, session, and setup audit IPs will still key on the direct peer IP until `TRUST_PROXY` is explicitly configured
 - Set `TRUST_PROXY=1` when Youtarr is behind one trusted reverse proxy and you want per-client rate limits
 - Prefer a specific hop count or trusted subnet over broad `true` when exposing Youtarr through a proxy you control
+
+## YouTube Cookies
+
+### YOUTARR_COOKIES_FILE
+**Required**: No
+**Default**: Unset (use cookies uploaded through Settings)
+**Description**: Absolute path inside the container to an externally maintained
+Netscape cookie file, up to 1 MB. Requires **Enable Cookies** in Settings. Takes
+precedence over uploaded cookies without modifying them. New operations use
+private copies checked by yt-dlp. If the file is missing, unreadable, or rejected,
+operations continue without cookies and a warning appears in Settings and logs.
+A usable replacement restores cookie use automatically. Validation checks file
+format, not whether YouTube accepts the session.
+**Example**: `YOUTARR_COOKIES_FILE=/app/config/cookies.external.txt`
+**Setup**: Put the file at `config/cookies.external.txt` and set this variable
+in `.env` to use the existing mount without editing Compose. See
+[External Cookie File](CONFIG.md#external-cookie-file).
 
 ## User and Permissions
 

--- a/server/modules/__tests__/configModule.test.js
+++ b/server/modules/__tests__/configModule.test.js
@@ -43,6 +43,7 @@ describe('ConfigModule', () => {
     delete process.env.DATA_PATH;
     delete process.env.PLATFORM;
     delete process.env.PLEX_URL;
+    delete process.env.YOUTARR_COOKIES_FILE;
 
     // Setup fs mocks
     fs = require('fs');
@@ -904,6 +905,26 @@ describe('ConfigModule', () => {
       fs.existsSync.mockReturnValue(true);
       fs.readFileSync.mockReturnValue(JSON.stringify(defaultTemplate));
       ConfigModule = require('../configModule');
+    });
+
+    test('uses an external source without an upload and still honors the cookie toggle', () => {
+      process.env.YOUTARR_COOKIES_FILE = '/external/cookies.txt';
+      ConfigModule.config.cookiesEnabled = true;
+      ConfigModule.config.customCookiesUploaded = false;
+      expect(ConfigModule.getCookiesPath()).toBe('/external/cookies.txt');
+      expect(ConfigModule.config.customCookiesUploaded).toBe(false);
+      ConfigModule.config.cookiesEnabled = false;
+      expect(ConfigModule.getCookiesPath()).toBeNull();
+    });
+
+    test('restores uploaded cookies when the external source is unset', () => {
+      ConfigModule.config.cookiesEnabled = true;
+      ConfigModule.config.customCookiesUploaded = true;
+      const uploadedPath = ConfigModule.getCookiesPath();
+      process.env.YOUTARR_COOKIES_FILE = '/external/cookies.txt';
+      expect(ConfigModule.getCookiesPath()).toBe('/external/cookies.txt');
+      delete process.env.YOUTARR_COOKIES_FILE;
+      expect(ConfigModule.getCookiesPath()).toBe(uploadedPath);
     });
 
     test('should return null for cookies path when cookies are disabled', () => {

--- a/server/modules/__tests__/externalCookies.test.js
+++ b/server/modules/__tests__/externalCookies.test.js
@@ -1,0 +1,192 @@
+/* eslint-env jest */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+jest.mock('child_process', () => ({ spawnSync: jest.fn() }));
+jest.mock('../../logger', () => ({ warn: jest.fn(), info: jest.fn() }));
+
+describe('external cookie validation and status', () => {
+  let originalSource;
+  let originalPath;
+  let directory;
+  let sourcePath;
+  let executable;
+  let validator;
+  let logger;
+  let cookies;
+  let workingDirs;
+  const source = '# Netscape HTTP Cookie File\n.youtube.com\tTRUE\t/\tTRUE\t0\tSID\tSECRET\n';
+  const helperResult = value => ({ status: 0, stdout: JSON.stringify(value) });
+
+  beforeEach(() => {
+    jest.resetModules();
+    originalSource = process.env.YOUTARR_COOKIES_FILE;
+    originalPath = process.env.PATH;
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'youtarr-validation-test-'));
+    sourcePath = path.join(directory, 'cookies.txt');
+    executable = path.join(directory, 'yt-dlp');
+    fs.writeFileSync(sourcePath, source);
+    fs.writeFileSync(executable, 'test executable', { mode: 0o700 });
+    process.env.YOUTARR_COOKIES_FILE = sourcePath;
+    process.env.PATH = directory;
+    validator = require('child_process').spawnSync;
+    validator.mockReturnValue(helperResult({ valid: true, warnings: false }));
+    logger = require('../../logger');
+    cookies = require('../externalCookies');
+    workingDirs = [];
+    const mkdtemp = fs.mkdtempSync;
+    jest.spyOn(fs, 'mkdtempSync').mockImplementation(prefix => {
+      const dir = mkdtemp(prefix);
+      workingDirs.push(dir);
+      return dir;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalSource === undefined) delete process.env.YOUTARR_COOKIES_FILE;
+    else process.env.YOUTARR_COOKIES_FILE = originalSource;
+    process.env.PATH = originalPath;
+    for (const dir of workingDirs) fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  test('reports no external status when the environment variable is unset', () => {
+    delete process.env.YOUTARR_COOKIES_FILE;
+    expect(cookies.getExternalCookiesStatus()).toBeNull();
+    expect(validator).not.toHaveBeenCalled();
+  });
+
+  test('validates a private copy with the installed executable and reports only safe metadata', () => {
+    expect(cookies.getExternalCookiesStatus()).toEqual({
+      path: sourcePath, ready: true, lastModified: fs.statSync(sourcePath).mtime.toISOString(),
+      warning: null, error: null,
+    });
+    expect(validator).toHaveBeenCalledWith('python3', [
+      path.resolve(__dirname, '../../utils/validate-cookies.py'), executable,
+      path.join(workingDirs[0], 'cookies.txt'),
+    ], expect.objectContaining({ timeout: 5000, maxBuffer: 16 * 1024 }));
+    expect(fs.existsSync(workingDirs[0])).toBe(false);
+    expect(fs.readFileSync(sourcePath, 'utf8')).toBe(source);
+  });
+
+  test('uses only normalized contents returned by yt-dlp and surfaces warnings', () => {
+    const normalized = source.replace('SECRET', 'ACCEPTED');
+    validator.mockImplementation((_command, args) => {
+      fs.writeFileSync(args[2], normalized);
+      return helperResult({ valid: true, warnings: true });
+    });
+    const first = cookies.prepareExternalCookies(['--cookies', sourcePath]);
+    expect(fs.readFileSync(first.args[1], 'utf8')).toBe(normalized);
+    first.cleanup();
+    const status = cookies.getExternalCookiesStatus();
+    expect(status).toMatchObject({ ready: true, warning: expect.stringContaining('Only the cookies it loaded'), error: null });
+    expect(validator).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(sourcePath, 'utf8')).toBe(source);
+    expect(JSON.stringify([status, logger.warn.mock.calls])).not.toContain('SECRET');
+  });
+
+  test.each([
+    ['missing', () => fs.unlinkSync(sourcePath), /not found/],
+    ['directory', () => { process.env.YOUTARR_COOKIES_FILE = directory; }, /regular file/],
+    ['relative path', () => { process.env.YOUTARR_COOKIES_FILE = 'cookies.txt'; }, /absolute path/],
+    ['oversized', () => fs.writeFileSync(sourcePath, Buffer.alloc(1024 * 1024 + 1)), /1 MB/],
+    ['unreadable', () => {
+      jest.spyOn(fs, 'openSync').mockImplementation(() => { throw Object.assign(new Error('SECRET'), { code: 'EACCES' }); });
+    }, /not readable/],
+  ])('omits a %s source and exposes a safe warning', (_name, arrange, message) => {
+    arrange();
+    const result = cookies.prepareExternalCookies(['--cookies', process.env.YOUTARR_COOKIES_FILE, '--dump-json']);
+    expect(result).toEqual({ args: ['--dump-json'], cleanup: null });
+    const status = cookies.getExternalCookiesStatus();
+    expect(status.ready).toBe(false);
+    expect(status.error).toMatch(message);
+    expect(JSON.stringify([status, logger.warn.mock.calls])).not.toContain('SECRET');
+    expect(validator).not.toHaveBeenCalled();
+  });
+
+  test.each(['invalid', 'empty'])('omits cookies when yt-dlp reports %s, caching the rejection without repeated logs', error => {
+    validator.mockReturnValue(helperResult({ valid: false, error }));
+    const args = ['--cookies', sourcePath, '--dump-json'];
+    expect(cookies.prepareExternalCookies(args).args).toEqual(['--dump-json']);
+    expect(cookies.getExternalCookiesStatus().ready).toBe(false);
+    expect(validator).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(args[1]).toBe(sourcePath);
+    expect(fs.existsSync(workingDirs[0])).toBe(false);
+  });
+
+  test.each([
+    { status: 1, stderr: 'SECRET traceback' },
+    { status: null, error: { code: 'ETIMEDOUT', message: 'SECRET timeout' } },
+    { status: 0, stdout: 'SECRET invalid JSON' },
+    helperResult({ valid: false, error: 'unavailable' }),
+  ])('omits cookies on validator failure and retries unchanged contents', failure => {
+    validator.mockReturnValueOnce(failure);
+    const status = cookies.getExternalCookiesStatus();
+    expect(status.ready).toBe(false);
+    expect(JSON.stringify([status, logger.warn.mock.calls])).not.toContain('SECRET');
+    expect(cookies.getExternalCookiesStatus().ready).toBe(true);
+    expect(validator).toHaveBeenCalledTimes(2);
+  });
+
+  test('recovers from a missing yt-dlp installation without a source change', () => {
+    fs.unlinkSync(executable);
+    expect(cookies.getExternalCookiesStatus()).toMatchObject({ ready: false, error: expect.stringContaining('installation') });
+    fs.writeFileSync(executable, 'restored', { mode: 0o700 });
+    expect(cookies.getExternalCookiesStatus().ready).toBe(true);
+  });
+
+  test.each(['mkdtempSync', 'writeFileSync'])('omits cookies on %s failure and retries when storage recovers', method => {
+    const failedWrite = jest.spyOn(fs, method).mockImplementation(() => { throw new Error('SECRET disk full'); });
+    expect(cookies.getExternalCookiesStatus()).toMatchObject({ ready: false, error: expect.stringContaining('working copy') });
+    failedWrite.mockRestore();
+    const restored = cookies.prepareExternalCookies(['--cookies', sourcePath]);
+    expect(restored.args).toContain('--cookies');
+    restored.cleanup();
+  });
+
+  test('never falls back to accepted cookies after the source disappears', () => {
+    expect(cookies.getExternalCookiesStatus().ready).toBe(true);
+    fs.unlinkSync(sourcePath);
+    expect(cookies.prepareExternalCookies(['--cookies', sourcePath]).args).toEqual([]);
+    expect(cookies.getExternalCookiesStatus().ready).toBe(false);
+  });
+
+  test('revalidates changed contents even when file size and modification time are preserved', () => {
+    cookies.getExternalCookiesStatus();
+    const stat = fs.statSync(sourcePath);
+    fs.writeFileSync(sourcePath, source.replace('SECRET', 'SECOND'));
+    fs.utimesSync(sourcePath, stat.atime, stat.mtime);
+    cookies.getExternalCookiesStatus();
+    expect(validator).toHaveBeenCalledTimes(2);
+  });
+
+  test('recovers automatically after a rejected update without using the previous cookies', () => {
+    cookies.getExternalCookiesStatus();
+    fs.writeFileSync(sourcePath, 'bad update');
+    validator.mockReturnValueOnce(helperResult({ valid: false, error: 'invalid' }));
+    expect(cookies.prepareExternalCookies(['--cookies', sourcePath]).args).toEqual([]);
+    fs.writeFileSync(sourcePath, source.replace('SECRET', 'FRESH'));
+    const prepared = cookies.prepareExternalCookies(['--cookies', sourcePath]);
+    expect(fs.readFileSync(prepared.args[1], 'utf8')).toContain('FRESH');
+    prepared.cleanup();
+    expect(logger.info).toHaveBeenCalledWith({ sourcePath }, 'External cookie file is ready');
+  });
+
+  test('revalidates unchanged cookie contents after a yt-dlp update', () => {
+    cookies.getExternalCookiesStatus();
+    fs.writeFileSync(executable, 'updated yt-dlp installation');
+    cookies.getExternalCookiesStatus();
+    expect(validator).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not reuse a result from another configured source', () => {
+    cookies.getExternalCookiesStatus();
+    process.env.YOUTARR_COOKIES_FILE = path.join(directory, 'other.txt');
+    fs.writeFileSync(process.env.YOUTARR_COOKIES_FILE, source);
+    cookies.getExternalCookiesStatus();
+    expect(validator).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/modules/__tests__/ytDlpRunner.test.js
+++ b/server/modules/__tests__/ytDlpRunner.test.js
@@ -2,6 +2,8 @@
 const path = require('path');
 const { EventEmitter } = require('events');
 
+jest.mock('../../logger', () => ({ warn: jest.fn(), info: jest.fn() }));
+
 describe('YtDlpRunner', () => {
   class MockChildProcess extends EventEmitter {
     constructor() {

--- a/server/modules/__tests__/ytdlpProcess.test.js
+++ b/server/modules/__tests__/ytdlpProcess.test.js
@@ -1,0 +1,148 @@
+/* eslint-env jest */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { EventEmitter } = require('events');
+
+jest.mock('child_process', () => ({ spawn: jest.fn(), spawnSync: jest.fn() }));
+jest.mock('../../logger', () => ({ warn: jest.fn(), info: jest.fn() }));
+
+describe('yt-dlp process snapshots', () => {
+  let originalSource;
+  let originalPath;
+  let sourceDir;
+  let sourcePath;
+  let workingDirs;
+  let childProcess;
+  let spawnYtDlp;
+  let spawnYtDlpSync;
+  const cookies = value => `# Netscape HTTP Cookie File\n.youtube.com\tTRUE\t/\tTRUE\t0\tSID\t${value}\n`;
+
+  beforeEach(() => {
+    jest.resetModules();
+    originalSource = process.env.YOUTARR_COOKIES_FILE;
+    originalPath = process.env.PATH;
+    sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'youtarr-process-test-'));
+    sourcePath = path.join(sourceDir, 'cookies.txt');
+    fs.writeFileSync(sourcePath, cookies('first'), { mode: 0o400 });
+    fs.writeFileSync(path.join(sourceDir, 'yt-dlp'), 'test executable', { mode: 0o700 });
+    process.env.PATH = sourceDir;
+    process.env.YOUTARR_COOKIES_FILE = sourcePath;
+    workingDirs = new Set();
+    childProcess = require('child_process');
+    childProcess.spawn.mockImplementation(() => new EventEmitter());
+    childProcess.spawnSync.mockImplementation(() => ({ status: 0, stdout: '{"valid":true,"warnings":false}' }));
+    ({ spawnYtDlp, spawnYtDlpSync } = require('../ytdlpProcess'));
+    const mkdtemp = fs.mkdtempSync;
+    jest.spyOn(fs, 'mkdtempSync').mockImplementation(prefix => {
+      const dir = mkdtemp(prefix);
+      workingDirs.add(dir);
+      return dir;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalSource === undefined) delete process.env.YOUTARR_COOKIES_FILE;
+    else process.env.YOUTARR_COOKIES_FILE = originalSource;
+    process.env.PATH = originalPath;
+    for (const dir of workingDirs) fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+  });
+
+  test('preserves uploaded-cookie args and process options when the feature is unset', () => {
+    delete process.env.YOUTARR_COOKIES_FILE;
+    const args = ['--cookies', sourcePath];
+    const options = { timeout: 1000 };
+    const child = spawnYtDlp(args, options);
+    expect(childProcess.spawn).toHaveBeenCalledWith('yt-dlp', args, options);
+    expect(childProcess.spawn.mock.calls[0][1]).toBe(args);
+    expect(child.listenerCount('close')).toBe(0);
+    expect(childProcess.spawnSync).not.toHaveBeenCalled();
+  });
+
+  test.each([['--help'], ['--cookies', '/one-time-upload.txt']])('preserves unrelated arguments: %j', (...args) => {
+    fs.unlinkSync(sourcePath);
+    spawnYtDlp(args);
+    expect(childProcess.spawn.mock.calls[0][1]).toBe(args);
+    expect(childProcess.spawnSync).not.toHaveBeenCalled();
+  });
+
+  test('launches without cookies when the initial external source is missing', () => {
+    fs.unlinkSync(sourcePath);
+    spawnYtDlp(['--cookies', sourcePath, '--dump-json']);
+    expect(childProcess.spawn).toHaveBeenCalledWith('yt-dlp', ['--dump-json'], undefined);
+  });
+
+  test('launches without cookies when no private directory can be created', () => {
+    fs.mkdtempSync.mockImplementation(() => { throw new Error('disk full'); });
+    spawnYtDlp(['--cookies', sourcePath, '--dump-json']);
+    expect(childProcess.spawn).toHaveBeenCalledWith('yt-dlp', ['--dump-json'], undefined);
+  });
+
+  test('isolates simultaneous operations, source replacements, and yt-dlp writeback', () => {
+    const args = ['--cookies', sourcePath];
+    const first = spawnYtDlp(args);
+    const firstCopy = childProcess.spawn.mock.calls[0][1][1];
+    expect(fs.statSync(firstCopy).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(path.dirname(firstCopy)).mode & 0o777).toBe(0o700);
+    const replacement = path.join(sourceDir, 'next.txt');
+    fs.writeFileSync(replacement, cookies('second'), { mode: 0o400 });
+    fs.renameSync(replacement, sourcePath);
+    const second = spawnYtDlp(args);
+    const secondCopy = childProcess.spawn.mock.calls[1][1][1];
+    expect(secondCopy).not.toBe(firstCopy);
+    expect(fs.readFileSync(firstCopy, 'utf8')).toBe(cookies('first'));
+    expect(fs.readFileSync(secondCopy, 'utf8')).toBe(cookies('second'));
+    fs.writeFileSync(firstCopy, cookies('writeback'));
+    first.emit('close', 0);
+    expect(fs.existsSync(firstCopy)).toBe(false);
+    expect(fs.readFileSync(sourcePath, 'utf8')).toBe(cookies('second'));
+    expect(fs.existsSync(secondCopy)).toBe(true);
+    second.emit('close', null, 'SIGTERM');
+    expect(fs.existsSync(secondCopy)).toBe(false);
+    expect(args[1]).toBe(sourcePath);
+  });
+
+  test('keeps the snapshot until close, including after a process error', () => {
+    const child = spawnYtDlp(['--cookies', sourcePath]);
+    const snapshot = childProcess.spawn.mock.calls[0][1][1];
+    child.on('error', () => {});
+    child.emit('error', new Error('spawn failed'));
+    expect(fs.existsSync(snapshot)).toBe(true);
+    child.emit('close', -2);
+    expect(fs.existsSync(snapshot)).toBe(false);
+  });
+
+  test('cleans the snapshot if spawning throws synchronously', () => {
+    let snapshot;
+    childProcess.spawn.mockImplementation((_command, args) => {
+      snapshot = args[1];
+      throw new Error('spawn failed');
+    });
+    expect(() => spawnYtDlp(['--cookies', sourcePath])).toThrow('spawn failed');
+    expect(fs.existsSync(snapshot)).toBe(false);
+  });
+
+  test('cleans synchronous snapshots after yt-dlp returns', () => {
+    let snapshot;
+    childProcess.spawnSync.mockImplementation((command, args) => {
+      if (command === 'python3') return { status: 0, stdout: '{"valid":true}' };
+      snapshot = args[1];
+      return { status: 0, stdout: 'ok' };
+    });
+    expect(spawnYtDlpSync(['--cookies', sourcePath])).toEqual({ status: 0, stdout: 'ok' });
+    expect(fs.existsSync(snapshot)).toBe(false);
+  });
+
+  test('cleans synchronous snapshots after yt-dlp throws', () => {
+    let snapshot;
+    childProcess.spawnSync.mockImplementation((command, args) => {
+      if (command === 'python3') return { status: 0, stdout: '{"valid":true}' };
+      snapshot = args[1];
+      throw new Error('sync spawn failed');
+    });
+    expect(() => spawnYtDlpSync(['--cookies', sourcePath])).toThrow('sync spawn failed');
+    expect(fs.existsSync(snapshot)).toBe(false);
+  });
+});

--- a/server/modules/channel/channelYtdlpExecutor.js
+++ b/server/modules/channel/channelYtdlpExecutor.js
@@ -3,7 +3,7 @@ const fsPromises = fs.promises;
 const path = require('path');
 const os = require('os');
 const { v4: uuidv4 } = require('uuid');
-const { spawn } = require('child_process');
+const { spawnYtDlp } = require('../ytdlpProcess');
 const tempPathManager = require('../download/tempPathManager');
 
 class ChannelYtdlpExecutor {
@@ -16,7 +16,7 @@ class ChannelYtdlpExecutor {
    * @returns {Promise<string>} - Output content if outputFile provided
    */
   async executeYtDlpCommand(args, outputFile = null) {
-    const ytDlp = spawn('yt-dlp', args, {
+    const ytDlp = spawnYtDlp(args, {
       env: {
         ...process.env,
         TMPDIR: tempPathManager.getTempBasePath()

--- a/server/modules/configModule.js
+++ b/server/modules/configModule.js
@@ -3,6 +3,7 @@ const path = require('path');
 const uuidv4 = require('uuid').v4;
 const EventEmitter = require('events');
 const logger = require('../logger');
+const { getExternalCookiesPath, getExternalCookiesStatus } = require('./externalCookies');
 const { getDefaultNameForUrl } = require('./notificationHelpers');
 
 class ConfigModule extends EventEmitter {
@@ -459,7 +460,16 @@ class ConfigModule extends EventEmitter {
 
   // Cookie helper methods
   getCookiesPath() {
-    if (!this.config.cookiesEnabled || !this.config.customCookiesUploaded) {
+    if (!this.config.cookiesEnabled) {
+      return null;
+    }
+
+    // At launch, yt-dlp validates a private copy of the external source.
+    // Unusable external cookies are omitted without changing the upload workflow.
+    const externalPath = getExternalCookiesPath();
+    if (externalPath) return externalPath;
+
+    if (!this.config.customCookiesUploaded) {
       return null;
     }
 
@@ -480,11 +490,13 @@ class ConfigModule extends EventEmitter {
     const configDir = path.dirname(this.configPath);
     const customPath = path.join(configDir, 'cookies.user.txt');
     const customExists = fs.existsSync(customPath);
+    const external = getExternalCookiesStatus();
 
     return {
       cookiesEnabled: this.config.cookiesEnabled,
       customCookiesUploaded: this.config.customCookiesUploaded,
-      customFileExists: customExists
+      customFileExists: customExists,
+      ...(external ? { external } : {})
     };
   }
 

--- a/server/modules/download/downloadExecutor.js
+++ b/server/modules/download/downloadExecutor.js
@@ -1,4 +1,4 @@
-const { spawn } = require('child_process');
+const { spawnYtDlp } = require('../ytdlpProcess');
 const path = require('path');
 const configModule = require('../configModule');
 const jobModule = require('../jobModule');
@@ -214,7 +214,7 @@ class DownloadExecutor {
         postProcessDirectives,
       });
 
-      const proc = spawn('yt-dlp', args, { env: procEnv });
+      const proc = spawnYtDlp(args, { env: procEnv });
 
       // Store process reference for manual termination
       this.currentProcess = proc;

--- a/server/modules/externalCookies.js
+++ b/server/modules/externalCookies.js
@@ -1,0 +1,191 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+const { spawnSync } = require('child_process');
+const logger = require('../logger');
+
+const MAX_COOKIE_BYTES = 1024 * 1024;
+const VALIDATOR_PATH = path.join(__dirname, '../utils/validate-cookies.py');
+const VALIDATION_ERRORS = {
+  invalid: 'yt-dlp could not load the file. Export cookies in Netscape format.',
+  empty: 'yt-dlp did not load any cookies from the file.',
+  unavailable: 'the yt-dlp cookie validator could not run. Check the yt-dlp installation.',
+  snapshot: 'a private working copy could not be created. Check temporary-directory permissions and free space.',
+};
+
+// Only memoize validation of the current contents, never fall back to old cookies.
+// The installed executable's identity invalidates the result after yt-dlp updates.
+let validationCache = null;
+let lastReportedState = null;
+
+function getExternalCookiesPath() {
+  return process.env.YOUTARR_COOKIES_FILE?.trim() || null;
+}
+
+function cookieError(message) {
+  const error = new Error(`External cookies: ${message}`);
+  error.code = 'EXTERNAL_COOKIES_INVALID';
+  return error;
+}
+
+// Read one opened file so an atomic replacement cannot mix two versions.
+function readExternalCookies(sourcePath) {
+  if (!path.isAbsolute(sourcePath)) {
+    throw cookieError('YOUTARR_COOKIES_FILE must be an absolute path inside the container.');
+  }
+
+  let fd;
+  try {
+    // O_NONBLOCK prevents a mistakenly configured FIFO from hanging the server.
+    fd = fs.openSync(sourcePath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) throw cookieError('the configured path must point to a regular file.');
+    if (stat.size > MAX_COOKIE_BYTES) throw cookieError('the file must be no larger than 1 MB.');
+
+    // Bound the read even if another process grows the file after fstat.
+    const buffer = Buffer.alloc(MAX_COOKIE_BYTES + 1);
+    let length = 0;
+    while (length < buffer.length) {
+      const bytesRead = fs.readSync(fd, buffer, length, buffer.length - length, null);
+      if (!bytesRead) break;
+      length += bytesRead;
+    }
+    if (length > MAX_COOKIE_BYTES) throw cookieError('the file must be no larger than 1 MB.');
+    return { contents: buffer.subarray(0, length), lastModified: stat.mtime.toISOString() };
+  } catch (error) {
+    if (error.code === 'EXTERNAL_COOKIES_INVALID') throw error;
+    if (error.code === 'ENOENT') {
+      throw cookieError('the file was not found. Check the directory mount and YOUTARR_COOKIES_FILE.');
+    }
+    if (error.code === 'EACCES' || error.code === 'EPERM') {
+      throw cookieError('the file is not readable. Check permissions for the container user.');
+    }
+    throw cookieError('the file could not be read. Check the path, permissions, and directory mount.');
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}
+
+function getYtDlpExecutable() {
+  for (const directory of (process.env.PATH || '').split(path.delimiter)) {
+    try {
+      const executable = fs.realpathSync(path.resolve(directory, 'yt-dlp'));
+      fs.accessSync(executable, fs.constants.X_OK);
+      const stat = fs.statSync(executable);
+      if (stat.isFile()) {
+        return { executable, identity: [executable, stat.dev, stat.ino, stat.size, stat.mtimeMs, stat.ctimeMs] };
+      }
+    } catch {
+      // Continue searching PATH, just as the process launcher does.
+    }
+  }
+  throw cookieError(VALIDATION_ERRORS.unavailable);
+}
+
+function reportStatus(sourcePath, status) {
+  const state = JSON.stringify([sourcePath, status.error, status.warning]);
+  if (state === lastReportedState) return;
+  if (status.error) {
+    logger.warn({ sourcePath, reason: status.error }, 'External cookies unavailable; operations will continue without cookies while this source is selected');
+  } else if (status.warning) {
+    logger.warn({ sourcePath, reason: status.warning }, 'External cookies loaded with warnings');
+  } else if (lastReportedState) {
+    logger.info({ sourcePath }, 'External cookie file is ready');
+  }
+  lastReportedState = state;
+}
+
+function prepareCookieFile(sourcePath) {
+  let tempDir;
+  let lastModified = null;
+  const cleanup = () => {
+    if (!tempDir) return;
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    } catch {
+      logger.warn('Failed to remove temporary external cookies');
+    }
+  };
+
+  let result;
+  try {
+    const source = readExternalCookies(sourcePath);
+    lastModified = source.lastModified;
+    const { executable, identity } = getYtDlpExecutable();
+    const digest = crypto.createHash('sha256').update(source.contents).digest('hex');
+    const key = JSON.stringify([sourcePath, digest, identity]);
+    if (validationCache?.key !== key) validationCache = null;
+    if (validationCache?.error) throw cookieError(validationCache.error);
+
+    try {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'youtarr-cookies-'));
+      const snapshotPath = path.join(tempDir, 'cookies.txt');
+      fs.writeFileSync(snapshotPath, validationCache?.contents || source.contents, { mode: 0o600 });
+      if (!validationCache) {
+        const checked = spawnSync('python3', [VALIDATOR_PATH, executable, snapshotPath], {
+          encoding: 'utf8', timeout: 5000, maxBuffer: 16 * 1024, windowsHide: true,
+        });
+        if (checked.error || checked.status !== 0) throw cookieError(VALIDATION_ERRORS.unavailable);
+        let validation;
+        try {
+          validation = JSON.parse(checked.stdout);
+        } catch {
+          throw cookieError(VALIDATION_ERRORS.unavailable);
+        }
+        if (validation?.valid !== true) {
+          const reason = VALIDATION_ERRORS[validation?.error] || VALIDATION_ERRORS.unavailable;
+          // Retry infrastructure failures on the next operation, even if contents are unchanged.
+          if (['invalid', 'empty'].includes(validation?.error)) validationCache = { key, error: reason };
+          throw cookieError(reason);
+        }
+        validationCache = {
+          key,
+          contents: fs.readFileSync(snapshotPath),
+          warning: validation.warnings
+            ? 'yt-dlp reported warnings while loading the file. Only the cookies it loaded will be used.'
+            : null,
+        };
+      }
+      result = { snapshotPath, cleanup, lastModified, error: null, warning: validationCache.warning };
+    } catch (error) {
+      if (error.code === 'EXTERNAL_COOKIES_INVALID') throw error;
+      throw cookieError(VALIDATION_ERRORS.snapshot);
+    }
+  } catch (error) {
+    cleanup();
+    // Do not expose parser output, exception text, or cookie contents to logs or the API.
+    result = {
+      snapshotPath: null, cleanup: null, lastModified, warning: null,
+      error: error.code === 'EXTERNAL_COOKIES_INVALID'
+        ? error.message : `External cookies: ${VALIDATION_ERRORS.unavailable}`,
+    };
+  }
+  reportStatus(sourcePath, result);
+  return result;
+}
+
+function getExternalCookiesStatus() {
+  const sourcePath = getExternalCookiesPath();
+  if (!sourcePath) return null;
+  const { snapshotPath, cleanup, ...status } = prepareCookieFile(sourcePath);
+  cleanup?.();
+  return { path: sourcePath, ready: Boolean(snapshotPath), ...status };
+}
+
+function prepareExternalCookies(args) {
+  const sourcePath = getExternalCookiesPath();
+  const cookieIndex = args.indexOf('--cookies');
+  if (!sourcePath || cookieIndex < 0 || args[cookieIndex + 1] !== sourcePath) {
+    return { args, cleanup: null };
+  }
+
+  const { snapshotPath, cleanup } = prepareCookieFile(sourcePath);
+  const preparedArgs = [...args];
+  if (snapshotPath) preparedArgs[cookieIndex + 1] = snapshotPath;
+  else preparedArgs.splice(cookieIndex, 2);
+  return { args: preparedArgs, cleanup };
+}
+
+module.exports = { getExternalCookiesPath, getExternalCookiesStatus, prepareExternalCookies };

--- a/server/modules/videoDownloadPostProcessFiles.js
+++ b/server/modules/videoDownloadPostProcessFiles.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const { execSync, spawnSync } = require('child_process');
+const { spawnYtDlpSync } = require('./ytdlpProcess');
 const configModule = require('./configModule');
 const nfoGenerator = require('./nfoGenerator');
 const ratingMapper = require('./ratingMapper');
@@ -84,7 +85,7 @@ async function downloadChannelThumbnailIfMissing(channelId) {
       // Build yt-dlp command using centralized helper so proxy/sleep/cookies are respected
       const ytdlpArgs = YtdlpCommandBuilder.buildThumbnailDownloadArgs(channelUrl, channelThumbPath);
 
-      const result = spawnSync('yt-dlp', ytdlpArgs, {
+      const result = spawnYtDlpSync(ytdlpArgs, {
         env: {
           ...process.env,
           TMPDIR: tempPathManager.getTempBasePath()

--- a/server/modules/ytDlpRunner.js
+++ b/server/modules/ytDlpRunner.js
@@ -1,4 +1,4 @@
-const { spawn } = require('child_process');
+const { spawnYtDlp } = require('./ytdlpProcess');
 const path = require('path');
 const fs = require('fs');
 const tempPathManager = require('./download/tempPathManager');
@@ -56,7 +56,7 @@ class YtDlpRunner {
         return;
       }
 
-      const ytDlpProcess = spawn('yt-dlp', args, {
+      const ytDlpProcess = spawnYtDlp(args, {
         shell: false,
         timeout: timeoutMs,
         env: {

--- a/server/modules/ytdlpProcess.js
+++ b/server/modules/ytdlpProcess.js
@@ -1,0 +1,32 @@
+const { spawn, spawnSync } = require('child_process');
+const { prepareExternalCookies } = require('./externalCookies');
+
+// Keep the existing ChildProcess API and event handling at each call site.
+// The external source is never passed to yt-dlp, which writes its cookie jar
+// back on exit. Every invocation gets its own writable snapshot instead.
+function spawnYtDlp(args, options) {
+  const prepared = prepareExternalCookies(args);
+  try {
+    const child = spawn('yt-dlp', prepared.args, options);
+    if (prepared.cleanup) {
+      // 'close' also follows a failed spawn. An 'error' alone can mean a failed
+      // kill while yt-dlp is still running, so do not remove its file then.
+      child.once('close', prepared.cleanup);
+    }
+    return child;
+  } catch (error) {
+    prepared.cleanup?.();
+    throw error;
+  }
+}
+
+function spawnYtDlpSync(args, options) {
+  const prepared = prepareExternalCookies(args);
+  try {
+    return spawnSync('yt-dlp', prepared.args, options);
+  } finally {
+    prepared.cleanup?.();
+  }
+}
+
+module.exports = { spawnYtDlp, spawnYtDlpSync };

--- a/server/routes/__tests__/config.test.js
+++ b/server/routes/__tests__/config.test.js
@@ -61,6 +61,33 @@ beforeEach(() => {
   filenamePreview.previewTemplate.mockReset();
 });
 
+describe('externally managed cookie routes', () => {
+  let originalSource;
+  beforeEach(() => {
+    originalSource = process.env.YOUTARR_COOKIES_FILE;
+    process.env.YOUTARR_COOKIES_FILE = '/external/cookies.txt';
+  });
+  afterEach(() => {
+    if (originalSource === undefined) delete process.env.YOUTARR_COOKIES_FILE;
+    else process.env.YOUTARR_COOKIES_FILE = originalSource;
+  });
+
+  test('rejects uploads without replacing saved cookies or enabling cookie use', async () => {
+    const { app, configModule } = makeApp();
+    const res = await supertest(app).post('/api/cookies/upload')
+      .attach('cookieFile', Buffer.from('# Netscape HTTP Cookie File'), 'cookies.txt');
+    expect(res.status).toBe(409);
+    expect(configModule.writeCustomCookiesFile).not.toHaveBeenCalled();
+  });
+
+  test('rejects deletion without removing previously uploaded cookies', async () => {
+    const { app, configModule } = makeApp();
+    const res = await supertest(app).delete('/api/cookies');
+    expect(res.status).toBe(409);
+    expect(configModule.deleteCustomCookiesFile).not.toHaveBeenCalled();
+  });
+});
+
 describe('POST /updateconfig', () => {
   test('returns 200 when ytdlpCustomArgs is empty', async () => {
     const { app } = makeApp();

--- a/server/routes/config.js
+++ b/server/routes/config.js
@@ -2,6 +2,7 @@ const express = require('express');
 const multer = require('multer');
 const customArgsParser = require('../modules/download/customArgsParser');
 const filenamePreview = require('../modules/filenamePreview');
+const { getExternalCookiesPath } = require('../modules/externalCookies');
 
 // Mirror of the frontend RATE_LIMIT_REGEX. Matches yt-dlp's --limit-rate
 // format: digits with optional decimal, optional K/M/G suffix.
@@ -331,7 +332,7 @@ module.exports = function createConfigRoutes({ verifyToken, configModule, valida
    * /api/cookies/status:
    *   get:
    *     summary: Get cookie file status
-   *     description: Check if a custom YouTube cookie file is configured.
+   *     description: Check uploaded cookies and validate the current external file with yt-dlp when configured. Unusable external cookies are omitted from operations. Does not verify YouTube authentication.
    *     tags: [Configuration]
    *     responses:
    *       200:
@@ -341,11 +342,32 @@ module.exports = function createConfigRoutes({ verifyToken, configModule, valida
    *             schema:
    *               type: object
    *               properties:
-   *                 hasCustomCookies:
+   *                 cookiesEnabled:
    *                   type: boolean
-   *                 lastModified:
-   *                   type: string
-   *                   format: date-time
+   *                 customCookiesUploaded:
+   *                   type: boolean
+   *                 customFileExists:
+   *                   type: boolean
+   *                 external:
+   *                   type: object
+   *                   description: Present only when YOUTARR_COOKIES_FILE is configured.
+   *                   properties:
+   *                     path:
+   *                       type: string
+   *                     ready:
+   *                       type: boolean
+   *                       description: yt-dlp loaded cookies from the current file and a private working copy can be created.
+   *                     lastModified:
+   *                       type: string
+   *                       format: date-time
+   *                       nullable: true
+   *                     warning:
+   *                       type: string
+   *                       nullable: true
+   *                       description: Safe summary of parser warnings. Only cookies loaded by yt-dlp are used.
+   *                     error:
+   *                       type: string
+   *                       nullable: true
    *       500:
    *         description: Failed to get cookie status
    */
@@ -382,11 +404,16 @@ module.exports = function createConfigRoutes({ verifyToken, configModule, valida
    *         description: Cookie file uploaded successfully
    *       400:
    *         description: Invalid file or format
+   *       409:
+   *         description: Cookies are managed externally via YOUTARR_COOKIES_FILE.
    *       500:
    *         description: Failed to upload cookie file
    */
   router.post('/api/cookies/upload', verifyToken, cookieUpload.single('cookieFile'), async (req, res) => {
     try {
+      if (getExternalCookiesPath()) {
+        return res.status(409).json({ error: 'Cookies are managed externally. Update the external file or unset YOUTARR_COOKIES_FILE to use uploads.' });
+      }
       if (!req.file) {
         return res.status(400).json({ error: 'No file uploaded' });
       }
@@ -424,11 +451,16 @@ module.exports = function createConfigRoutes({ verifyToken, configModule, valida
    *     responses:
    *       200:
    *         description: Cookie file deleted successfully
+   *       409:
+   *         description: Cookies are managed externally via YOUTARR_COOKIES_FILE.
    *       500:
    *         description: Failed to delete cookie file
    */
   router.delete('/api/cookies', verifyToken, (req, res) => {
     try {
+      if (getExternalCookiesPath()) {
+        return res.status(409).json({ error: 'Cookies are managed externally. Unset YOUTARR_COOKIES_FILE to manage uploaded cookies.' });
+      }
       configModule.deleteCustomCookiesFile();
       const status = configModule.getCookiesStatus();
       res.json({

--- a/server/utils/__tests__/test_validate_cookies.py
+++ b/server/utils/__tests__/test_validate_cookies.py
@@ -1,0 +1,76 @@
+"""Regression coverage against the actual yt-dlp zipimport cookie loader.
+
+Requires python3 and yt-dlp on PATH, or YOUTARR_TEST_YTDLP pointing to the
+zipimport executable (the same distribution used by the Docker image).
+"""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+class CookieValidationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.executable = os.environ.get("YOUTARR_TEST_YTDLP") or shutil.which("yt-dlp")
+        if not cls.executable:
+            raise RuntimeError("Install yt-dlp or set YOUTARR_TEST_YTDLP to its zipimport executable")
+        cls.helper = Path(__file__).resolve().parents[1] / "validate-cookies.py"
+
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.snapshot = Path(self.directory.name) / "cookies.txt"
+
+    def validate(self, contents):
+        self.snapshot.write_text(contents, encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(self.helper), self.executable, str(self.snapshot)],
+            capture_output=True, text=True, timeout=10, check=True,
+        )
+        self.assertNotIn("SECRET", result.stdout + result.stderr)
+        self.assertEqual(result.stderr, "")
+        return json.loads(result.stdout)
+
+    def test_accepts_httponly_whitespace_and_fractional_expiration(self):
+        result = self.validate(
+            "# Netscape HTTP Cookie File\r\n   \r\n"
+            "#HttpOnly_.youtube.com\tTRUE\t/\tTRUE\t2000000000.5\tSID\tSECRET\r\n"
+        )
+        self.assertTrue(result["valid"])
+        self.assertIn("SID\tSECRET", self.snapshot.read_text())
+
+    def test_skips_malformed_records_and_normalizes_the_snapshot(self):
+        result = self.validate(
+            "# Netscape HTTP Cookie File\n"
+            "malformed SECRET record\n"
+            ".youtube.com\tTRUE\t/\tTRUE\t0\tSID\tACCEPTED\n"
+        )
+        self.assertEqual(result, {"valid": True, "warnings": True})
+        normalized = self.snapshot.read_text()
+        self.assertNotIn("malformed", normalized)
+        self.assertIn("SID\tACCEPTED", normalized)
+
+    def test_rejects_json_without_exposing_cookie_values(self):
+        self.assertEqual(self.validate('[{"value":"SECRET"}]'), {"valid": False, "error": "invalid"})
+
+    def test_rejects_header_only_and_all_skipped_records(self):
+        for contents in ["# Netscape HTTP Cookie File\n", "# Netscape HTTP Cookie File\nmalformed SECRET\n"]:
+            with self.subTest(contents=contents):
+                self.assertEqual(self.validate(contents), {"valid": False, "error": "empty"})
+
+    def test_rejects_parser_errors_without_leaking_records_or_tracebacks(self):
+        result = self.validate(
+            "# Netscape HTTP Cookie File\n"
+            ".youtube.com\tFALSE\t/\tTRUE\t0\tSID\tSECRET\n"
+        )
+        self.assertEqual(result, {"valid": False, "error": "invalid"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/utils/validate-cookies.py
+++ b/server/utils/validate-cookies.py
@@ -1,0 +1,41 @@
+"""Load a private cookie snapshot with the installed yt-dlp; never access YouTube."""
+
+import contextlib
+import io
+import json
+import sys
+
+
+def validate(executable, snapshot):
+    # The Docker image uses yt-dlp's Python zipimport executable. Import from
+    # that exact installation so self-updates also update the cookie parser.
+    sys.path.insert(0, executable)
+    diagnostics = io.StringIO()
+    # yt-dlp and Python's cookie loader can print entire malformed records.
+    # Suppress those diagnostics even on failure; return only fixed error codes.
+    with contextlib.redirect_stderr(diagnostics), contextlib.redirect_stdout(io.StringIO()):
+        try:
+            from yt_dlp.cookies import YoutubeDLCookieJar
+        except Exception:
+            return {"valid": False, "error": "unavailable"}
+
+        try:
+            jar = YoutubeDLCookieJar(snapshot)
+            jar.load()
+        except Exception:
+            return {"valid": False, "error": "invalid"}
+        if not len(jar):
+            return {"valid": False, "error": "empty"}
+
+        try:
+            # Use precisely the cookies the parser accepted, without passing
+            # rejected lines to the eventual download or its logs a second time.
+            jar.save()
+        except Exception:
+            return {"valid": False, "error": "snapshot"}
+        return {"valid": True, "warnings": bool(diagnostics.getvalue())}
+
+
+if __name__ == "__main__":
+    result = validate(*sys.argv[1:]) if len(sys.argv) == 3 else {"valid": False, "error": "unavailable"}
+    print(json.dumps(result))


### PR DESCRIPTION
Allow external processes to refresh cookies through YOUTARR_COOKIES_FILE without repeated uploads or restarts.

Validate private snapshots with the installed yt-dlp parser. Continue without cookies when the source is unusable, surface warnings in Settings and logs, and resume cookie use when a valid file is available.

Add expandable setup guidance, live status, and test coverage.

Preserve the existing upload workflow when the environment variable is unset.

Refs: #772